### PR TITLE
Dynamic Values in Assert.That

### DIFF
--- a/TUnit.Assertions.Analyzers.Tests/DynamicInAssertThatAnalyzerTests.cs
+++ b/TUnit.Assertions.Analyzers.Tests/DynamicInAssertThatAnalyzerTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+using Verifier = TUnit.Assertions.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<TUnit.Assertions.Analyzers.DynamicInAssertThatAnalyzer>;
+
+namespace TUnit.Assertions.Analyzers.Tests;
+
+public class DynamicInAssertThatAnalyzerTests
+{
+    [Test]
+    public async Task Assert_That_Is_Flagged_When_Using_Dynamic()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System.Threading.Tasks;
+                using TUnit.Assertions;
+                using TUnit.Assertions.Extensions;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    public async Task MyTest()
+                    {
+                        dynamic one = 1;
+                        await {|#0:Assert.That(one)|}.IsEqualTo(1);
+                    }
+                }
+                """,
+
+                Verifier.Diagnostic(Rules.DynamicValueInAssertThat)
+                    .WithLocation(0)
+            );
+    }
+    
+    [Test]
+    public async Task Assert_That_Is_Flagged_When_Using_Nullable_Dynamic()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                #nullable enable
+                using System.Threading.Tasks;
+                using TUnit.Assertions;
+                using TUnit.Assertions.Extensions;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    public async Task MyTest()
+                    {
+                        dynamic? one = null;
+                        await {|#0:Assert.That(one)|}.IsNull();
+                    }
+                }
+                """,
+
+                Verifier.Diagnostic(Rules.DynamicValueInAssertThat)
+                    .WithLocation(0)
+            );
+    }
+
+    [Test]
+    public async Task No_Error_When_Using_Casted_To_Object()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System;
+                using System.Threading.Tasks;
+                using TUnit.Assertions;
+                using TUnit.Assertions.Extensions;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                            
+                    public async Task MyTest()
+                    {
+                        dynamic one = 1;
+                        await Assert.That((object)one).IsEqualTo(1);
+                    }
+
+                }
+                """
+            );
+    }
+}

--- a/TUnit.Assertions.Analyzers/Resources.Designer.cs
+++ b/TUnit.Assertions.Analyzers/Resources.Designer.cs
@@ -238,5 +238,32 @@ namespace TUnit.Assertions.Analyzers {
                 return ResourceManager.GetString("TUnitAssertions0006Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cast dynamic values to `object?` when using Assert.That(...)..
+        /// </summary>
+        internal static string TUnitAssertions0007Description {
+            get {
+                return ResourceManager.GetString("TUnitAssertions0007Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cast dynamic values to `object?` when using Assert.That(...).
+        /// </summary>
+        internal static string TUnitAssertions0007MessageFormat {
+            get {
+                return ResourceManager.GetString("TUnitAssertions0007MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cast dynamic values to `object?` when using Assert.That(...).
+        /// </summary>
+        internal static string TUnitAssertions0007Title {
+            get {
+                return ResourceManager.GetString("TUnitAssertions0007Title", resourceCulture);
+            }
+        }
     }
 }

--- a/TUnit.Assertions.Analyzers/Resources.resx
+++ b/TUnit.Assertions.Analyzers/Resources.resx
@@ -78,4 +78,13 @@
     <data name="TUnitAssertions0006Title" xml:space="preserve">
         <value>Object `Equals` base method should not be called</value>
     </data>
+    <data name="TUnitAssertions0007Description" xml:space="preserve">
+        <value>Cast dynamic values to `object?` when using Assert.That(...).</value>
+    </data>
+    <data name="TUnitAssertions0007MessageFormat" xml:space="preserve">
+        <value>Cast dynamic values to `object?` when using Assert.That(...)</value>
+    </data>
+    <data name="TUnitAssertions0007Title" xml:space="preserve">
+        <value>Cast dynamic values to `object?` when using Assert.That(...)</value>
+    </data>
 </root>

--- a/TUnit.Assertions.Analyzers/Rules.cs
+++ b/TUnit.Assertions.Analyzers/Rules.cs
@@ -23,6 +23,9 @@ internal static class Rules
         
     public static readonly DiagnosticDescriptor ObjectEqualsBaseMethod =
         CreateDescriptor("TUnitAssertions0006", UsageCategory, DiagnosticSeverity.Error);
+    
+    public static readonly DiagnosticDescriptor DynamicValueInAssertThat =
+        CreateDescriptor("TUnitAssertions0007", UsageCategory, DiagnosticSeverity.Error);
 
 
     private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity)

--- a/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
@@ -9,6 +9,6 @@ public class DynamicAssertionTests
     public async Task Test1()
     {
         dynamic? foo = null;
-        await TUnitAssert.That(foo).IsNotNull();
+        await TUnitAssert.That((object?)foo).IsNotNull();
     }
 }

--- a/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
@@ -8,6 +8,6 @@ public class DynamicAssertionTests
     public async Task Test1()
     {
         dynamic? foo = null;
-        await TUnitAssert.That((object?)foo).IsNotNull();
+        await TUnitAssert.That((object?)foo).IsNull();
     }
 }

--- a/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
@@ -1,8 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.UnitTests;
 
-[SuppressMessage("Trimming", "IL2026:Members annotated with \'RequiresUnreferencedCodeAttribute\' require dynamic access otherwise can break functionality when trimming application code")]
 public class DynamicAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/DynamicAssertionTests.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace TUnit.Assertions.UnitTests;
+
+[SuppressMessage("Trimming", "IL2026:Members annotated with \'RequiresUnreferencedCodeAttribute\' require dynamic access otherwise can break functionality when trimming application code")]
+public class DynamicAssertionTests
+{
+    [Test]
+    public async Task Test1()
+    {
+        dynamic? foo = null;
+        await TUnitAssert.That(foo).IsNotNull();
+    }
+}

--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Dynamic;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertionBuilders;
 using TUnit.Assertions.Extensions;


### PR DESCRIPTION
Analyzer instructing users to cast dynamic values to an object if used inside `Assert.That(...)`