### PR TITLE
Use Ellipsis when truncating strings

### DIFF
--- a/TUnit.Assertions.UnitTests/StringEqualsAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/StringEqualsAssertionTests.cs
@@ -154,10 +154,10 @@ public class StringEqualsAssertionTests
         
         var exception = NUnitAssert.ThrowsAsync<TUnitAssertionException>(async () => await TUnitAssert.That(value1).IsEqualTo(value2));
         NUnitAssert.That(exception!.Message, Is.EqualTo("""
-                                                        Expected value1 to be equal to "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se..., but found "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se... which differs at index 556:
-                                                           "Consequat odio ea veniam. Amet enim in gubergren s..."
+                                                        Expected value1 to be equal to "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se…, but found "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se… which differs at index 556:
+                                                           "Consequat odio ea veniam. Amet enim in gubergren s…"
                                                                                     ^
-                                                           "Consequat odio ea veniam! Amet enim in gubergren s..."
+                                                           "Consequat odio ea veniam! Amet enim in gubergren s…"
                                                                                     ^.
                                                         At Assert.That(value1).IsEqualTo(value2, StringComparison.Ordinal)
                                                         """));

--- a/TUnit.Assertions/Extensions/StringExtensions.cs
+++ b/TUnit.Assertions/Extensions/StringExtensions.cs
@@ -24,7 +24,8 @@ internal static class StringExtensions
             return value;
         }
 
-        return $"{value[..maxLength]}...";
+        const char ellipsis = '\u2026';
+        return $"{value[..maxLength]}{ellipsis}";
     }
 
     public static string PrependAOrAn(this string value)


### PR DESCRIPTION
`TruncateWithEllipsis` uses three dots instead of the ellipsis character ([`\u2026`](https://www.compart.com/en/unicode/U+2026)), which is the [correct hint for omitted text](https://editorsmanual.com/articles/ellipsis/):
> In a quotation, an ellipsis signifies omitted words and sentences.

- #764