### PR TITLE
Utilize dependabot to help keep dependencies current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: /
+  schedule:
+    interval: weekly
+  ignore:
+  - dependency-name: System.Text.Json # Should be updated with minimum .NET target version
+    update-types: ["version-update:semver-major"]


### PR DESCRIPTION
I include a special bit for System.Text.Json to prevent major version upgrades (while allowing minor updates) to be consistent with .NET Standard 2.0 target should avoid a System.Text.Json 9.0.0 dependency #1460, though I haven't included #1461 directly in this one so you can make the decisions regarding the PRs independently.