### PR TITLE
Allow Matrix/NonTypedDataSourceGeneratorAttribute values to inject arguments that have an implicit conversion operator to the parameter type

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,7 @@
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="Polly" Version="8.5.1" />
     <PackageVersion Include="Polyfill" Version="7.13.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
@@ -143,10 +143,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
-				double methodArg2 = (double)(dynamic)methodArgGeneratedData[2];
-				bool methodArg3 = (bool)(dynamic)methodArgGeneratedData[3];
+				string methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<string>(methodArgGeneratedData[0]);
+				int methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[1]);
+				double methodArg2 = global::TUnit.Core.Helpers.CastHelper.Cast<double>(methodArgGeneratedData[2]);
+				bool methodArg3 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[3]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.AutoDataTests>(() => 
 				new global::TUnit.TestProject.AutoDataTests()
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
@@ -143,10 +143,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)methodArgGeneratedData[0];
-				int methodArg1 = (int)methodArgGeneratedData[1];
-				double methodArg2 = (double)methodArgGeneratedData[2];
-				bool methodArg3 = (bool)methodArgGeneratedData[3];
+				string methodArg = (dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (dynamic)methodArgGeneratedData[1];
+				double methodArg2 = (dynamic)methodArgGeneratedData[2];
+				bool methodArg3 = (dynamic)methodArgGeneratedData[3];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.AutoDataTests>(() => 
 				new global::TUnit.TestProject.AutoDataTests()
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DataSourceGeneratorTests.NonTyped.verified.txt
@@ -143,10 +143,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (dynamic)methodArgGeneratedData[1];
-				double methodArg2 = (dynamic)methodArgGeneratedData[2];
-				bool methodArg3 = (dynamic)methodArgGeneratedData[3];
+				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
+				double methodArg2 = (double)(dynamic)methodArgGeneratedData[2];
+				bool methodArg3 = (bool)(dynamic)methodArgGeneratedData[3];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.AutoDataTests>(() => 
 				new global::TUnit.TestProject.AutoDataTests()
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
@@ -145,9 +145,9 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (dynamic)methodArgGeneratedData[1];
-				bool methodArg2 = (dynamic)methodArgGeneratedData[2];
+				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
+				bool methodArg2 = (bool)(dynamic)methodArgGeneratedData[2];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -371,10 +371,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (dynamic)methodArgGeneratedData[1];
-				int methodArg2 = (dynamic)methodArgGeneratedData[2];
-				bool methodArg3 = (dynamic)methodArgGeneratedData[3];
+				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
+				int methodArg2 = (int)(dynamic)methodArgGeneratedData[2];
+				bool methodArg3 = (bool)(dynamic)methodArgGeneratedData[3];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -554,8 +554,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::TUnit.TestPro
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (dynamic)methodArgGeneratedData[0];
-				global::TUnit.TestProject.TestEnum methodArg1 = (dynamic)methodArgGeneratedData[1];
+				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
+				global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -729,8 +729,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
+				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -910,8 +910,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
+				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -1091,8 +1091,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				OneOf<global::TUnit.TestProject.TestEnum, TestEnum2> methodArg = (dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
+				OneOf<global::TUnit.TestProject.TestEnum, TestEnum2> methodArg = (OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>)(dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
@@ -145,9 +145,9 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
-				bool methodArg2 = (bool)(dynamic)methodArgGeneratedData[2];
+				string methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<string>(methodArgGeneratedData[0]);
+				int methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[1]);
+				bool methodArg2 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[2]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -371,10 +371,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
-				int methodArg1 = (int)(dynamic)methodArgGeneratedData[1];
-				int methodArg2 = (int)(dynamic)methodArgGeneratedData[2];
-				bool methodArg3 = (bool)(dynamic)methodArgGeneratedData[3];
+				int methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[0]);
+				int methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[1]);
+				int methodArg2 = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[2]);
+				bool methodArg3 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[3]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -554,8 +554,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::TUnit.TestPro
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
-				global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)(dynamic)methodArgGeneratedData[1];
+				int methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[0]);
+				global::TUnit.TestProject.TestEnum methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<global::TUnit.TestProject.TestEnum>(methodArgGeneratedData[1]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -729,8 +729,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
+				string methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<string>(methodArgGeneratedData[0]);
+				bool methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[1]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -910,8 +910,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)(dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
+				string methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<string>(methodArgGeneratedData[0]);
+				bool methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[1]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -1091,8 +1091,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				OneOf<global::TUnit.TestProject.TestEnum, TestEnum2> methodArg = (OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>)(dynamic)methodArgGeneratedData[0];
-				bool methodArg1 = (bool)(dynamic)methodArgGeneratedData[1];
+				OneOf<global::TUnit.TestProject.TestEnum, TestEnum2> methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>>(methodArgGeneratedData[0]);
+				bool methodArg1 = global::TUnit.Core.Helpers.CastHelper.Cast<bool>(methodArgGeneratedData[1]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/MatrixTests.Test.verified.txt
@@ -145,9 +145,9 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)methodArgGeneratedData[0];
-				int methodArg1 = (int)methodArgGeneratedData[1];
-				bool methodArg2 = (bool)methodArgGeneratedData[2];
+				string methodArg = (dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (dynamic)methodArgGeneratedData[1];
+				bool methodArg2 = (dynamic)methodArgGeneratedData[2];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -166,7 +166,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 					ResettableClassFactory = resettableClassFactory,
 					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.MatrixTest_One(methodArg, methodArg1, methodArg2)),
 					TestFilePath = @"",
-					TestLineNumber = 5,
+					TestLineNumber = 7,
 					TestAttributes = [ new global::TUnit.Core.TestAttribute()
 {
     
@@ -194,7 +194,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				ParameterTypeFullNames = [typeof(string), typeof(int), typeof(bool)],
 				TestName = "MatrixTest_One",
 				TestFilePath = @"",
-				TestLineNumber = 5,
+				TestLineNumber = 7,
 				Exception = exception,
 			});
 		}
