### PR TITLE
Fix `.IsTypeOf<T>()` not returning `T` if wanting to assign the result to a variable

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Tests1774.cs
+++ b/TUnit.Assertions.Tests/Bugs/Tests1774.cs
@@ -1,0 +1,29 @@
+﻿using TUnit.Assertions.AssertConditions.Throws;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+public class Tests1774
+{
+    [Test]
+    public async Task Test()
+    {
+        Type1 type1 = new Type2();
+        
+        var type2 = await Assert.That(() => type1)
+            .ThrowsNothing()
+            .And
+            .IsTypeOf<Type2>()
+            .And
+            .Satisfies(res => res?.Property2, assert => assert.IsNotNullOrEmpty()!);
+    }
+
+    public record Type1
+    {
+        public string Property1 => "Value1";
+    }
+
+    public record Type2 : Type1
+    {
+        public string Property2 => "Value2";
+    }
+}

--- a/TUnit.Assertions/AssertionBuilders/CastableAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/CastableAssertionBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace TUnit.Assertions.AssertionBuilders;
 
-public class CastableAssertionBuilder<TActual, TExpected> : InvokableValueAssertionBuilder<TActual>
+public class CastableAssertionBuilder<TActual, TExpected> : InvokableValueAssertionBuilder<TExpected>
 {
     private readonly Func<AssertionData, TExpected?> _mapper;
 


### PR DESCRIPTION
Fixes #1774