### PR TITLE
Only run After hooks if the Before hooks ran.

### DIFF
--- a/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
+++ b/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
@@ -18,8 +18,12 @@ internal class AssemblyHookOrchestrator(InstanceTracker instanceTracker, HooksCo
     private readonly GetOnlyDictionary<Assembly, Task> _before = new();
     private readonly GetOnlyDictionary<Assembly, Task> _after = new();
 
+    private readonly ConcurrentDictionary<Assembly, bool> _beforeHooksReached = new();
+
     public async Task ExecuteBeforeHooks(Assembly assembly)
     {
+        _beforeHooksReached.GetOrAdd(assembly, true);
+        
         await _before.GetOrAdd(assembly, async _ =>
             {
                 var context = GetContext(assembly);
@@ -58,9 +62,9 @@ internal class AssemblyHookOrchestrator(InstanceTracker instanceTracker, HooksCo
         {
             var context = GetContext(assembly);
             
-            if (context.AllTests.All(x => x.Result?.Status is Status.Skipped))
+            if (!_beforeHooksReached.TryGetValue(assembly, out var _))
             {
-                // We didn't actually execute these tests so nothing to clean up.
+                // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
                 return;
             }
             

--- a/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
+++ b/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
@@ -58,15 +58,15 @@ internal class AssemblyHookOrchestrator(InstanceTracker instanceTracker, HooksCo
            return;
         }
         
+        if (!_beforeHooksReached.TryGetValue(assembly, out var _))
+        {
+            // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
+            return;
+        }
+        
         await _after.GetOrAdd(assembly, async _ =>
         {
             var context = GetContext(assembly);
-            
-            if (!_beforeHooksReached.TryGetValue(assembly, out var _))
-            {
-                // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
-                return;
-            }
             
             AssemblyHookContext.Current = context;
             

--- a/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
+++ b/TUnit.Engine/Hooks/AssemblyHookOrchestrator.cs
@@ -58,7 +58,7 @@ internal class AssemblyHookOrchestrator(InstanceTracker instanceTracker, HooksCo
            return;
         }
         
-        if (!_beforeHooksReached.TryGetValue(assembly, out var _))
+        if (!_beforeHooksReached.TryGetValue(assembly, out _))
         {
             // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
             return;

--- a/TUnit.Engine/Hooks/ClassHookOrchestrator.cs
+++ b/TUnit.Engine/Hooks/ClassHookOrchestrator.cs
@@ -63,7 +63,7 @@ internal class ClassHookOrchestrator(InstanceTracker instanceTracker, HooksColle
            return;
         }
         
-        if (!_beforeHooksReached.TryGetValue(testClassType, out var _))
+        if (!_beforeHooksReached.TryGetValue(testClassType, out _))
         {
             // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
             return;

--- a/TUnit.Engine/Hooks/ClassHookOrchestrator.cs
+++ b/TUnit.Engine/Hooks/ClassHookOrchestrator.cs
@@ -63,15 +63,15 @@ internal class ClassHookOrchestrator(InstanceTracker instanceTracker, HooksColle
            return;
         }
         
+        if (!_beforeHooksReached.TryGetValue(testClassType, out var _))
+        {
+            // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
+            return;
+        }
+        
         await _after.GetOrAdd(testClassType, async _ =>
         {
             var context = GetContext(testClassType);
-
-            if (!_beforeHooksReached.TryGetValue(testClassType, out var _))
-            {
-                // The before hooks were never hit, meaning no tests were executed, so nothing to clean up.
-                return;
-            }
             
             ClassHookContext.Current = context;
 

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -87,7 +87,7 @@ internal class SingleTestExecutor(
                 
                 start = DateTimeOffset.Now;
                 
-                await ExecuteTest(test, context, testContext, cleanUpExceptions);
+                await ExecuteTest(test, testContext, cleanUpExceptions);
 
                 ExceptionsHelper.ThrowIfAny(cleanUpExceptions);
 
@@ -164,14 +164,14 @@ internal class SingleTestExecutor(
         }
     }
 
-    private async Task ExecuteTest(DiscoveredTest test, ExecuteRequestContext context, TestContext testContext,
+    private async Task ExecuteTest(DiscoveredTest test, TestContext testContext,
         List<Exception> cleanUpExceptions)
     {
         var start = DateTimeOffset.Now;
 
         try
         {
-            await ExecuteStaticBeforeHooks(test, context, testContext);
+            await ExecuteStaticBeforeHooks(test);
 
             TestContext.Current = testContext;
             
@@ -239,7 +239,7 @@ internal class SingleTestExecutor(
         }
     }
 
-    private async Task ExecuteStaticBeforeHooks(DiscoveredTest test, ExecuteRequestContext context, TestContext testContext)
+    private async Task ExecuteStaticBeforeHooks(DiscoveredTest test)
     {
         try
         {


### PR DESCRIPTION
@campersau Running only if we know the setups were run.