### PR TITLE
Add `OnlyIf` method for throw assertions

### DIFF
--- a/TUnit.Assertions.Tests/Assertions/Delegates/Throws.OnlyIfTests.cs
+++ b/TUnit.Assertions.Tests/Assertions/Delegates/Throws.OnlyIfTests.cs
@@ -1,0 +1,64 @@
+﻿namespace TUnit.Assertions.Tests.Assertions.Delegates;
+
+public partial class Throws
+{
+    public class OnlyIfTests
+    {
+        [Test]
+        public async Task Fails_When_False_And_Exception_Is_Thrown()
+        {
+            string expectedMessage = $$"""
+                Expected action to throw nothing, but a CustomException was thrown:
+                {{nameof(Fails_When_False_And_Exception_Is_Thrown)}}.
+                At Assert.That(action).ThrowsExactly<CustomException>().OnlyIf(false)
+                """;
+            Exception exception = CreateCustomException();
+            Action action = () => throw exception;
+
+            var sut = async ()
+                => await Assert.That(action).ThrowsExactly<CustomException>().OnlyIf(false);
+
+            await Assert.That(sut).ThrowsException()
+                .WithMessage(expectedMessage);
+        }
+
+        [Test]
+        public async Task Fails_When_True_And_Exception_Is_Not_Thrown()
+        {
+            string expectedMessage = """
+                Expected action to throw a CustomException, but none was thrown.
+                At Assert.That(action).Throws<CustomException>().OnlyIf(true)
+                """;
+            Action action = () => { };
+
+            var sut = async ()
+                => await Assert.That(action).Throws<CustomException>().OnlyIf(true);
+
+            await Assert.That(sut).ThrowsException()
+                .WithMessage(expectedMessage);
+        }
+
+        [Test]
+        public async Task Succeeds_When_False_And_Exception_Is_Not_Thrown()
+        {
+            Action action = () => { };
+
+            var sut = async ()
+                => await Assert.That(action).ThrowsExactly<CustomException>().OnlyIf(false);
+
+            await Assert.That(sut).ThrowsNothing();
+        }
+
+        [Test]
+        public async Task Succeeds_When_True_And_Exception_Is_Thrown()
+        {
+            Exception exception = CreateCustomException();
+            Action action = () => throw exception;
+
+            var sut = async ()
+                => await Assert.That(action).ThrowsExactly<CustomException>().OnlyIf(true);
+
+            await Assert.That(sut).ThrowsNothing();
+        }
+    }
+}

--- a/TUnit.Assertions.Tests/Assertions/Delegates/Throws.WithMessageMatchingTests.cs
+++ b/TUnit.Assertions.Tests/Assertions/Delegates/Throws.WithMessageMatchingTests.cs
@@ -22,14 +22,7 @@ public partial class Throws
             var sut = async ()
                 => await Assert.That(action).Throws<CustomException>().WithMessageMatching(pattern);
 
-            if (expectMatch)
-            {
-                await Assert.That(sut).ThrowsNothing();
-            }
-            else
-            {
-                await Assert.That(sut).ThrowsException();
-            }
+            await Assert.That(sut).ThrowsException().OnlyIf(!expectMatch);
         }
 
         [Test]
@@ -94,14 +87,7 @@ public partial class Throws
                 => await Assert.That(action).ThrowsException()
                 .WithMessageMatching(StringMatcher.AsWildcard(pattern).IgnoringCase());
 
-            if (expectMatch)
-            {
-                await Assert.That(sut).ThrowsNothing();
-            }
-            else
-            {
-                await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression);
-            }
+            await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression).OnlyIf(!expectMatch);
         }
 
         [Test]
@@ -123,14 +109,7 @@ public partial class Throws
                 => await Assert.That(action).ThrowsException()
                 .WithMessageMatching(StringMatcher.AsRegex(pattern));
 
-            if (expectMatch)
-            {
-                await Assert.That(sut).ThrowsNothing();
-            }
-            else
-            {
-                await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression);
-            }
+            await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression).OnlyIf(!expectMatch);
         }
 
         [Test]