@@ -371,10 +371,10 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)methodArgGeneratedData[0];
-				int methodArg1 = (int)methodArgGeneratedData[1];
-				int methodArg2 = (int)methodArgGeneratedData[2];
-				bool methodArg3 = (bool)methodArgGeneratedData[3];
+				int methodArg = (dynamic)methodArgGeneratedData[0];
+				int methodArg1 = (dynamic)methodArgGeneratedData[1];
+				int methodArg2 = (dynamic)methodArgGeneratedData[2];
+				bool methodArg3 = (dynamic)methodArgGeneratedData[3];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -393,7 +393,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 					ResettableClassFactory = resettableClassFactory,
 					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.MatrixTest_Two(methodArg, methodArg1, methodArg2, methodArg3)),
 					TestFilePath = @"",
-					TestLineNumber = 15,
+					TestLineNumber = 17,
 					TestAttributes = [ new global::TUnit.Core.TestAttribute()
 {
     
@@ -421,7 +421,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				ParameterTypeFullNames = [typeof(int), typeof(int), typeof(int), typeof(bool)],
 				TestName = "MatrixTest_Two",
 				TestFilePath = @"",
-				TestLineNumber = 15,
+				TestLineNumber = 17,
 				Exception = exception,
 			});
 		}
@@ -554,8 +554,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::TUnit.TestPro
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)methodArgGeneratedData[0];
-				global::TUnit.TestProject.TestEnum methodArg1 = (global::TUnit.TestProject.TestEnum)methodArgGeneratedData[1];
+				int methodArg = (dynamic)methodArgGeneratedData[0];
+				global::TUnit.TestProject.TestEnum methodArg1 = (dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -574,7 +574,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::TUnit.TestPro
 					ResettableClassFactory = resettableClassFactory,
 					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.MatrixTest_Enum(methodArg, methodArg1)),
 					TestFilePath = @"",
-					TestLineNumber = 26,
+					TestLineNumber = 28,
 					TestAttributes = [ new global::TUnit.Core.TestAttribute()
 {
     
@@ -602,7 +602,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::TUnit.TestPro
 				ParameterTypeFullNames = [typeof(int), typeof(global::TUnit.TestProject.TestEnum)],
 				TestName = "MatrixTest_Enum",
 				TestFilePath = @"",
-				TestLineNumber = 26,
+				TestLineNumber = 28,
 				Exception = exception,
 			});
 		}
