### PR TITLE
Dispose static property validation via pipeline reading expected file

### DIFF
--- a/TUnit.Pipeline/Modules/Tests/PropertySetterTests.cs
+++ b/TUnit.Pipeline/Modules/Tests/PropertySetterTests.cs
@@ -17,7 +17,7 @@ public class PropertySetterTests : TestModule
                 result => result.Passed.Should().Be(1),
                 result => result.Failed.Should().Be(0),
                 result => result.Skipped.Should().Be(0),
-                _ => context.Git().RootDirectory.FindFile(x => x.Name == "StaticProperty_IAsyncDisposable").AssertExists().Delete()
+                _ => context.Git().RootDirectory.FindFile(x => x.Name == "StaticProperty_IAsyncDisposable.txt").AssertExists().Delete()
             ], cancellationToken);
     }
 }

--- a/TUnit.Pipeline/Modules/Tests/PropertySetterTests.cs
+++ b/TUnit.Pipeline/Modules/Tests/PropertySetterTests.cs
@@ -1,5 +1,7 @@
 ﻿using FluentAssertions;
 using ModularPipelines.Context;
+using ModularPipelines.Extensions;
+using ModularPipelines.Git.Extensions;
 
 namespace TUnit.Pipeline.Modules.Tests;
 
@@ -14,7 +16,8 @@ public class PropertySetterTests : TestModule
                 result => result.Total.Should().Be(1),
                 result => result.Passed.Should().Be(1),
                 result => result.Failed.Should().Be(0),
-                result => result.Skipped.Should().Be(0)
+                result => result.Skipped.Should().Be(0),
+                _ => context.Git().RootDirectory.FindFile(x => x.Name == "StaticProperty_IAsyncDisposable").AssertExists().Delete()
             ], cancellationToken);
     }
 }

--- a/TUnit.TestProject/PropertySetterTests.cs
+++ b/TUnit.TestProject/PropertySetterTests.cs
@@ -38,7 +38,7 @@ public class PropertySetterTests
         await Assert.That(StaticProperty.IsInitialized).IsTrue();
     }
 
-    public class InnerModel : IAsyncInitializer
+    public class InnerModel : IAsyncInitializer, IAsyncDisposable
     {
         public Task InitializeAsync()
         {
@@ -47,6 +47,11 @@ public class PropertySetterTests
         }
 
         public bool IsInitialized { get; private set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await File.WriteAllTextAsync("StaticProperty_IAsyncDisposable.txt", "true");
+        }
     }
 
     public static string MethodData() => "2";


### PR DESCRIPTION
… == "StaticProperty_IAsyncDisposable").AssertExists().Delete()