### PR TITLE
Fix un-typed IEnumerable IsEqualTo and IsSameReferenceAs assertions

### DIFF
--- a/TUnit.Assertions.Tests/EnumerableTests.cs
+++ b/TUnit.Assertions.Tests/EnumerableTests.cs
@@ -140,4 +140,24 @@ public class EnumerableTests
 
         await Assert.That(enumerable).IsInOrder();
     }
+    
+    [Test]
+    public async Task Untyped_Enumerable_EqualTo()
+    {
+        int[] array = [1, 2, 3];
+        
+        IEnumerable enumerable = array;
+
+        await Assert.That(enumerable).IsEqualTo(enumerable);
+    }
+    
+    [Test]
+    public async Task Untyped_Enumerable_ReferenceEqualTo()
+    {
+        int[] array = [1, 2, 3];
+        
+        IEnumerable enumerable = array;
+
+        await Assert.That(enumerable).IsSameReferenceAs(enumerable);
+    }
 }

--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertionBuilders;
 using TUnit.Assertions.Extensions;
+using TUnit.Assertions.Wrappers;
 
 namespace TUnit.Assertions;
 
@@ -15,7 +16,7 @@ public static class Assert
     
     public static ValueAssertionBuilder<IEnumerable<object>> That(IEnumerable enumerable, [CallerArgumentExpression(nameof(enumerable))] string? doNotPopulateThisValue = null)
     {
-        return new ValueAssertionBuilder<IEnumerable<object>>(enumerable.Cast<object>(), doNotPopulateThisValue);
+        return new ValueAssertionBuilder<IEnumerable<object>>(new UnTypedEnumerableWrapper(enumerable), doNotPopulateThisValue);
     }
     
     public static DelegateAssertionBuilder That(Action value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)

--- a/TUnit.Assertions/Assertions/Generics/Conditions/NotSameReferenceExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/NotSameReferenceExpectedValueAssertCondition.cs
@@ -1,4 +1,5 @@
 ﻿using TUnit.Assertions.AssertConditions;
+using TUnit.Assertions.Wrappers;
 
 namespace TUnit.Assertions.Assertions.Generics.Conditions;
 
@@ -8,7 +9,17 @@ public class NotSameReferenceExpectedValueAssertCondition<TActual, TExpected>(TE
     protected override string GetExpectation()
         => $"to not have the same reference as {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue) => AssertionResult
-        .FailIf(ReferenceEquals(actualValue, expectedValue),
-            "they did");
+    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    {
+        if (actualValue is UnTypedEnumerableWrapper unTypedEnumerableWrapper)
+        {
+            return AssertionResult
+                .FailIf(ReferenceEquals(unTypedEnumerableWrapper.Enumerable, expectedValue),
+                    "they did");
+        }
+        
+        return AssertionResult
+            .FailIf(ReferenceEquals(actualValue, expectedValue),
+                "they did");
+    }
 }

--- a/TUnit.Assertions/Assertions/Generics/Conditions/SameReferenceExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/SameReferenceExpectedValueAssertCondition.cs
@@ -1,4 +1,5 @@
 ﻿using TUnit.Assertions.AssertConditions;
+using TUnit.Assertions.Wrappers;
 
 namespace TUnit.Assertions.Assertions.Generics.Conditions;
 
@@ -8,7 +9,17 @@ public class SameReferenceExpectedValueAssertCondition<TActual, TExpected>(TExpe
     protected override string GetExpectation()
         => $"to have the same reference as {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue) => AssertionResult
-        .FailIf(!ReferenceEquals(actualValue, expectedValue),
-            "they did not");
+    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    {
+        if (actualValue is UnTypedEnumerableWrapper unTypedEnumerableWrapper)
+        {
+            return AssertionResult
+                .FailIf(!ReferenceEquals(unTypedEnumerableWrapper.Enumerable, expectedValue),
+                    "they did not");
+        }
+        
+        return AssertionResult
+            .FailIf(!ReferenceEquals(actualValue, expectedValue),
+                "they did not");
+    }
 }

--- a/TUnit.Assertions/Wrappers/UnTypedEnumerableWrapper.cs
+++ b/TUnit.Assertions/Wrappers/UnTypedEnumerableWrapper.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+
+namespace TUnit.Assertions.Wrappers;
+
+internal class UnTypedEnumerableWrapper(IEnumerable enumerable) 
+    : IEnumerable<object>, 
+        IEquatable<UnTypedEnumerableWrapper>, 
+        IEquatable<IEnumerable>
+{
+    public IEnumerable Enumerable { get; } = enumerable;
+
+    public IEnumerator<object> GetEnumerator()
+    {
+        return Enumerable.Cast<object>().GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return Enumerable.GetEnumerator();
+    }
+
+    public bool Equals(UnTypedEnumerableWrapper? other)
+    {
+        return Equals(other?.Enumerable, Enumerable);
+    }
+
+    public bool Equals(IEnumerable? other)
+    {
+        return other?.Equals(Enumerable) is true;
+    }
+}


### PR DESCRIPTION
Fixes #1718