@@ -729,8 +729,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)methodArgGeneratedData[0];
-				bool methodArg1 = (bool)methodArgGeneratedData[1];
+				string methodArg = (dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -749,7 +749,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 					ResettableClassFactory = resettableClassFactory,
 					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.AutoGenerateBools(methodArg, methodArg1)),
 					TestFilePath = @"",
-					TestLineNumber = 35,
+					TestLineNumber = 37,
 					TestAttributes = [ new global::TUnit.Core.TestAttribute()
 {
     
@@ -777,7 +777,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				ParameterTypeFullNames = [typeof(string), typeof(bool)],
 				TestName = "AutoGenerateBools",
 				TestFilePath = @"",
-				TestLineNumber = 35,
+				TestLineNumber = 37,
 				Exception = exception,
 			});
 		}
@@ -910,8 +910,8 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				testMethodDataIndex++;
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				string methodArg = (string)methodArgGeneratedData[0];
-				bool methodArg1 = (bool)methodArgGeneratedData[1];
+				string methodArg = (dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
 				new global::TUnit.TestProject.MatrixTests()
 				, sessionId, testBuilderContext);
@@ -930,7 +930,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 					ResettableClassFactory = resettableClassFactory,
 					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.AutoGenerateBools2(methodArg, methodArg1)),
 					TestFilePath = @"",
