### PR TITLE
Order tests ascending

### DIFF
--- a/TUnit.Engine/Services/TestGrouper.cs
+++ b/TUnit.Engine/Services/TestGrouper.cs
@@ -8,9 +8,9 @@ internal class TestGrouper
     public GroupedTests OrganiseTests(DiscoveredTest[] testCases)
     {
         var allTestsOrderedByClass = testCases
+            .OrderBy(x => x.TestDetails.Order)
             .GroupBy(x => x.TestDetails.ClassType)
             .SelectMany(x => x)
-            .OrderByDescending(x => x.TestDetails.Order)
             .ToList();
 
         var notInParallel = new Queue<DiscoveredTest>();

--- a/TUnit.Engine/Services/TestsExecutor.cs
+++ b/TUnit.Engine/Services/TestsExecutor.cs
@@ -71,7 +71,7 @@ internal class TestsExecutor
     private async Task ProcessGroup(ITestExecutionFilter? filter, ExecuteRequestContext context,
         IEnumerable<NotInParallelTestCase> tests)
     {
-        foreach (var test in tests.OrderBy(x => x.Test.TestDetails.Order))
+        foreach (var test in tests)
         {
             var keys = test.ConstraintKeys;
 


### PR DESCRIPTION
Tests are now always ordered ascending and grouped by class.

---

```c#
public class A
{
    [Test]
    [NotInParallel(Order = 1)]
    public async Task A1() { }

    [Test]
    [NotInParallel(Order = 2)]
    public async Task A2() { }

    [Test]
    [NotInParallel(Order = 3)]
    public async Task A3() { }
}
public class B
{
    [Test]
    [NotInParallel(Order = 1)]
    public async Task B1() { }

    [Test]
    [NotInParallel(Order = 2)]
    public async Task B2() { }

    [Test]
    [NotInParallel(Order = 3)]
    public async Task B3() { }
}
```
Would execute like this:

- A1
- A2
- A3
- B1
- B2
- B3

---

```c#
public class A
{
    [Test]
    [NotInParallel("shared", Order = 1)]
    public async Task A1() { }

    [Test]
    [NotInParallel("shared", Order = 2)]
    public async Task A2() { }

    [Test]
    [NotInParallel("shared", Order = 3)]
    public async Task A3() { }
}
public class B
{
    [Test]
    [NotInParallel("shared", Order = 1)]
    public async Task B1() { }

    [Test]
    [NotInParallel("shared", Order = 2)]
    public async Task B2() { }

    [Test]
    [NotInParallel("shared", Order = 3)]
    public async Task B3() { }
}
```
Would execute like this:

- A1
- A2
- A3
- B1
- B2
- B3

---

```c#
public class A
{
    [Test]
    [NotInParallel("a", Order = 1)]
    public async Task A1() { }

    [Test]
    [NotInParallel("a", Order = 2)]
    public async Task A2() { }

    [Test]
    [NotInParallel("a", Order = 3)]
    public async Task A3() { }
}
public class B
{
    [Test]
    [NotInParallel("b", Order = 1)]
    public async Task B1() { }

    [Test]
    [NotInParallel("b", Order = 2)]
    public async Task B2() { }

    [Test]
    [NotInParallel("b", Order = 3)]
    public async Task B3() { }
}
```

Would execute in parallel like this:

- A1
- B1
- A2
- B2
- A3
- B3

---

Fixes #1033