### PR TITLE
Fix NullReferenceException in Throws and ThrowsExactly.

### DIFF
--- a/TUnit.Assertions/Assertions/Throws/ThrowsExactlyAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsExactlyAssertCondition.cs
@@ -12,7 +12,7 @@ public class ThrowsExactTypeOfDelegateAssertCondition<TActual, TExpectedExceptio
         => AssertionResult
         .FailIf(exception is null,
             "none was thrown")
-        .OrFailIf(exception!.GetType() != typeof(TExpectedException),
+        .OrFailIf(exception?.GetType() != typeof(TExpectedException),
             $"{exception?.GetType().Name.PrependAOrAn()} was thrown"
         );
 }

--- a/TUnit.Assertions/Assertions/Throws/ThrowsOfTypeAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsOfTypeAssertCondition.cs
@@ -10,7 +10,7 @@ public class ThrowsOfTypeAssertCondition<TActual, TExpectedException> : Delegate
     protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception)
         => AssertionResult
         .FailIf(exception is null, "none was thrown")
-        .OrFailIf(!typeof(TExpectedException).IsAssignableFrom(exception!.GetType()),
+        .OrFailIf(!typeof(TExpectedException).IsAssignableFrom(exception?.GetType()),
             $"{exception?.GetType().Name.PrependAOrAn()} was thrown"
         );
 }


### PR DESCRIPTION
Fixes https://github.com/thomhurst/TUnit/issues/1629.