### PR TITLE
Fix location of `StringDifference` when actual starts with expected

### DIFF
--- a/TUnit.Assertions.Tests/Helpers/StringDifferenceTests.cs
+++ b/TUnit.Assertions.Tests/Helpers/StringDifferenceTests.cs
@@ -1,0 +1,88 @@
+﻿namespace TUnit.Assertions.Tests.AssertConditions;
+
+public class StringDifferenceTests
+{
+    [Test]
+    public async Task Works_For_Empty_String_As_Actual()
+    {
+        string expectedMessage = """
+                                 Expected actual to be equal to "some text", but found "" which differs at index 0:
+                                     ↓
+                                    ""
+                                    "some text"
+                                     ↑.
+                                 At Assert.That(actual).IsEqualTo(expected, StringComparison.Ordinal)
+                                 """;
+        var actual = "";
+        var expected = "some text";
+
+        var sut = async ()
+            => await Assert.That(actual).IsEqualTo(expected);
+
+        await Assert.That(sut).ThrowsException()
+            .WithMessage(expectedMessage);
+    }
+
+    [Test]
+    public async Task Works_For_Empty_String_As_Expected()
+    {
+        string expectedMessage = """
+                                 Expected actual to be equal to "", but found "actual text" which differs at index 0:
+                                     ↓
+                                    "actual text"
+                                    ""
+                                     ↑.
+                                 At Assert.That(actual).IsEqualTo(expected, StringComparison.Ordinal)
+                                 """;
+        var actual = "actual text";
+        var expected = "";
+
+        var sut = async ()
+            => await Assert.That(actual).IsEqualTo(expected);
+
+        await Assert.That(sut).ThrowsException()
+            .WithMessage(expectedMessage);
+    }
+
+    [Test]
+    public async Task Works_When_Actual_Starts_With_Expected()
+    {
+        string expectedMessage = """
+                                 Expected actual to be equal to "some text", but found "some" which differs at index 4:
+                                         ↓
+                                    "some"
+                                    "some text"
+                                         ↑.
+                                 At Assert.That(actual).IsEqualTo(expected, StringComparison.Ordinal)
+                                 """;
+        var actual = "some";
+        var expected = "some text";
+
+        var sut = async ()
+            => await Assert.That(actual).IsEqualTo(expected);
+
+        await Assert.That(sut).ThrowsException()
+            .WithMessage(expectedMessage);
+    }
+
+    [Test]
+    public async Task Works_When_Expected_Starts_With_Actual()
+    {
+        string expectedMessage = """
+                                 Expected actual to be equal to "some", but found "some text" which differs at index 4:
+                                         ↓
+                                    "some text"
+                                    "some"
+                                         ↑.
+                                 At Assert.That(actual).IsEqualTo(expected, StringComparison.Ordinal)
+                                 """;
+        var actual = "some text";
+        var expected = "some";
+
+        var sut = async ()
+            => await Assert.That(actual).IsEqualTo(expected);
+
+        await Assert.That(sut).ThrowsException()
+            .WithMessage(expectedMessage);
+    }
+}

--- a/TUnit.Assertions/Helpers/StringDifference.cs
+++ b/TUnit.Assertions/Helpers/StringDifference.cs
@@ -37,6 +37,11 @@ internal class StringDifference(string? actualValue, string? expectedValue, IEqu
             }
         }
 
+        if (actualValue.Length < expectedValue.Length)
+        {
+            return actualValue.Length;
+        }
+
         return -1;
     }
 


### PR DESCRIPTION
When the actual value starts with the expected value (but is not identical), the `StringDifference` class incorrectly returned -1 as index of first mismatch.