### PR TITLE
`ExpectedValueAssertCondition` `GetResult` now returns a Task to allo…

### DIFF
--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -30,7 +30,7 @@ public abstract class BaseAssertCondition
     internal virtual string GetExpectationWithReason()
         => $"{GetExpectation()}{GetBecauseReason()}";
 
-    internal abstract Task<AssertionResult> Assert(object? actualValue, Exception? exception, string? actualExpression);
+    public abstract Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression);
     
     internal void SetSubject(string? subject)
         => Subject = subject;
@@ -39,26 +39,26 @@ public abstract class BaseAssertCondition
 public abstract class BaseAssertCondition<TActual> : BaseAssertCondition
 {
     
-    internal Task<AssertionResult> Assert(AssertionData assertionData)
+    internal Task<AssertionResult> GetAssertionResult(AssertionData assertionData)
     {
-        return Assert(assertionData.Result, assertionData.Exception, assertionData.ActualExpression);
+        return GetAssertionResult(assertionData.Result, assertionData.Exception, assertionData.ActualExpression);
     }
 
-    internal override Task<AssertionResult> Assert(object? actualValue, Exception? exception, string? actualExpression)
+    public override Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
         if (actualValue is not null && actualValue is not TActual)
         {
             throw new AssertionException($"Expected {typeof(TActual).Name} but received {actualValue.GetType().Name}");
         } 
         
-        return Assert((TActual?) actualValue, exception, actualExpression);
+        return GetAssertionResult((TActual?) actualValue, exception, actualExpression);
     }
 
     internal TActual? ActualValue { get; private set; }
     internal Exception? Exception { get; private set; }
     public string? ActualExpression { get; private set; }
     
-    internal Task<AssertionResult> Assert(TActual? actualValue, Exception? exception, string? actualExpression)
+    internal Task<AssertionResult> GetAssertionResult(TActual? actualValue, Exception? exception, string? actualExpression)
     {
         ActualValue = actualValue;
         Exception = exception;

--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -58,7 +58,7 @@ public abstract class BaseAssertCondition<TActual> : BaseAssertCondition
     internal Exception? Exception { get; private set; }
     public string? ActualExpression { get; private set; }
     
-    public Task<AssertionResult> GetAssertionResult(TActual? actualValue, Exception? exception, string? actualExpression)
+    public Task<AssertionResult> GetAssertionResult(TActual? actualValue, Exception? exception, string? actualExpression = null)
     {
         ActualValue = actualValue;
         Exception = exception;

--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -30,7 +30,7 @@ public abstract class BaseAssertCondition
     internal virtual string GetExpectationWithReason()
         => $"{GetExpectation()}{GetBecauseReason()}";
 
-    public abstract Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression);
+    internal abstract Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression);
     
     internal void SetSubject(string? subject)
         => Subject = subject;
@@ -44,7 +44,7 @@ public abstract class BaseAssertCondition<TActual> : BaseAssertCondition
         return GetAssertionResult(assertionData.Result, assertionData.Exception, assertionData.ActualExpression);
     }
 
-    public override Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
+    internal override Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
         if (actualValue is not null && actualValue is not TActual)
         {
@@ -58,7 +58,7 @@ public abstract class BaseAssertCondition<TActual> : BaseAssertCondition
     internal Exception? Exception { get; private set; }
     public string? ActualExpression { get; private set; }
     
-    internal Task<AssertionResult> GetAssertionResult(TActual? actualValue, Exception? exception, string? actualExpression)
+    public Task<AssertionResult> GetAssertionResult(TActual? actualValue, Exception? exception, string? actualExpression)
     {
         ActualValue = actualValue;
         Exception = exception;

--- a/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
@@ -22,7 +22,7 @@ internal class AndAssertCondition : BaseAssertCondition
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} and {_condition2.GetExpectationWithReason()}";
 
-    public sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
+    internal sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
         return (await _condition1.GetAssertionResult(actualValue, exception, actualExpression))
             .And(await _condition2.GetAssertionResult(actualValue, exception, actualExpression));

--- a/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/AndAssertCondition.cs
@@ -22,10 +22,10 @@ internal class AndAssertCondition : BaseAssertCondition
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} and {_condition2.GetExpectationWithReason()}";
 
