### PR TITLE
Reference System.Text.Json 8.0.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="Sourcy.Git" Version="0.0.66" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.20" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageVersion Include="trxparser" Version="0.5.0" />


### PR DESCRIPTION
The package dependency only shows up in the netstandard2.0 target framework anyway, and by referencing 9.0.0, even .NET 8 test projects were required to reference STJ 9 rather than the one that comes with the runtime.
Given tests should be testing the library in their natural environment, we should avoid forcing a test to update dependencies beyond what the library under test would naturally require.

Fixes #1460