### PR TITLE
Fix `ITestStartEventReceiver` and `ITestEndEventReceiver` not firing for custom classes when injected in via `[ClassDataSource<>]`

### DIFF
--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute.cs
@@ -12,7 +12,7 @@ public sealed class ClassDataSourceAttribute<T> : DataSourceGeneratorAttribute<T
             var item = ClassDataSources.Get(dataGeneratorMetadata.TestSessionId)
                 .Get<T>(Shared, dataGeneratorMetadata.TestClassType, Key, dataGeneratorMetadata);
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestRegistered(
                     context.TestContext,
@@ -22,7 +22,7 @@ public sealed class ClassDataSourceAttribute<T> : DataSourceGeneratorAttribute<T
                     item);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnInitialize(
                     context,
@@ -31,13 +31,23 @@ public sealed class ClassDataSourceAttribute<T> : DataSourceGeneratorAttribute<T
                     Key,
                     item);
             };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestStart += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, item);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestEnd += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, item);
+            };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(context, Shared, Key, item);
             };
             
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(context, Shared, Key, item);
             };

--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_2.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_2.cs
@@ -25,7 +25,7 @@ public sealed class ClassDataSourceAttribute<
                         .GetItemForIndex<T2>(1, dataGeneratorMetadata.TestClassType, Shared, Keys, dataGeneratorMetadata)
                 );
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (obj, context) =>
             {
                 var testContext = context.TestContext;
 
@@ -44,7 +44,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item2.T);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnInitialize(
                     context,
@@ -61,7 +61,19 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item2.T);
             };
             
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestStart += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestEnd += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item2.T);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context, 
@@ -76,7 +88,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item2.T);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context, 

--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_3.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_3.cs
@@ -30,7 +30,7 @@ public sealed class ClassDataSourceAttribute<
                         .GetItemForIndex<T3>(2, dataGeneratorMetadata.TestClassType, Shared, Keys, dataGeneratorMetadata)
                 );
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (obj, context) =>
             {
                 var testContext = context.TestContext;
 
@@ -56,7 +56,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item3.T);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnInitialize(
                     context,
@@ -79,8 +79,22 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item3.Key,
                     itemsWithMetadata.Item3.T);
             };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestStart += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestEnd += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item3.T);
+            };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context, 
@@ -101,7 +115,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item3.T);
             };
             
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context, 

--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_4.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_4.cs
@@ -35,7 +35,7 @@ public sealed class ClassDataSourceAttribute<
                         .GetItemForIndex<T4>(3, dataGeneratorMetadata.TestClassType, Shared, Keys, dataGeneratorMetadata)
                 );
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (obj, context) =>
             {
                 var testContext = context.TestContext;
 
@@ -68,7 +68,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item4.T);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnInitialize(
                     context,
@@ -98,8 +98,24 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item4.Key,
                     itemsWithMetadata.Item4.T);
             };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestStart += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item4.T);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestEnd += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item3.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item4.T);
+            };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context,
@@ -126,7 +142,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item4.T);
             };
             
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context,

--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_5.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute_5.cs
@@ -40,7 +40,7 @@ public sealed class ClassDataSourceAttribute<
                         .GetItemForIndex<T5>(4, dataGeneratorMetadata.TestClassType, Shared, Keys, dataGeneratorMetadata)
                 );
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestRegistered += async (obj, context) =>
             {
                 var testContext = context.TestContext;
 
@@ -80,7 +80,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item5.T);
             };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnInitialize += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnInitialize(
                     context,
@@ -117,8 +117,26 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item5.Key,
                     itemsWithMetadata.Item5.T);
             };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestStart += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item4.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestStart(context, itemsWithMetadata.Item5.T);
+            };
+            
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestEnd += async (obj, context) =>
+            {
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item1.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item2.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item3.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item4.T);
+                await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnTestEnd(context, itemsWithMetadata.Item5.T);
+            };
 
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnTestSkipped += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context,
@@ -151,7 +169,7 @@ public sealed class ClassDataSourceAttribute<
                     itemsWithMetadata.Item5.T);
             };
             
