### PR TITLE
Refactor DataDrivenArgumentsRetriever and MatrixRetriever to directly embed attribute value expressions

### DIFF
--- a/TUnit.Engine.SourceGenerator.Tests/DataDrivenTests.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/DataDrivenTests.cs
@@ -20,7 +20,7 @@ internal class DataDrivenTests : TestsBase<TestsGenerator>
         },
         generatedFiles =>
         {
-            Assert.That(generatedFiles.Length, Is.EqualTo(15));
+            Assert.That(generatedFiles.Length, Is.EqualTo(18));
 
             Assert.That(generatedFiles[0], Does.Contain("global::System.Int32 methodArg0 = 1;"));
             Assert.That(generatedFiles[1], Does.Contain("global::System.Int32 methodArg0 = 2;"));
@@ -33,8 +33,8 @@ internal class DataDrivenTests : TestsBase<TestsGenerator>
             Assert.That(generatedFiles[5], Does.Contain("global::System.Int32 methodArg0 = 3;"));
             Assert.That(generatedFiles[5], Does.Contain("global::System.String methodArg1 = \"String3\";"));
 
-            Assert.That(generatedFiles[6], Does.Contain("global::TUnit.TestProject.TestEnum methodArg0 = (global::TUnit.TestProject.TestEnum)(0);"));
-            Assert.That(generatedFiles[7], Does.Contain("global::TUnit.TestProject.TestEnum methodArg0 = (global::TUnit.TestProject.TestEnum)(1);"));
+            Assert.That(generatedFiles[6], Does.Contain("global::TUnit.TestProject.TestEnum methodArg0 = global::TUnit.TestProject.TestEnum.One;"));
+            Assert.That(generatedFiles[7], Does.Contain("global::TUnit.TestProject.TestEnum methodArg0 = global::TUnit.TestProject.TestEnum.Two;"));
             Assert.That(generatedFiles[8], Does.Contain("global::TUnit.TestProject.TestEnum methodArg0 = (global::TUnit.TestProject.TestEnum)(-1);"));
             
             Assert.That(generatedFiles[9], Does.Contain("global::System.String methodArg0 = null;"));
@@ -46,5 +46,11 @@ internal class DataDrivenTests : TestsBase<TestsGenerator>
             Assert.That(generatedFiles[12], Does.Contain("global::System.Boolean? methodArg0 = null;"));
             Assert.That(generatedFiles[13], Does.Contain("global::System.Boolean? methodArg0 = false;"));
             Assert.That(generatedFiles[14], Does.Contain("global::System.Boolean? methodArg0 = true;"));
+
+            Assert.That(generatedFiles[15], Does.Contain("global::System.Type methodArg0 = typeof(global::System.Object);"));
+
+            Assert.That(generatedFiles[16], Does.Contain("global::System.Int32[] methodArg0 = new[] { 1, 2, 3 };"));
+
+            Assert.That(generatedFiles[17], Does.Contain("global::System.Int32 methodArg0 = global::System.Int32.MaxValue;"));
         });
 }

