### PR TITLE
Fixed output of 'BetweenAssertCondition'

### DIFF
--- a/TUnit.Assertions/Assertions/Comparables/Conditions/BetweenAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Comparables/Conditions/BetweenAssertCondition.cs
@@ -5,7 +5,7 @@ public class BetweenAssertCondition<TActual>(TActual minimum, TActual maximum) :
 {
     private bool _inclusiveBounds;
 
-    protected override string GetExpectation() => $"to be between {minimum} & {minimum} ({GetRange()} Range)";
+    protected override string GetExpectation() => $"to be between {minimum} & {maximum} ({GetRange()} Range)";
 
     protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception)
     {


### PR DESCRIPTION
Output in case of failure is now properly showing the lower and upper bounds instead of the lower bound twice
See #1785 for a screenshot.
