### PR TITLE
Avoid an array/list allocation in TestsGenerator CollectTests

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/TestsGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/TestsGenerator.cs
@@ -94,6 +94,7 @@ internal class TestsGenerator : IIncrementalGenerator
                      .GroupBy(x => $"{prefix}{x.ClassNameToGenerate}_{Guid.NewGuid():N}"))
         {
             var className = classGrouping.Key;
+            var count = classGrouping.Count();
 
             using var sourceBuilder = new SourceCodeWriter();
 
@@ -117,13 +118,20 @@ internal class TestsGenerator : IIncrementalGenerator
 
             sourceBuilder.WriteLine("public global::System.Collections.Generic.IReadOnlyList<SourceGeneratedTestNode> CollectTests()");
             sourceBuilder.WriteLine("{");
-            sourceBuilder.WriteLine("return");
-            sourceBuilder.WriteLine("[");
-            for (var i = 0; i < classGrouping.Count(); i++)
+            if (count == 1)
             {
-                sourceBuilder.WriteLine($"..Tests{i}(),");
+                sourceBuilder.WriteLine("return Tests0();");
             }
-            sourceBuilder.WriteLine("];");
+            else
+            {
+                sourceBuilder.WriteLine("return");
+                sourceBuilder.WriteLine("[");
+                for (var i = 0; i < count; i++)
+                {
+                    sourceBuilder.WriteLine($"..Tests{i}(),");
+                }
+                sourceBuilder.WriteLine("];");
+            }
             sourceBuilder.WriteLine("}");
 
             var index = 0;


### PR DESCRIPTION
The first commit aligns the logic for `GetSemanticTargetForTestMethodGeneration` to `GetSemanticTargetForInheritedTestsGeneration`.

The second commit avoids an array/list allocation per `CollectTests` calls in the common case.
Since tests are now grouped individually
https://github.com/thomhurst/TUnit/blob/eb45709f7246fb1a54a22ee1ac00eb18091e2aa0/TUnit.Core.SourceGenerator/CodeGenerators/TestsGenerator.cs#L97
the common case is that there is just one `TestSourceDataModel` per file.
So we can just return the `Tests0` collection directly instead of creating another copy of the `SourceGeneratedTestNode` list.