### PR TITLE
Short circuit 'Or' asserts on the first success

### DIFF
--- a/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
@@ -18,20 +18,6 @@ public sealed class OrAssertionTests
 
         await Assert.That(action).Throws<MixedAndOrAssertionsException>();
     }
-    
-    
-    [Test]
-    public async Task Basic()
-    {
-        var foo = await Assert.That(ThrowException).ThrowsException();
-        await Assert.That(foo)
-                    .IsNotAssignableTo<ArgumentOutOfRangeException>()
-                    .Or
-                    .Satisfies(x => (ArgumentOutOfRangeException)x,
-                               x => x.HasMember(y => y.ActualValue).EqualTo("foo"));
-    }
-    
-    private void ThrowException() => throw new InvalidOperationException("foo");
 
     [Test]
     public async Task Does_Not_Throw_For_Multiple_Or()
@@ -46,5 +32,17 @@ public sealed class OrAssertionTests
 #pragma warning restore TUnitAssertions0001
 
         await Assert.That(action).ThrowsNothing();
+    }
+    
+    
+    [Test]
+    public async Task Short_Circuits_When_First_Assertion_Succeeds()
+    {
+        var exception = await Assert.That(() => throw new InvalidOperationException()).ThrowsException();
+        await Assert.That(exception)
+                    .IsNotAssignableTo<ArgumentOutOfRangeException>()
+                    .Or
+                    .Satisfies(x => (ArgumentOutOfRangeException)x,
+                               x => x.HasMember(y => y.ActualValue).EqualTo("foo"));
     }
 }

--- a/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
@@ -34,7 +34,6 @@ public sealed class OrAssertionTests
         await Assert.That(action).ThrowsNothing();
     }
     
-    
     [Test]
     public async Task Short_Circuits_When_First_Assertion_Succeeds()
     {

--- a/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
@@ -42,6 +42,6 @@ public sealed class OrAssertionTests
                     .IsNotAssignableTo<ArgumentOutOfRangeException>()
                     .Or
                     .Satisfies(x => (ArgumentOutOfRangeException)x,
-                               x => x.HasMember(y => y.ActualValue).EqualTo("foo"));
+                               x => x.HasMember(y => y!.ActualValue).EqualTo("foo"));
     }
 }

--- a/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
@@ -18,6 +18,20 @@ public sealed class OrAssertionTests
 
         await Assert.That(action).Throws<MixedAndOrAssertionsException>();
     }
+    
+    
+    [Test]
+    public async Task Basic()
+    {
+        var foo = await Assert.That(ThrowException).ThrowsException();
+        await Assert.That(foo)
+                    .IsNotAssignableTo<ArgumentOutOfRangeException>()
+                    .Or
+                    .Satisfies(x => (ArgumentOutOfRangeException)x,
+                               x => x.HasMember(y => y.ActualValue).EqualTo("foo"));
+    }
+    
+    private void ThrowException() => throw new InvalidOperationException("foo");
 
     [Test]
     public async Task Does_Not_Throw_For_Multiple_Or()

--- a/TUnit.Assertions/AssertConditions/AssertionResult.cs
+++ b/TUnit.Assertions/AssertConditions/AssertionResult.cs
@@ -56,19 +56,6 @@ public class AssertionResult
             : Fail(Message + " and " + other.Message);
     }
 
-    // TODO: Should this be removed/obsoleted?
-    public AssertionResult Or(AssertionResult other)
-    {
-        if (!IsPassed && !other.IsPassed)
-        {
-            return Message == other.Message 
-                ? Fail(Message) 
-                : Fail(Message + " and " + other.Message);
-        }
-
-        return Passed;
-    }
-
     public async ValueTask<AssertionResult> OrAsync(Func<ValueTask<AssertionResult>> otherResult)
     {
         if (IsPassed)

--- a/TUnit.Assertions/AssertConditions/AssertionResult.cs
+++ b/TUnit.Assertions/AssertConditions/AssertionResult.cs
@@ -68,6 +68,24 @@ public class AssertionResult
         return Passed;
     }
 
+    public async ValueTask<AssertionResult> OrAsync(Func<ValueTask<AssertionResult>> otherResult)
+    {
+        if (IsPassed)
+        {
+            return Passed;
+        }
+
+        var other = await otherResult();
+        if (other.IsPassed)
+        {
+            return Passed;
+        }
+
+        return Message == other.Message 
+                   ? Fail(Message) 
+                   : Fail(Message + " and " + other.Message);
+    }
+
     public AssertionResult OrFailIf(bool isFailed, string message)
     {
         if (!IsPassed || !isFailed)

--- a/TUnit.Assertions/AssertConditions/AssertionResult.cs
+++ b/TUnit.Assertions/AssertConditions/AssertionResult.cs
@@ -56,6 +56,7 @@ public class AssertionResult
             : Fail(Message + " and " + other.Message);
     }
 
+    // TODO: Should this be removed/obsoleted?
     public AssertionResult Or(AssertionResult other)
     {
         if (!IsPassed && !other.IsPassed)

--- a/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/Connectors/OrAssertCondition.cs
@@ -23,8 +23,8 @@ internal class OrAssertCondition : BaseAssertCondition
 
     internal sealed override async ValueTask<AssertionResult> GetAssertionResult(object? actualValue, Exception? exception, AssertionMetadata assertionMetadata, string? actualExpression)
     {
-        return (await _condition1.GetAssertionResult(actualValue, exception, assertionMetadata, actualExpression))
-            .Or(await _condition2.GetAssertionResult(actualValue, exception, assertionMetadata, actualExpression));
+        return  await (await _condition1.GetAssertionResult(actualValue, exception, assertionMetadata, actualExpression))
+            .OrAsync(() => _condition2.GetAssertionResult(actualValue, exception, assertionMetadata, actualExpression));
     }
 
     internal override void SetBecauseReason(BecauseReason becauseReason)


### PR DESCRIPTION
This resolves #1997 , though the implementation and test are extremely basic, merely enough to demonstrate the issue and a potential fix. Please let me know where you would like me to go with this PR.

Note the breaking change in removing `AssertionResult.Or` in favour of `OrAsync`.