### PR TITLE
Consistently use `GetResult` in assertions

### DIFF
--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -93,5 +93,5 @@ public abstract class BaseAssertCondition<TActual> : BaseAssertCondition
         return GetResult(actualValue, exception);
     }
 
-    protected internal abstract AssertionResult GetResult(TActual? actualValue, Exception? exception);
+    protected abstract AssertionResult GetResult(TActual? actualValue, Exception? exception);
 }

--- a/TUnit.Assertions/AssertConditions/Chronology/DateOnlyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Chronology/DateOnlyEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class DateOnlyEqualsExpectedValueAssertCondition(DateOnly expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(DateOnly actualValue, DateOnly expectedValue)
+    protected override AssertionResult GetResult(DateOnly actualValue, DateOnly expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/AssertConditions/Chronology/DateTimeEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Chronology/DateTimeEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class DateTimeEqualsExpectedValueAssertCondition(DateTime expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(DateTime actualValue, DateTime expectedValue)
+    protected override AssertionResult GetResult(DateTime actualValue, DateTime expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/AssertConditions/Chronology/DateTimeOffsetEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Chronology/DateTimeOffsetEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class DateTimeOffsetEqualsExpectedValueAssertCondition(DateTimeOffset exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(DateTimeOffset actualValue, DateTimeOffset expectedValue)
+    protected override AssertionResult GetResult(DateTimeOffset actualValue, DateTimeOffset expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/AssertConditions/Chronology/TimeOnlyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Chronology/TimeOnlyEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class TimeOnlyEqualsExpectedValueAssertCondition(TimeOnly expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(TimeOnly actualValue, TimeOnly expectedValue)
+    protected override AssertionResult GetResult(TimeOnly actualValue, TimeOnly expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/AssertConditions/Chronology/TimeSpanEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Chronology/TimeSpanEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class TimeSpanEqualsExpectedValueAssertCondition(TimeSpan expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(TimeSpan actualValue, TimeSpan expectedValue)
+    protected override AssertionResult GetResult(TimeSpan actualValue, TimeSpan expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/AssertConditions/ClassMember/PropertyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/ClassMember/PropertyEqualsExpectedValueAssertCondition.cs
@@ -11,7 +11,7 @@ public class PropertyEqualsExpectedValueAssertCondition<TRootObjectType, TProper
         return $"{typeof(TRootObjectType).Name}.{ExpressionHelpers.GetName(propertySelector)} to be equal to {expected}";
     }
 
-    protected internal override AssertionResult Passes(TRootObjectType? actualValue, TPropertyType? expectedValue)
+    protected override AssertionResult GetResult(TRootObjectType? actualValue, TPropertyType? expectedValue)
     {
         var propertyValue = GetPropertyValue(actualValue);
         return AssertionResult

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableContainsExpectedValueAssertCondition<TActual, TInner>(
 {
     protected override string GetExpectation() => $"to contain {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TInner? inner)
+    protected override AssertionResult GetResult(TActual? actualValue, TInner? inner)
         => AssertionResult
             .FailIf(
                 () => actualValue is null,

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableCountEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableCountEqualToExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableCountEqualToExpectedValueAssertCondition<TActual>(int exp
 {
     protected override string GetExpectation() => $"to have a count of {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, int count)
+    protected override AssertionResult GetResult(TActual? actualValue, int count)
     {
         var actualCount = GetCount(actualValue);
 

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableCountNotEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableCountNotEqualToExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableCountNotEqualToExpectedValueAssertCondition<TActual>(int 
 {
     protected override string GetExpectation() => $"to have a count different to {expected}";
     
-    protected internal override AssertionResult Passes(TActual? actualValue, int count)
+    protected override AssertionResult GetResult(TActual? actualValue, int count)
     {
         var actualCount = GetCount(actualValue);
 

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableDistinctItemsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableDistinctItemsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableDistinctItemsExpectedValueAssertCondition<TActual, TInner
 {
     protected override string GetExpectation() => "items to be distinct";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableEquivalentToExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>
 {
     protected override string GetExpectation() => $"to be equivalent to {(expected != null ? string.Join(',', expected) : null)}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, IEnumerable<TInner>? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
     {
         if (actualValue is null && expectedValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableNotContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableNotContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableNotContainsExpectedValueAssertCondition<TActual, TInner>(
 {
     protected override string GetExpectation() => $"to not contain {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TInner? inner)
+    protected override AssertionResult GetResult(TActual? actualValue, TInner? inner)
         => AssertionResult
             .FailIf(
                 () => actualValue is null,

--- a/TUnit.Assertions/AssertConditions/Collections/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Collections/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInn
 {
     protected override string GetExpectation() => $" to be not equivalent to {(expected != null ? string.Join(',', expected) : null)}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, IEnumerable<TInner>? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
     {
         if (actualValue is null != expectedValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Comparable/BetweenAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Comparable/BetweenAssertCondition.cs
@@ -7,7 +7,7 @@ public class BetweenAssertCondition<TActual>(TActual minimum, TActual maximum) :
 
     protected override string GetExpectation() => $"to be between {minimum} & {minimum} ({GetRange()} Range)";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         bool isInRange;
 

--- a/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
@@ -22,7 +22,7 @@ internal class AndAssertCondition<TActual> : BaseAssertCondition<TActual>
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} and{Environment.NewLine}{_condition2.GetExpectationWithReason()}";
     
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         return _condition1.Assert(actualValue, exception, ActualExpression)
             .And(_condition2.Assert(actualValue, exception, ActualExpression));

--- a/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
@@ -21,7 +21,7 @@ internal class OrAssertCondition<TActual> : BaseAssertCondition<TActual>
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} or{Environment.NewLine}{_condition2.GetExpectationWithReason()}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         return _condition1.Assert(actualValue, exception, ActualExpression)
             .Or(_condition2.Assert(actualValue, exception, ActualExpression));

--- a/TUnit.Assertions/AssertConditions/DelegateAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/DelegateAssertCondition.cs
@@ -15,7 +15,7 @@ public abstract class DelegateAssertCondition<TActual, TException> : BaseAssertC
         _customComparers.Add(comparer);
     }
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         if (exception != null && exception is not TException)
         {

--- a/TUnit.Assertions/AssertConditions/ExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/ExpectedValueAssertCondition.cs
@@ -20,7 +20,7 @@ public abstract class ExpectedValueAssertCondition<TActual, TExpected>(TExpected
         _customComparers.Add(comparer);
     }
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         var expected = ExpectedValue;
         
@@ -41,8 +41,8 @@ public abstract class ExpectedValueAssertCondition<TActual, TExpected>(TExpected
             }
         }
 
-        return Passes(actualValue, expected);
+        return GetResult(actualValue, expected);
     }
     
-    protected internal abstract AssertionResult Passes(TActual? actualValue, TExpected? expectedValue);
+    protected abstract AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue);
 }

--- a/TUnit.Assertions/AssertConditions/FuncValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/FuncValueAssertCondition.cs
@@ -10,7 +10,7 @@ public class FuncValueAssertCondition<TActual, TExpected>(
     protected override string GetExpectation()
         => $"to satisfy {this.GetType().Name}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TExpected? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
     {
         // TODO VAB
         return AssertionResult.FailIf(

--- a/TUnit.Assertions/AssertConditions/Generic/DefaultAssertionCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/DefaultAssertionCondition.cs
@@ -7,7 +7,7 @@ public class DefaultExpectedValueAssertCondition<TActual> : BaseAssertCondition<
     protected override string GetExpectation()
         => $"to be {(_defaultValue is null ? "null" : _defaultValue)}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
             .FailIf(
                 () => actualValue is not null && !actualValue.Equals(_defaultValue),

--- a/TUnit.Assertions/AssertConditions/Generic/EqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/EqualsExpectedValueAssertCondition.cs
@@ -5,7 +5,7 @@ public class EqualsExpectedValueAssertCondition<TActual>(TActual expected) : Exp
     protected override string GetExpectation()
         => $"to be equal to {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
     {
         if (actualValue is IEquatable<TActual> equatable)
         {

--- a/TUnit.Assertions/AssertConditions/Generic/EquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/EquivalentToExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class EquivalentToExpectedValueAssertCondition<TActual>(TActual expected,
     protected override string GetExpectation()
         => $"to be equivalent to {expectedExpression}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
     {
         if (actualValue is null && ExpectedValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Generic/NotDefaultAssertionCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/NotDefaultAssertionCondition.cs
@@ -7,7 +7,7 @@ public class NotDefaultExpectedValueAssertCondition<TActual>() : ExpectedValueAs
         protected override string GetExpectation()
             => $"to not be {(_defaultValue is null ? "null" : _defaultValue)}";
 
-        protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue)
+        protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
             => AssertionResult
                 .FailIf(
                     () => actualValue is null || actualValue.Equals(_defaultValue),

--- a/TUnit.Assertions/AssertConditions/Generic/NotEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/NotEqualsExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ public class NotEqualsExpectedValueAssertCondition<TActual>(TActual expected)
     protected override string GetExpectation()
         => $"to not be equal to {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue) => AssertionResult
+    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue) => AssertionResult
         .FailIf(
             () => Equals(actualValue, expectedValue),
             "it was");

--- a/TUnit.Assertions/AssertConditions/Generic/NotTypeOfExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/NotTypeOfExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ public class NotTypeOfExpectedValueAssertCondition<TActual, TExpected>
     protected override string GetExpectation()
         => $"to not be of type {typeof(TExpected).Name}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
             .FailIf(
                 () => actualValue?.GetType() == typeof(TExpected),

--- a/TUnit.Assertions/AssertConditions/Generic/SameReferenceExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/SameReferenceExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ public class SameReferenceExpectedValueAssertCondition<TActual, TExpected>(TExpe
     protected override string GetExpectation()
         => $"to have the same reference as {expected}";
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TExpected? expectedValue) => AssertionResult
+    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue) => AssertionResult
         .FailIf(
             () => !ReferenceEquals(actualValue, expectedValue),
             "they did not");

--- a/TUnit.Assertions/AssertConditions/Generic/TypeOfExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Generic/TypeOfExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ public class TypeOfExpectedValueAssertCondition<TActual>(Type expectedType)
     protected override string GetExpectation()
         => $"to be of type {expectedType.Name}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
             .FailIf(
                 () => actualValue?.GetType() != expectedType,

--- a/TUnit.Assertions/AssertConditions/NotNullExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/NotNullExpectedValueAssertCondition.cs
@@ -5,7 +5,7 @@ public class NotNullExpectedValueAssertCondition<TActual> : BaseAssertCondition<
     protected override string GetExpectation()
         => "to not be null";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
             .FailIf(
                 () => actualValue is null,

--- a/TUnit.Assertions/AssertConditions/NullExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/NullExpectedValueAssertCondition.cs
@@ -5,7 +5,7 @@ public class NullExpectedValueAssertCondition<TActual> : BaseAssertCondition<TAc
     protected override string GetExpectation()
         => "to be null";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
             .FailIf(
                 () => actualValue is not null,

--- a/TUnit.Assertions/AssertConditions/Numbers/NumericEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Numbers/NumericEqualsExpectedValueAssertCondition.cs
@@ -18,7 +18,7 @@ public class NumericEqualsExpectedValueAssertCondition<TActual>(TActual expected
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
     {
         if (actualValue is null && expectedValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Numbers/NumericNotEqualExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Numbers/NumericNotEqualExpectedValueAssertCondition.cs
@@ -17,7 +17,7 @@ public class NumericNotEqualExpectedValueAssertCondition<TActual>(TActual expect
         return $"to not be equal to {expected} +-{_tolerance}";
     }
 
-    protected internal override AssertionResult Passes(TActual? actualValue, TActual? expectedValue)
+    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/String/StringContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/String/StringContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class StringContainsExpectedValueAssertCondition(string expected, StringC
     protected override string GetExpectation()
         => $"to contain {Format(expected).TruncateWithEllipsis(100)}";
 
-    protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/String/StringEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/String/StringEqualsExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class StringEqualsExpectedValueAssertCondition(string expected, StringCom
     protected override string GetExpectation()
         => $"to be equal to {Format(expected).TruncateWithEllipsis(100)}";
 
-    protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/String/StringNotContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/String/StringNotContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class StringNotContainsExpectedValueAssertCondition(string expected, Stri
     protected override string GetExpectation()
         => $"to not contain {Format(expected).TruncateWithEllipsis(100)}";
 
-    protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/String/StringNotEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/String/StringNotEqualsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class StringNotEqualsExpectedValueAssertCondition(string expected, String
     protected override string GetExpectation()
         => $"to not be equal to {Format(expected).TruncateWithEllipsis(100)}";
 
-    protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
 
         if (actualValue is null)

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsAnythingExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsAnythingExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ public class ThrowsAnythingExpectedValueAssertCondition<TActual>
     protected override string GetExpectation()
         => "to throw an exception";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult.FailIf(
             () => exception is null,
             $"none was thrown");

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsExactTypeOfExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsExactTypeOfExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class ThrowsExactTypeOfDelegateAssertCondition<TActual, TExpectedExceptio
     protected override string GetExpectation()
         => $"to throw exactly {typeof(TExpectedException).Name.PrependAOrAn()}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
         .FailIf(
             () => exception is null,

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsNothingExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsNothingExpectedValueAssertCondition.cs
@@ -7,7 +7,7 @@ public class ThrowsNothingExpectedValueAssertCondition<TActual> : DelegateAssert
     protected override string GetExpectation()
         => "to throw nothing";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
         .FailIf(
             () => exception is not null,

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsSubClassOfExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsSubClassOfExpectedValueAssertCondition.cs
@@ -7,7 +7,7 @@ public class ThrowsSubClassOfExpectedValueAssertCondition<TActual, TExpectedExce
     protected override string GetExpectation()
         => $"to throw {typeof(TExpectedException).Name.PrependAOrAn()}";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
         .FailIf(
             () => exception is null,

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageContainingExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageContainingExpectedValueAssertCondition.cs
@@ -11,7 +11,7 @@ public class ThrowsWithMessageContainingExpectedValueAssertCondition<TActual>(
     protected override string GetExpectation()
         => $"to have Message containing \"{expectedMessage}\"";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         var actualException = exceptionSelector(exception);
 

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsWithMessageEqualToExpectedValueAssertCondition.cs
@@ -12,7 +12,7 @@ public class ThrowsWithMessageEqualToExpectedValueAssertCondition<TActual>(
     protected override string GetExpectation()
         => $"to have Message equal to \"{expectedMessage.ShowNewLines().TruncateWithEllipsis(100)}\"";
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         var actualException = exceptionSelector(exception);
 

--- a/TUnit.Assertions/AssertConditions/ValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/ValueAssertCondition.cs
@@ -18,7 +18,7 @@ public abstract class ValueAssertCondition<TActual>
         _customComparers.Add(comparer);
     }
 
-    protected internal override AssertionResult GetResult(TActual? actualValue, Exception? exception)
+    protected override AssertionResult GetResult(TActual? actualValue, Exception? exception)
     {
         if (exception is not null)
         {

--- a/TUnit.Assertions/AssertionBuilders/InvokableAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/InvokableAssertionBuilder.cs
@@ -25,7 +25,7 @@ public class InvokableAssertionBuilder<TActual> :
         
         foreach (var assertion in Assertions.Reverse())
         {
-            var result = assertion.GetResult(assertionData.Result, assertionData.Exception);
+            var result = assertion.Assert(assertionData.Result, assertionData.Exception, assertionData.ActualExpression);
             if (!result.IsPassed)
             {
                 assertion.SetSubject(assertionData.ActualExpression);
@@ -46,7 +46,7 @@ public class InvokableAssertionBuilder<TActual> :
         foreach (var assertion in Assertions.Reverse())
         {
             assertion.SetSubject(assertionData.ActualExpression);
-            var result = assertion.GetResult(assertionData.Result, assertionData.Exception);
+            var result = assertion.Assert(assertionData.Result, assertionData.Exception, assertionData.ActualExpression);
             if (!result.IsPassed)
             {
                 yield return (assertion, result);

--- a/docs/docs/tutorial-assertions/extensibility.md
+++ b/docs/docs/tutorial-assertions/extensibility.md
@@ -26,7 +26,7 @@ So to create a custom assertion:
    `TExpected` will be the data (if any) that you receive from your extension method, so you'll be responsible for passing this in. You must pass it to the base class via the base constructor: `base(expectedValue)`
 
 3. Override the method: 
-   `protected override AssertionResult Passes(...)`
+   `protected override AssertionResult GetResult(...)`
 
    `AssertionResult` has static methods to represent a pass or a fail.
 
@@ -48,7 +48,7 @@ In your assertion class, that'd be set up like:
     protected override string GetExpectation()
         => $"to be equal to {Format(expected).TruncateWithEllipsis(100)}";
 
-   protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+   protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {
@@ -91,7 +91,7 @@ public class StringEqualsExpectedValueAssertCondition(string expected, StringCom
     protected override string GetExpectation()
         => $"to be equal to {Format(expected).TruncateWithEllipsis(100)}";
 
-    protected internal override AssertionResult Passes(string? actualValue, string? expectedValue)
+    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {


### PR DESCRIPTION
As mentioned in #844, I had a look and realized, that the method name `Passes` was still used in some overloads. I now consistently renamed them to `GetResult` and also adapted the documentation accordingly.