-    internal override async Task<AssertionResult> Assert(object? actualValue, Exception? exception, string? actualExpression)
+    public sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
-        return (await _condition1.Assert(actualValue, exception, actualExpression))
-            .And(await _condition2.Assert(actualValue, exception, actualExpression));
+        return (await _condition1.GetAssertionResult(actualValue, exception, actualExpression))
+            .And(await _condition2.GetAssertionResult(actualValue, exception, actualExpression));
     }
 
     internal override void SetBecauseReason(BecauseReason becauseReason)

--- a/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
@@ -21,7 +21,7 @@ internal class OrAssertCondition : BaseAssertCondition
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} or {_condition2.GetExpectationWithReason()}";
 
-    public sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
+    internal sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
         return (await _condition1.GetAssertionResult(actualValue, exception, actualExpression))
             .Or(await _condition2.GetAssertionResult(actualValue, exception, actualExpression));

--- a/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
@@ -21,10 +21,10 @@ internal class OrAssertCondition : BaseAssertCondition
     internal override string GetExpectationWithReason()
         => $"{_condition1.GetExpectationWithReason()}{Environment.NewLine} or {_condition2.GetExpectationWithReason()}";
 
-    internal override async Task<AssertionResult> Assert(object? actualValue, Exception? exception, string? actualExpression)
+    public sealed override async Task<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, string? actualExpression)
     {
-        return (await _condition1.Assert(actualValue, exception, actualExpression))
-            .Or(await _condition2.Assert(actualValue, exception, actualExpression));
+        return (await _condition1.GetAssertionResult(actualValue, exception, actualExpression))
+            .Or(await _condition2.GetAssertionResult(actualValue, exception, actualExpression));
     }
 
     internal override void SetBecauseReason(BecauseReason becauseReason)