-					TestLineNumber = 44,
+					TestLineNumber = 46,
 					TestAttributes = [ new global::TUnit.Core.TestAttribute()
 {
     
@@ -958,7 +958,188 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
 				ParameterTypeFullNames = [typeof(string), typeof(bool)],
 				TestName = "AutoGenerateBools2",
 				TestFilePath = @"",
-				TestLineNumber = 44,
+				TestLineNumber = 46,
+				Exception = exception,
+			});
+		}
+		return nodes;
+	}
+}
+
+  
+// <auto-generated/>
+#pragma warning disable
+using global::System.Linq;
+using global::System.Reflection;
+using global::TUnit.Core;
+using global::TUnit.Core.Extensions;
+
+namespace TUnit.SourceGenerated;
+
+[global::System.Diagnostics.StackTraceHidden]
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+file partial class MatrixTests : global::TUnit.Core.Interfaces.SourceGenerator.ITestSource
+{
+	[global::System.Runtime.CompilerServices.ModuleInitializer]
+	public static void Initialise()
+	{
+		global::TUnit.Core.SourceRegistrar.Register(new MatrixTests());
+	}
+	public global::System.Collections.Generic.IReadOnlyList<SourceGeneratedTestNode> CollectTests(string sessionId)
+	{
+		return Tests0(sessionId);
+	}
+	private global::System.Collections.Generic.List<SourceGeneratedTestNode> Tests0(string sessionId)
+	{
+		global::System.Collections.Generic.List<SourceGeneratedTestNode> nodes = [];
+		var classDataIndex = 0;
+		var testMethodDataIndex = 0;
+		try
+		{
+			var testClassType = typeof(global::TUnit.TestProject.MatrixTests);
+			var methodInfo = global::TUnit.Core.Helpers.MethodInfoRetriever.GetMethodInfo(typeof(global::TUnit.TestProject.MatrixTests), "ImplicitConversion", 0, [typeof(OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>), typeof(bool)]);
+
+			var testBuilderContext = new global::TUnit.Core.TestBuilderContext();
+			var testBuilderContextAccessor = new global::TUnit.Core.TestBuilderContextAccessor(testBuilderContext);
+			var classInformation = new global::TUnit.Core.SourceGeneratedClassInformation<global::TUnit.TestProject.MatrixTests>
+{
+     Name = "MatrixTests",
+     Attributes = 
+     [
+         
+     ],  
+     Parameters = [],
+     Properties = [],
+};
+			var testInformation = new global::TUnit.Core.SourceGeneratedTestInformation<global::TUnit.TestProject.MatrixTests>
+{
+     Name = "ImplicitConversion",
+     Attributes = 
+     [
+         new global::TUnit.Core.TestAttribute()
+{
+    
+}, 
+new global::TUnit.Core.MatrixDataSourceAttribute()
+{
+    
+}
+     ],  
+     Parameters = [new global::TUnit.Core.SourceGeneratedParameterInformation<OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>>
+    {
+        Name = "enum",
+        Attributes = 
+        [
+            new global::TUnit.Core.MatrixAttribute(global::TUnit.TestProject.TestEnum.One, Two)
+{
+    
+}
+        ]
+    }, 
+new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
+    {
+        Name = "boolean",
+        Attributes = 
+        [
+            new global::TUnit.Core.MatrixAttribute()
+{
+    
+}
+        ]
+    }],
+     Class = classInformation,
+};
+			var methodArgDataGeneratorMetadata = new DataGeneratorMetadata
+{
+   Type = global::TUnit.Core.Enums.DataGeneratorType.TestParameters,
+   TestClassType = testClassType,
+   TestBuilderContext = testBuilderContextAccessor,
+   TestInformation = testInformation,
+   MembersToGenerate = [new global::TUnit.Core.SourceGeneratedParameterInformation<OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>>
+    {
+        Name = "enum",
+        Attributes = 
+        [
+            new global::TUnit.Core.MatrixAttribute(global::TUnit.TestProject.TestEnum.One, Two)
+{
+    
+}
+        ]
+    }, 
+new global::TUnit.Core.SourceGeneratedParameterInformation<bool>
+    {
+        Name = "boolean",
+        Attributes = 
+        [
+            new global::TUnit.Core.MatrixAttribute()
+{
+    
+}
+        ]
+    }],
+   TestSessionId = sessionId,
+};
+			var methodDataAttribute = new global::TUnit.Core.MatrixDataSourceAttribute()
+{
+    
+};
+
+			var methodArgGeneratedDataArray = methodDataAttribute.GenerateDataSources(methodArgDataGeneratorMetadata);
+
+			foreach (var methodArgGeneratedDataAccessor in methodArgGeneratedDataArray)
+			{
+				testMethodDataIndex++;
+
+				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
+				OneOf<global::TUnit.TestProject.TestEnum, TestEnum2> methodArg = (dynamic)methodArgGeneratedData[0];
+				bool methodArg1 = (dynamic)methodArgGeneratedData[1];
+				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.MatrixTests>(() => 
+				new global::TUnit.TestProject.MatrixTests()
+				, sessionId, testBuilderContext);
+
+				var resettableClassFactory = resettableClassFactoryDelegate();
+
+				nodes.Add(new TestMetadata<global::TUnit.TestProject.MatrixTests>
+				{
+					TestId = $"global::TUnit.Core.MatrixDataSourceAttribute:{testMethodDataIndex}:TL-GAC0:TUnit.TestProject.MatrixTests.ImplicitConversion(OneOf<TUnit.TestProject.TestEnum, TestEnum2>,bool):0",
+					TestClassArguments = [],
+					TestMethodArguments = [methodArg, methodArg1],
+					TestClassProperties = [],
+					CurrentRepeatAttempt = 0,
+					RepeatLimit = 0,
+					MethodInfo = methodInfo,
+					ResettableClassFactory = resettableClassFactory,
+					TestMethodFactory = (classInstance, cancellationToken) => AsyncConvert.Convert(() => classInstance.ImplicitConversion(methodArg, methodArg1)),
+					TestFilePath = @"",
+					TestLineNumber = 55,
+					TestAttributes = [ new global::TUnit.Core.TestAttribute()
+{
+    
+}, new global::TUnit.Core.MatrixDataSourceAttribute()
+{
+    
+} ],
+					ClassAttributes = [  ],
+					AssemblyAttributes = [  ],
+					DataAttributes = [ methodDataAttribute ],
+					TestBuilderContext = testBuilderContext,
+				});
+				resettableClassFactory = resettableClassFactoryDelegate();
+				testBuilderContext = new();
+				testBuilderContextAccessor.Current = testBuilderContext;
+			}
+		}
+		catch (global::System.Exception exception)
+		{
+			nodes.Add(new global::TUnit.Core.FailedInitializationTest
+			{
+				TestId = $"global::TUnit.Core.MatrixDataSourceAttribute:{testMethodDataIndex}:TL-GAC0:TUnit.TestProject.MatrixTests.ImplicitConversion(OneOf<TUnit.TestProject.TestEnum, TestEnum2>,bool):0",
+				TestClass = typeof(global::TUnit.TestProject.MatrixTests),
+				ReturnType = global::TUnit.Core.Helpers.MethodInfoRetriever.GetMethodInfo(typeof(global::TUnit.TestProject.MatrixTests), "ImplicitConversion", 0, [typeof(OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>), typeof(bool)]).ReturnType,
+				ParameterTypeFullNames = [typeof(OneOf<global::TUnit.TestProject.TestEnum, TestEnum2>), typeof(bool)],
+				TestName = "ImplicitConversion",
+				TestFilePath = @"",
+				TestLineNumber = 55,
 				Exception = exception,
 			});
 		}

--- a/TUnit.Core.SourceGenerator.Tests/MatrixTests.cs
+++ b/TUnit.Core.SourceGenerator.Tests/MatrixTests.cs
@@ -20,6 +20,6 @@ internal class MatrixTests : TestsBase<TestsGenerator>
         },
         async generatedFiles =>
         {
-            await Assert.That(generatedFiles.Length).IsEqualTo(5);
+            await Assert.That(generatedFiles.Length).IsEqualTo(6);
         });
 }

