### PR TITLE
Fix `ThrowsNothing` losing its strong typing to its object type

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Tests1770.cs
+++ b/TUnit.Assertions.Tests/Bugs/Tests1770.cs
@@ -1,0 +1,26 @@
+﻿using TUnit.Assertions.AssertConditions.Throws;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+public class Tests1770
+{
+    [Test]
+    public async Task Throws_Nothing_Keeps_Type()
+    {
+        var guid = await Assert.That(Guid.NewGuid).ThrowsNothing();
+
+        await Assert.That(guid.ToByteArray()).IsNotEmpty();
+    }
+    
+    [Test]
+    public async Task Throws_Nothing_Keeps_Type_Async_Delegate()
+    {
+        var guid = await Assert.That(async () =>
+        {
+            await Task.CompletedTask;
+            return Guid.NewGuid();
+        }).ThrowsNothing();
+
+        await Assert.That(guid.ToByteArray()).IsNotEmpty();
+    }
+}

--- a/TUnit.Assertions/AssertionBuilders/CastableAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/CastableAssertionBuilder.cs
@@ -25,7 +25,7 @@ public class CastableAssertionBuilder<TActual, TExpected> : InvokableValueAssert
     {
         try
         {
-            return (TExpected)Convert.ChangeType(data.Result, typeof(TExpected))!;
+            return (TExpected?)data.Result;
         }
         catch
         {

--- a/TUnit.Assertions/AssertionBuilders/ValueDelegateAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/ValueDelegateAssertionBuilder.cs
@@ -4,9 +4,7 @@ using TUnit.Assertions.Extensions;
 namespace TUnit.Assertions.AssertionBuilders;
 
 public class ValueDelegateAssertionBuilder<TActual> 
-    : AssertionBuilder,
-        IDelegateSource,
-        IValueSource<TActual>
+    : AssertionBuilder, IValueDelegateSource<TActual>
 {
     internal ValueDelegateAssertionBuilder(Func<TActual> function, string? expressionBuilder) : base(function.AsAssertionData(expressionBuilder), expressionBuilder)
     {

--- a/TUnit.Assertions/Assertions/Throws/ThrowsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsExtensions.cs
@@ -41,6 +41,14 @@ public static class ThrowsExtensions
             assertionData => assertionData.Result);
     }
 
+    public static CastableAssertionBuilder<TActual, TActual> ThrowsNothing<TActual>(this IValueDelegateSource<TActual> delegateSource)
+    {
+        IValueSource<TActual> valueSource = delegateSource;
+        return new CastableAssertionBuilder<TActual, TActual>(
+            valueSource.RegisterAssertion(new ThrowsNothingAssertCondition<TActual>(), []),
+            assertionData => assertionData.Result is TActual actual ? actual : default);
+    }
+
     public static ThrowsException<TActual, TException> WithParameterName<TActual, TException>(this ThrowsException<TActual, TException> throwsException, string expected, [CallerArgumentExpression(nameof(expected))] string? doNotPopulateThisValue = null)
         where TException : ArgumentException
     {


### PR DESCRIPTION
Fixes #1770