--- a/TUnit.Assertions/AssertConditions/EnumerableSatisfiesAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/EnumerableSatisfiesAssertCondition.cs
@@ -54,7 +54,7 @@ public class EnumerableSatisfiesAssertCondition<TActual, TInner, TExpected> : Ba
         var assertion = _assertionBuilder(innerAssertionBuilder);
         foreach (var baseAssertCondition in assertion.Assertions)
         {
-            var result = await baseAssertCondition.Assert(innerItem, exception, "");
+            var result = await baseAssertCondition.GetAssertionResult(innerItem, exception, "");
             if (!result.IsPassed)
             {
                 return result;

--- a/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageContainingExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageContainingExpectedValueAssertCondition.cs
@@ -10,7 +10,7 @@ where TException : Exception
     protected override string GetExpectation()
         => $"message to contain {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(TException? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(TException? actualValue, string? expectedValue)
     {
         if (actualValue?.Message is null)
         {

--- a/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageEndingWithExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageEndingWithExpectedValueAssertCondition.cs
@@ -10,7 +10,7 @@ where TException : Exception
     protected override string GetExpectation()
         => $"message to end with {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(TException? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(TException? actualValue, string? expectedValue)
     {
         if (actualValue?.Message is null)
         {

--- a/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageEqualsExpectedValueAssertCondition.cs
@@ -10,7 +10,7 @@ where TException : Exception
     protected override string GetExpectation()
         => $"message to be equal to {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(TException? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(TException? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageMatchingExpectedAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageMatchingExpectedAssertCondition.cs
@@ -10,7 +10,7 @@ where TException : Exception
     protected override string GetExpectation()
         => $"message to match {Formatter.Format(match).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(TException? actualValue, StringMatcher? expectedValue)
+    protected override Task<AssertionResult> GetResult(TException? actualValue, StringMatcher? expectedValue)
     {
         if (actualValue?.Message is null)
         {

--- a/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageStartingWithExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Exceptions/ExceptionMessageStartingWithExpectedValueAssertCondition.cs
@@ -10,7 +10,7 @@ where TException : Exception
     protected override string GetExpectation()
         => $"message to start with {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(TException? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(TException? actualValue, string? expectedValue)
     {
         if (actualValue?.Message is null)
         {

--- a/TUnit.Assertions/AssertConditions/ExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/ExpectedValueAssertCondition.cs
@@ -44,5 +44,5 @@ public abstract class ExpectedValueAssertCondition<TActual, TExpected>(TExpected
         return GetResult(actualValue, expected);
     }
     
-    protected abstract AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue);
+    protected abstract Task<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue);
 }

--- a/TUnit.Assertions/AssertConditions/FuncValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/FuncValueAssertCondition.cs
@@ -12,7 +12,7 @@ public class FuncValueAssertCondition<TActual, TExpected>(
 {
     protected override string GetExpectation() => expectation;
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
     {
         return AssertionResult.FailIf(!condition(actualValue, ExpectedValue, this),
             $"{defaultMessageFactory(actualValue, Exception, Formatter.Format(expectedValue))}");

--- a/TUnit.Assertions/AssertConditions/SatisfiesAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/SatisfiesAssertCondition.cs
@@ -39,7 +39,7 @@ public class SatisfiesAssertCondition<TActual, TExpected> : BaseAssertCondition<
         
         foreach (var baseAssertCondition in ((ISource)assertion).Assertions)
         {
-            var result = await baseAssertCondition.Assert(innerItem, exception, "");
+            var result = await baseAssertCondition.GetAssertionResult(innerItem, exception, "");
 
             if (!result.IsPassed)
             {

--- a/TUnit.Assertions/AssertionBuilders/AssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/AssertionBuilder.cs
@@ -138,7 +138,7 @@ public abstract class AssertionBuilder : ISource
         
         foreach (var assertion in _assertions.Reverse())
         {
-            var result = await assertion.Assert(AwaitedAssertionData.Value.Result, AwaitedAssertionData.Value.Exception, AwaitedAssertionData.Value.ActualExpression);
+            var result = await assertion.GetAssertionResult(AwaitedAssertionData.Value.Result, AwaitedAssertionData.Value.Exception, AwaitedAssertionData.Value.ActualExpression);
             
             Results.Add(result);
             

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/StringEqualToAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/StringEqualToAssertionBuilderWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using TUnit.Assertions.AssertConditions;
+using TUnit.Assertions.AssertConditions.String;
 
 namespace TUnit.Assertions.AssertionBuilders.Wrappers;
 
@@ -10,9 +11,9 @@ public class StringEqualToAssertionBuilderWrapper : InvokableValueAssertionBuild
 
     public StringEqualToAssertionBuilderWrapper WithTrimming()
     {
-        var assertion = (ExpectedValueAssertCondition<string, string>) Assertions.Peek();
+        var assertion = (StringEqualsExpectedValueAssertCondition) Assertions.Peek();
 
-        assertion.WithTransform(s => s?.Trim(), s => s?.Trim());
+        assertion.WithTrimming();
         
         AppendCallerMethod([]);
         
@@ -21,22 +22,9 @@ public class StringEqualToAssertionBuilderWrapper : InvokableValueAssertionBuild
     
     public StringEqualToAssertionBuilderWrapper WithNullAndEmptyEquality()
     {
-        var assertion = (ExpectedValueAssertCondition<string, string>) Assertions.Peek();
+        var assertion = (StringEqualsExpectedValueAssertCondition) Assertions.Peek();
 
-        assertion.WithComparer((actual, expected) =>
-        {
-            if (actual == null && expected == string.Empty)
-            {
-                return AssertionDecision.Pass;
-            }
-
-            if (expected == null && actual == string.Empty)
-            {
-                return AssertionDecision.Pass;
-            }
-
-            return AssertionDecision.Continue;
-        });
+        assertion.WithNullAndEmptyEquality();
         
         AppendCallerMethod([]);
         
@@ -45,9 +33,9 @@ public class StringEqualToAssertionBuilderWrapper : InvokableValueAssertionBuild
     
     public StringEqualToAssertionBuilderWrapper IgnoringWhitespace()
     {
-        var assertion = (ExpectedValueAssertCondition<string, string>) Assertions.Peek();
+        var assertion = (StringEqualsExpectedValueAssertCondition) Assertions.Peek();
 
-        assertion.WithTransform(StringUtils.StripWhitespace, StringUtils.StripWhitespace);
+        assertion.IgnoringWhitespace();
         
         AppendCallerMethod([]);
         

--- a/TUnit.Assertions/Assertions/Chronology/Conditions/DateOnlyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Chronology/Conditions/DateOnlyEqualsExpectedValueAssertCondition.cs
@@ -16,7 +16,7 @@ public class DateOnlyEqualsExpectedValueAssertCondition(DateOnly expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected override AssertionResult GetResult(DateOnly actualValue, DateOnly expectedValue)
+    protected override Task<AssertionResult> GetResult(DateOnly actualValue, DateOnly expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/Assertions/Chronology/Conditions/DateTimeEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Chronology/Conditions/DateTimeEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class DateTimeEqualsExpectedValueAssertCondition(DateTime expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected override AssertionResult GetResult(DateTime actualValue, DateTime expectedValue)
+    protected override Task<AssertionResult> GetResult(DateTime actualValue, DateTime expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/Assertions/Chronology/Conditions/DateTimeOffsetEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Chronology/Conditions/DateTimeOffsetEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class DateTimeOffsetEqualsExpectedValueAssertCondition(DateTimeOffset exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected override AssertionResult GetResult(DateTimeOffset actualValue, DateTimeOffset expectedValue)
+    protected override Task<AssertionResult> GetResult(DateTimeOffset actualValue, DateTimeOffset expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/Assertions/Chronology/Conditions/TimeOnlyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Chronology/Conditions/TimeOnlyEqualsExpectedValueAssertCondition.cs
@@ -16,7 +16,7 @@ public class TimeOnlyEqualsExpectedValueAssertCondition(TimeOnly expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected override AssertionResult GetResult(TimeOnly actualValue, TimeOnly expectedValue)
+    protected override Task<AssertionResult> GetResult(TimeOnly actualValue, TimeOnly expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/Assertions/Chronology/Conditions/TimeSpanEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Chronology/Conditions/TimeSpanEqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class TimeSpanEqualsExpectedValueAssertCondition(TimeSpan expected) : Exp
         return $"to be equal to {expected} +-{_tolerance}";
     }
 
-    protected override AssertionResult GetResult(TimeSpan actualValue, TimeSpan expectedValue)
+    protected override Task<AssertionResult> GetResult(TimeSpan actualValue, TimeSpan expectedValue)
     {
         if (_tolerance is not null)
         {

--- a/TUnit.Assertions/Assertions/ClassMembers/Conditions/PropertyEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/ClassMembers/Conditions/PropertyEqualsExpectedValueAssertCondition.cs
@@ -11,7 +11,7 @@ public class PropertyEqualsExpectedValueAssertCondition<TRootObjectType, TProper
         return $"{typeof(TRootObjectType).Name}.{ExpressionHelpers.GetName(propertySelector)} to be equal to {expected}";
     }
 
-    protected override AssertionResult GetResult(TRootObjectType? actualValue, TPropertyType? expectedValue)
+    protected override Task<AssertionResult> GetResult(TRootObjectType? actualValue, TPropertyType? expectedValue)
     {
         var propertyValue = GetPropertyValue(actualValue);
         return AssertionResult

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableContainsExpectedValueAssertCondition<TActual, TInner>(
 {
     protected override string GetExpectation() => $"to contain {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TInner? inner)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TInner? inner)
         => AssertionResult
             .FailIf(actualValue is null,
                 $"{ActualExpression ?? typeof(TActual).Name} is null")

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableCountEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableCountEqualToExpectedValueAssertCondition.cs
@@ -7,7 +7,7 @@ public class EnumerableCountEqualToExpectedValueAssertCondition<TInner>(int expe
 {
     protected override string GetExpectation() => $"to have a count of {expected}";
 
-    protected override AssertionResult GetResult(IEnumerable<TInner>? actualValue, int count)
+    protected override Task<AssertionResult> GetResult(IEnumerable<TInner>? actualValue, int count)
     {
         var actualCount = GetCount(actualValue);
 

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableCountNotEqualToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableCountNotEqualToExpectedValueAssertCondition.cs
@@ -7,7 +7,7 @@ public class EnumerableCountNotEqualToExpectedValueAssertCondition<TInner>(int e
 {
     protected override string GetExpectation() => $"to have a count different to {expected}";
     
-    protected override AssertionResult GetResult(IEnumerable<TInner>? actualValue, int count)
+    protected override Task<AssertionResult> GetResult(IEnumerable<TInner>? actualValue, int count)
     {
         var actualCount = GetCount(actualValue);
 

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableEquivalentToExpectedValueAssertCondition.cs
@@ -23,7 +23,7 @@ public class EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>
         return $"to be equivalent to {(expected != null ? Formatter.Format(expected) : null)}";
     }
 
-    protected override AssertionResult GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
     {
         if (actualValue is null && expectedValue is null)
         {

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotContainsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableNotContainsExpectedValueAssertCondition<TActual, TInner>(
 {
     protected override string GetExpectation() => $"to not contain {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TInner? inner)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TInner? inner)
         => AssertionResult
             .FailIf(actualValue is null,
                 $"{ActualExpression ?? typeof(TActual).Name} is null")

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInn
 {
     protected override string GetExpectation() => $" to be not equivalent to {(expected != null ? string.Join(",", expected) : null)}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
     {
         if (actualValue is null != expectedValue is null)
         {

--- a/TUnit.Assertions/Assertions/Generics/Conditions/EqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/EqualsExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class EqualsExpectedValueAssertCondition<TActual>(TActual expected, IEqua
     protected override string GetExpectation()
         => $"to be equal to {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TActual? expectedValue)
     {
         if (equalityComparer.Equals(actualValue, expectedValue))
         {

--- a/TUnit.Assertions/Assertions/Generics/Conditions/EquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/EquivalentToExpectedValueAssertCondition.cs
@@ -14,7 +14,7 @@ public class EquivalentToExpectedValueAssertCondition<[DynamicallyAccessedMember
     protected override string GetExpectation()
         => $"to be equivalent to {expectedExpression}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
     {
         if (actualValue is null && ExpectedValue is null)
         {

--- a/TUnit.Assertions/Assertions/Generics/Conditions/NotDefaultAssertionCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/NotDefaultAssertionCondition.cs
@@ -9,7 +9,7 @@ public class NotDefaultExpectedValueAssertCondition<TActual>() : ExpectedValueAs
         protected override string GetExpectation()
             => $"to not be {(_defaultValue is null ? "null" : _defaultValue)}";
 
-        protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue)
+        protected override Task<AssertionResult> GetResult(TActual? actualValue, TActual? expectedValue)
             => AssertionResult
                 .FailIf(actualValue is null || actualValue.Equals(_defaultValue),
                     "it was");

--- a/TUnit.Assertions/Assertions/Generics/Conditions/NotEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/NotEqualsExpectedValueAssertCondition.cs
@@ -8,7 +8,7 @@ public class NotEqualsExpectedValueAssertCondition<TActual>(TActual expected)
     protected override string GetExpectation()
         => $"to not be equal to {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TActual? expectedValue) => AssertionResult
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TActual? expectedValue) => AssertionResult
         .FailIf(Equals(actualValue, expectedValue),
             "it was");
 }

--- a/TUnit.Assertions/Assertions/Generics/Conditions/NotSameReferenceExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/NotSameReferenceExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class NotSameReferenceExpectedValueAssertCondition<TActual, TExpected>(TE
     protected override string GetExpectation()
         => $"to not have the same reference as {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
     {
         if (actualValue is UnTypedEnumerableWrapper unTypedEnumerableWrapper)
         {

--- a/TUnit.Assertions/Assertions/Generics/Conditions/SameReferenceExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/SameReferenceExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class SameReferenceExpectedValueAssertCondition<TActual, TExpected>(TExpe
     protected override string GetExpectation()
         => $"to have the same reference as {expected}";
 
-    protected override AssertionResult GetResult(TActual? actualValue, TExpected? expectedValue)
+    protected override Task<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
     {
         if (actualValue is UnTypedEnumerableWrapper unTypedEnumerableWrapper)
         {

--- a/TUnit.Assertions/Assertions/Strings/Conditions/StringContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Strings/Conditions/StringContainsExpectedValueAssertCondition.cs
@@ -12,7 +12,7 @@ public class StringContainsExpectedValueAssertCondition(string expected, StringC
     protected override string GetExpectation()
         => $"to contain {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/Assertions/Strings/Conditions/StringEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Strings/Conditions/StringEqualsExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class StringEqualsExpectedValueAssertCondition(string expected, StringCom
     protected override string GetExpectation()
         => $"to be equal to {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {
@@ -21,5 +21,37 @@ public class StringEqualsExpectedValueAssertCondition(string expected, StringCom
         return AssertionResult
             .FailIf(!string.Equals(actualValue, expectedValue, stringComparison),
                 $"found {Formatter.Format(ActualValue).TruncateWithEllipsis(100)} which {new StringDifference(actualValue, expectedValue)}");
+    }
+
+    public StringEqualsExpectedValueAssertCondition WithTrimming()
+    {
+        WithTransform(s => s?.Trim(), s => s?.Trim());
+        return this;
+    }
+
+    public StringEqualsExpectedValueAssertCondition WithNullAndEmptyEquality()
+    {
+        WithComparer((actual, expected) =>
+        {
+            if (actual == null && expected == string.Empty)
+            {
+                return AssertionDecision.Pass;
+            }
+
+            if (expected == null && actual == string.Empty)
+            {
+                return AssertionDecision.Pass;
+            }
+
+            return AssertionDecision.Continue;
+        });
+        
+        return this;
+    }
+
+    public StringEqualsExpectedValueAssertCondition IgnoringWhitespace()
+    {
+        WithTransform(StringUtils.StripWhitespace, StringUtils.StripWhitespace);
+        return this;
     }
 }

--- a/TUnit.Assertions/Assertions/Strings/Conditions/StringNotContainsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Strings/Conditions/StringNotContainsExpectedValueAssertCondition.cs
@@ -9,7 +9,7 @@ public class StringNotContainsExpectedValueAssertCondition(string expected, Stri
     protected override string GetExpectation()
         => $"to not contain {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(string? actualValue, string? expectedValue)
     {
         if (actualValue is null)
         {

--- a/TUnit.Assertions/Assertions/Strings/Conditions/StringNotEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Strings/Conditions/StringNotEqualsExpectedValueAssertCondition.cs
@@ -9,9 +9,8 @@ public class StringNotEqualsExpectedValueAssertCondition(string expected, String
     protected override string GetExpectation()
         => $"to not be equal to {Formatter.Format(expected).TruncateWithEllipsis(100)}";
 
-    protected override AssertionResult GetResult(string? actualValue, string? expectedValue)
+    protected override Task<AssertionResult> GetResult(string? actualValue, string? expectedValue)
     {
-
         if (actualValue is null)
         {
             return AssertionResult


### PR DESCRIPTION
…w async assertions & Custom Assertions can new up other assertions and call their `GetAssertionResult` method to get an `AssertionResult` so code can be shared/re-used more easily

Fixes #1724 