### PR TITLE
Expose `CancellationToken` within `TestContext`

### DIFF
--- a/TUnit.Core/DiscoveredTest.cs
+++ b/TUnit.Core/DiscoveredTest.cs
@@ -14,6 +14,7 @@ internal record DiscoveredTest<
 
     public override async Task ExecuteTest(CancellationToken cancellationToken)
     {
+        TestContext.CancellationToken = cancellationToken;
         await TestExecutor.ExecuteTest(TestContext, () => TestBody.Invoke(TestClass, cancellationToken));
     }
     

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -45,6 +45,9 @@ public partial class TestContext : Context, IDisposable
     public Dictionary<string, object?> ObjectBag { get; }
     
     public TestResult? Result { get; internal set; }
+    
+    public CancellationToken CancellationToken { get; internal set; }
+    
     internal DiscoveredTest InternalDiscoveredTest { get; set; } = null!;
 
     public void SuppressReportingResult()

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -443,7 +443,7 @@ internal class SingleTestExecutor(
     {
         var timeout = discoveredTest.TestDetails.Timeout;
 
-        if (timeout == null || timeout.Value == default)
+        if (timeout == null || timeout.Value == TimeSpan.Zero)
         {
             await RunTest(discoveredTest, cancellationToken, cleanupExceptions);
             return;


### PR DESCRIPTION
Fixes #1779