### PR TITLE
use nameof for CallerArgumentExpression

### DIFF
--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -58,18 +58,18 @@ public static class Assert
     }
 
     public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
 
     public static Task<Exception> ThrowsAsync(Task @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
     
     public static Task<Exception> ThrowsAsync(ValueTask @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
     
-    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {
@@ -90,18 +90,18 @@ public static class Assert
     }
 
     public static Task<TException> ThrowsAsync<TException>(Task @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
     
     public static Task<TException> ThrowsAsync<TException>(ValueTask @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
 
     public static Exception Throws(Action @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => Throws<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+    public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {

--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -7,47 +7,47 @@ namespace TUnit.Assertions;
 
 public static class Assert
 {
-    public static ValueAssertionBuilder<TActual> That<TActual>(TActual value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static ValueAssertionBuilder<TActual> That<TActual>(TActual value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new ValueAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
     
-    public static DelegateAssertionBuilder That(Action value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static DelegateAssertionBuilder That(Action value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new DelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
     
-    public static ValueDelegateAssertionBuilder<TActual> That<TActual>(Func<TActual> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static ValueDelegateAssertionBuilder<TActual> That<TActual>(Func<TActual> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new ValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
     
-    public static AsyncDelegateAssertionBuilder That(Func<Task> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncDelegateAssertionBuilder That(Func<Task> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncDelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
     
-    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Func<Task<TActual>> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Func<Task<TActual>> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
     
-    public static AsyncDelegateAssertionBuilder That(Task value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncDelegateAssertionBuilder That(Task value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncDelegateAssertionBuilder(async () => await value, doNotPopulateThisValue);
     }
     
-    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Task<TActual> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Task<TActual> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(async () => await value, doNotPopulateThisValue);
     }
     
-    public static AsyncDelegateAssertionBuilder That(ValueTask value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncDelegateAssertionBuilder That(ValueTask value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncDelegateAssertionBuilder(async () => await value, doNotPopulateThisValue);
     }
     
-    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(ValueTask<TActual> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(ValueTask<TActual> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(async () => await value, doNotPopulateThisValue);
     }
@@ -58,18 +58,18 @@ public static class Assert
     }
 
     public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
 
     public static Task<Exception> ThrowsAsync(Task @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
     
     public static Task<Exception> ThrowsAsync(ValueTask @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
     
-    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {
@@ -90,18 +90,18 @@ public static class Assert
     }
 
     public static Task<TException> ThrowsAsync<TException>(Task @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
     
     public static Task<TException> ThrowsAsync<TException>(ValueTask @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
 
     public static Exception Throws(Action @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => Throws<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+    public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/DateOnlyEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/DateOnlyEqualToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class DateOnlyEqualToAssertionBuilderWrapper : InvokableValueAssertionBui
     {
     }
 
-    public DateOnlyEqualToAssertionBuilderWrapper WithinDays(int days, [CallerArgumentExpression("days")] string doNotPopulateThis = "")
+    public DateOnlyEqualToAssertionBuilderWrapper WithinDays(int days, [CallerArgumentExpression(nameof(days))] string doNotPopulateThis = "")
     {
         var assertion = (DateOnlyEqualsExpectedValueAssertCondition) Assertions.Peek();
 

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/DateTimeEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/DateTimeEqualToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class DateTimeEqualToAssertionBuilderWrapper : InvokableValueAssertionBui
     {
     }
 
-    public DateTimeEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+    public DateTimeEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
     {
         var assertion = (DateTimeEqualsExpectedValueAssertCondition) Assertions.Peek();
 

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/DateTimeOffsetEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/DateTimeOffsetEqualToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class DateTimeOffsetEqualToAssertionBuilderWrapper : InvokableValueAssert
     {
     }
 
-    public DateTimeOffsetEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+    public DateTimeOffsetEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
     {
         var assertion = (DateTimeOffsetEqualsExpectedValueAssertCondition) Assertions.Peek();
 

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/EquivalentToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/EquivalentToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class EquivalentToAssertionBuilderWrapper<TActual> : InvokableValueAssert
     {
     }
     
-    public EquivalentToAssertionBuilderWrapper<TActual> IgnoringMember(string propertyName, [CallerArgumentExpression("propertyName")] string doNotPopulateThis = "")
+    public EquivalentToAssertionBuilderWrapper<TActual> IgnoringMember(string propertyName, [CallerArgumentExpression(nameof(propertyName))] string doNotPopulateThis = "")
     {
         var assertion = (EquivalentToExpectedValueAssertCondition<TActual>) Assertions.Peek();
 

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/TimeOnlyEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/TimeOnlyEqualToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class TimeOnlyEqualToAssertionBuilderWrapper : InvokableValueAssertionBui
     {
     }
 
-    public TimeOnlyEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+    public TimeOnlyEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
     {
         var assertion = (TimeOnlyEqualsExpectedValueAssertCondition) Assertions.Peek();
 

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/TimeSpanEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/TimeSpanEqualToAssertionBuilderWrapper.cs
@@ -9,7 +9,7 @@ public class TimeSpanEqualToAssertionBuilderWrapper : InvokableValueAssertionBui
     {
     }
 
-    public TimeSpanEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+    public TimeSpanEqualToAssertionBuilderWrapper Within(TimeSpan tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
     {
         var assertion = (TimeSpanEqualsExpectedValueAssertCondition) Assertions.Peek();
 

--- a/TUnit.Assertions/Assertions/Chronology/DateOnlyIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateOnlyIsExtensions.cs
@@ -11,7 +11,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class DateOnlyIsExtensions
 {
-    public static DateOnlyEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static DateOnlyEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return new DateOnlyEqualToAssertionBuilderWrapper(
             valueSource.RegisterAssertion(new DateOnlyEqualsExpectedValueAssertCondition(expected),
@@ -19,21 +19,21 @@ public static class DateOnlyIsExtensions
         );
     }
     
-    public static InvokableValueAssertionBuilder<DateOnly> IsAfter(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<DateOnly> IsAfter(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateOnly, DateOnly>(default, (value, _, _) => value > expected,
             (value, _, _) => $"{value} was not greater than {expected}",
             $"to be after {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateOnly> IsAfterOrEqualTo(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateOnly> IsAfterOrEqualTo(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateOnly, DateOnly>(default, (value, _, _) => value >= expected,
             (value, _, _) => $"{value} was not greater than or equal to {expected}",
             $"to be after or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateOnly> IsBefore(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateOnly> IsBefore(this IValueSource<DateOnly> valueSource, DateOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateOnly, DateOnly>(default, (value, _, _) => value < expected,
             (value, _, _) => $"{value} was not less than {expected}",
@@ -41,7 +41,7 @@ public static class DateOnlyIsExtensions
             , [doNotPopulateThisValue]); }
 
     public static InvokableValueAssertionBuilder<DateOnly> IsBeforeOrEqualTo(this IValueSource<DateOnly> valueSource,
-        DateOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        DateOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateOnly, DateOnly>(default,
                 (value, _, _) => value <= expected,

--- a/TUnit.Assertions/Assertions/Chronology/DateTimeIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateTimeIsExtensions.cs
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class DateTimeIsExtensions
 {
-    public static DateTimeEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static DateTimeEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return new DateTimeEqualToAssertionBuilderWrapper(
             valueSource.RegisterAssertion(new DateTimeEqualsExpectedValueAssertCondition(expected),
@@ -20,7 +20,7 @@ public static class DateTimeIsExtensions
         );
     }
     
-    public static InvokableValueAssertionBuilder<DateTime> IsAfter(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<DateTime> IsAfter(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTime, DateTime>(default, (value, _, _) =>
             {
@@ -30,7 +30,7 @@ public static class DateTimeIsExtensions
             $"to be after {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateTime> IsAfterOrEqualTo(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateTime> IsAfterOrEqualTo(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTime, DateTime>(default, (value, _, _) =>
             {
@@ -40,7 +40,7 @@ public static class DateTimeIsExtensions
             $"to be after or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateTime> IsBefore(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateTime> IsBefore(this IValueSource<DateTime> valueSource, DateTime expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTime, DateTime>(default, (value, _, _) =>
             {
@@ -51,7 +51,7 @@ public static class DateTimeIsExtensions
             , [doNotPopulateThisValue]); }
 
     public static InvokableValueAssertionBuilder<DateTime> IsBeforeOrEqualTo(this IValueSource<DateTime> valueSource,
-        DateTime expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        DateTime expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTime, DateTime>(default,
                 (value, _, _) => { return value <= expected; },

--- a/TUnit.Assertions/Assertions/Chronology/DateTimeOffsetIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/DateTimeOffsetIsExtensions.cs
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class DateTimeOffsetIsExtensions
 {
-    public static DateTimeOffsetEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static DateTimeOffsetEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return new DateTimeOffsetEqualToAssertionBuilderWrapper(
             valueSource.RegisterAssertion(new DateTimeOffsetEqualsExpectedValueAssertCondition(expected),
@@ -20,7 +20,7 @@ public static class DateTimeOffsetIsExtensions
         );
     }
     
-    public static InvokableValueAssertionBuilder<DateTimeOffset> IsAfter(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<DateTimeOffset> IsAfter(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTimeOffset, DateTimeOffset>(default, (value, _, _) =>
             {
@@ -30,7 +30,7 @@ public static class DateTimeOffsetIsExtensions
             $"to be after {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateTimeOffset> IsAfterOrEqualTo(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateTimeOffset> IsAfterOrEqualTo(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTimeOffset, DateTimeOffset>(default, (value, _, _) =>
             {
@@ -40,7 +40,7 @@ public static class DateTimeOffsetIsExtensions
             $"to be after or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<DateTimeOffset> IsBefore(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<DateTimeOffset> IsBefore(this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTimeOffset, DateTimeOffset>(default, (value, _, _) =>
             {
@@ -52,7 +52,7 @@ public static class DateTimeOffsetIsExtensions
 
     public static InvokableValueAssertionBuilder<DateTimeOffset> IsBeforeOrEqualTo(
         this IValueSource<DateTimeOffset> valueSource, DateTimeOffset expected,
-        [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<DateTimeOffset, DateTimeOffset>(default,
                 (value, _, _) => { return value <= expected; },

--- a/TUnit.Assertions/Assertions/Chronology/TimeOnlyIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/TimeOnlyIsExtensions.cs
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class TimeOnlyIsExtensions
 {
-    public static TimeOnlyEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<TimeOnly> valueSource, TimeOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static TimeOnlyEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<TimeOnly> valueSource, TimeOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return new TimeOnlyEqualToAssertionBuilderWrapper(
             valueSource.RegisterAssertion(new TimeOnlyEqualsExpectedValueAssertCondition(expected),
@@ -21,7 +21,7 @@ public static class TimeOnlyIsExtensions
     }
     
     public static InvokableValueAssertionBuilder<TimeOnly> IsAfter(this IValueSource<TimeOnly> valueSource,
-        TimeOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        TimeOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TimeOnly, TimeOnly>(default,
                 (value, _, _) => { return value > expected; },
@@ -32,7 +32,7 @@ public static class TimeOnlyIsExtensions
     }
 
     public static InvokableValueAssertionBuilder<TimeOnly> IsAfterOrEqualTo(this IValueSource<TimeOnly> valueSource,
-        TimeOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        TimeOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TimeOnly, TimeOnly>(default,
                 (value, _, _) => { return value >= expected; },
@@ -43,7 +43,7 @@ public static class TimeOnlyIsExtensions
     }
 
     public static InvokableValueAssertionBuilder<TimeOnly> IsBefore(this IValueSource<TimeOnly> valueSource,
-        TimeOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        TimeOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TimeOnly, TimeOnly>(default,
                 (value, _, _) => { return value < expected; },
@@ -54,7 +54,7 @@ public static class TimeOnlyIsExtensions
     }
 
     public static InvokableValueAssertionBuilder<TimeOnly> IsBeforeOrEqualTo(this IValueSource<TimeOnly> valueSource,
-        TimeOnly expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        TimeOnly expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TimeOnly, TimeOnly>(default,
                 (value, _, _) => { return value <= expected; },

--- a/TUnit.Assertions/Assertions/Chronology/TimeSpanIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Chronology/TimeSpanIsExtensions.cs
@@ -11,7 +11,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class TimeSpanIsExtensions
 {
-    public static TimeSpanEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<TimeSpan> valueSource, TimeSpan expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static TimeSpanEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<TimeSpan> valueSource, TimeSpan expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return new TimeSpanEqualToAssertionBuilderWrapper(
             valueSource.RegisterAssertion(new TimeSpanEqualsExpectedValueAssertCondition(expected),

--- a/TUnit.Assertions/Assertions/ClassMembers/Conditions/Member.cs
+++ b/TUnit.Assertions/Assertions/ClassMembers/Conditions/Member.cs
@@ -8,13 +8,13 @@ namespace TUnit.Assertions.AssertConditions.ClassMember;
 
 public class Member<TActualRootType, TPropertyType>(IValueSource<TActualRootType> valueSource, Expression<Func<TActualRootType, TPropertyType>> selector)
 {
-    public InvokableValueAssertionBuilder<TActualRootType> EqualTo(TPropertyType expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActualRootType> EqualTo(TPropertyType expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new PropertyEqualsExpectedValueAssertCondition<TActualRootType, TPropertyType>(selector, expected, true)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<TActualRootType> NotEqualTo(TPropertyType expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActualRootType> NotEqualTo(TPropertyType expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new PropertyEqualsExpectedValueAssertCondition<TActualRootType, TPropertyType>(selector, expected, false)
             , [doNotPopulateThisValue]);

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
@@ -10,7 +10,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class CollectionsIsExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsEquivalentCollectionTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsEquivalentCollectionTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
@@ -10,7 +10,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class CollectionsIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Collections/DoesExtensions_Dictionary.cs
+++ b/TUnit.Assertions/Assertions/Collections/DoesExtensions_Dictionary.cs
@@ -10,7 +10,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesExtensions
 {
-    public static InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TKey>(expected,
@@ -24,7 +24,7 @@ public static partial class DoesExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TDictionary> ContainsValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> ContainsValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TValue>(expected,

--- a/TUnit.Assertions/Assertions/Collections/DoesNotExtensions_Dictionary.cs
+++ b/TUnit.Assertions/Assertions/Collections/DoesNotExtensions_Dictionary.cs
@@ -10,7 +10,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainKey<TDictionary, TKey>(this IValueSource<TDictionary> valueSource, TKey expected, IEqualityComparer<TKey> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TKey>(expected,
@@ -24,7 +24,7 @@ public static partial class DoesNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TDictionary> DoesNotContainValue<TDictionary, TValue>(this IValueSource<TDictionary> valueSource, TValue expected, IEqualityComparer<TValue> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TDictionary : IDictionary
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TDictionary, TValue>(expected,

--- a/TUnit.Assertions/Assertions/Collections/HasExtensions_Exception.cs
+++ b/TUnit.Assertions/Assertions/Collections/HasExtensions_Exception.cs
@@ -10,51 +10,51 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class HasExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> HasMessageEqualTo<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageEqualTo<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") where TActual : Exception
     {
         return HasMessageEqualTo(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
 
-    public static InvokableValueAssertionBuilder<TActual> HasMessageEqualTo<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageEqualTo<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "") where TActual : Exception
     {
         return valueSource.RegisterAssertion(new ExceptionMessageEqualsExpectedValueAssertCondition<TActual>(expected, stringComparison), 
             [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> HasMessageContaining<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageContaining<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") where TActual : Exception
     {
         return HasMessageContaining(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
 
-    public static InvokableValueAssertionBuilder<TActual> HasMessageContaining<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageContaining<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "") where TActual : Exception
     {
         return valueSource.RegisterAssertion(new ExceptionMessageContainingExpectedValueAssertCondition<TActual>(expected, stringComparison), 
             [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> HasMessageStartingWith<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageStartingWith<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") where TActual : Exception
     {
         return HasMessageStartingWith(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
 
-    public static InvokableValueAssertionBuilder<TActual> HasMessageStartingWith<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageStartingWith<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "") where TActual : Exception
     {
         return valueSource.RegisterAssertion(new ExceptionMessageStartingWithExpectedValueAssertCondition<TActual>(expected, stringComparison), 
             [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> HasMessageEndingWith<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageEndingWith<TActual>(this IValueSource<TActual> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") where TActual : Exception
     {
         return HasMessageEndingWith(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
 
-    public static InvokableValueAssertionBuilder<TActual> HasMessageEndingWith<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageEndingWith<TActual>(this IValueSource<TActual> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "") where TActual : Exception
     {
         return valueSource.RegisterAssertion(new ExceptionMessageEndingWithExpectedValueAssertCondition<TActual>(expected, stringComparison), 
             [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> HasMessageMatching<TActual>(this IValueSource<TActual> valueSource, StringMatcher expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "") where TActual : Exception
+    public static InvokableValueAssertionBuilder<TActual> HasMessageMatching<TActual>(this IValueSource<TActual> valueSource, StringMatcher expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "") where TActual : Exception
     {
         return valueSource.RegisterAssertion(new ExceptionMessageMatchingExpectedAssertCondition<TActual>(expected), 
             [doNotPopulateThisValue1, doNotPopulateThisValue2]);

--- a/TUnit.Assertions/Assertions/Collections/HasExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Collections/HasExtensions_Generic.cs
@@ -7,7 +7,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class HasExtensions
 {
-    public static Member<TRootObject, TPropertyType> HasMember<TRootObject, TPropertyType>(this IValueSource<TRootObject> valueSource, Expression<Func<TRootObject, TPropertyType>> selector, [CallerArgumentExpression("selector")] string expression = "")
+    public static Member<TRootObject, TPropertyType> HasMember<TRootObject, TPropertyType>(this IValueSource<TRootObject> valueSource, Expression<Func<TRootObject, TPropertyType>> selector, [CallerArgumentExpression(nameof(selector))] string expression = "")
     {
         valueSource.AssertionBuilder.AppendCallerMethod([expression]);
         return new(valueSource, selector);

--- a/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
@@ -11,7 +11,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class ComparableIsExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -22,7 +22,7 @@ public static class ComparableIsExtensions
             $"to be greater than {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -33,7 +33,7 @@ public static class ComparableIsExtensions
             $"be greater than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -44,7 +44,7 @@ public static class ComparableIsExtensions
             $"be less than {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -55,7 +55,7 @@ public static class ComparableIsExtensions
             $"be less than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static BetweenAssertionBuilderWrapper<TActual> IsBetween<TActual>(this IValueSource<TActual> valueSource, TActual lowerBound, TActual upperBound, [CallerArgumentExpression("lowerBound")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("upperBound")] string doNotPopulateThisValue2 = "")
+    public static BetweenAssertionBuilderWrapper<TActual> IsBetween<TActual>(this IValueSource<TActual> valueSource, TActual lowerBound, TActual upperBound, [CallerArgumentExpression(nameof(lowerBound))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(upperBound))] string doNotPopulateThisValue2 = "")
         where TActual : IComparable<TActual>
     {
         var assertionBuilder = valueSource.RegisterAssertion(new BetweenAssertCondition<TActual>(lowerBound, upperBound)

--- a/TUnit.Assertions/Assertions/Comparables/ComparableIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Comparables/ComparableIsNotExtensions.cs
@@ -11,7 +11,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class ComparableIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -22,7 +22,7 @@ public static class ComparableIsNotExtensions
             $"to not be greater than {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -33,7 +33,7 @@ public static class ComparableIsNotExtensions
             $"to not be greater than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -44,7 +44,7 @@ public static class ComparableIsNotExtensions
             $"to not be less than {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : IComparable<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, _) =>
@@ -55,7 +55,7 @@ public static class ComparableIsNotExtensions
             $"to not be less than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
-    public static NotBetweenAssertionBuilderWrapper<TActual> IsNotBetween<TActual>(this IValueSource<TActual> valueSource, TActual lowerBound, TActual upperBound, [CallerArgumentExpression("lowerBound")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("upperBound")] string doNotPopulateThisValue2 = "")
+    public static NotBetweenAssertionBuilderWrapper<TActual> IsNotBetween<TActual>(this IValueSource<TActual> valueSource, TActual lowerBound, TActual upperBound, [CallerArgumentExpression(nameof(lowerBound))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(upperBound))] string doNotPopulateThisValue2 = "")
         where TActual : IComparable<TActual>
     {
         var assertionBuilder = valueSource.RegisterAssertion(new NotBetweenAssertCondition<TActual>(lowerBound, upperBound)

--- a/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
@@ -9,7 +9,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableContainsExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Generics/DoesNotExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesNotExtensions_Generic.cs
@@ -7,7 +7,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> DoesNotContain<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner?>? equalityComparer = null, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> DoesNotContain<TActual, TInner>(this IValueSource<TActual> valueSource, TInner expected, IEqualityComparer<TInner?>? equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(new EnumerableNotContainsExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)

--- a/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class GenericIsExtensions
 {
-    public static GenericEqualToAssertionBuilderWrapper<TActual> IsEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static GenericEqualToAssertionBuilderWrapper<TActual> IsEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         var assertionBuilder = valueSource
             .RegisterAssertion(new EqualsExpectedValueAssertCondition<TActual>(expected), [doNotPopulateThisValue1]);
@@ -20,13 +20,13 @@ public static class GenericIsExtensions
         return new GenericEqualToAssertionBuilderWrapper<TActual>(assertionBuilder);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static InvokableValueAssertionBuilder<TActual> IsEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return valueSource
             .RegisterAssertion(new EqualsExpectedValueAssertCondition<TActual>(expected), [doNotPopulateThisValue1]);
     }
     
-    public static EquivalentToAssertionBuilderWrapper<TActual> IsEquivalentTo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static EquivalentToAssertionBuilderWrapper<TActual> IsEquivalentTo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         var assertionBuilder = valueSource.RegisterAssertion(new EquivalentToExpectedValueAssertCondition<TActual>(expected, doNotPopulateThisValue1)
             , [doNotPopulateThisValue1]);
@@ -34,7 +34,7 @@ public static class GenericIsExtensions
         return new EquivalentToAssertionBuilderWrapper<TActual>(assertionBuilder);
     }
     
-    public static InvokableValueAssertionBuilder<object> IsSameReference(this IValueSource<object> valueSource, object expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static InvokableValueAssertionBuilder<object> IsSameReference(this IValueSource<object> valueSource, object expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return valueSource.RegisterAssertion(new SameReferenceExpectedValueAssertCondition<object, object>(expected)
             , [doNotPopulateThisValue1]);

--- a/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
@@ -11,7 +11,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class GenericIsNotExtensions
 {
-    public static GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
     {
         var assertionBuilder = valueSource.RegisterAssertion(new NotEqualsExpectedValueAssertCondition<TActual>(expected)
             , [doNotPopulateThisValue]);
@@ -25,7 +25,7 @@ public static class GenericIsNotExtensions
             , []);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new NotEqualsExpectedValueAssertCondition<TActual>(expected)
             , [doNotPopulateThisValue]);

--- a/TUnit.Assertions/Assertions/Generics/GenericSatisfiesExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericSatisfiesExtensions.cs
@@ -10,8 +10,8 @@ public static class GenericSatisfiesExtensions
     public static InvokableValueAssertionBuilder<TActual> Satisfies<TActual, TExpected>(
         this IValueSource<TActual> valueSource, Func<TActual, TExpected> mapper,
         Func<IValueSource<TExpected?>, InvokableAssertionBuilder<TExpected?>> assert,
-        [CallerArgumentExpression("mapper")] string mapperExpression = "", 
-        [CallerArgumentExpression("assert")] string assertionBuilderExpression = "")
+        [CallerArgumentExpression(nameof(mapper))] string mapperExpression = "", 
+        [CallerArgumentExpression(nameof(assert))] string assertionBuilderExpression = "")
     {
         return valueSource.RegisterAssertion(new SatisfiesAssertCondition<TActual, TExpected>(t => Task.FromResult(mapper(t)), assert, mapperExpression, assertionBuilderExpression),
             [mapperExpression, assertionBuilderExpression]);
@@ -20,8 +20,8 @@ public static class GenericSatisfiesExtensions
     public static InvokableValueAssertionBuilder<TActual> Satisfies<TActual, TExpected>(
         this IValueSource<TActual> valueSource, Func<TActual, Task<TExpected>?> asyncMapper,
         Func<IValueSource<TExpected?>, InvokableAssertionBuilder<TExpected?>> assert,
-        [CallerArgumentExpression("asyncMapper")] string mapperExpression = "", 
-        [CallerArgumentExpression("assert")] string assertionBuilderExpression = "")
+        [CallerArgumentExpression(nameof(asyncMapper))] string mapperExpression = "", 
+        [CallerArgumentExpression(nameof(assert))] string assertionBuilderExpression = "")
     {
         return valueSource.RegisterAssertion(new SatisfiesAssertCondition<TActual, TExpected>(asyncMapper, assert, mapperExpression, assertionBuilderExpression),
             [mapperExpression, assertionBuilderExpression]);

--- a/TUnit.Assertions/Assertions/Numbers/NumberIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Numbers/NumberIsExtensions.cs
@@ -13,7 +13,7 @@ namespace TUnit.Assertions.Extensions;
 public static class NumberIsExtensions
 {
     public static GenericEqualToAssertionBuilderWrapper<TActual> Within<TActual>(
-        this GenericEqualToAssertionBuilderWrapper<TActual> assertionBuilder, TActual tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+        this GenericEqualToAssertionBuilderWrapper<TActual> assertionBuilder, TActual tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
         where TActual : INumber<TActual>
     {
         var assertion = (EqualsExpectedValueAssertCondition<TActual>) assertionBuilder.Assertions.Peek();
@@ -42,7 +42,7 @@ public static class NumberIsExtensions
     }
     
     public static InvokableValueAssertionBuilder<TActual> IsDivisibleBy<TActual>(
-        this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : INumber<TActual>, IModulusOperators<TActual, TActual, TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>

--- a/TUnit.Assertions/Assertions/Numbers/NumberIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Numbers/NumberIsNotExtensions.cs
@@ -13,7 +13,7 @@ namespace TUnit.Assertions.Extensions;
 public static class NumberIsNotExtensions
 {
     public static GenericNotEqualToAssertionBuilderWrapper<TActual> Within<TActual>(
-        this GenericNotEqualToAssertionBuilderWrapper<TActual> assertionBuilder, TActual tolerance, [CallerArgumentExpression("tolerance")] string doNotPopulateThis = "")
+        this GenericNotEqualToAssertionBuilderWrapper<TActual> assertionBuilder, TActual tolerance, [CallerArgumentExpression(nameof(tolerance))] string doNotPopulateThis = "")
         where TActual : INumber<TActual>
     {
         var assertion = (NotEqualsExpectedValueAssertCondition<TActual>) assertionBuilder.Assertions.Peek();
@@ -41,7 +41,7 @@ public static class NumberIsNotExtensions
     }
     
     public static InvokableValueAssertionBuilder<TActual> IsNotDivisibleBy<TActual>(
-        this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+        this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
         where TActual : INumber<TActual>, IModulusOperators<TActual, TActual, TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>
@@ -59,7 +59,7 @@ public static class NumberIsNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") where TActual : INumber<TActual>
+    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") where TActual : INumber<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>
             {
@@ -76,7 +76,7 @@ public static class NumberIsNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotGreaterThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : INumber<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>
@@ -94,7 +94,7 @@ public static class NumberIsNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotLessThan<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : INumber<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>
@@ -112,7 +112,7 @@ public static class NumberIsNotExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "") 
+    public static InvokableValueAssertionBuilder<TActual> IsNotLessThanOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "") 
         where TActual : INumber<TActual>
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, TActual>(default, (value, _, self) =>

--- a/TUnit.Assertions/Assertions/Strings/DoesExtensions_String.cs
+++ b/TUnit.Assertions/Assertions/Strings/DoesExtensions_String.cs
@@ -12,12 +12,12 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesExtensions
 {
-    public static StringContainsAssertionBuilderWrapper Contains(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static StringContainsAssertionBuilderWrapper Contains(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return Contains(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
     
-    public static StringContainsAssertionBuilderWrapper Contains(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static StringContainsAssertionBuilderWrapper Contains(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         var assertionBuilder = valueSource.RegisterAssertion(new StringContainsExpectedValueAssertCondition(expected, stringComparison)
             , [doNotPopulateThisValue1, doNotPopulateThisValue2]);
@@ -25,12 +25,12 @@ public static partial class DoesExtensions
         return new StringContainsAssertionBuilderWrapper(assertionBuilder);
     }
     
-    public static InvokableValueAssertionBuilder<string> StartsWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> StartsWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return StartsWith(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
     
-    public static InvokableValueAssertionBuilder<string> StartsWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> StartsWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, string>(expected,
             (actual, _, self) =>
@@ -49,12 +49,12 @@ public static partial class DoesExtensions
     }
     
         
-    public static InvokableValueAssertionBuilder<string> EndsWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> EndsWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return EndsWith(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
     
-    public static InvokableValueAssertionBuilder<string> EndsWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> EndsWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, string>(expected,
             (actual, _, _) =>
@@ -67,12 +67,12 @@ public static partial class DoesExtensions
             , [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<string> Matches(this IValueSource<string> valueSource, string regex, [CallerArgumentExpression("regex")] string expression = "")
+    public static InvokableValueAssertionBuilder<string> Matches(this IValueSource<string> valueSource, string regex, [CallerArgumentExpression(nameof(regex))] string expression = "")
     {
         return Matches(valueSource, new Regex(regex), expression);
     }
     
-    public static InvokableValueAssertionBuilder<string> Matches(this IValueSource<string> valueSource, Regex regex, [CallerArgumentExpression("regex")] string expression = "")
+    public static InvokableValueAssertionBuilder<string> Matches(this IValueSource<string> valueSource, Regex regex, [CallerArgumentExpression(nameof(regex))] string expression = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, Regex>(regex,
             (actual, _, _) =>

--- a/TUnit.Assertions/Assertions/Strings/DoesNotExtensions_String.cs
+++ b/TUnit.Assertions/Assertions/Strings/DoesNotExtensions_String.cs
@@ -10,23 +10,23 @@ namespace TUnit.Assertions.Extensions;
 
 public static partial class DoesNotExtensions
 {
-    public static InvokableValueAssertionBuilder<string> DoesNotContain(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotContain(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return DoesNotContain(valueSource, expected, StringComparison.Ordinal);
     }
     
-    public static InvokableValueAssertionBuilder<string> DoesNotContain(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotContain(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new StringNotContainsExpectedValueAssertCondition(expected, stringComparison)
             , [doNotPopulateThisValue1, doNotPopulateThisValue2]);
     }
     
-    public static InvokableValueAssertionBuilder<string> DoesNotStartWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotStartWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return DoesNotStartWith(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
     
-    public static InvokableValueAssertionBuilder<string> DoesNotStartWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotStartWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, string>(expected,
             (actual, _, _) =>
@@ -40,12 +40,12 @@ public static partial class DoesNotExtensions
     }
     
         
-    public static InvokableValueAssertionBuilder<string> DoesNotEndWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotEndWith(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return DoesNotEndWith(valueSource, expected, StringComparison.Ordinal);
     }
     
-    public static InvokableValueAssertionBuilder<string> DoesNotEndWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> DoesNotEndWith(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, string>(expected,
             (actual, _, _) =>

--- a/TUnit.Assertions/Assertions/Strings/StringIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Strings/StringIsExtensions.cs
@@ -11,12 +11,12 @@ namespace TUnit.Assertions.Extensions;
 
 public static class StringIsExtensions
 {
-    public static StringEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "")
+    public static StringEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "")
     {
         return IsEqualTo(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue1, null);
     }
     
-    public static StringEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static StringEqualToAssertionBuilderWrapper IsEqualTo(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         var assertionBuilder = valueSource.RegisterAssertion(new StringEqualsExpectedValueAssertCondition(expected, stringComparison)
             , [doNotPopulateThisValue1, doNotPopulateThisValue2]);

--- a/TUnit.Assertions/Assertions/Strings/StringIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Strings/StringIsNotExtensions.cs
@@ -10,12 +10,12 @@ namespace TUnit.Assertions.Extensions;
 
 public static class StringIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<string> IsNotEqualTo(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public static InvokableValueAssertionBuilder<string> IsNotEqualTo(this IValueSource<string> valueSource, string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return IsNotEqualTo(valueSource, expected, StringComparison.Ordinal, doNotPopulateThisValue);
     }
     
-    public static InvokableValueAssertionBuilder<string> IsNotEqualTo(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+    public static InvokableValueAssertionBuilder<string> IsNotEqualTo(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(new StringNotEqualsExpectedValueAssertCondition(expected, stringComparison)
             , [doNotPopulateThisValue1, doNotPopulateThisValue2]);

--- a/TUnit.Assertions/Assertions/Throws/ThrowsException.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsException.cs
@@ -24,14 +24,14 @@ public class ThrowsException<TActual, TException> where TException : Exception
         delegateAssertionBuilder.AppendExpression(callerMemberName);
     }
 
-    public ThrowsException<TActual, TException> WithMessageMatching(StringMatcher match, [CallerArgumentExpression("match")] string doNotPopulateThisValue = "")
+    public ThrowsException<TActual, TException> WithMessageMatching(StringMatcher match, [CallerArgumentExpression(nameof(match))] string doNotPopulateThisValue = "")
     {
         _source.RegisterAssertion(new ThrowsWithMessageMatchingAssertCondition<TActual, TException>(match, _selector)
             , [doNotPopulateThisValue]);
         return this;
     }
 
-    public ThrowsException<TActual, TException> WithMessage(string expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public ThrowsException<TActual, TException> WithMessage(string expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         _source.RegisterAssertion(new ThrowsWithMessageAssertCondition<TActual, TException>(expected, StringComparison.Ordinal, _selector)
             , [doNotPopulateThisValue]);

--- a/TUnit.Assertions/Extensions/EnumerableCount.cs
+++ b/TUnit.Assertions/Extensions/EnumerableCount.cs
@@ -11,7 +11,7 @@ public class EnumerableCount<TActual>(IValueSource<TActual> valueSource)
 {
     protected internal AssertionBuilder<TActual> AssertionBuilder { get; } = valueSource.AssertionBuilder.AppendExpression("HasCount");
 
-    public InvokableValueAssertionBuilder<TActual> EqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActual> EqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, int>(expected, (enumerable, _, self) =>
             {
@@ -45,7 +45,7 @@ public class EnumerableCount<TActual>(IValueSource<TActual> valueSource)
                 $"to be empty")
         , []);
     
-    public InvokableValueAssertionBuilder<TActual> GreaterThan(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActual> GreaterThan(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, int>(expected,
             (enumerable, _, self) =>
@@ -64,7 +64,7 @@ public class EnumerableCount<TActual>(IValueSource<TActual> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<TActual> GreaterThanOrEqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActual> GreaterThanOrEqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, int>(expected, (enumerable, _, self) =>
             {
@@ -82,7 +82,7 @@ public class EnumerableCount<TActual>(IValueSource<TActual> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<TActual> LessThan(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActual> LessThan(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, int>(expected, (enumerable, _, self) =>
             {
@@ -100,7 +100,7 @@ public class EnumerableCount<TActual>(IValueSource<TActual> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<TActual> LessThanOrEqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<TActual> LessThanOrEqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<TActual, int>(expected, (enumerable, _, self) =>
             {

--- a/TUnit.Assertions/Extensions/StringLength.cs
+++ b/TUnit.Assertions/Extensions/StringLength.cs
@@ -9,7 +9,7 @@ public class StringLength(IValueSource<string> valueSource)
 {
     protected AssertionBuilder<string> AssertionBuilder { get; } = valueSource.AssertionBuilder.AppendExpression("HasLength");
 
-    public InvokableValueAssertionBuilder<string> EqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<string> EqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, int>(expected, (actual, _, self) =>
             {
@@ -60,7 +60,7 @@ public class StringLength(IValueSource<string> valueSource)
             $"have a positive string length"), []);
 
 
-    public InvokableValueAssertionBuilder<string> GreaterThan(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<string> GreaterThan(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, int>(expected,
             (@string, _, self) =>
@@ -79,7 +79,7 @@ public class StringLength(IValueSource<string> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<string> GreaterThanOrEqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<string> GreaterThanOrEqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, int>(expected, (@string, _, self) =>
             {
@@ -97,7 +97,7 @@ public class StringLength(IValueSource<string> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<string> LessThan(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<string> LessThan(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, int>(expected, (@string, _, self) =>
             {
@@ -115,7 +115,7 @@ public class StringLength(IValueSource<string> valueSource)
             , [doNotPopulateThisValue]);
     }
 
-    public InvokableValueAssertionBuilder<string> LessThanOrEqualTo(int expected, [CallerArgumentExpression("expected")] string doNotPopulateThisValue = "")
+    public InvokableValueAssertionBuilder<string> LessThanOrEqualTo(int expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = "")
     {
         return valueSource.RegisterAssertion(new FuncValueAssertCondition<string, int>(expected, (@string, _, self) =>
             {

--- a/TUnit.Assertions/Warn.cs
+++ b/TUnit.Assertions/Warn.cs
@@ -8,27 +8,27 @@ namespace TUnit.Assertions;
 
 internal static class Warn
 {
-    public static ValueAssertionBuilder<TActual> Unless<TActual>(TActual value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "") 
+    public static ValueAssertionBuilder<TActual> Unless<TActual>(TActual value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "") 
     {
         return new ValueAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
     
-    public static DelegateAssertionBuilder Unless(Action value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static DelegateAssertionBuilder Unless(Action value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new DelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
     
-    public static ValueDelegateAssertionBuilder<TActual> Unless<TActual>(Func<TActual> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static ValueDelegateAssertionBuilder<TActual> Unless<TActual>(Func<TActual> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new ValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
     
-    public static AsyncDelegateAssertionBuilder Unless(Func<Task> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncDelegateAssertionBuilder Unless(Func<Task> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncDelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
     
-    public static AsyncValueDelegateAssertionBuilder<TActual> Unless<TActual>(Func<Task<TActual>> value, [CallerArgumentExpression("value")] string doNotPopulateThisValue = "")
+    public static AsyncValueDelegateAssertionBuilder<TActual> Unless<TActual>(Func<Task<TActual>> value, [CallerArgumentExpression(nameof(value))] string doNotPopulateThisValue = "")
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
@@ -45,10 +45,10 @@ internal static class Warn
     }
 
     public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {
@@ -69,10 +69,10 @@ internal static class Warn
     }
 
     public static Exception ThrowsAsync(Action @delegate,
-        [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static TException ThrowsAsync<TException>(Action @delegate, [CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) where TException : Exception
+    public static TException ThrowsAsync<TException>(Action @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {

--- a/TUnit.Assertions/Warn.cs
+++ b/TUnit.Assertions/Warn.cs
@@ -45,10 +45,10 @@ internal static class Warn
     }
 
     public static Task<Exception> ThrowsAsync(Func<Task> @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+    public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {
@@ -69,10 +69,10 @@ internal static class Warn
     }
 
     public static Exception ThrowsAsync(Action @delegate,
-        [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync<Exception>(@delegate, doNotPopulateThisValue);
     
-    public static TException ThrowsAsync<TException>(Action @delegate, [CallerArgumentExpression(nameof(delegate))] string? doNotPopulateThisValue = null) where TException : Exception
+    public static TException ThrowsAsync<TException>(Action @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
         try
         {

--- a/TUnit.Pipeline/Modules/Tests/TestModule.cs
+++ b/TUnit.Pipeline/Modules/Tests/TestModule.cs
@@ -27,14 +27,14 @@ public abstract class TestModule : Module<TestResult>
     protected Task<TestResult?> RunTestsWithFilter(IPipelineContext context, string filter,
         List<Action<TestResult>> assertions,
         CancellationToken cancellationToken = default,
-        [CallerArgumentExpression("assertions")] string assertionExpression = "")
+        [CallerArgumentExpression(nameof(assertions))] string assertionExpression = "")
     {
         return RunTestsWithFilter(context, filter, assertions, new RunOptions(), cancellationToken, assertionExpression);
     }
 
     protected async Task<TestResult?> RunTestsWithFilter(IPipelineContext context, string filter,
         List<Action<TestResult>> assertions, RunOptions runOptions, CancellationToken cancellationToken = default,
-        [CallerArgumentExpression("assertions")] string assertionExpression = "")
+        [CallerArgumentExpression(nameof(assertions))] string assertionExpression = "")
     {
         await SubModule("WithoutAot", async () =>
         {

--- a/docs/docs/tutorial-assertions/extensibility.md
+++ b/docs/docs/tutorial-assertions/extensibility.md
@@ -75,7 +75,7 @@ In your assertion class, that'd be set up like:
 Here's a fully fledged assertion in action:
 
 ```csharp
-public static InvokableValueAssertionBuilder<string> Contains(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = "", [CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = "")
+public static InvokableValueAssertionBuilder<string> Contains(this IValueSource<string> valueSource, string expected, StringComparison stringComparison, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = "", [CallerArgumentExpression(nameof(stringComparison))] string doNotPopulateThisValue2 = "")
     {
         return valueSource.RegisterAssertion(
             assertCondition: new StringEqualsAssertCondition(expected, stringComparison),


### PR DESCRIPTION
use `nameof` for `CallerArgumentExpression`