### PR TITLE
using System.Threading.Lock in .NET 9+

### DIFF
--- a/TUnit.Core/AsyncEvent.cs
+++ b/TUnit.Core/AsyncEvent.cs
@@ -3,12 +3,16 @@
 public class AsyncEvent<TEventArgs>
 {
     private readonly List<Func<object, TEventArgs, Task>> _invocationList;
+    #if NET9_0_OR_GREATER
+    private readonly Lock _locker;
+    #else
     private readonly object _locker;
+    #endif
 
     private AsyncEvent()
     {
         _invocationList = [];
-        _locker = new object();
+        _locker = new();
     }
 
     public static AsyncEvent<TEventArgs> operator +(

--- a/TUnit.Core/InstanceTracker.cs
+++ b/TUnit.Core/InstanceTracker.cs
@@ -5,10 +5,18 @@ namespace TUnit.Core;
 
 internal static class InstanceTracker
 {
+#if NET9_0_OR_GREATER
+    private static readonly Lock PerClassTypeLock = new();
+#else
     private static readonly object PerClassTypeLock = new();
+#endif
     private static readonly ConcurrentDictionary<Type, int> PerClassType = new();
     
+#if NET9_0_OR_GREATER
+    private static readonly Lock PerAssemblyLock = new();
+#else
     private static readonly object PerAssemblyLock = new();
+#endif
     private static readonly ConcurrentDictionary<Assembly, int> PerAssembly = new();
 
     private static int TotalInstances;

--- a/TUnit.Core/Models/LazyHook.cs
+++ b/TUnit.Core/Models/LazyHook.cs
@@ -2,7 +2,11 @@
 
 internal class LazyHook<T1, T2>(Func<T1, T2, Task> func)
 {
+#if NET9_0_OR_GREATER
+    private readonly Lock _lock = new();
+#else
     private readonly object _lock = new();
+#endif
     private Task? _value;
 
     public Task Value(T1 arg1, T2 arg2)

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -4,6 +4,11 @@ public partial class TestContext : Context, IDisposable
 {
     internal readonly TaskCompletionSource<object?> TaskCompletionSource = new();
     internal readonly List<Artifact> Artifacts = [];
+#if NET9_0_OR_GREATER
+    public readonly Lock Lock = new();
+#else
+    public readonly object Lock = new();
+#endif
 
     internal TestContext(TestDetails testDetails, Dictionary<string, object?> objectBag)
     {

--- a/TUnit.Core/TestDataContainer.cs
+++ b/TUnit.Core/TestDataContainer.cs
@@ -17,7 +17,11 @@ public static class TestDataContainer
 
     internal static readonly Dictionary<Type, Lazy<Task>> InjectedSharedGloballyInitializations = new();
     
+#if NET9_0_OR_GREATER
+    private static readonly Lock Lock = new();
+#else
     private static readonly object Lock = new();
+#endif
     private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, int>> CountsPerKey = new();
     private static readonly ConcurrentDictionary<Type, int> CountsPerGlobalType = new();
 

--- a/TUnit.Engine/Helpers/Timings.cs
+++ b/TUnit.Engine/Helpers/Timings.cs
@@ -16,7 +16,7 @@ internal static class Timings
         {
             var end = DateTimeOffset.Now;
             
-            lock (context.Timings)
+            lock (context.Lock)
             {
                 context.Timings.Add(new Timing(name, start, end));
             }

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -305,7 +305,7 @@ internal class SingleTestExecutor(
     {
         var end = DateTimeOffset.Now;
 
-        lock (testContext.Timings)
+        lock (testContext.Lock)
         {
             var stepTimings = testContext.Timings.Select(x =>
                 new StepTimingInfo(x.StepName, string.Empty, new TimingInfo(x.Start, x.End, x.Duration)));

--- a/TUnit.Engine/Services/TestsExecutor.cs
+++ b/TUnit.Engine/Services/TestsExecutor.cs
@@ -20,7 +20,11 @@ internal class TestsExecutor
     private readonly ICommandLineOptions _commandLineOptions;
 
     private readonly ConcurrentDictionary<string, Semaphore> _notInParallelKeyedLocks = new();
+#if NET9_0_OR_GREATER
+    private readonly Lock _notInParallelDictionaryLock = new();
+#else
     private readonly object _notInParallelDictionaryLock = new();
+#endif
     
     private readonly int _maximumParallelTests;
 

--- a/TUnit.Pipeline/Modules/GenerateReadMeModule.cs
+++ b/TUnit.Pipeline/Modules/GenerateReadMeModule.cs
@@ -18,7 +18,7 @@ namespace TUnit.Pipeline.Modules;
 [SkipIfDependabot]
 public class GenerateReadMeModule : Module<File>
 {
-    private readonly object _stringBuilderLock = new();
+    private readonly object _stringBuilderLock = new(); //unused?
     protected override async Task<File?> ExecuteAsync(IPipelineContext context, CancellationToken cancellationToken)
     {
         var template = await context.Git()


### PR DESCRIPTION
this is an alternative to #883 that uses preprocessors to use Lock in .NET 9+ and object in .NET 8