--- a/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
@@ -621,7 +621,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::System.Thread
 				int classArg = global::TUnit.TestProject.TimeoutCancellationTokenTests.DataSource();
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
+				int methodArg = global::TUnit.Core.Helpers.CastHelper.Cast<int>(methodArgGeneratedData[0]);
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.TimeoutCancellationTokenTests>(() => 
 				new global::TUnit.TestProject.TimeoutCancellationTokenTests(classArg)
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
@@ -621,7 +621,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::System.Thread
 				int classArg = global::TUnit.TestProject.TimeoutCancellationTokenTests.DataSource();
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (int)methodArgGeneratedData[0];
+				int methodArg = (dynamic)methodArgGeneratedData[0];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.TimeoutCancellationTokenTests>(() => 
 				new global::TUnit.TestProject.TimeoutCancellationTokenTests(classArg)
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/TimeoutCancellationTokenTests.Test.verified.txt
@@ -621,7 +621,7 @@ new global::TUnit.Core.SourceGeneratedParameterInformation<global::System.Thread
 				int classArg = global::TUnit.TestProject.TimeoutCancellationTokenTests.DataSource();
 
 				var methodArgGeneratedData = methodArgGeneratedDataAccessor();
-				int methodArg = (dynamic)methodArgGeneratedData[0];
+				int methodArg = (int)(dynamic)methodArgGeneratedData[0];
 				var resettableClassFactoryDelegate = () => new ResettableLazy<global::TUnit.TestProject.TimeoutCancellationTokenTests>(() => 
 				new global::TUnit.TestProject.TimeoutCancellationTokenTests(classArg)
 				, sessionId, testBuilderContext);

--- a/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/ArgumentsRetriever.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/ArgumentsRetriever.cs
@@ -60,15 +60,33 @@ public static class ArgumentsRetriever
                 if (dataAttribute.AttributeClass?.IsOrInherits(WellKnownFullyQualifiedClassNames
                         .DataSourceGeneratorAttribute.WithGlobalPrefix) == true)
                 {
-                    yield return DataSourceGeneratorRetriever.Parse(context, testClass, testMethod, parameters, property, parameterOrPropertyTypes, dataAttribute, argumentsType,
-                        index, propertyName);
+                    yield return DataSourceGeneratorRetriever.Parse(context, 
+                        testClass, 
+                        testMethod, 
+                        parameters, 
+                        property, 
+                        parameterOrPropertyTypes, 
+                        dataAttribute, 
+                        argumentsType,
+                        index, 
+                        propertyName, 
+                        true);
                 }
                 
                 if (dataAttribute.AttributeClass?.IsOrInherits(WellKnownFullyQualifiedClassNames
                         .NonTypedDataSourceGeneratorAttribute.WithGlobalPrefix) == true)
                 {
-                    yield return DataSourceGeneratorRetriever.Parse(context, testClass, testMethod, parameters, property, parameterOrPropertyTypes, dataAttribute, argumentsType,
-                        index, propertyName);
+                    yield return DataSourceGeneratorRetriever.Parse(context, 
+                        testClass, 
+                        testMethod, 
+                        parameters, 
+                        property, 
+                        parameterOrPropertyTypes, 
+                        dataAttribute, 
+                        argumentsType,
+                        index, 
+                        propertyName,
+                        false);
                 }
             }
         }

