### PR TITLE
Don't wait for delegates in assertions if they exceed the `CompletesWithin(TimeSpan)` value 

### DIFF
--- a/TUnit.Assertions.Tests/ExecutionTimeTests.cs
+++ b/TUnit.Assertions.Tests/ExecutionTimeTests.cs
@@ -1,4 +1,5 @@
-﻿using TUnit.Assertions.AssertConditions;
+﻿using System.Diagnostics;
+using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Throws;
 using TUnit.Assertions.Assertions.Delegates;
 
@@ -17,12 +18,18 @@ public class ExecutionTimeTests
     [Test]
     public async Task Completes_Within_Unhappy()
     {
+        var stopwatch = Stopwatch.StartNew();
+    
         var action = () => Thread.Sleep(1000);
 
         await Assert.That(
             async () => await Assert.That(action).CompletesWithin(TimeSpan.FromMilliseconds(250))
         ).Throws<AssertionException>()
-        .WithMessageMatching(StringMatcher.AsRegex(@"Expected action to complete within 250 milliseconds\s+but it took \d{1} seconds and \d+ milliseconds"));
+        .WithMessageMatching(StringMatcher.AsRegex(@"Expected action to complete within 250 milliseconds\s+but it took too long to complete"));
+
+        var duration = stopwatch.Elapsed;
+
+        await Assert.That(duration).IsLessThan(TimeSpan.FromSeconds(1));
     }
     
     [Test]
@@ -36,11 +43,17 @@ public class ExecutionTimeTests
     [Test]
     public async Task Completes_Within_Unhappy2()
     {
+        var stopwatch = Stopwatch.StartNew();
+
         var action = () => Task.Delay(1000);
 
         await Assert.That(
             async () => await Assert.That(action).CompletesWithin(TimeSpan.FromMilliseconds(250))
         ).Throws<AssertionException>()
-        .WithMessageMatching(StringMatcher.AsRegex(@"Expected action to complete within 250 milliseconds\s+but it took \d{1} seconds and \d+ milliseconds"));
+        .WithMessageMatching(StringMatcher.AsRegex(@"Expected action to complete within 250 milliseconds\s+but it took too long to complete"));
+        
+        var duration = stopwatch.Elapsed;
+
+        await Assert.That(duration).IsLessThan(TimeSpan.FromSeconds(1));
     }
 }

--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -24,6 +24,11 @@ public abstract class BaseAssertCondition
     public string? OverriddenMessage { get; internal set; }
     
     public string? Subject { get; private set; }
+    
+    /// <summary>
+    /// Sets a timeout to wait for the assertion to complete.
+    /// </summary>
+    public virtual TimeSpan? WaitFor { get; protected set; }
 
     protected abstract string GetExpectation();
 

--- a/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Comparables/ComparableIsExtensions.cs
@@ -18,7 +18,7 @@ public static class ComparableIsExtensions
             {
                 return value.CompareTo(expected) > 0;
             },
-            (value, _, _) => $"{value} was not greater than {expected}",
+            (value, _, _) => $"it was {value}",
             $"to be greater than {expected}")
             , [doNotPopulateThisValue]); }
     
@@ -29,7 +29,7 @@ public static class ComparableIsExtensions
             {
                 return value.CompareTo(expected) >= 0;
             },
-            (value, _, _) => $"{value} was not greater than or equal to {expected}",
+            (value, _, _) => $"it was {value}",
             $"be greater than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     
@@ -40,7 +40,7 @@ public static class ComparableIsExtensions
             {
                 return value.CompareTo(expected) < 0;
             },
-            (value, _, _) => $"{value} was not less than {expected}",
+            (value, _, _) => $"it was {value}",
             $"be less than {expected}")
             , [doNotPopulateThisValue]); }
     
@@ -51,7 +51,7 @@ public static class ComparableIsExtensions
             {
                 return value.CompareTo(expected) <= 0;
             },
-            (value, _, _) => $"{value} was not less than or equal to {expected}",
+            (value, _, _) => $"it was {value}",
             $"be less than or equal to {expected}")
             , [doNotPopulateThisValue]); }
     

--- a/TUnit.Assertions/Assertions/Delegates/Conditions/CompleteWithinAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Delegates/Conditions/CompleteWithinAssertCondition.cs
@@ -1,4 +1,5 @@
 using TUnit.Assertions.AssertConditions;
+using TUnit.Assertions.Exceptions;
 using TUnit.Assertions.Helpers;
 
 namespace TUnit.Assertions.Assertions.Delegates;
@@ -11,9 +12,13 @@ public class CompleteWithinAssertCondition<TActual>(TimeSpan timeSpan) : Delegat
     protected override Task<AssertionResult> GetResult(TActual? actualValue, Exception? exception,
         AssertionMetadata assertionMetadata)
         => AssertionResult
