### PR TITLE
Add dynamic `Skip` to TUnit.Core

### DIFF
--- a/TUnit.Assertions.Tests/SkipTests.cs
+++ b/TUnit.Assertions.Tests/SkipTests.cs
@@ -1,0 +1,58 @@
+﻿using TUnit.Core.Exceptions;
+
+namespace TUnit.Assertions.Tests;
+
+public class SkipTests
+{
+    [Test]
+    public async Task Skip_Test_Throws_SkipTestException()
+    {
+        string reason = "foo";
+        var action = () => Skip.Test(reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<SkipTestException>();
+        await Assert.That(exception!.Reason).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Skip_Unless_Throws_SkipTestException_When_Condition_Is_False()
+    {
+        bool condition = false;
+        string reason = "foo";
+        var action = () => Skip.Unless(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<SkipTestException>();
+        await Assert.That(exception!.Reason).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Skip_Unless_Does_Not_Throw_When_Condition_Is_True()
+    {
+        bool condition = true;
+        string reason = "foo";
+        var action = () => Skip.Unless(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Skip_When_Throws_SkipTestException_When_Condition_Is_True()
+    {
+        bool condition = true;
+        string reason = "foo";
+        var action = () => Skip.When(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<SkipTestException>();
+        await Assert.That(exception!.Reason).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Skip_When_Does_Not_Throw_When_Condition_Is_False()
+    {
+        bool condition = false;
+        string reason = "foo";
+        var action = () => Skip.When(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsNothing();
+    }
+}

--- a/TUnit.Core/Skip.cs
+++ b/TUnit.Core/Skip.cs
@@ -1,0 +1,47 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using TUnit.Core.Exceptions;
+
+namespace TUnit.Core
+{
+    public static class Skip
+    {
+        /// <summary>
+        /// Dynamically skips the current test.
+        /// <para/>
+        /// This is used, when the decision whether a test should be skipped happens at runtime rather than at discovery time.
+        /// Otherwise consider using the <see cref="SkipAttribute"/> instead.
+        /// </summary>
+        /// <param name="reason">The reason why the test was skipped</param>
+        [DoesNotReturn]
+        public static void Test(string reason)
+        {
+            throw new SkipTestException(reason);
+        }
+
+        /// <summary>
+        /// Dynamically skips the current test when the <paramref name="condition"/> is <c>false</c>.
+        /// </summary>
+        /// <param name="condition">When <c>false</c>, the test will be skipped; otherwise it will continue to run</param>
+        /// <param name="reason">The reason why the test was skipped</param>
+        public static void Unless([DoesNotReturnIf(false)] bool condition, string reason)
+        {
+            if (!condition)
+            {
+                Test(reason);
+            }
+        }
+
+        /// <summary>
+        /// Dynamically skips the current test when the <paramref name="condition"/> is <c>true</c>.
+        /// </summary>
+        /// <param name="condition">When <c>true</c>, the test will be skipped; otherwise it will continue to run</param>
+        /// <param name="reason">The reason why the test was skipped</param>
+        public static void When([DoesNotReturnIf(true)] bool condition, string reason)
+        {
+            if (condition)
+            {
+                Test(reason);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements #888 by adding a `Skip` class to `TUnit.Core`.
This way, the skip methods will only be available when using `TUnit.Engine` and not when only using the assertions library.

Note: It is possible to use the `SkipAttribute` and the `Skip` class in the same tests without collissions:
![image](https://github.com/user-attachments/assets/293bcd95-4f14-4943-ac10-ee763256db13)