--- a/TUnit.Engine.SourceGenerator.Tests/MatrixTests.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/MatrixTests.cs
@@ -38,8 +38,8 @@ internal class MatrixTests : TestsBase<TestsGenerator>
     private void AssertTestThree(string[] generatedFiles)
     {
         Assert.That(generatedFiles[72], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(-1);"));
-        Assert.That(generatedFiles[73], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(0);"));
+        Assert.That(generatedFiles[73], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = global::TUnit.TestProject.TestEnum.One;"));
         Assert.That(generatedFiles[74], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(-1);"));
-        Assert.That(generatedFiles[75], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(0);"));
+        Assert.That(generatedFiles[75], Does.Contain("global::TUnit.TestProject.TestEnum methodArg1 = global::TUnit.TestProject.TestEnum.One;"));
     }
 }

--- a/TUnit.Engine.SourceGenerator.Tests/NullableByteArgumentTests.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/NullableByteArgumentTests.cs
@@ -15,7 +15,7 @@ internal class NullableByteArgumentTests : TestsBase<TestsGenerator>
 
             Assert.That(generatedFiles[0], Does.Contain(
                 """
-                global::System.Byte? methodArg0 = 1;
+                global::System.Byte? methodArg0 = (global::System.Byte)1;
                 """));
             
             Assert.That(generatedFiles[1], Does.Contain(
@@ -25,13 +25,13 @@ internal class NullableByteArgumentTests : TestsBase<TestsGenerator>
             
             Assert.That(generatedFiles[2].IgnoreWhitespaceFormatting(), Does.Contain(
                 """
-                global::System.Byte methodArg0 = 1;
-                global::System.Byte? methodArg1 = 1;
+                global::System.Byte methodArg0 = (global::System.Byte)1;
+                global::System.Byte? methodArg1 = (global::System.Byte)1;
                 """.IgnoreWhitespaceFormatting()));
             
             Assert.That(generatedFiles[3].IgnoreWhitespaceFormatting(), Does.Contain(
                 """
-                global::System.Byte methodArg0 = 1;
+                global::System.Byte methodArg0 = (global::System.Byte)1;
                 global::System.Byte? methodArg1 = null;
                 """.IgnoreWhitespaceFormatting()));
         });

--- a/TUnit.Engine.SourceGenerator.Tests/NumberArgumentTests.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/NumberArgumentTests.cs
@@ -13,8 +13,8 @@ internal class NumberArgumentTests : TestsBase<TestsGenerator>
             Assert.That(generatedFiles.Length, Is.EqualTo(6));
             
             Assert.That(generatedFiles[0], Does.Contain("global::System.Int32 methodArg0 = 1;"));
-            Assert.That(generatedFiles[1], Does.Contain("global::System.Double methodArg0 = 1.1D;"));
-            Assert.That(generatedFiles[2], Does.Contain("global::System.Single methodArg0 = 1.1F;"));
+            Assert.That(generatedFiles[1], Does.Contain("global::System.Double methodArg0 = 1.1;"));
+            Assert.That(generatedFiles[2], Does.Contain("global::System.Single methodArg0 = 1.1f;"));
             Assert.That(generatedFiles[3], Does.Contain("global::System.Int64 methodArg0 = 1L;"));
             Assert.That(generatedFiles[4], Does.Contain("global::System.UInt64 methodArg0 = 1UL;"));
             Assert.That(generatedFiles[5], Does.Contain("global::System.UInt32 methodArg0 = 1U;"));

--- a/TUnit.Engine.SourceGenerator.Tests/StringArgumentTests.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/StringArgumentTests.cs
@@ -17,17 +17,17 @@ internal class StringArgumentTests : TestsBase<TestsGenerator>
             
             Assert.That(generatedFiles[1], Does.Contain(
                 """
-                global::System.String methodArg0 = "\\";
+                global::System.String methodArg0 = @"\";
                 """));
             
             Assert.That(generatedFiles[2], Does.Contain(
                 """
-                global::System.String methodArg0 = "\\t";
+                global::System.String methodArg0 = @"\t";
                 """));
             
             Assert.That(generatedFiles[3], Does.Contain(
                 """
-                global::System.String methodArg0 = "	
+                global::System.String methodArg0 = "\t";
                 """));
             
             Assert.That(generatedFiles[4], Does.Contain(
@@ -37,12 +37,20 @@ internal class StringArgumentTests : TestsBase<TestsGenerator>
             
             Assert.That(generatedFiles[5], Does.Contain(
                 """
-                global::System.String methodArg0 = "\\	
+                global::System.String methodArg0 = "\\\t";
                 """));
             
             Assert.That(generatedFiles[6], Does.Contain(
                 """
-                global::System.String methodArg0 = "\\\\t
+                global::System.String methodArg0 = "\\\\t";
                 """));
+
+            Assert.That(generatedFiles[7], Does.Contain(
+                """"
+                global::System.String methodArg0 = """
+                        Hello
+                        World
+                        """;
+                """"));
         });
 }

--- a/TUnit.Engine.SourceGenerator.Tests/TestsBase.cs
+++ b/TUnit.Engine.SourceGenerator.Tests/TestsBase.cs
@@ -53,7 +53,7 @@ internal class TestsBase<TGenerator> where TGenerator : IIncrementalGenerator, n
             )
             .AddReferences(ReferencesHelper.References)
             .AddSyntaxTrees(additionalSources.Select(x => CSharpSyntaxTree.ParseText(x)));
-        
+
         foreach (var error in compilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error))
         {
             throw new Exception(
@@ -62,6 +62,12 @@ internal class TestsBase<TGenerator> where TGenerator : IIncrementalGenerator, n
         
         // Run generators. Don't forget to use the new compilation rather than the previous one.
         driver.RunGeneratorsAndUpdateCompilation(compilation, out var newCompilation, out _);
+
+        foreach (var error in newCompilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error))
+        {
+            throw new Exception(
+                $"There was an error with the generator compilation.{Environment.NewLine}{Environment.NewLine}{error}");
+        }
 
         // Retrieve all files in the compilation.
         var generatedFiles = newCompilation.SyntaxTrees

--- a/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/ArgumentsRetriever.cs
+++ b/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/ArgumentsRetriever.cs
@@ -26,7 +26,7 @@ internal static class ArgumentsRetriever
             yield break;
         }
 
-        foreach (var argumentsContainer in MatrixRetriever.Parse(parameters))
+        foreach (var argumentsContainer in MatrixRetriever.Parse(context, parameters))
         {
             yield return argumentsContainer;
         }
@@ -44,7 +44,7 @@ internal static class ArgumentsRetriever
             
             if (name == WellKnownFullyQualifiedClassNames.ArgumentsAttribute.WithGlobalPrefix)
             {
-                yield return DataDrivenArgumentsRetriever.ParseArguments(dataAttribute, parameters, index);
+                yield return DataDrivenArgumentsRetriever.ParseArguments(context, dataAttribute, parameters, index);
             }
             
             if (name == WellKnownFullyQualifiedClassNames.MethodDataSourceAttribute.WithGlobalPrefix)

--- a/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/MatrixRetriever.cs
+++ b/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/MatrixRetriever.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
 using TUnit.Engine.SourceGenerator.Extensions;
 using TUnit.Engine.SourceGenerator.Models.Arguments;
 
@@ -8,50 +9,58 @@ namespace TUnit.Engine.SourceGenerator.CodeGenerators.Helpers;
 internal static class MatrixRetriever
 {
     // We return a List of a List. Inner List is for each test.
-    public static IEnumerable<ArgumentsContainer> Parse(ImmutableArray<IParameterSymbol> parameters)
+    public static IEnumerable<ArgumentsContainer> Parse(GeneratorAttributeSyntaxContext context, ImmutableArray<IParameterSymbol> parameters)
     {
         if (parameters.IsDefaultOrEmpty || !parameters.HasMatrixAttribute())
         {
             return [];
         }
-        
+
         var matrixAttributes = parameters
             .Select(p => p.GetAttributes().SafeFirstOrDefault(a => a.GetFullyQualifiedAttributeTypeName()
                                                                == WellKnownFullyQualifiedClassNames.MatrixAttribute.WithGlobalPrefix))
             .OfType<AttributeData>()
             .ToList();
-        
-        var mappedToConstructorArrays = matrixAttributes
-            .Select(x => x.ConstructorArguments.SafeFirstOrDefault().Values);
+
+        var mappedToArgumentArrays = matrixAttributes
+            .Select(x =>
+            {
+                var attributeSyntax = (AttributeSyntax)x.ApplicationSyntaxReference!.GetSyntax();
+                var arguments = attributeSyntax.ArgumentList!.Arguments;
+
+                var objectArray = x.ConstructorArguments.SafeFirstOrDefault().Values;
+
+                return objectArray.Zip(arguments, (o, a) => (o, a));
+            });
 
         var attr = matrixAttributes.SafeFirstOrDefault();
-        
+
         var index = 0;
-        return GetMatrixArgumentsList(mappedToConstructorArrays)
-            .Select(x => MapToArgumentEnumerable(x, parameters))
+        return GetMatrixArgumentsList(mappedToArgumentArrays)
+            .Select(x => MapToArgumentEnumerable(context, x, parameters))
             .Select(x => new ArgumentsContainer
             {
                 DataAttribute = attr,
                 DataAttributeIndex = ++index,
                 IsEnumerableData = false,
-                Arguments = [..x]
+                Arguments = [.. x]
             });
     }
-
-    private static IEnumerable<Argument> MapToArgumentEnumerable(IEnumerable<TypedConstant> typedConstants, ImmutableArray<IParameterSymbol> parameterSymbols)
+    private static IEnumerable<Argument> MapToArgumentEnumerable(GeneratorAttributeSyntaxContext context, IEnumerable<(TypedConstant ArgumentConstant, AttributeArgumentSyntax ArgumentSyntax)> elements, ImmutableArray<IParameterSymbol> parameterSymbols)
     {
-        return typedConstants.Select((typedConstant, index) =>
-            {
-                var parameterSymbolType = parameterSymbols.ElementAt(index).Type;
-                
-                return new Argument(parameterSymbolType.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix),
-                    TypedConstantParser.GetTypedConstantValue(typedConstant, parameterSymbolType));
-            });
+        return elements.Select((element, index) =>
+        {
+            var type = parameterSymbols.ElementAt(index).Type;
+
+            return new Argument(type?.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix) ??
+                                TypedConstantParser.GetFullyQualifiedTypeNameFromTypedConstantValue(element.ArgumentConstant),
+                TypedConstantParser.GetTypedConstantValue(context.SemanticModel, element.ArgumentSyntax.Expression, type));
+        });
     }
 
-    private static readonly IEnumerable<IEnumerable<TypedConstant>> Seed = [[]];
-    
-    private static IEnumerable<IEnumerable<TypedConstant>> GetMatrixArgumentsList(IEnumerable<ImmutableArray<TypedConstant>> elements)
+    private static readonly IEnumerable<IEnumerable<(TypedConstant, AttributeArgumentSyntax)>> Seed = [[]];
+
+    private static IEnumerable<IEnumerable<(TypedConstant, AttributeArgumentSyntax)>> GetMatrixArgumentsList(IEnumerable<IEnumerable<(TypedConstant, AttributeArgumentSyntax)>> elements)
     {
         return elements.Aggregate(Seed, (accumulator, enumerable)
             => accumulator.SelectMany(x => enumerable.Select(x.Append)));

--- a/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/MethodDataSourceRetriever.cs
+++ b/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/MethodDataSourceRetriever.cs
@@ -102,7 +102,7 @@ internal static class MethodDataSourceRetriever
 
         return new Argument(
             dataSourceMethod.ReturnType.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix),
-            methodInvocation, isUnfoldableTuple: true)
+            methodInvocation)
         {
             TupleVariableNames = variableNames,
             DisposeAfterTest = disposeAfterTest

--- a/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/TypedConstantParser.cs
+++ b/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/TypedConstantParser.cs
@@ -29,7 +29,10 @@ internal static class TypedConstantParser
         public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
         {
             var symbol = semanticModel.GetSymbolInfo(node);
-            if (symbol.Symbol!.Kind != SymbolKind.NamedType) return base.VisitIdentifierName(node);
+            if (symbol.Symbol!.Kind != SymbolKind.NamedType)
+            {
+                return base.VisitIdentifierName(node);
+            }
             return node.WithIdentifier(SyntaxFactory.Identifier(symbol.Symbol!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix)));
         }
 

--- a/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/TypedConstantParser.cs
+++ b/TUnit.Engine.SourceGenerator/CodeGenerators/Helpers/TypedConstantParser.cs
@@ -1,93 +1,53 @@
 ﻿using Microsoft.CodeAnalysis;
-using System.Globalization;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace TUnit.Engine.SourceGenerator.CodeGenerators.Helpers;
 
 internal static class TypedConstantParser
 {
-    public static string? GetTypedConstantValue(TypedConstant constructorArgument, ITypeSymbol? type = null)
+    public static string? GetTypedConstantValue(SemanticModel semanticModel, ExpressionSyntax argumentExpression, ITypeSymbol? type = null)
     {
-        if (constructorArgument.IsNull)
+        var newExpression = argumentExpression.Accept(new FullyQualifiedWithGlobalPrefixRewriter(semanticModel))!;
+
+        if (type?.TypeKind == TypeKind.Enum && !newExpression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
         {
-            return "null";
-        }
-        
-        if (constructorArgument.Kind == TypedConstantKind.Error)
-        {
-            return null;
+            return $"({type.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix)})({newExpression})";
         }
 
-        if (constructorArgument.Type?.SpecialType is SpecialType.System_String or SpecialType.System_Char)
+        return newExpression.ToString();
+    }
+
+    private sealed class FullyQualifiedWithGlobalPrefixRewriter(SemanticModel semanticModel) : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode? VisitPredefinedType(PredefinedTypeSyntax node)
         {
-            return $"{ValueToString(constructorArgument.Value)?.Replace(@"\", @"\\")}";
+            var symbol = semanticModel.GetSymbolInfo(node);
+            return SyntaxFactory.IdentifierName(symbol.Symbol!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix));
         }
 
-        if (constructorArgument.Kind is TypedConstantKind.Enum || type?.TypeKind == TypeKind.Enum)
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
         {
-            return $"({(type ?? constructorArgument.Type)!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix)})({ValueToString(constructorArgument.Value)})";
-        }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_Single)
-        {
-            return $"{ValueToString(constructorArgument.Value)}F";
-        }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_Int64)
-        {
-            return $"{ValueToString(constructorArgument.Value)}L";
-        }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_Double)
-        {
-            return $"{ValueToString(constructorArgument.Value)}D";
-        }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_Decimal)
-        {
-            return $"{ValueToString(constructorArgument.Value)}M";
+            var symbol = semanticModel.GetSymbolInfo(node);
+            if (symbol.Symbol!.Kind != SymbolKind.NamedType) return base.VisitIdentifierName(node);
+            return node.WithIdentifier(SyntaxFactory.Identifier(symbol.Symbol!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix)));
         }
 
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_UInt32)
+        public override SyntaxNode? VisitTypeOfExpression(TypeOfExpressionSyntax node)
         {
-            return $"{ValueToString(constructorArgument.Value)}U";
+            var symbol = semanticModel.GetSymbolInfo(node.Type);
+            return node.WithType(SyntaxFactory.ParseTypeName(symbol.Symbol!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix)));
         }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_UInt64)
