### PR TITLE
Add Assertions on Enumerables taking a Func matcher

### DIFF
--- a/TUnit.Assertions.Tests/EnumerableTests.cs
+++ b/TUnit.Assertions.Tests/EnumerableTests.cs
@@ -3,10 +3,56 @@
 public class EnumerableTests
 {
     [Test]
-    public async Task Test1()
+    public async Task Enumerable_Contains_Item_Good()
     {
         int[] array = [1, 2, 3];
 
         await Assert.That(array).Contains(1);
+    }
+    
+    [Test]
+    public async Task Enumerable_Contains_Item_Bad()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(
+                async () => await Assert.That(array).Contains(4)
+        ).Throws<AssertionException>();
+    }
+    
+    [Test]
+    public async Task Enumerable_Contains_Matcher_Good()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(array).Contains((int x) => x == 1);
+    }
+    
+    [Test]
+    public async Task Enumerable_Contains_Matcher_Bad()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(
+            async () => await Assert.That(array).Contains((int x) => x == 4)
+        ).Throws<AssertionException>();
+    }
+    
+    [Test]
+    public async Task Enumerable_ContainsOnly_Matcher_Good()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(array).ContainsOnly((int x) => x < 10);
+    }
+    
+    [Test]
+    public async Task Enumerable_ContainsOnly_Matcher_Bad()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(
+            async () => await Assert.That(array).ContainsOnly((int x) => x < 3)
+        ).Throws<AssertionException>();
     }
 }

--- a/TUnit.Assertions.Tests/EnumerableTests.cs
+++ b/TUnit.Assertions.Tests/EnumerableTests.cs
@@ -55,4 +55,40 @@ public class EnumerableTests
             async () => await Assert.That(array).ContainsOnly((int x) => x < 3)
         ).Throws<AssertionException>();
     }
+    
+    [Test]
+    public async Task Enumerable_DoesNotContain_Item_Good()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(array).DoesNotContain(5);
+    }
+    
+    [Test]
+    public async Task Enumerable_DoesNotContain_Item_Bad()
+    {
+        int[] array = [1, 2, 3];
+        
+        await Assert.That(
+            async () => await Assert.That(array).DoesNotContain(3)
+        ).Throws<AssertionException>();
+    }
+    
+    [Test]
+    public async Task Enumerable_DoesNotContain_Matcher_Good()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(array).DoesNotContain((int x) => x > 10);
+    }
+    
+    [Test]
+    public async Task Enumerable_DoesNotContain_Matcher_Bad()
+    {
+        int[] array = [1, 2, 3];
+
+        await Assert.That(
+            async () => await Assert.That(array).DoesNotContain((int x) => x < 3)
+        ).Throws<AssertionException>();
+    }
 }

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
@@ -1,0 +1,21 @@
+﻿namespace TUnit.Assertions.AssertConditions.Collections;
+
+public class EnumerableAllExpectedFuncAssertCondition<TActual, TInner>(
+    Func<TInner, bool> matcher, string matcherString)
+    : BaseAssertCondition<TActual>
+    where TActual : IEnumerable<TInner>
+{
+    protected override string GetExpectation() => $"to contain only entries matching {matcherString}";
+    
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception)
+    {
+        return AssertionResult
+            .FailIf(
+                () => actualValue is null,
+                () => $"{ActualExpression ?? typeof(TActual).Name} is null")
+            .OrFailIf(
+                () => !actualValue!.All(matcher),
+                //TODO: Add entry that failed to match
+                () => $"not all entries in the collection matched");
+    }
+}

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedFuncAssertCondition.cs
@@ -1,0 +1,20 @@
+namespace TUnit.Assertions.AssertConditions.Collections;
+
+public class EnumerableContainsExpectedFuncAssertCondition<TActual, TInner>(
+    Func<TInner, bool> matcher, string matcherString)
+    : BaseAssertCondition<TActual>
+    where TActual : IEnumerable<TInner>
+{
+    protected override string GetExpectation() => $"to contain an entry matching {matcherString}";
+    
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception)
+    {
+        return AssertionResult
+            .FailIf(
+                () => actualValue is null,
+                () => $"{ActualExpression ?? typeof(TActual).Name} is null")
+            .OrFailIf(
+                () => !actualValue!.Any(matcher),
+                () => "there was no match found in the collection");
+    }
+}

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotContainsExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotContainsExpectedFuncAssertCondition.cs
@@ -1,0 +1,20 @@
+namespace TUnit.Assertions.AssertConditions.Collections;
+
+public class EnumerableNotContainsExpectedFuncAssertCondition<TActual, TInner>(
+    Func<TInner, bool> matcher, string matcherString)
+    : BaseAssertCondition<TActual>
+    where TActual : IEnumerable<TInner>
+{
+    protected override string GetExpectation() => $"to contain no entry matching {matcherString}";
+    
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception)
+    {
+        return AssertionResult
+            .FailIf(
+                () => actualValue is null,
+                () => $"{ActualExpression ?? typeof(TActual).Name} is null")
+            .OrFailIf(
+                () => actualValue!.Any(matcher),
+                () => "there was a match found in the collection");
+    }
+}

--- a/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
@@ -15,4 +15,19 @@ public static partial class DoesExtensions
         return valueSource.RegisterAssertion(new EnumerableContainsExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)
             , [doNotPopulateThisValue]);
     }
+    
+    public static InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this IValueSource<TActual> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = "")
+        where TActual : IEnumerable<TInner>
+    {
+        return valueSource.RegisterAssertion(new EnumerableContainsExpectedFuncAssertCondition<TActual, TInner>(matcher, doNotPopulateThisValue)
+            , [doNotPopulateThisValue]);
+    }
+
+    public static InvokableValueAssertionBuilder<TActual> ContainsOnly<TActual, TInner>(this IValueSource<TActual> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = "")
+        where TActual : IEnumerable<TInner>
+    {
+        return valueSource.RegisterAssertion(new EnumerableAllExpectedFuncAssertCondition<TActual, TInner>(matcher, doNotPopulateThisValue)
+            , [doNotPopulateThisValue]);
+    }
+
 }

--- a/TUnit.Assertions/Assertions/Generics/DoesNotExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesNotExtensions_Generic.cs
@@ -13,4 +13,11 @@ public static partial class DoesNotExtensions
         return valueSource.RegisterAssertion(new EnumerableNotContainsExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)
             , [doNotPopulateThisValue]);
     }
+
+    public static InvokableValueAssertionBuilder<TActual> DoesNotContain<TActual, TInner>(this IValueSource<TActual> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = "")
+        where TActual : IEnumerable<TInner>
+    {
+        return valueSource.RegisterAssertion(new EnumerableNotContainsExpectedFuncAssertCondition<TActual, TInner>(matcher, doNotPopulateThisValue)
+            , [doNotPopulateThisValue]);
+    }
 }


### PR DESCRIPTION
I added a first basic implementation to use Funcs to find matches in IEnumerables. Currently missing some more of those (like NotContains) and nicer error messages.