### PR TITLE
Feature: add IsDefault/IsNotDefault assertions

### DIFF
--- a/TUnit.Assertions.UnitTests/DefaultAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/DefaultAssertionTests.cs
@@ -1,0 +1,109 @@
+﻿using TUnit.Assertions.Extensions;
+using TUnit.Assertions.Extensions.Throws;
+
+namespace TUnit.Assertions.UnitTests;
+
+public class DefaultAssertionTests
+{
+		[Test]
+		public async Task IsDefault_ReferenceType_Default()
+		{
+				string? s = null;
+				await TUnitAssert.That(s).IsDefault();
+		}
+	    
+		[Test]
+		public async Task IsDefault_ReferenceType_NotDefault()
+		{
+			  await TUnitAssert.That(async () => 
+			  {
+			  		string? s = "1";
+			  		await TUnitAssert.That(s).IsDefault();
+			  }).ThrowsException().OfType<TUnitAssertionException>();
+		}
+		
+		[Test]
+		public async Task IsDefault_ValueType_Integer_Default()
+		{
+				int x = 0;
+				await TUnitAssert.That(x).IsDefault();
+		}
+	    
+		[Test]
+		public async Task IsDefault_ValueType_Integer_NotDefault()
+		{
+			  await TUnitAssert.That(async () =>
+			  {
+						int x = 1;
+						await TUnitAssert.That(x).IsDefault();
+			  }).ThrowsException().OfType<TUnitAssertionException>();
+		}
+		
+		[Test]
+		public async Task IsDefault_ValueType_DateTime_Default()
+		{
+				DateTime dt = default;
+				await TUnitAssert.That(dt).IsDefault();
+		}
+		
+		[Test]
+		public async Task IsDefault_ValueType_DateTime_NotDefault()
+		{
+				await TUnitAssert.That(async () =>
+				{
+						var dt = DateTime.Now;
+						await TUnitAssert.That(dt).IsDefault();
+				}).ThrowsException().OfType<TUnitAssertionException>();
+		}
+		
+		[Test]
+		public async Task IsNotDefault_ReferenceType_Default()
+		{
+				await TUnitAssert.That(async () =>
+				{
+						string? s = null;
+						await TUnitAssert.That(s).IsNotDefault();
+				}).ThrowsException().OfType<TUnitAssertionException>();
+		}
+	    
+		[Test]
+		public async Task IsNotDefault_ReferenceType_NotDefault()
+		{
+				string? s = "1";
+				await TUnitAssert.That(s).IsNotDefault();
+		}
+		
+		[Test]
+		public async Task IsNotDefault_ValueType_Integer_Default()
+		{
+				await TUnitAssert.That(async () =>
+				{
+						int x = 0;
+						await TUnitAssert.That(x).IsNotDefault();
+				}).ThrowsException().OfType<TUnitAssertionException>();
+		}
+	    
+		[Test]
+		public async Task IsNotDefault_ValueType_Integer_NotDefault()
+		{
+				int x = 1;
+				await TUnitAssert.That(x).IsNotDefault();
+		}
+		
+		[Test]
+		public async Task IsNotDefault_ValueType_DateTime_Default()
+		{
+				await TUnitAssert.That(async () =>
+				{
+						DateTime dt = default;
+						await TUnitAssert.That(dt).IsNotDefault();
+				}).ThrowsException().OfType<TUnitAssertionException>();
+		}
+	    
+		[Test]
+		public async Task IsNotDefault_ValueType_DateTime_NotDefault()
+		{
+				var dt = DateTime.Now;
+				await TUnitAssert.That(dt).IsNotDefault();
+		}
+}

--- a/TUnit.Assertions/AssertConditions/Generic/DefaultAssertionCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/DefaultAssertionCondition.cs
@@ -1,0 +1,14 @@
+﻿namespace TUnit.Assertions.AssertConditions.Generic;
+
+public class DefaultAssertCondition<TActual>() : AssertCondition<TActual, TActual>(default)
+{
+	  private readonly TActual? _defaultValue = default;
+	
+		protected internal override string GetFailureMessage()
+			  => _defaultValue is null ?
+						   $"{ActualExpression ?? typeof(TActual).Name} was not default value null" : 
+						   $"{ActualExpression ?? typeof(TActual).Name} was not default value {_defaultValue}";
+
+		protected override bool Passes(TActual? actualValue, Exception? exception)
+				=> actualValue is null || actualValue.Equals(_defaultValue);
+} 

--- a/TUnit.Assertions/AssertConditions/Generic/NotDefaultAssertionCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/NotDefaultAssertionCondition.cs
@@ -1,0 +1,14 @@
+﻿namespace TUnit.Assertions.AssertConditions.Generic;
+
+public class NotDefaultAssertCondition<TActual>() : AssertCondition<TActual, TActual>(default)
+{
+		private readonly TActual? _defaultValue = default;
+
+	  protected internal override string GetFailureMessage()
+				=> _defaultValue is null ? 
+					     $"{ActualExpression ?? typeof(TActual).Name} was default value null" : 
+					     $"{ActualExpression ?? typeof(TActual).Name} was default value {_defaultValue}";
+	
+	  protected override bool Passes(TActual? actualValue, Exception? exception)
+				=> actualValue is not null && !actualValue.Equals(_defaultValue);
+}

--- a/TUnit.Assertions/Extensions/Is/Not/IsNotExtensions_Generic.cs
+++ b/TUnit.Assertions/Extensions/Is/Not/IsNotExtensions_Generic.cs
@@ -45,4 +45,16 @@ public static partial class IsNotExtensions
             (actual, _, _) => $"{actual?.GetType()} is assignable from {type.Name}")
             , [type.Name]);
     }
+    
+    public static InvokableValueAssertionBuilder<TActual> IsDefault<TActual>(this IValueSource<TActual> valueSource)
+    {
+        return valueSource.RegisterAssertion(new DefaultAssertCondition<TActual>()
+            , []);
+    }
+    
+    public static InvokableValueAssertionBuilder<TActual> IsNotDefault<TActual>(this IValueSource<TActual> valueSource)
+    {
+        return valueSource.RegisterAssertion(new NotDefaultAssertCondition<TActual>()
+            , []);
+    }
 }


### PR DESCRIPTION
IsDefault/IsNotDefault assertions are similar to IsNull/IsNotNull in that they're a short-hand assertion for an equality check, except instead of comparing against `null` they compare against `default(T)`. This means that writing assertions against primarily value types becomes shorter.

E.g., 
```
await Assert.That(myVariable).IsNotEqualTo(default);
```
Becomes
```
await Assert.That(myVariable).IsNotDefault();
```