### PR TITLE
Resolve Dependencies earlier and run them bottom-up (most nested dependencies run first)

### DIFF
--- a/TUnit.Core/DiscoveredTest.cs
+++ b/TUnit.Core/DiscoveredTest.cs
@@ -41,6 +41,8 @@ internal abstract record DiscoveredTest : IComparable<DiscoveredTest>, IComparab
     public abstract IClassConstructor? ClassConstructor { get; }
     
     public IHookExecutor? HookExecutor { get; internal set; }
+
+    internal Dependency[] Dependencies { get; set; } = [];
     
     public int CompareTo(object? obj)
     {

--- a/TUnit.Core/Models/Dependency.cs
+++ b/TUnit.Core/Models/Dependency.cs
@@ -1,0 +1,6 @@
+﻿namespace TUnit.Core;
+
+internal record Dependency(DiscoveredTest Test, bool ProceedOnFailure)
+{
+    public TestDetails TestDetails => Test.TestDetails;
+}

--- a/TUnit.Engine/Extensions/TestContextExtensions.cs
+++ b/TUnit.Engine/Extensions/TestContextExtensions.cs
@@ -85,11 +85,22 @@ public static class TestContextExtensions
 
         if (testContext.Result?.Exception is not null && exception is not null)
         {
-            exception = new AggregateException(testContext.Result.Exception, exception);
+            if (exception is AggregateException aggregateException)
+            {
+                exception = new AggregateException([
+                    testContext.Result.Exception, ..aggregateException.InnerExceptions
+                ]);
+            }
+            else
+            {
+                exception = new AggregateException(testContext.Result.Exception, exception);
+            }
         }
 
-        var start = testContext.Timings.MinBy(x => x.Start)?.Start;
-        var end = testContext.Timings.MaxBy(x => x.End)?.End;
+        DateTimeOffset? now = null;
+        
+        var start = testContext.Timings.MinBy(x => x.Start)?.Start ?? (now ??= DateTimeOffset.UtcNow);
+        var end = testContext.Timings.MaxBy(x => x.End)?.End ?? (now ??= DateTimeOffset.UtcNow);
         
         testContext.Result = new TestResult
         {

--- a/TUnit.Engine/Services/DependencyCollector.cs
+++ b/TUnit.Engine/Services/DependencyCollector.cs
@@ -1,0 +1,87 @@
+﻿using TUnit.Core;
+using TUnit.Core.Exceptions;
+
+namespace TUnit.Engine.Services;
+
+internal class DependencyCollector
+{
+    public void ResolveDependencies(DiscoveredTest[] discoveredTests)
+    {
+        foreach (var discoveredTest in discoveredTests)
+        {
+            discoveredTest.Dependencies = GetDependencies(discoveredTest, discoveredTests);
+        }
+    }
+
+    private Dependency[] GetDependencies(DiscoveredTest test, DiscoveredTest[] allTests)
+    {
+        return GetDependencies(test, test, [test], allTests).ToArray();
+    }
+
+    private IEnumerable<Dependency> GetDependencies(DiscoveredTest original, DiscoveredTest test,
+        List<DiscoveredTest> currentChain, DiscoveredTest[] allTests)
+    {
+        if (test.Dependencies is { Length: > 0 })
+        {
+            foreach (var testDependency in test.Dependencies)
+            {
+                yield return testDependency;
+            }
+            
+            yield break;
+        }
+        
+        foreach (var dependsOnAttribute in test.TestDetails.Attributes.OfType<DependsOnAttribute>())
+        {
+            var dependencies = GetDependencies(test, dependsOnAttribute, allTests);
+
+            foreach (var dependency in dependencies)
+            {
+                currentChain.Add(dependency);
+
+                if (dependency.TestDetails.IsSameTest(original.TestDetails))
+                {
+                    throw new DependencyConflictException(currentChain.Select(x => x.TestDetails));
+                }
+
+                yield return new Dependency(dependency, dependsOnAttribute.ProceedOnFailure);
+
+                foreach (var nestedDependency in GetDependencies(original, dependency, currentChain, allTests))
+                {
+                    yield return nestedDependency;
+                }
+            }
+        }
+    }
+
+    private DiscoveredTest[] GetDependencies(DiscoveredTest test, DependsOnAttribute dependsOnAttribute, DiscoveredTest[] allTests)
+    {
+        var testsForClass = allTests.Where(x => x.TestDetails.TestClass.Type == (dependsOnAttribute.TestClass ?? test.TestDetails.TestClass.Type));
+
+        if (dependsOnAttribute.TestClass == null)
+        {
+            testsForClass = testsForClass
+                .Where(x => x.TestDetails.TestClassArguments.SequenceEqual(test.TestDetails.TestClassArguments));
+        }
+
+        if (dependsOnAttribute.TestName != null)
+        {
+            testsForClass = testsForClass.Where(x => x.TestDetails.TestName == dependsOnAttribute.TestName);
+        }
+
+        if (dependsOnAttribute.ParameterTypes != null)
+        {
+            testsForClass = testsForClass.Where(x =>
+                x.TestDetails.TestMethodParameterTypes.SequenceEqual(dependsOnAttribute.ParameterTypes));
+        }
+        
+        var foundTests = testsForClass.ToArray();
+
+        if (!foundTests.Any())
+        {
+            throw new TUnitException($"No tests found for DependsOn({dependsOnAttribute}) - If using Inheritance remember to use an [InheritsTest] attribute");
+        }
+
+        return foundTests;
+    }
+}

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -70,6 +70,11 @@ internal class SingleTestExecutor(
 
             try
             {
+                if (testContext.Result?.Exception is {} exception)
+                {
+                    throw exception;
+                }
+                
                 await WaitForDependencies(test, filter, context);
 
                 start = DateTimeOffset.Now;

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -70,7 +70,7 @@ internal class SingleTestExecutor(
 
             try
             {
-                await WaitForDepencies(test, filter, context);
+                await WaitForDependencies(test, filter, context);
 
                 start = DateTimeOffset.Now;
 
@@ -455,7 +455,7 @@ internal class SingleTestExecutor(
         return Task.Run(() => testInvoker.Invoke(discoveredTest, cancellationToken, cleanupExceptions), cancellationToken);
     }
 
-    private async ValueTask WaitForDepencies(DiscoveredTest test, ITestExecutionFilter? filter,
+    private async ValueTask WaitForDependencies(DiscoveredTest test, ITestExecutionFilter? filter,
         ExecuteRequestContext context)
     {
         // Reverse so most nested dependencies resolve first

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -7,7 +7,6 @@ using TUnit.Core;
 using TUnit.Core.Enums;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Extensions;
-using TUnit.Core.Interfaces;
 using TUnit.Core.Logging;
 using TUnit.Engine.Extensions;
 using TUnit.Engine.Helpers;
@@ -25,7 +24,6 @@ internal class SingleTestExecutor(
     ParallelLimitLockProvider parallelLimitLockProvider,
     AssemblyHookOrchestrator assemblyHookOrchestrator,
     ClassHookOrchestrator classHookOrchestrator,
-    ITestFinder testFinder,
     ITUnitMessageBus messageBus,
     TUnitFrameworkLogger logger,
     EngineCancellationToken engineCancellationToken,
@@ -72,7 +70,7 @@ internal class SingleTestExecutor(
 
             try
             {
-                await WaitForDependsOnTests(test, filter, context);
+                await WaitForDepencies(test, filter, context);
 
                 start = DateTimeOffset.Now;
 
@@ -457,10 +455,11 @@ internal class SingleTestExecutor(
         return Task.Run(() => testInvoker.Invoke(discoveredTest, cancellationToken, cleanupExceptions), cancellationToken);
     }
 
-    private async ValueTask WaitForDependsOnTests(DiscoveredTest test, ITestExecutionFilter? filter,
+    private async ValueTask WaitForDepencies(DiscoveredTest test, ITestExecutionFilter? filter,
         ExecuteRequestContext context)
     {
-        foreach (var dependency in GetDependencies(test.TestDetails))
+        // Reverse so most nested dependencies resolve first
+        foreach (var dependency in test.Dependencies.Reverse())
         {
             try
             {
@@ -475,67 +474,6 @@ internal class SingleTestExecutor(
                 throw new InconclusiveTestException($"A dependency has failed: {dependency.Test.TestDetails.TestName}", e);
             }
         }
-    }
-
-    private (DiscoveredTest Test, bool ProceedOnFailure)[] GetDependencies(TestDetails testDetails)
-    {
-        return GetDependencies(testDetails, testDetails, [testDetails]).ToArray();
-    }
-
-    private IEnumerable<(DiscoveredTest Test, bool ProceedOnFailure)> GetDependencies(TestDetails original, TestDetails testDetails, List<TestDetails> currentChain)
-    {
-        foreach (var dependsOnAttribute in testDetails.Attributes.OfType<DependsOnAttribute>())
-        {
-            var dependencies = GetDependencies(testDetails, dependsOnAttribute);
-
-            foreach (var dependency in dependencies)
-            {
-                currentChain.Add(dependency.TestDetails);
-
-                if (dependency.TestDetails.IsSameTest(original))
-                {
-                    throw new DependencyConflictException(currentChain);
-                }
-
-                yield return (dependency.InternalDiscoveredTest, dependsOnAttribute.ProceedOnFailure);
-
-                foreach (var nestedDependency in GetDependencies(original, dependency.TestDetails, currentChain))
-                {
-                    yield return nestedDependency;
-                }
-            }
-        }
-    }
-
-    private TestContext[] GetDependencies(TestDetails testDetails, DependsOnAttribute dependsOnAttribute)
-    {
-        var testsForClass = testFinder.GetTests(dependsOnAttribute.TestClass ?? testDetails.TestClass.Type);
-
-        if (dependsOnAttribute.TestClass == null)
-        {
-            testsForClass = testsForClass
-                .Where(x => x.TestDetails.TestClassArguments.SequenceEqual(testDetails.TestClassArguments));
-        }
-
-        if (dependsOnAttribute.TestName != null)
-        {
-            testsForClass = testsForClass.Where(x => x.TestDetails.TestName == dependsOnAttribute.TestName);
-        }
-
-        if (dependsOnAttribute.ParameterTypes != null)
-        {
-            testsForClass = testsForClass.Where(x =>
-                x.TestDetails.TestMethodParameterTypes.SequenceEqual(dependsOnAttribute.ParameterTypes));
-        }
-        
-        var foundTests = testsForClass.ToArray();
-
-        if (!foundTests.Any())
-        {
-            throw new TUnitException($"No tests found for DependsOn({dependsOnAttribute}) - If using Inheritance remember to use an [InheritsTest] attribute");
-        }
-
-        return foundTests;
     }
 
     public Task<bool> IsEnabledAsync()

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -464,7 +464,7 @@ internal class SingleTestExecutor(
             try
             {
                 await ExecuteTestAsync(dependency.Test, filter, context, true);
-            }
+            }   
             catch (Exception e) when (dependency.ProceedOnFailure)
             {
                 test.TestContext.OutputWriter.WriteLine($"A dependency has failed: {dependency.Test.TestDetails.TestName}", e);

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -459,19 +459,22 @@ internal class SingleTestExecutor(
         ExecuteRequestContext context)
     {
         // Reverse so most nested dependencies resolve first
-        foreach (var dependency in test.Dependencies.Reverse())
+        for (var index = test.Dependencies.Length - 1; index >= 0; index--)
         {
+            var dependency = test.Dependencies[index];
             try
             {
                 await ExecuteTestAsync(dependency.Test, filter, context, true);
-            }   
+            }
             catch (Exception e) when (dependency.ProceedOnFailure)
             {
-                test.TestContext.OutputWriter.WriteLine($"A dependency has failed: {dependency.Test.TestDetails.TestName}", e);
+                test.TestContext.OutputWriter.WriteLine(
+                    $"A dependency has failed: {dependency.Test.TestDetails.TestName}", e);
             }
             catch (Exception e)
             {
-                throw new InconclusiveTestException($"A dependency has failed: {dependency.Test.TestDetails.TestName}", e);
+                throw new InconclusiveTestException($"A dependency has failed: {dependency.Test.TestDetails.TestName}",
+                    e);
             }
         }
     }

--- a/TUnit.Engine/Services/TUnitTestDiscoverer.cs
+++ b/TUnit.Engine/Services/TUnitTestDiscoverer.cs
@@ -83,7 +83,7 @@ internal class TUnitTestDiscoverer(
             }
         }
         
-        var allDiscoveredTests = testsConstructor.GetTests().ToArray();
+        var allDiscoveredTests = testsConstructor.GetTests();
 
         var afterDiscoveryHooks = testDiscoveryHookOrchestrator.CollectAfterHooks();
         var afterContext = testDiscoveryHookOrchestrator.GetAfterContext(allDiscoveredTests);

--- a/TUnit.Engine/Services/TestsConstructor.cs
+++ b/TUnit.Engine/Services/TestsConstructor.cs
@@ -5,15 +5,22 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.Engine.Services;
 
-internal class TestsConstructor(IExtension extension, TestMetadataCollector testMetadataCollector, IServiceProvider serviceProvider) : IDataProducer
+internal class TestsConstructor(IExtension extension, 
+    TestMetadataCollector testMetadataCollector,
+    DependencyCollector dependencyCollector, 
+    IServiceProvider serviceProvider) : IDataProducer
 {
-    public IEnumerable<DiscoveredTest> GetTests()
+    public DiscoveredTest[] GetTests()
     {
         var testMetadatas = testMetadataCollector.GetTests();
 
-        return testMetadatas.Select(ConstructTest);
+        var discoveredTests = testMetadatas.Select(ConstructTest).ToArray();
+
+        dependencyCollector.ResolveDependencies(discoveredTests);
+        
+        return discoveredTests;
     }
-    
+
     public DiscoveredTest ConstructTest(TestMetadata testMetadata)
     {
         var testDetails = testMetadata.BuildTestDetails();


### PR DESCRIPTION
cc. @Artmos

By executing the most nested dependencies first, we might be able to resolve the hanging by not overloading the framework with lots of suspended tasks.

This may or may not work. Would you be able to try it out when it's released?

You'd need to switch back to trying `[DependsOn]` again as that's what this affects.