### PR TITLE
Remove `Throw` methods from `Assert`

### DIFF
--- a/TUnit.Assertions.Tests/AssertConditions/BecauseTests.cs
+++ b/TUnit.Assertions.Tests/AssertConditions/BecauseTests.cs
@@ -13,7 +13,7 @@ public class BecauseTests
             await Assert.That(variable).IsFalse().Because(because);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(because);
     }
 
@@ -30,7 +30,7 @@ public class BecauseTests
             await Assert.That(variable).IsFalse().Because(because);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(expectedWithPrefix);
     }
 
@@ -45,7 +45,7 @@ public class BecauseTests
             await Assert.That(variable).IsFalse().Because(because);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(because)
             .And.DoesNotContain("because because");
     }
@@ -65,7 +65,7 @@ public class BecauseTests
             await Assert.That(variable).IsFalse();
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).IsEqualTo(expectedMessage);
     }
 
@@ -87,7 +87,7 @@ public class BecauseTests
                 .And.IsFalse();
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).IsEqualTo(expectedMessage);
     }
 
@@ -104,7 +104,7 @@ public class BecauseTests
                 .And.IsFalse().Because(because2);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(because1);
     }
 
@@ -121,7 +121,7 @@ public class BecauseTests
                 .And.IsFalse().Because(because2);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(because2);
     }
 
@@ -138,7 +138,7 @@ public class BecauseTests
                 .Or.IsFalse().Because(because2);
         };
 
-        var exception = await Assert.ThrowsAsync<AssertionException>(action);
+        var exception = await Assert.That(action).Throws<AssertionException>();
         await Assert.That(exception.Message).Contains(because1).And.Contains(because2);
     }
 }

--- a/TUnit.Assertions.UnitTests/AsyncTaskTests.cs
+++ b/TUnit.Assertions.UnitTests/AsyncTaskTests.cs
@@ -40,30 +40,30 @@ public class AsyncTaskTests
     [Test]
     public async Task Func_Throws_Task_Is_Callable()
     {
-        await TUnitAssert.ThrowsAsync(() => Task.FromException(new DivideByZeroException()));
+        await TUnitAssert.That(() => Task.FromException(new DivideByZeroException())).ThrowsException();
     }
     
     [Test]
     public async Task Func_Throws_Awaited_Task_Is_Callable()
     {
-        await TUnitAssert.ThrowsAsync(async () => await Task.FromException(new DivideByZeroException()));
+        await TUnitAssert.That(async () => await Task.FromException(new DivideByZeroException())).ThrowsException();
     }
     
     [Test]
     public async Task Func_Throws_Awaited_ValueTask_Is_Callable()
     {
-        await TUnitAssert.ThrowsAsync(async () => await ValueTask.FromException(new DivideByZeroException()));
+        await TUnitAssert.That(async () => await ValueTask.FromException(new DivideByZeroException())).ThrowsException();
     }
     
     [Test]
     public async Task Throws_Task_Is_Callable()
     {
-        await TUnitAssert.ThrowsAsync(Task.FromException(new DivideByZeroException()));
+        await TUnitAssert.That(Task.FromException(new DivideByZeroException())).ThrowsException();
     }
     
     [Test]
     public async Task Throws_ValueTask_Is_Callable()
     {
-        await TUnitAssert.ThrowsAsync(ValueTask.FromException(new DivideByZeroException()));
+        await TUnitAssert.That(ValueTask.FromException(new DivideByZeroException())).ThrowsException();
     }
 }

--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertionBuilders;
 using TUnit.Assertions.Exceptions;
-using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions;
 
