### PR TITLE
Support displaying correct difference for multi-line strings

### DIFF
--- a/TUnit.Assertions.Tests/ThrowTests.cs
+++ b/TUnit.Assertions.Tests/ThrowTests.cs
@@ -185,20 +185,52 @@ public class ThrowTests
         public async Task Fails_For_Exceptions_With_Different_Message()
         {
             string expectedMessage = """
-                Expected action to have Message equal to "Fails_For_Some_Other_Reason", but it differs at index 10:
-                              ↓
-                   "Fails_For_Exceptions_With_Different_Message"
-                   "Fails_For_Some_Other_Reason"
-                              ↑.
-                At Assert.That(action).ThrowsException.With.Message.EqualTo("Fails_For_Some_Other_Reason", StringCompar...
-                """;
+                                     Expected action to have Message equal to "Fails_For_Some_Other_Reason", but it differs at index 10:
+                                                   ↓
+                                        "Fails_For_Exceptions_With_Different_Message"
+                                        "Fails_For_Some_Other_Reason"
+                                                   ↑.
+                                     At Assert.That(action).ThrowsException.With.Message.EqualTo("Fails_For_Some_Other_Reason", StringCompar...
+                                     """;
 
             Exception exception = CustomException.Create();
             Action action = () => throw exception;
 
             var sut = async ()
                 => await Assert.That(action).ThrowsException()
-                .With.Message.EqualTo("Fails_For_Some_Other_Reason");
+                    .With.Message.EqualTo("Fails_For_Some_Other_Reason");
+
+            await Assert.That(sut).ThrowsException()
+                .With.Message.EqualTo(expectedMessage);
+        }
+
+        [Test]
+        public async Task Fails_For_Exceptions_With_Different_Multiline_Message()
+        {
+            string newline = $"{Environment.NewLine}".Replace("\n", "\\n").Replace("\r", "\\r");
+            string longCommonString = """
+                                      Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+                                      sed diam nonumy eirmod tempor invidunt ut labore et dolore
+                                      magna aliquyam erat, sed diam voluptua. At vero eos et
+                                      accusam et justo duo dolores et ea rebum. Stet clita kasd
+                                      gubergren, no sea takimata sanctus est Lorem ipsum dolor
+                                      sit amet.
+                                      """;
+            string expectedMessage = $$"""
+                                     Expected action to have Message equal to "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,{{newline}}sed diam nonumy eirmod tempor invidunt u…", but it differs at index 302:
+                                                                     ↓
+                                        "ipsum dolor\r\nsit amet.\r\nsome value"
+                                        "ipsum dolor\r\nsit amet.\r\nanother value"
+                                                                     ↑.
+                                     At Assert.That(action).ThrowsException.With.Message.EqualTo($"{longCommonString}{Environment.NewLine}an...
+                                     """;
+
+            Exception exception = CustomException.Create($"{longCommonString}{Environment.NewLine}some value");
+            Action action = () => throw exception;
+
+            var sut = async ()
+                => await Assert.That(action).ThrowsException()
+                    .With.Message.EqualTo($"{longCommonString}{Environment.NewLine}another value");
 
             await Assert.That(sut).ThrowsException()
                 .With.Message.EqualTo(expectedMessage);

--- a/TUnit.Assertions.UnitTests/StringEqualsAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/StringEqualsAssertionTests.cs
@@ -155,10 +155,10 @@ public class StringEqualsAssertionTests
         var exception = NUnitAssert.ThrowsAsync<TUnitAssertionException>(async () => await TUnitAssert.That(value1).IsEqualTo(value2));
         NUnitAssert.That(exception!.Message, Is.EqualTo("""
                                                         Expected value1 to be equal to "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se…, but found "Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se… which differs at index 556:
+                                                                                    ↓
                                                            "Consequat odio ea veniam. Amet enim in gubergren s…"
-                                                                                    ^
                                                            "Consequat odio ea veniam! Amet enim in gubergren s…"
-                                                                                    ^.
+                                                                                    ↑.
                                                         At Assert.That(value1).IsEqualTo(value2, StringComparison.Ordinal)
                                                         """));
     }

--- a/TUnit.Assertions/AssertConditions/String/StringEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/String/StringEqualsExpectedValueAssertCondition.cs
@@ -1,4 +1,5 @@
 ﻿using TUnit.Assertions.Extensions;
+using TUnit.Assertions.Helpers;
 
 namespace TUnit.Assertions.AssertConditions.String;
 
@@ -21,35 +22,6 @@ public class StringEqualsExpectedValueAssertCondition(string expected, StringCom
         return AssertionResult
             .FailIf(
                 () => !string.Equals(actualValue, expectedValue, stringComparison),
-                $"found {Format(actualValue).TruncateWithEllipsis(100)} which differs at {GetLocation(actualValue, expectedValue)}");
-    }
-
-    private string GetLocation(string? actualValue, string? expectedValue)
-    {
-        var initialIndexOfDifference = StringUtils.IndexOfDifference(actualValue, expectedValue);
-
-        var startIndex = Math.Max(0, initialIndexOfDifference - 25);
-        
-        var actualLine = actualValue
-            ?.Substring(startIndex, Math.Min(actualValue.Length - startIndex, 55))
-            .ReplaceNewLines()
-            .Trim()
-            .TruncateWithEllipsis(50) ?? string.Empty;
-
-        var expectedLine = expectedValue
-            ?.Substring(startIndex, Math.Min(expectedValue.Length - startIndex, 55))
-            .ReplaceNewLines()
-            .Trim()
-            .TruncateWithEllipsis(50) ?? string.Empty;
-        
-        var spacesBeforeArrow = StringUtils.IndexOfDifference(actualLine, expectedLine) + 1;
-        
-        return $"""
-                index {initialIndexOfDifference}:
-                   {Format(actualLine)}
-                   {new string(' ', spacesBeforeArrow)}^
-                   {Format(expectedLine)}
-                   {new string(' ', spacesBeforeArrow)}^
-                """;
+                $"found {Format(actualValue).TruncateWithEllipsis(100)} which {new StringDifference(actualValue, expectedValue)}");
     }
 }

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageEqualToExpectedValueAssertCondition.cs
@@ -1,4 +1,5 @@
 using TUnit.Assertions.Extensions;
+using TUnit.Assertions.Helpers;
 
 namespace TUnit.Assertions.AssertConditions.Throws;
 
@@ -9,7 +10,7 @@ public class ThrowsWithMessageEqualToExpectedValueAssertCondition<TActual>(
     : DelegateAssertCondition<TActual, Exception>
 {
     protected override string GetExpectation()
-        => $"to have Message equal to \"{expectedMessage}\"";
+        => $"to have Message equal to \"{expectedMessage.ShowNewLines().TruncateWithEllipsis(100)}\"";
 
     protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
@@ -20,38 +21,8 @@ public class ThrowsWithMessageEqualToExpectedValueAssertCondition<TActual>(
                 () => actualException is null,
                 "the exception is null")
             .OrFailIf(
-                () => !string.Equals(actualException.Message, expectedMessage, stringComparison),
-                $"it differs at {GetLocation(actualException.Message, expectedMessage)}");
-    }
-
-    private string GetLocation(string? actualValue, string? expectedValue)
-    {
-        const char arrowDown = '\u2193';
-        const char arrowUp = '\u2191';
-        var initialIndexOfDifference = StringUtils.IndexOfDifference(actualValue, expectedValue);
-
-        var startIndex = Math.Max(0, initialIndexOfDifference - 25);
-
-        var actualLine = actualValue
-            ?.Substring(startIndex, Math.Min(actualValue.Length - startIndex, 55))
-            .ReplaceNewLines()
-            .Trim()
-            .TruncateWithEllipsis(50) ?? string.Empty;
-
-        var expectedLine = expectedValue
-            ?.Substring(startIndex, Math.Min(expectedValue.Length - startIndex, 55))
-            .ReplaceNewLines()
-            .Trim()
-            .TruncateWithEllipsis(50) ?? string.Empty;
-
-        var spacesBeforeArrow = StringUtils.IndexOfDifference(actualLine, expectedLine) + 1;
-
-        return $"""
-                index {initialIndexOfDifference}:
-                   {new string(' ', spacesBeforeArrow)}{arrowDown}
-                   {Format(actualLine)}
-                   {Format(expectedLine)}
-                   {new string(' ', spacesBeforeArrow)}{arrowUp}
-                """;
+                () => !string.Equals(actualException!.Message, expectedMessage, stringComparison),
+                new StringDifference(actualException!.Message, expectedMessage)
+                    .ToString("it differs at index"));
     }
 }

--- a/TUnit.Assertions/Extensions/StringExtensions.cs
+++ b/TUnit.Assertions/Extensions/StringExtensions.cs
@@ -16,7 +16,12 @@ internal static class StringExtensions
     {
         return value.ReplaceLineEndings(" ");
     }
-    
+
+    public static string ShowNewLines(this string value)
+    {
+        return value.Replace("\n", "\\n").Replace("\r", "\\r");
+    }
+
     public static string TruncateWithEllipsis(this string value, int maxLength)
     {
         if (value.Length <= maxLength)

--- a/TUnit.Assertions/Helpers/StringDifference.cs
+++ b/TUnit.Assertions/Helpers/StringDifference.cs
@@ -1,0 +1,81 @@
+﻿using TUnit.Assertions.Extensions;
+
+namespace TUnit.Assertions.Helpers;
+
+internal class StringDifference(string? actualValue, string? expectedValue, IEqualityComparer<string>? comparer = null)
+{
+    private const char ArrowDown = '\u2193';
+    private const char ArrowUp = '\u2191';
+
+    private readonly IEqualityComparer<string> _comparer = comparer ?? StringComparer.Ordinal;
+
+    /// <summary>
+    /// Returns the first index at which the two values do not match.
+    /// </summary>
+    public int IndexOfFirstMismatch()
+    {
+        if (actualValue == expectedValue)
+        {
+            return -1;
+        }
+
+        if (actualValue is null || expectedValue is null)
+        {
+            return 0;
+        }
+
+        return IndexOfFirstMismatch(actualValue, expectedValue, _comparer);
+    }
+
+    private static int IndexOfFirstMismatch(string actualValue, string expectedValue, IEqualityComparer<string> comparer)
+    {
+        for (int index = 0; index < actualValue.Length; index++)
+        {
+            if (index >= expectedValue.Length || !comparer.Equals(actualValue[index..(index + 1)], expectedValue[index..(index + 1)]))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public override string ToString()
+    {
+        return ToString("differs at index");
+    }
+
+    /// <summary>
+    /// Writes a string representation of the difference, starting with the <paramref name="prefix"/>.
+    /// </summary>
+    /// <param name="prefix">The prefix, e.g. <c>differs at index</c></param>
+    /// <returns></returns>
+    public string ToString(string prefix)
+    {
+        var initialIndexOfDifference = IndexOfFirstMismatch();
+
+        var startIndex = Math.Max(0, initialIndexOfDifference - 25);
+
+        var actualLine = actualValue
+            ?.Substring(startIndex, Math.Min(actualValue.Length - startIndex, 55))
+            .ShowNewLines()
+            .Trim()
+            .TruncateWithEllipsis(50) ?? string.Empty;
+
+        var expectedLine = expectedValue
+            ?.Substring(startIndex, Math.Min(expectedValue.Length - startIndex, 55))
+            .ShowNewLines()
+            .Trim()
+            .TruncateWithEllipsis(50) ?? string.Empty;
+
+        var spacesBeforeArrow = IndexOfFirstMismatch(actualLine, expectedLine, _comparer) + 1;
+
+        return $"""
+                {prefix} {initialIndexOfDifference}:
+                   {new string(' ', spacesBeforeArrow)}{ArrowDown}
+                   "{actualLine}"
+                   "{expectedLine}"
+                   {new string(' ', spacesBeforeArrow)}{ArrowUp}
+                """;
+    }
+}

--- a/TUnit.Assertions/StringUtils.cs
+++ b/TUnit.Assertions/StringUtils.cs
@@ -11,23 +11,4 @@ internal static class StringUtils
         
         return string.Join(string.Empty, input.Where(c=>!char.IsWhiteSpace(c)));
     }
-
-    public static int IndexOfDifference(string? value1, string? value2)
-    {
-        if (value1 == value2)
-        {
-            return -1;
-        }
-
-        if (value1 is null || value2 is null)
-        {
-            return 0;
-        }
-        
-        return value1
-            .Zip(value2, (item, updated) => (Item: item, Updated: updated))
-            .Select((pair, index) => (Pair: pair, Index: index))
-            .FirstOrDefault(x => x.Pair.Item != x.Pair.Updated)
-            .Index;
-    }
 }


### PR DESCRIPTION
Currently two methods highlight the difference between two strings:
- `StringEqualsExpectedValueAssertCondition`
- `ThrowsWithMessageEqualToExpectedValueAssertCondition`

There is a bug, that the index of first difference for multiline-strings is incorrectly set to `0`, when the first difference is on the first character of a new line, e.g.
```
foo
bar
```
and
```
foo
something-other
```

Also moved the calculation and display of such a difference to a common helper class.

- #764 