### PR TITLE
Use WriteLine when constructing new test class

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/Writers/NewClassWriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Writers/NewClassWriter.cs
@@ -15,7 +15,7 @@ internal static class NewClassWriter
         
         sourceCodeWriter.WriteLine($"var resettableClassFactoryDelegate = () => new ResettableLazy<{typeName}>(() => ");
 
-        sourceCodeWriter.Write($"new {typeName}({argumentsContainer.DataVariables.Select(x => x.Name).ToCommaSeparatedString()})");
+        sourceCodeWriter.WriteLine($"new {typeName}({argumentsContainer.DataVariables.Select(x => x.Name).ToCommaSeparatedString()})");
 
         classPropertiesContainer.WriteObjectInitializer(sourceCodeWriter);
         

--- a/TUnit.Core.SourceGenerator/SourceCodeWriter.cs
+++ b/TUnit.Core.SourceGenerator/SourceCodeWriter.cs
@@ -43,11 +43,6 @@ internal class SourceCodeWriter : IDisposable
         }
     }
 
-    public void Write(string value)
-    {
-        _stringBuilder.Append(value);
-    }
-
     public override string ToString()
     {
         return _stringBuilder.ToString();


### PR DESCRIPTION
Improves indentation in generated source code a little bit.

Before
```cs
					var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.PropertySetterTests>(() => 
new global::TUnit.TestProject.PropertySetterTests()					{
						Property1 = propertyArg,
						Property2 = propertyArg1,
						Property3 = propertyArg2,
						Property4 = propertyArg3,
						Property5 = propertyArg4,
						Property6 = propertyArg5,
					}
					);
```

After
```cs
					var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.PropertySetterTests>(() => 
					new global::TUnit.TestProject.PropertySetterTests()
					{
						Property1 = propertyArg,
						Property2 = propertyArg1,
						Property3 = propertyArg2,
						Property4 = propertyArg3,
						Property5 = propertyArg4,
						Property6 = propertyArg5,
					}
					);
```