-        .FailIf(exception is not null,
+            .FailIf(exception is not null && exception.GetType().IsAssignableTo(typeof(CompleteWithinException)),
+                "it took too long to complete")
+        .OrFailIf(exception is not null,
             $"a {exception!.GetType().Name} was thrown")
         .OrFailIf(assertionMetadata.Duration > timeSpan,
             $"it took {assertionMetadata.Duration.PrettyPrint()}"
         );
+
+    public override TimeSpan? WaitFor => timeSpan;
 }

--- a/TUnit.Assertions/Assertions/Throws/ThrowsWithinAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Throws/ThrowsWithinAssertCondition.cs
@@ -1,4 +1,5 @@
 using TUnit.Assertions.AssertConditions;
+using TUnit.Assertions.Exceptions;
 using TUnit.Assertions.Extensions;
 using TUnit.Assertions.Helpers;
 
@@ -15,9 +16,13 @@ public class ThrowsWithinAssertCondition<TActual, TExpectedException>(TimeSpan t
         => AssertionResult
         .FailIf(exception is null,
             "none was thrown")
-        .OrFailIf(exception?.GetType().IsAssignableTo(typeof(TExpectedException)) != true,
-            $"{exception?.GetType().Name.PrependAOrAn()} was thrown"
+        .OrFailIf(exception!.GetType().IsAssignableTo(typeof(CompleteWithinException)),
+            "it took too long to throw")
+        .OrFailIf(!exception.GetType().IsAssignableTo(typeof(TExpectedException)),
+            $"{exception.GetType().Name.PrependAOrAn()} was thrown"
         )
         .OrFailIf(assertionMetadata.Duration > timeSpan,
             $"it threw after {assertionMetadata.Duration.PrettyPrint()}");
+    
+    public override TimeSpan? WaitFor => timeSpan;
 }

--- a/TUnit.Assertions/Exceptions/CompleteWithinException.cs
+++ b/TUnit.Assertions/Exceptions/CompleteWithinException.cs
@@ -1,0 +1,12 @@
+﻿namespace TUnit.Assertions.Exceptions;
+
+internal class CompleteWithinException : AssertionException
+{
+    public CompleteWithinException(string? message) : base(message)
+    {
+    }
+
+    public CompleteWithinException(string? message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/TUnit.Assertions/Extensions/DelegateExtensions.cs
+++ b/TUnit.Assertions/Extensions/DelegateExtensions.cs
@@ -5,23 +5,23 @@ namespace TUnit.Assertions.Extensions;
 [StackTraceHidden]
 internal static class DelegateExtensions
 {
-    public static ValueTask<AssertionData> AsAssertionData(this Action action, string? actualExpression)
+    public static async ValueTask<AssertionData> AsAssertionData(this Action action, string? actualExpression)
     {
         var start = DateTimeOffset.Now;
 
         try
         {
-            action();
+            await Task.Run(action);
             
             var end = DateTimeOffset.Now;
 
-            return new ValueTask<AssertionData>((null, null, actualExpression, start, end));
+            return (null, null, actualExpression, start, end);
         }
         catch (Exception e)
         {
             var end = DateTimeOffset.Now;
 
-            return new ValueTask<AssertionData>((null, e, actualExpression, start, end));
+            return (null, e, actualExpression, start, end);
         }
     }
     

--- a/TUnit.Assertions/Extensions/DelegateExtensions.cs
+++ b/TUnit.Assertions/Extensions/DelegateExtensions.cs
@@ -65,23 +65,23 @@ internal static class DelegateExtensions
         }
     }
     
-    public static ValueTask<AssertionData> AsAssertionData<T>(this Func<T> action, string? actualExpression)
+    public static async ValueTask<AssertionData> AsAssertionData<T>(this Func<T> action, string? actualExpression)
     {
         var start = DateTimeOffset.Now;
 
         try
         {
-            var result = action();
+            var result = await Task.Run(action);
             
             var end = DateTimeOffset.Now;
 
-            return new ValueTask<AssertionData>((result, null, actualExpression, start, end));
+            return (result, null, actualExpression, start, end);
         }
         catch (Exception e)
         {
             var end = DateTimeOffset.Now;
 
-            return new ValueTask<AssertionData>((null, e, actualExpression, start, end));
+            return (null, e, actualExpression, start, end);
         }
     }
     

--- a/TUnit.TestProject/TUnit.TestProject.csproj
+++ b/TUnit.TestProject/TUnit.TestProject.csproj
@@ -59,4 +59,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Test.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
cc @AlexandreBossard