--- a/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceGeneratorRetriever.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceGeneratorRetriever.cs
@@ -17,7 +17,8 @@ public static class DataSourceGeneratorRetriever
         AttributeData attributeData,
         ArgumentsType argumentsType,
         int index,
-        string? propertyName)
+        string? propertyName, 
+        bool isStronglyTyped)
     {
         return new GeneratedArgumentsContainer
         (
@@ -38,7 +39,8 @@ public static class DataSourceGeneratorRetriever
                 true,
             PropertyName = propertyName,
             Attribute = attributeData,
-            AttributeIndex = index
+            AttributeIndex = index,
+            IsStronglyTyped = isStronglyTyped,
         };
     }
 

--- a/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/FullyQualifiedWithGlobalPrefixRewriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/FullyQualifiedWithGlobalPrefixRewriter.cs
@@ -36,7 +36,7 @@ public sealed class FullyQualifiedWithGlobalPrefixRewriter(SemanticModel semanti
             .WithoutTrivia();
     }
 
-    public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
     {
         var symbol = node.GetSymbolInfo(semanticModel);
 
@@ -55,8 +55,13 @@ public sealed class FullyQualifiedWithGlobalPrefixRewriter(SemanticModel semanti
                 .WithoutTrivia();
         }
 
+        if (symbol is null)
+        {
+            return base.VisitIdentifierName(node);
+        }
+
         return SyntaxFactory
-            .IdentifierName(symbol!.GloballyQualified())
+            .IdentifierName(symbol.GloballyQualified())
             .WithoutTrivia();
     }
     

--- a/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/FullyQualifiedWithGlobalPrefixRewriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/FullyQualifiedWithGlobalPrefixRewriter.cs
@@ -13,13 +13,18 @@ public sealed class FullyQualifiedWithGlobalPrefixRewriter(SemanticModel semanti
         return SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(node.ToFullString()));
     }
 
-    public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+    public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
     {
         var symbol = node.GetSymbolInfo(semanticModel);
 
         if (node.Name is IdentifierNameSyntax identifierName)
         {
             return VisitIdentifierName(identifierName);
+        }
+
+        if (symbol is null)
+        {
+            return base.VisitMemberAccessExpression(node);
         }
         
         return SyntaxFactory

--- a/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
+++ b/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
@@ -118,7 +118,7 @@ public record GeneratedArgumentsContainer(
                 }
                 else
                 {
-                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"(dynamic){generatedDataVariableName}[{i}]", ref refIndex).ToString());
+                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"({ParameterOrPropertyTypes[i].GloballyQualified()})(dynamic){generatedDataVariableName}[{i}]", ref refIndex).ToString());
                 }
             }
         }

--- a/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
+++ b/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
@@ -18,6 +18,7 @@ public record GeneratedArgumentsContainer(
     string[] GenericArguments) : ArgumentsContainer(ArgumentsType)
 {
     public required string? PropertyName { get; init; }
+    public required bool IsStronglyTyped { get; init; }
 
     public override void OpenScope(SourceCodeWriter sourceCodeWriter, ref int variableIndex)
     {
@@ -111,7 +112,14 @@ public record GeneratedArgumentsContainer(
             {
                 var refIndex = i;
                 
-                sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"({ParameterOrPropertyTypes[i].GloballyQualified()}){generatedDataVariableName}[{i}]", ref refIndex).ToString());
+                if (IsStronglyTyped)
+                {
+                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"({ParameterOrPropertyTypes[i].GloballyQualified()}){generatedDataVariableName}[{i}]", ref refIndex).ToString());
+                }
+                else
+                {
+                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"(dynamic){generatedDataVariableName}[{i}]", ref refIndex).ToString());
+                }
             }
         }
         else if (GenericArguments.Length > 1)

--- a/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
+++ b/TUnit.Core.SourceGenerator/Models/Arguments/GeneratedArgumentsContainer.cs
@@ -118,7 +118,7 @@ public record GeneratedArgumentsContainer(
                 }
                 else
                 {
-                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"({ParameterOrPropertyTypes[i].GloballyQualified()})(dynamic){generatedDataVariableName}[{i}]", ref refIndex).ToString());
+                    sourceCodeWriter.WriteLine(GenerateVariable(ParameterOrPropertyTypes[i].GloballyQualified(), $"global::TUnit.Core.Helpers.CastHelper.Cast<{ParameterOrPropertyTypes[i].GloballyQualified()}>({generatedDataVariableName}[{i}])", ref refIndex).ToString());
                 }
             }
         }