-        {
-            return $"{ValueToString(constructorArgument.Value)}UL";
-        }
-        
-        if (constructorArgument.Type?.SpecialType == SpecialType.System_Decimal)
-        {
-            return $"{ValueToString(constructorArgument.Value)}M";
-        }
-        
-        if (constructorArgument.Kind is TypedConstantKind.Primitive)
-        {
-            return $"{ValueToString(constructorArgument.Value)}";
-        }
-        
-        if (constructorArgument.Kind is TypedConstantKind.Type)
-        {
-            return $"typeof({GetFullyQualifiedTypeNameFromTypedConstantValue(constructorArgument)})";
-        }
-
-        if (constructorArgument.Kind == TypedConstantKind.Array)
-        {
-            return $"[{string.Join(",", constructorArgument.Values.Select(constructorArgument1 => GetTypedConstantValue(constructorArgument1)))}]";
-        }
-
-        throw new ArgumentOutOfRangeException();
     }
 
     public static string GetFullyQualifiedTypeNameFromTypedConstantValue(TypedConstant typedConstant)
     {
         if (typedConstant.Kind == TypedConstantKind.Type)
         {
-            var type = (INamedTypeSymbol) typedConstant.Value!;
+            var type = (INamedTypeSymbol)typedConstant.Value!;
             return type.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix);
         }
