### PR TITLE
docs: update ITestEndEventReceiver name in docs

### DIFF
--- a/docs/docs/tutorial-extras/class-constructors.md
+++ b/docs/docs/tutorial-extras/class-constructors.md
@@ -22,7 +22,7 @@ using TUnit.Core;
 
 namespace MyTestProject;
 
-public class DependencyInjectionClassConstructor : IClassConstructor, ITestEndEvent
+public class DependencyInjectionClassConstructor : IClassConstructor, ITestEndEventReceiver
 {
     private static readonly IServiceProvider _serviceProvider = CreateServiceProvider();
 


### PR DESCRIPTION
Hi Tom,

First off, thanks for writing TUnit and providing it to the community. I've been enjoying writing tests with the library and I'm cheering for it's continued support and adoption.

In [this pull request](https://github.com/thomhurst/TUnit/commit/fcd70be762018dc6fb45fc490b5217c56d1f5249), the **ITestEndEvent** interface was renamed to **ITestEndEventReceiver**. This pull request just updates the class constructors documentation to reflect this change.