--- a/TUnit.Core/Helpers/CastHelper.cs
+++ b/TUnit.Core/Helpers/CastHelper.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace TUnit.Core.Helpers;
+
+public static class CastHelper
+{
+    public static T? Cast<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object? value)
+    {
+        if (value is null)
+        {
+            return default;
+        }
+
+        if (typeof(T).IsEnum)
+        {
+            return (T?) Enum.ToObject(typeof(T), value);
+        }
+
+        if (value.GetType().IsAssignableTo<T>())
+        {
+            return (T)value;
+        }
+
+        return (T?) GetImplicitConversion(value.GetType(), typeof(T)).Invoke(null, [value]);
+    }
+    
+    public static MethodInfo GetImplicitConversion([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
+    {
+        return baseType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Concat(targetType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .Where(mi => mi.Name == "op_Implicit" && mi.ReturnType == targetType)
+            .FirstOrDefault(mi =>
+            {
+                var pi = mi.GetParameters().FirstOrDefault();
+                return pi != null && pi.ParameterType == baseType;
+            }) ?? throw new ArgumentException($"Cannot convert from {baseType} to {targetType}");
+    }
+}

--- a/TUnit.Core/Helpers/CastHelper.cs
+++ b/TUnit.Core/Helpers/CastHelper.cs
@@ -5,6 +5,7 @@ namespace TUnit.Core.Helpers;
 
 public static class CastHelper
 {
+    [UnconditionalSuppressMessage("", "IL2072")]
     public static T? Cast<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(object? value)
     {
         if (value is null)

--- a/TUnit.Core/Helpers/CastHelper.cs
+++ b/TUnit.Core/Helpers/CastHelper.cs
@@ -24,8 +24,8 @@ public static class CastHelper
 
         return (T?) GetImplicitConversion(value.GetType(), typeof(T)).Invoke(null, [value]);
     }
-    
-    public static MethodInfo GetImplicitConversion([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
+
+    private static MethodInfo GetImplicitConversion([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type targetType)
     {
         return baseType.GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Concat(targetType.GetMethods(BindingFlags.Public | BindingFlags.Static))

--- a/TUnit.TestProject/MatrixTests.cs
+++ b/TUnit.TestProject/MatrixTests.cs
@@ -1,4 +1,6 @@
-﻿namespace TUnit.TestProject;
+﻿using OneOf;
+
+namespace TUnit.TestProject;
 
 public class MatrixTests
 {
@@ -45,6 +47,15 @@ public class MatrixTests
     [MatrixDataSource]
     public async Task AutoGenerateBools2(
         [Matrix("A", "B", "C")] string str, 
+        [Matrix] bool boolean)
+    {
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    [MatrixDataSource]
+    public async Task ImplicitConversion(
+        [Matrix(TestEnum.One, TestEnum2.Two)] OneOf<TestEnum, TestEnum2> @enum,
         [Matrix] bool boolean)
     {
         await Task.CompletedTask;

--- a/TUnit.TestProject/MatrixTests.cs
+++ b/TUnit.TestProject/MatrixTests.cs
@@ -58,6 +58,10 @@ public class MatrixTests
         [Matrix(TestEnum.One, TestEnum2.Two)] OneOf<TestEnum, TestEnum2> @enum,
         [Matrix] bool boolean)
     {
+        object @enum1 = TestEnum.One;
+        
+        OneOf<TestEnum, TestEnum2> oneOf = (OneOf<TestEnum, TestEnum2>)(dynamic) @enum1;
+        
         await Task.CompletedTask;
     }
 }

--- a/TUnit.TestProject/TUnit.TestProject.csproj
+++ b/TUnit.TestProject/TUnit.TestProject.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="OneOf" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/TUnit.TestProject/TestEnum2.cs
+++ b/TUnit.TestProject/TestEnum2.cs
@@ -1,0 +1,7 @@
+﻿namespace TUnit.TestProject;
+
+public enum TestEnum2
+{
+    One,
+    Two
+}


### PR DESCRIPTION
Fixes #1663