### PR TITLE
Use _maximumParallelTests instead of calling GetParallelTestsLimit() again

### DIFF
--- a/TUnit.Engine/Services/TestsExecutor.cs
+++ b/TUnit.Engine/Services/TestsExecutor.cs
@@ -108,7 +108,7 @@ internal class TestsExecutor
     {
         await Parallel.ForEachAsync(queue, new ParallelOptions
         {
-            MaxDegreeOfParallelism = GetParallelTestsLimit(),
+            MaxDegreeOfParallelism = _maximumParallelTests,
             CancellationToken = context.CancellationToken
         }, (test, token) => ProcessTest(test, filter, context, token));
     }


### PR DESCRIPTION
`_maximumParallelTests` gets initialized in the constructor.

---

Unrelated question:
Since both of these groups are running concurrently does it mean that the real concurrent test count is actually `_maximumParallelTests * 2` when using `NotInParallelAttribute([keys])` and "normal" tests together?

https://github.com/thomhurst/TUnit/blob/ba9dc4901873ac0919244541794a65aaf73eaee4/TUnit.Engine/Services/TestsExecutor.cs#L40-L44