-        
+
         if (typedConstant.Kind == TypedConstantKind.Enum)
         {
             return typedConstant.Type!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix);
@@ -97,16 +57,7 @@ internal static class TypedConstantParser
         {
             return $"global::{typedConstant.Value!.GetType().FullName}";
         }
-        
-        return typedConstant.Type!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix);
-    }
 
-    private static string? ValueToString(object? value)
-    {
-        if (value is IFormattable formattable)
-        {
-            return formattable.ToString(null, CultureInfo.InvariantCulture);
-        }
-        return value?.ToString();
+        return typedConstant.Type!.ToDisplayString(DisplayFormats.FullyQualifiedGenericWithGlobalPrefix);
     }
 }

--- a/TUnit.Engine.SourceGenerator/Models/Arguments/Argument.cs
+++ b/TUnit.Engine.SourceGenerator/Models/Arguments/Argument.cs
@@ -2,48 +2,14 @@
 
 internal record Argument
 {
-    public Argument(string type, string? invocation, bool isUnfoldableTuple = false)
+    public Argument(string type, string? invocation)
     {
         Type = type;
-        IsUnfoldableTuple = isUnfoldableTuple;
-        Invocation = MapValue(type, invocation, isUnfoldableTuple);
+        Invocation = invocation ?? "null";
     }
 
     public string Type { get; }
-    public bool IsUnfoldableTuple { get; }
     public string Invocation { get; }
     public string[]? TupleVariableNames { get; init; }
     public bool DisposeAfterTest { get; init; }
-
-    private static string MapValue(string type, string? value, bool isTuple)
-    {
-        type = type.TrimEnd('?');
-        
-        if (value is null)
-        {
-            return "null";
-        }
-
-        if (isTuple)
-        {
-            return value;
-        }
-        
-        if (type == "global::System.Char")
-        {
-            return $"'{value}'";
-        }
-        
-        if (type == "global::System.Boolean")
-        {
-            return value.ToLower();
-        }
-        
-        if (type == "global::System.String")
-        {
-            return $"\"{value}\"";
-        }
-
-        return value;
-    }
 }

