### PR TITLE
Update BaseAssertCondition Char Format

### DIFF
--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -32,7 +32,7 @@ public abstract class BaseAssertCondition
 
         if (obj is char)
         {
-            return "'{obj}";
+            return "'{obj}'";
         }
 
         if (obj is IEnumerable enumerable)


### PR DESCRIPTION
Looks like the `'` suffix is missing for formatting char.