-            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (_, context) =>
+            dataGeneratorMetadata.TestBuilderContext.Current.Events.OnDispose += async (obj, context) =>
             {
                 await ClassDataSources.Get(dataGeneratorMetadata.TestSessionId).OnDispose(
                     context,

--- a/TUnit.Core/Attributes/TestData/ClassDataSources.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSources.cs
@@ -108,6 +108,11 @@ internal class ClassDataSources
         {
             await Initialize(testContext, shared, key, item);
         }
+
+        if (item is ITestRegisteredEventReceiver testRegisteredEventReceiver)
+        {
+            await testRegisteredEventReceiver.OnTestRegistered(new TestRegisteredContext(testContext.InternalDiscoveredTest));
+        }
     }
 
     public async ValueTask OnInitialize<T>(TestContext testContext, bool isStatic, SharedType shared, string key, T? item)
@@ -213,6 +218,22 @@ internal class ClassDataSources
             }
 
             throw;
+        }
+    }
+
+    public async Task OnTestStart<T>(BeforeTestContext context, T item) where T : new()
+    {
+        if (item is ITestStartEventReceiver testStartEventReceiver)
+        {
+            await testStartEventReceiver.OnTestStart(context);
+        }
+    }
+    
+    public async Task OnTestEnd<T>(TestContext context, T item) where T : new()
+    {
+        if (item is ITestEndEventReceiver testEndEventReceiver)
+        {
+            await testEndEventReceiver.OnTestEnd(context);
         }
     }
 }

--- a/TUnit.Engine.Tests/Bugs/Bug2067.cs
+++ b/TUnit.Engine.Tests/Bugs/Bug2067.cs
@@ -1,0 +1,20 @@
+﻿using Shouldly;
+
+namespace TUnit.Engine.Tests.Bugs;
+
+public class Bug2067 : InvokableTestBase
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/TUnit.TestProject.Bugs._2067/*/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}

--- a/TUnit.TestProject/Bugs/2067/DataClass.cs
+++ b/TUnit.TestProject/Bugs/2067/DataClass.cs
@@ -1,0 +1,51 @@
+﻿using TUnit.Core.Interfaces;
+
+namespace TUnit.TestProject.Bugs._2067;
+
+public class DataClass : 
+    IAsyncInitializer,
+    ITestRegisteredEventReceiver,
+    ITestStartEventReceiver,
+    ITestEndEventReceiver,
+    IAsyncDisposable
+{
+    public bool IsRegistered { get; set; }
+    public bool IsInitialized { get; set; }
+    public bool IsStarted { get; set; }
+    public bool IsEnded { get; set; }
+    public bool IsDisposed { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        IsInitialized = true;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        IsRegistered = true;
+        return default;
+    }
+
+
+    public ValueTask OnTestStart(BeforeTestContext beforeTestContext)
+    {
+        IsStarted = true;
+        return default;
+    }
+
+
+    public ValueTask OnTestEnd(TestContext testContext)
+    {
+        IsEnded = true;
+        return default;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        IsDisposed = true;
+        return default;
+    }
+
+    public int Order => 0;
+}

--- a/TUnit.TestProject/Bugs/2067/Tests.cs
+++ b/TUnit.TestProject/Bugs/2067/Tests.cs
@@ -1,0 +1,46 @@
+﻿using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.TestProject.Bugs._2067;
+
+[ClassDataSource<DataClass>(Shared = SharedType.PerTestSession)]
+[NotInParallel]
+public class Tests(DataClass dataClass)
+{
+    [Test]
+    public void ClassDataSource()
+    {
+        Console.WriteLine(dataClass);
+    }
+    
+    [After(TestSession)]
+#pragma warning disable TUnit0042
+    public static async Task AssertAllDataClassesDisposed(TestSessionContext context)
+#pragma warning restore TUnit0042
+    {
+        var tests = context.TestClasses
+            .FirstOrDefault(x => x.ClassType == typeof(Tests))
+            ?.Tests;
+
+        if (tests is null)
+        {
+            return;
+        }
+        
+        var dataClasses = tests
+            .SelectMany(x => x.TestDetails.TestClassArguments)
+            .OfType<DataClass>()
+            .ToArray();
+
+        using var _ = Assert.Multiple();
+
+        var dataClass = await Assert.That(dataClasses).HasSingleItem();
+        
+        await Assert.That(dataClass).IsNotNull();
+        await Assert.That(dataClass!.IsRegistered).IsTrue();
+        await Assert.That(dataClass.IsInitialized).IsTrue();
+        await Assert.That(dataClass.IsStarted).IsTrue();
+        await Assert.That(dataClass.IsEnded).IsTrue();
+        await Assert.That(dataClass.IsDisposed).IsTrue();
+    }
+}


### PR DESCRIPTION
Fixes #2067