@@ -147,14 +126,7 @@ public partial class Throws
                 => await Assert.That(action).ThrowsException()
                 .WithMessageMatching(StringMatcher.AsRegex(pattern).IgnoringCase());
 
-            if (expectMatch)
-            {
-                await Assert.That(sut).ThrowsNothing();
-            }
-            else
-            {
-                await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression);
-            }
+            await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression).OnlyIf(!expectMatch);
         }
     }
 }

--- a/TUnit.Assertions/AssertionBuilders/AssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/AssertionBuilder.cs
@@ -81,7 +81,7 @@ public abstract class AssertionBuilder<TActual>
         
         return builder;
     }
-    
+
     [Obsolete("This is a base `object` method that should not be called.", true)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [DebuggerHidden]

--- a/TUnit.Assertions/Assertions/Throws/ThrowsException.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsException.cs
@@ -17,6 +17,17 @@ public class ThrowsException<TActual, TException>(
     private IDelegateSource<TActual> delegateSource;
     private Func<Exception?, TException?> exceptionSelector;
 
+    public ThrowsException<TActual, TException> OnlyIf(bool predicate, [CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+    {
+        if (predicate)
+        {
+            _delegateSource.AssertionBuilder.AppendExpression($"{nameof(OnlyIf)}({doNotPopulateThisValue})");
+            return this;
+        }
+        _delegateSource.ReplaceAssertionsWith(new ThrowsNothingAssertCondition<TActual>(), [doNotPopulateThisValue]);
+        return new(delegateAssertionBuilder, _delegateSource, e => null);
+    }
+
     public ThrowsException<TActual, TException> WithMessageMatching(StringMatcher match, [CallerArgumentExpression("match")] string doNotPopulateThisValue = "")
     {
         _delegateSource.RegisterAssertion(new ThrowsWithMessageMatchingAssertCondition<TActual, TException>(match, _exceptionSelector)

--- a/TUnit.Assertions/Extensions/SourceExtensions.cs
+++ b/TUnit.Assertions/Extensions/SourceExtensions.cs
@@ -18,13 +18,20 @@ public static class SourceExtensions
     {
         return new InvokableValueAssertionBuilder<TActual>(assertCondition.ChainedToWithoutExpression(source.AssertionBuilder));
     }
-    
+
     public static InvokableDelegateAssertionBuilder<TActual> RegisterAssertion<TActual>(this IDelegateSource<TActual> source,
         BaseAssertCondition<TActual> assertCondition, string[] argumentExpressions, [CallerMemberName] string caller = "")
     {
         return new InvokableDelegateAssertionBuilder<TActual>(assertCondition.ChainedTo(source.AssertionBuilder, argumentExpressions, caller));
     }
-    
+
+    public static InvokableDelegateAssertionBuilder<TActual> ReplaceAssertionsWith<TActual>(this IDelegateSource<TActual> source,
+        BaseAssertCondition<TActual> assertCondition, string[] argumentExpressions, [CallerMemberName] string caller = "")
+    {
+        source.AssertionBuilder.Assertions.Clear();
+        return new InvokableDelegateAssertionBuilder<TActual>(assertCondition.ChainedTo(source.AssertionBuilder, argumentExpressions, caller));
+    }
+
     public static InvokableDelegateAssertionBuilder<TActual> RegisterAssertionWithoutExpression<TActual>(this IDelegateSource<TActual> source,
         BaseAssertCondition<TActual> assertCondition)
     {


### PR DESCRIPTION
I often have the issue that I want to assert in a test, that an exception was only thrown when a certain condition applies.
Currently I have to introduce an if/else clause, e.g.
```csharp
if (expectMatch)
{
    await Assert.That(sut).ThrowsNothing();
}
else
{
    await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression);
}
```

This PR adds an `OnlyIf` method to the `ThrowsException` class, so that this can be simplified to
```csharp
await Assert.That(sut).ThrowsException().WithMessageMatching(expectedExpression).OnlyIf(!expectMatch);
```

The `OnlyIf` will check the predicate, and if it is `true` it will ensure, that the exception was thrown as specified. If it is `false`, it will instead ensure, that no exception was thrown.