### PR TITLE
Enable nullability in assertion classes

### DIFF
--- a/TUnit.Assertions/Assertions/Chronology/DateOnlyIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateOnlyIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Chronology;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Chronology/DateTimeIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateTimeIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Chronology;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Chronology/DateTimeOffsetIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateTimeOffsetIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Chronology;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Chronology/TimeOnlyIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/TimeOnlyIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Chronology;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Chronology/TimeSpanIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/TimeSpanIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Chronology;
 using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Chronology/TimeSpanIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/TimeSpanIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -10,7 +8,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class CollectionsIsExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsEquivalentCollectionTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsEquivalentCollectionTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner?>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -10,7 +8,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class CollectionsIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner?>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Collections/DoesExtensions_Dictionary.cs
+++ b/TUnit.Assertions/Assertions/Collections/DoesExtensions_Dictionary.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -10,7 +8,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesExtensions
 {
-    public static InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TKey>(expected,
@@ -23,7 +21,7 @@ public static partial class DoesExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TDictionary> ContainsValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> ContainsValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TValue>(expected,

--- a/TUnit.Assertions/Assertions/Collections/DoesNotExtensions_Dictionary.cs
+++ b/TUnit.Assertions/Assertions/Collections/DoesNotExtensions_Dictionary.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -10,7 +8,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TKey>(expected,
@@ -23,7 +21,7 @@ public static partial class DoesNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TValue>(expected,

--- a/TUnit.Assertions/Assertions/Collections/HasExtensions_Enumerable.cs
+++ b/TUnit.Assertions/Assertions/Collections/HasExtensions_Enumerable.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System.Collections;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -9,7 +7,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class HasExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> HasSingleItem<TActual>(this IValueSource<TActual> valueSource, IEqualityComparer equalityComparer = null) 
+    public static InvokableValueAssertionBuilder<TActual> HasSingleItem<TActual>(this IValueSource<TActual> valueSource, IEqualityComparer? equalityComparer = null) 
         where TActual : IEnumerable
     {
         return valueSource.RegisterAssertion(new EnumerableCountEqualToExpectedValueAssertCondition<TActual>(1)
@@ -23,7 +21,7 @@ public static partial class HasExtensions
             , []);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> HasDistinctItems<TActual, TInner>(this IValueSource<TActual> valueSource, IEqualityComparer<TInner> equalityComparer) 
+    public static InvokableValueAssertionBuilder<TActual> HasDistinctItems<TActual, TInner>(this IValueSource<TActual> valueSource, IEqualityComparer<TInner?>? equalityComparer) 
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableDistinctItemsExpectedValueAssertCondition<TActual, TInner>(equalityComparer)

--- a/TUnit.Assertions/Assertions/Collections/HasExtensions_Exception.cs
+++ b/TUnit.Assertions/Assertions/Collections/HasExtensions_Exception.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using TUnit.Assertions.AssertConditions.Interfaces;
 
 namespace TUnit.Assertions.Extensions;

--- a/TUnit.Assertions/Assertions/Collections/HasExtensions_String.cs
+++ b/TUnit.Assertions/Assertions/Collections/HasExtensions_String.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using TUnit.Assertions.AssertConditions.Interfaces;
 
 namespace TUnit.Assertions.Extensions;

--- a/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Comparable;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -16,7 +14,7 @@ public static class ComparableIsExtensions
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
             {
-                return value.CompareTo(expected) > 0;
+                return value?.CompareTo(expected) > 0;
             },
             (value, _, _) => $"{value} was not greater than {expected}")
             , [doNotPopulateThisValue]); }
@@ -26,7 +24,7 @@ public static class ComparableIsExtensions
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
             {
-                return value.CompareTo(expected) >= 0;
+                return value?.CompareTo(expected) >= 0;
             },
             (value, _, _) => $"{value} was not greater than or equal to {expected}")
             , [doNotPopulateThisValue]); }
@@ -36,7 +34,7 @@ public static class ComparableIsExtensions
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
             {
-                return value.CompareTo(expected) < 0;
+                return value?.CompareTo(expected) < 0;
             },
             (value, _, _) => $"{value} was not less than {expected}")
             , [doNotPopulateThisValue]); }
@@ -46,7 +44,7 @@ public static class ComparableIsExtensions
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
             {
-                return value.CompareTo(expected) <= 0;
+                return value?.CompareTo(expected) <= 0;
             },
             (value, _, _) => $"{value} was not less than or equal to {expected}")
             , [doNotPopulateThisValue]); }

--- a/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
@@ -9,7 +7,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner?>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableContainsExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Generic;

--- a/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
@@ -12,7 +10,7 @@ public static class GenericIsNotExtensions
 {
     public static InvokableValueAssertionBuilder<TActual> IsNotNull<TActual>(this IValueSource<TActual> valueSource)
     {
-        return valueSource!.RegisterAssertion(new NotNullExpectedValueAssertCondition<TActual>()
+        return valueSource.RegisterAssertion(new NotNullExpectedValueAssertCondition<TActual>()
             , []);
     }
     

--- a/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions_Namespaced.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions_Namespaced.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;

--- a/TUnit.Assertions/Assertions/Numbers/NumberIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Numbers/NumberIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Numerics;
+﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Generic;

--- a/TUnit.Assertions/Assertions/Numbers/NumberIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Numbers/NumberIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Numerics;
+﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Generic;

--- a/TUnit.Assertions/Assertions/Primitives/BooleanIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Primitives/BooleanIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using TUnit.Assertions.AssertConditions.Generic;
+﻿using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
 

--- a/TUnit.Assertions/Assertions/Primitives/BooleanIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Primitives/BooleanIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using TUnit.Assertions.AssertConditions.Generic;
+﻿using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
 

--- a/TUnit.Assertions/Assertions/Primitives/CharIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Primitives/CharIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using TUnit.Assertions.AssertConditions.Generic;
+﻿using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
 

--- a/TUnit.Assertions/Assertions/Primitives/CharIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Primitives/CharIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using TUnit.Assertions.AssertConditions.Generic;
+﻿using TUnit.Assertions.AssertConditions.Generic;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
 

--- a/TUnit.Assertions/Assertions/Strings/DoesExtensions_String.cs
+++ b/TUnit.Assertions/Assertions/Strings/DoesExtensions_String.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;

--- a/TUnit.Assertions/Assertions/Strings/DoesNotExtensions_String.cs
+++ b/TUnit.Assertions/Assertions/Strings/DoesNotExtensions_String.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertConditions.String;

--- a/TUnit.Assertions/Assertions/Strings/StringIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Strings/StringIsExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertConditions.String;

--- a/TUnit.Assertions/Assertions/Strings/StringIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Strings/StringIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertConditions.String;


### PR DESCRIPTION
Nullability was arbitrarily disabled in some assertion classes, even though the missing annotations were trivial.
Especially as they are "outside-facing" methods, having properly applied nullable annotations, adds great value to users.