@@ -62,74 +61,5 @@ public static class Assert
     public static void Fail(string reason)
     {
         throw new AssertionException(reason);
-    }
-
-    public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
-        => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
-
-    public static Task<Exception> ThrowsAsync(Task @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
-        => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
-    
-    public static Task<Exception> ThrowsAsync(ValueTask @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
-        => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
-    
-    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
-    {
-        try
-        {
-            await @delegate();
-            Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
-        }
-        catch (Exception e) when(e is not AssertionException)
-        {
-            if (e is TException exception)
-            {
-                return exception;
-            }
-            
-            Fail($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
-        }
-        catch (TException e)
-        {
-            // In case we want to assert to catch an AssertionException
-            return e;
-        }
-
-        return null!;
-    }
-
-    public static Task<TException> ThrowsAsync<TException>(Task @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
-        => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
-    
-    public static Task<TException> ThrowsAsync<TException>(ValueTask @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
-        => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
-
-    public static Exception Throws(Action @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
-        => Throws<Exception>(@delegate, doNotPopulateThisValue);
-    
-    public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
-    {
-        try
-        {
-            @delegate();
-            Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
-        }
-        catch (Exception e) when(e is not AssertionException)
-        {
-            if (e is TException exception)
-            {
-                return exception;
-            }
-            
-            Fail($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
-        }
-
-        return null!;
     }
 }

--- a/TUnit.Assertions/AssertConditions/Throws/ThrowsException.cs
+++ b/TUnit.Assertions/AssertConditions/Throws/ThrowsException.cs
@@ -8,39 +8,35 @@ namespace TUnit.Assertions.AssertConditions.Throws;
 public class ThrowsException<TActual, TException>(
     InvokableDelegateAssertionBuilder<TActual> delegateAssertionBuilder,
     IDelegateSource<TActual> delegateSource,
-    Func<Exception?, Exception?> exceptionSelector,
-    [CallerMemberName] string callerMemberName = "")
+    Func<Exception?, Exception?> exceptionSelector)
     where TException : Exception
 {
-    private readonly IDelegateSource<TActual> _delegateSource = delegateSource;
-    private readonly Func<Exception?, Exception?> _exceptionSelector = exceptionSelector;
-    private IDelegateSource<TActual> delegateSource;
-    private Func<Exception?, TException?> exceptionSelector;
-
     public ThrowsException<TActual, TException> WithMessageMatching(StringMatcher match, [CallerArgumentExpression("match")] string doNotPopulateThisValue = "")
     {
-        _delegateSource.RegisterAssertion(new ThrowsWithMessageMatchingAssertCondition<TActual, TException>(match, _exceptionSelector)
-            , [doNotPopulateThisValue]);
+        delegateSource.RegisterAssertion(
+            new ThrowsWithMessageMatchingAssertCondition<TActual, TException>(match, exceptionSelector),
+            [doNotPopulateThisValue]);
         return this;
     }
 
     public ThrowsException<TActual, TException> WithMessage(string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
     {
-        _delegateSource.RegisterAssertion(new ThrowsWithMessageAssertCondition<TActual, TException>(expected, StringComparison.Ordinal, _exceptionSelector)
-            , [doNotPopulateThisValue]);
+        delegateSource.RegisterAssertion(
+            new ThrowsWithMessageAssertCondition<TActual, TException>(expected, StringComparison.Ordinal, exceptionSelector),
+            [doNotPopulateThisValue]);
         return this;
     }
 
     public ThrowsException<TActual, Exception> WithInnerException()
     {
-        _delegateSource.AssertionBuilder.AppendExpression($"{nameof(WithInnerException)}()");
-        return new(delegateAssertionBuilder, _delegateSource, e => _exceptionSelector(e)?.InnerException);
+        delegateSource.AssertionBuilder.AppendExpression($"{nameof(WithInnerException)}()");
+        return new(delegateAssertionBuilder, delegateSource, e => exceptionSelector(e)?.InnerException);
     }
 
-    public TaskAwaiter<TException?> GetAwaiter()
+    public TaskAwaiter<TException> GetAwaiter()
     {
         var task = delegateAssertionBuilder.ProcessAssertionsAsync(
             d => d.Exception as TException);
-        return task.GetAwaiter();
+        return task.GetAwaiter()!;
     }
 }


### PR DESCRIPTION
As we improved the `Throw` methods with #870, we should use them consistently. Therefore I would suggest to remove the `Throw` methods from the static `Assert` class, as they are redundant.