--- a/TUnit.Engine.SourceGenerator/Models/Arguments/GloballySharedArgument.cs
+++ b/TUnit.Engine.SourceGenerator/Models/Arguments/GloballySharedArgument.cs
@@ -2,7 +2,7 @@
 
 internal record GloballySharedArgument : Argument
 {
-    public GloballySharedArgument(string type, string? invocation, bool isUnfoldableTuple = false) : base(type, invocation, isUnfoldableTuple)
+    public GloballySharedArgument(string type, string? invocation) : base(type, invocation)
     {
     }
 }

--- a/TUnit.Engine.SourceGenerator/Models/Arguments/KeyedSharedArgument.cs
+++ b/TUnit.Engine.SourceGenerator/Models/Arguments/KeyedSharedArgument.cs
@@ -2,7 +2,7 @@
 
 internal record KeyedSharedArgument : Argument
 {
-    public KeyedSharedArgument(string type, string? invocation, bool isUnfoldableTuple = false) : base(type, invocation, isUnfoldableTuple)
+    public KeyedSharedArgument(string type, string? invocation) : base(type, invocation)
     {
     }
     

--- a/TUnit.Engine.SourceGenerator/Models/Arguments/TestClassTypeSharedArgument.cs
+++ b/TUnit.Engine.SourceGenerator/Models/Arguments/TestClassTypeSharedArgument.cs
@@ -2,7 +2,7 @@
 
 internal record TestClassTypeSharedArgument : Argument
 {
-    public TestClassTypeSharedArgument(string type, string? invocation, bool isUnfoldableTuple = false) : base(type, invocation, isUnfoldableTuple)
+    public TestClassTypeSharedArgument(string type, string? invocation) : base(type, invocation)
     {
     }
     

--- a/TUnit.TestProject/DataDrivenTests.cs
+++ b/TUnit.TestProject/DataDrivenTests.cs
@@ -10,7 +10,7 @@ public class DataDrivenTests
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments(1, "String")]
     [Arguments(2, "String2")]
@@ -19,7 +19,7 @@ public class DataDrivenTests
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments(TestEnum.One)]
     [Arguments(TestEnum.Two)]
