### PR TITLE
Added ReferenceHandler.Preserve to avoid cyclic exceptions outputting…

### DIFF
--- a/TUnit.RpcTests/RpcJsonSerializerOptions.cs
+++ b/TUnit.RpcTests/RpcJsonSerializerOptions.cs
@@ -12,6 +12,7 @@ public static class RpcJsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,
+            ReferenceHandler = ReferenceHandler.Preserve,
         };
     }
 }


### PR DESCRIPTION
Some Exceptions are cyclic, when this occurs and the test fails, the test handler appears to dump the exceptions endlessly (in a loop) to the console.

* https://github.com/thomhurst/TUnit/issues/1018

It didn't seem appropriate to create tests given there are no tests currently specifically for serialization, it is only tested by proxy in the RPC tests.