### PR TITLE
Move `Assert.Fail` to a separate class

### DIFF
--- a/TUnit.Assertions.Tests/FailTests.cs
+++ b/TUnit.Assertions.Tests/FailTests.cs
@@ -1,0 +1,56 @@
+﻿namespace TUnit.Assertions.Tests;
+
+public class FailTests
+{
+    [Test]
+    public async Task Fail_Test_Throws_AssertionException()
+    {
+        string reason = "foo";
+        var action = () => Fail.Test(reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<AssertionException>();
+        await Assert.That(exception!.Message).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Fail_Unless_Throws_AssertionException_When_Condition_Is_False()
+    {
+        bool condition = false;
+        string reason = "foo";
+        var action = () => Fail.Unless(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<AssertionException>();
+        await Assert.That(exception!.Message).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Fail_Unless_Does_Not_Throw_When_Condition_Is_True()
+    {
+        bool condition = true;
+        string reason = "foo";
+        var action = () => Fail.Unless(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Fail_When_Throws_AssertionException_When_Condition_Is_True()
+    {
+        bool condition = true;
+        string reason = "foo";
+        var action = () => Fail.When(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsExactly<AssertionException>();
+        await Assert.That(exception!.Message).IsEqualTo(reason);
+    }
+
+    [Test]
+    public async Task Fail_When_Does_Not_Throw_When_Condition_Is_False()
+    {
+        bool condition = false;
+        string reason = "foo";
+        var action = () => Fail.When(condition, reason);
+
+        var exception = await Assert.That(action).ThrowsNothing();
+    }
+}

--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -58,12 +58,6 @@ public static class Assert
         return new AssertionScope();
     }
 
-    [DoesNotReturn]
-    public static void Fail(string reason)
-    {
-        throw new AssertionException(reason);
-    }
-
     public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
         [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
@@ -81,7 +75,7 @@ public static class Assert
         try
         {
             await @delegate();
-            Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
+            Fail.Test($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
         }
         catch (Exception e) when(e is not AssertionException)
         {
@@ -90,7 +84,7 @@ public static class Assert
                 return exception;
             }
             
-            Fail($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
+            Fail.Test($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
         }
         catch (TException e)
         {
@@ -118,7 +112,7 @@ public static class Assert
         try
         {
             @delegate();
-            Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
+            Fail.Test($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
         }
         catch (Exception e) when(e is not AssertionException)
         {
@@ -127,7 +121,7 @@ public static class Assert
                 return exception;
             }
             
-            Fail($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
+            Fail.Test($"Exception is of type {e.GetType().Name} instead of {typeof(TException).Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
         }
 
         return null!;

--- a/TUnit.Assertions/Fail.cs
+++ b/TUnit.Assertions/Fail.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using TUnit.Assertions.Exceptions;
+
+namespace TUnit.Assertions;
+
+public static class Fail
+{
+    /// <summary>
+    /// Fails the current test.
+    /// </summary>
+    /// <param name="reason">The reason why the test failed</param>
+    [DoesNotReturn]
+    public static void Test(string reason)
+    {
+        throw new AssertionException(reason);
+    }
+
+    /// <summary>
+    /// Fails the current test when the <paramref name="condition"/> is <c>false</c>.
+    /// </summary>
+    /// <param name="condition">When <c>false</c>, the test will be failed; otherwise it will continue to run</param>
+    /// <param name="reason">The reason why the test was failed</param>
+    public static void Unless([DoesNotReturnIf(false)] bool condition, string reason)
+    {
+        if (!condition)
+        {
+            Test(reason);
+        }
+    }
+
+    /// <summary>
+    /// Fails the current test when the <paramref name="condition"/> is <c>true</c>.
+    /// </summary>
+    /// <param name="condition">When <c>true</c>, the test will be failed; otherwise it will continue to run</param>
+    /// <param name="reason">The reason why the test was failed</param>
+    public static void When([DoesNotReturnIf(true)] bool condition, string reason)
+    {
+        if (condition)
+        {
+            Test(reason);
+        }
+    }
+}


### PR DESCRIPTION
Move the `Fail` method on `Assert` to a static class `Test.Fail`, which allows a similar usage to the `Skip` methods in #902: 

So instead of
```csharp
Assert.Fail("my reason");
```
we write
```csharp
Fail.Test("my reason");
```
which is similar to
```csharp
Skip.Test("my reason");
```