### PR TITLE
ContainsOnly fail with message with the unmatched item (#1586)

### DIFF
--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
@@ -15,12 +15,16 @@ public class EnumerableAllExpectedFuncAssertCondition<TActual, TInner>(
         var unmatchedEntries = GetUnmatchedEntries(actualValue);
         return AssertionResult
             .FailIf(actualValue is null, $"{ActualExpression ?? typeof(TActual).Name} is null")
+            .OrFailIf(!unmatchedEntries.IsPassed, unmatchedEntries.Message)
             .And(unmatchedEntries);
     }
 
     private AssertionResult GetUnmatchedEntries(TActual? actualValue)
     {
-        if(actualValue == null) return AssertionResult.Passed;
+        if (actualValue == null)
+        {
+            return AssertionResult.Passed;
+        }
         long i = 0;
         foreach (var item in actualValue)
         {

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableAllExpectedFuncAssertCondition.cs
@@ -12,11 +12,25 @@ public class EnumerableAllExpectedFuncAssertCondition<TActual, TInner>(
         AssertionMetadata assertionMetadata
     )
     {
+        var unmatchedEntries = GetUnmatchedEntries(actualValue);
         return AssertionResult
-            .FailIf(actualValue is null,
-                $"{ActualExpression ?? typeof(TActual).Name} is null")
-            .OrFailIf(!actualValue!.All(matcher),
-                //TODO: Add entry that failed to match
-                $"not all entries in the collection matched");
+            .FailIf(actualValue is null, $"{ActualExpression ?? typeof(TActual).Name} is null")
+            .And(unmatchedEntries);
     }
+
+    private AssertionResult GetUnmatchedEntries(TActual? actualValue)
+    {
+        if(actualValue == null) return AssertionResult.Passed;
+        long i = 0;
+        foreach (var item in actualValue)
+        {
+            if (!matcher(item))
+            {
+                return AssertionResult.Fail($"not all entries in the collection matched, first unmatched entry found at index {i}: \"{item}\"");
+            }
+            i++;
+        }
+        return AssertionResult.Passed; 
+    }
+    
 }


### PR DESCRIPTION
This fixes the TODO of my old pull request #1604 , which I slightly forgot about.
I don't particullary like the `And()` there, but I didn't find a more fitting method that would work.
`.OrFailIf(!unmatchedEntries.IsPassed, unmatchedEntries.Message)`
would also be possible, but I'm not sure if that's nicer?