@@ -28,33 +28,54 @@ public class DataDrivenTests
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments(null)]
     public void NullValue(string? value)
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments("")]
     public void EmptyString(string? value)
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments("Foo bar!")]
     public void NonEmptyString(string? value)
     {
         // Dummy method
     }
-    
+
     [Test]
     [Arguments(null)]
     [Arguments(false)]
     [Arguments(true)]
     public void BooleanString(bool? value)
+    {
+        // Dummy method
+    }
+
+    [Test]
+    [Arguments(typeof(object))]
+    public void Type(Type value)
+    {
+        // Dummy method
+    }
+
+    [Test]
+    [Arguments(new[] { 1, 2, 3 })]
+    public void IntegerArray(int[] values)
+    {
+        // Dummy method
+    }
+
+    [Test]
+    [Arguments(int.MaxValue)]
+    public void IntMaxValue(int value)
     {
         // Dummy method
     }

--- a/TUnit.TestProject/StringArgumentTests.cs
+++ b/TUnit.TestProject/StringArgumentTests.cs
@@ -10,6 +10,12 @@ public class StringArgumentTests
     [Arguments("\\t")]
     [Arguments("\\\t")]
     [Arguments("\\\\t")]
+    [Arguments(
+        """
+        Hello
+        World
+        """
+    )]
     public void Normal(string s)
     {
         // Dummy method


### PR DESCRIPTION
Instead of extracting the values from `MatrixAttribute` / `ArgumentsAttribute` and then `ToString` them again, we could just use the argument expressions and embed them directly into the generated source code.
This avoids culture related issues like #660, adds support for more string expression like `""" """` and avoids updating the source generator in the future to support new ones.