### PR TITLE
Improve exception message for IsEquivalentTo when using enumerables without CollectionOrdering enum overload

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Tests2117.cs
+++ b/TUnit.Assertions.Tests/Bugs/Tests2117.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Immutable;
+using TUnit.Assertions.AssertConditions.Throws;
+using TUnit.Assertions.Enums;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+public class Tests2117
+{
+    [Test]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 3, 2, 1 }, CollectionOrdering.Matching,
+        """
+        Expected a to be equivalent to [3, 2, 1]
+
+        but it is [1, 2, 3]
+
+        at Assert.That(a).IsEquivalentTo(b, collectionOrdering.Value)
+        """)]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 1, 2, 3, 4 }, CollectionOrdering.Any,
+        """
+        Expected a to be equivalent to [1, 2, 3, 4]
+
+        but it is [1, 2, 3]
+
+        at Assert.That(a).IsEquivalentTo(b, collectionOrdering.Value)
+        """)]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 1, 2, 3, 4 }, null,
+        """
+        Expected a to be equivalent to [1, 2, 3, 4]
+
+        but it is [1, 2, 3]
+
+        at Assert.That(a).IsEquivalentTo(b)
+        """)]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 3, 2, 1 }, null,
+        """
+        Expected a to be equivalent to [3, 2, 1]
+
+        but it is [1, 2, 3]
+
+        at Assert.That(a).IsEquivalentTo(b)
+        """)]
+    public async Task IsEquivalent_Fail(int[] a, int[] b, CollectionOrdering? collectionOrdering, string expectedError)
+    {
+        await Assert.That(async () =>
+                await (collectionOrdering is null
+                    ? Assert.That(a).IsEquivalentTo(b)
+                    : Assert.That(a).IsEquivalentTo(b, collectionOrdering.Value))
+            ).Throws<AssertionException>()
+            .WithMessage(expectedError);
+    }
+    
+    [Test]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 3, 2, 1 }, CollectionOrdering.Any,
+        """
+        Expected a to not be equivalent to [3, 2, 1]
+
+        but the two Enumerables were equivalent
+
+        at Assert.That(a).IsNotEquivalentTo(b, collectionOrdering.Value)
+        """)]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, CollectionOrdering.Matching,
+        """
+        Expected a to not be equivalent to [1, 2, 3]
+
+        but the two Enumerables were equivalent
+
+        at Assert.That(a).IsNotEquivalentTo(b, collectionOrdering.Value)
+        """)]
+    [Arguments(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, null,
+        """
+        Expected a to not be equivalent to [1, 2, 3]
+
+        but the two Enumerables were equivalent
+
+        at Assert.That(a).IsNotEquivalentTo(b)
+        """)]
+    public async Task IsNotEquivalent_Fail(int[] a, int[] b, CollectionOrdering? collectionOrdering, string expectedError)
+    {
+        await Assert.That(async () =>
+                await (collectionOrdering is null
+                    ? Assert.That(a).IsNotEquivalentTo(b)
+                    : Assert.That(a).IsNotEquivalentTo(b, collectionOrdering.Value))
+            ).Throws<AssertionException>()
+            .WithMessage(expectedError);
+    }
+}

--- a/TUnit.Assertions.Tests/GlobalSetup.cs
+++ b/TUnit.Assertions.Tests/GlobalSetup.cs
@@ -1,0 +1,10 @@
+﻿namespace TUnit.Assertions.Tests;
+
+public class GlobalSetup
+{
+    [Before(TestSession)]
+    public static void DisableTruncation()
+    {
+        Environment.SetEnvironmentVariable("TUNIT_ASSERTIONS_DISABLE_TRUNCATION", "true");
+    }
+}

--- a/TUnit.Assertions.UnitTests/EquivalentAssertionTests.cs
+++ b/TUnit.Assertions.UnitTests/EquivalentAssertionTests.cs
@@ -88,7 +88,7 @@ public class EquivalentAssertionTests
             
             but it is [1, 5, 2, 3, 4]
             
-            at Assert.That(array).IsEquivalentTo(list)
+            at Assert.That(array).IsEquivalentTo(list, CollectionOrdering.Matching)
             """
         ));    }
     
@@ -107,7 +107,7 @@ public class EquivalentAssertionTests
             
             but it is [1, 5, 2, 3, 4]
             
-            at Assert.That(array).IsEquivalentTo(list)
+            at Assert.That(array).IsEquivalentTo(list, CollectionOrdering.Matching)
             """
         ));
     }

--- a/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/BaseAssertCondition.cs
@@ -32,6 +32,8 @@ public abstract class BaseAssertCondition
 
     protected abstract string GetExpectation();
 
+    internal string Expectation => GetExpectation();
+
     internal virtual string GetExpectationWithReason()
         => $"{GetExpectation()}{GetBecauseReason()}";
 

--- a/TUnit.Assertions/AssertConditions/Interfaces/ConvertedValueSource.cs
+++ b/TUnit.Assertions/AssertConditions/Interfaces/ConvertedValueSource.cs
@@ -8,7 +8,7 @@ namespace TUnit.Assertions.AssertConditions.Interfaces;
 public class ConvertedValueSource<TFromType, TToType>(IValueSource<TFromType> source, ConvertToAssertCondition<TFromType, TToType> convertToAssertCondition) : IValueSource<TToType?>
 {
     public string? ActualExpression { get; } = source.ActualExpression;
-    public Stack<BaseAssertCondition> Assertions { get; } = new([new NoOpAssertionCondition<TToType>()]);
+    public Stack<BaseAssertCondition> Assertions { get; } = new([new NoOpAssertionCondition<TToType>(convertToAssertCondition.Expectation)]);
     public ValueTask<AssertionData> AssertionDataTask { get; } = ConvertAsync(source, convertToAssertCondition);
 
     public StringBuilder ExpressionBuilder { get; } = source.ExpressionBuilder;

--- a/TUnit.Assertions/AssertionBuilders/AndConvertedTypeAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/AndConvertedTypeAssertionBuilder.cs
@@ -15,7 +15,7 @@ public abstract class ConvertedDelegateAssertionBuilder<TToType> : AssertionBuil
     // Due to the new generic constraint, so we need to populate the stack with something
     protected ConvertedDelegateAssertionBuilder(ISource source, 
         ValueTask<AssertionData> mappedData) 
-        : base(mappedData, source.ActualExpression!, source.ExpressionBuilder, new Stack<BaseAssertCondition>([new NoOpAssertionCondition<TToType>()]))
+        : base(mappedData, source.ActualExpression!, source.ExpressionBuilder, new Stack<BaseAssertCondition>([new NoOpAssertionCondition<TToType>(source.Assertions.Peek().Expectation)]))
     {
         OtherTypeAssertionBuilder = source as IInvokableAssertionBuilder;
     }

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsExtensions.cs
@@ -26,26 +26,27 @@ public static class CollectionsIsExtensions
         TActual,
         TInner>(this IValueSource<TActual> valueSource,
         IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer,
-        [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+        [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null,
+        [CallerArgumentExpression(nameof(comparer))] string doNotPopulateThisValue2 = null)
         where TActual : IEnumerable<TInner>
     {
-        return IsEquivalentTo(valueSource, expected, comparer, CollectionOrdering.Matching, doNotPopulateThisValue);
+        return IsEquivalentTo(valueSource, expected, comparer, CollectionOrdering.Matching, doNotPopulateThisValue, doNotPopulateThisValue2);
     }
 
     public static InvokableValueAssertionBuilder<TActual> IsEquivalentTo<TActual,  
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
-        TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+        TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
         where TActual : IEnumerable<TInner>
     {
-        return IsEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), collectionOrdering, doNotPopulateThisValue);
+        return IsEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), collectionOrdering, doNotPopulateThisValue, doNotPopulateThisValue2);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+    public static InvokableValueAssertionBuilder<TActual> IsEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
         where TActual : IEnumerable<TInner>
     {
         return valueSource.RegisterAssertion(
             new EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected,
-                comparer, collectionOrdering), [doNotPopulateThisValue]);
+                comparer, collectionOrdering), [doNotPopulateThisValue, doNotPopulateThisValue2]);
     }
 
     public static InvokableValueAssertionBuilder<IEnumerable<TInner>> IsInOrder<TInner>(

--- a/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/CollectionsIsNotExtensions.cs
@@ -1,19 +1,50 @@
 ﻿#nullable disable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
+using TUnit.Assertions.Enums;
+using TUnit.Assertions.Equality;
 
 namespace TUnit.Assertions.Extensions;
 
 public static class CollectionsIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual,  
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
         where TActual : IEnumerable<TInner>
     {
-        return valueSource.RegisterAssertion(new EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected, equalityComparer)
-            , [doNotPopulateThisValue]);
+        return IsNotEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), doNotPopulateThisValue, null);
+    }
+
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<
+        TActual,
+        TInner>(this IValueSource<TActual> valueSource,
+        IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer,
+        [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null,
+        [CallerArgumentExpression(nameof(comparer))] string doNotPopulateThisValue2 = null)
+        where TActual : IEnumerable<TInner>
+    {
+        return IsNotEquivalentTo(valueSource, expected, comparer, CollectionOrdering.Matching, doNotPopulateThisValue, doNotPopulateThisValue2);
+    }
+
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual,  
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
+        where TActual : IEnumerable<TInner>
+    {
+        return IsNotEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), collectionOrdering, doNotPopulateThisValue, doNotPopulateThisValue2);
+    }
+    
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquivalentTo<TActual, TInner>(this IValueSource<TActual> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
+        where TActual : IEnumerable<TInner>
+    {
+        return valueSource.RegisterAssertion(
+            new EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInner>(expected,
+                comparer, collectionOrdering), [doNotPopulateThisValue, doNotPopulateThisValue2]);
     }
     
     public static InvokableValueAssertionBuilder<IEnumerable<TInner>> IsNotEmpty<TInner>(this IValueSource<IEnumerable<TInner>> valueSource)

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableEquivalentToExpectedValueAssertCondition.cs
@@ -6,7 +6,7 @@ using TUnit.Assertions.Helpers;
 namespace TUnit.Assertions.AssertConditions.Collections;
 
 public class EnumerableEquivalentToExpectedValueAssertCondition<TActual, TInner>(
-    IEnumerable<TInner> expected,
+    IEnumerable<TInner>? expected,
     IEqualityComparer<TInner?> equalityComparer,
     CollectionOrdering collectionOrdering)
     : ExpectedValueAssertCondition<TActual, IEnumerable<TInner>>(expected)

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableNotEquivalentToExpectedValueAssertCondition.cs
@@ -1,12 +1,16 @@
+using TUnit.Assertions.Enums;
+using TUnit.Assertions.Helpers;
+
 namespace TUnit.Assertions.AssertConditions.Collections;
 
 public class EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInner>(
-    IEnumerable<TInner> expected,
-    IEqualityComparer<TInner?>? equalityComparer)
+    IEnumerable<TInner>? expected,
+    IEqualityComparer<TInner?> equalityComparer,
+    CollectionOrdering collectionOrdering)
     : ExpectedValueAssertCondition<TActual, IEnumerable<TInner>>(expected)
     where TActual : IEnumerable<TInner>?
 {
-    protected override string GetExpectation() => $" to be not equivalent to {(expected != null ? string.Join(",", expected) : null)}";
+    protected override string GetExpectation() => $"to not be equivalent to {(expected != null ? Formatter.Format(expected) : null)}";
 
     protected override ValueTask<AssertionResult> GetResult(TActual? actualValue, IEnumerable<TInner>? expectedValue)
     {
@@ -15,11 +19,19 @@ public class EnumerableNotEquivalentToExpectedValueAssertCondition<TActual, TInn
             return AssertionResult.Passed;
         }
 
+        var enumeratedActual = actualValue?.ToArray();
+        var enumeratedExpected = expectedValue?.ToArray();
+        
         return AssertionResult
             .FailIf(actualValue is null && expectedValue is null,
                 "it is null")
-            .OrFailIf(actualValue!.SequenceEqual(expectedValue!, equalityComparer),
-                "the two Enumerables were equivalent"
-            );
+            .OrFailIf(collectionOrdering == CollectionOrdering.Matching && enumeratedActual!.SequenceEqual(enumeratedExpected!, equalityComparer), "the two Enumerables were equivalent")
+            .OrFailIf(collectionOrdering == CollectionOrdering.Any && EqualsAnyOrder(enumeratedActual!, enumeratedExpected!, equalityComparer), "the two Enumerables were equivalent");
+    }
+
+    private static bool EqualsAnyOrder(TInner[] actualValue, TInner[] expectedValue,
+        IEqualityComparer<TInner?> equalityComparer)
+    {
+        return actualValue.Length == expectedValue.Length && !actualValue.Except(expectedValue, equalityComparer).Any(); 
     }
 }

--- a/TUnit.Assertions/Assertions/Collections/ImmutableArrayIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Collections/ImmutableArrayIsNotExtensions.cs
@@ -1,19 +1,45 @@
 ﻿#nullable disable
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions.Collections;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
+using TUnit.Assertions.Enums;
+using TUnit.Assertions.Equality;
 
 namespace TUnit.Assertions.Extensions;
 
 public static class ImmutableArrayIsNotExtensions
 {
-    public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEquivalentTo<TInner>(this IValueSource<ImmutableArray<TInner>> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> equalityComparer = null, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+    public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEquivalentTo<  
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        TInner>(this IValueSource<ImmutableArray<TInner>> valueSource, IEnumerable<TInner> expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
     {
-        return valueSource.RegisterAssertion(new EnumerableNotEquivalentToExpectedValueAssertCondition<ImmutableArray<TInner>, TInner>(expected, equalityComparer)
-            , [doNotPopulateThisValue]);
+        return IsNotEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), doNotPopulateThisValue);
+    }
+
+    public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEquivalentTo<TInner>(this IValueSource<ImmutableArray<TInner>> valueSource,
+        IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer,
+        [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null,
+        [CallerArgumentExpression(nameof(comparer))] string doNotPopulateThisValue2 = null)
+    {
+        return IsNotEquivalentTo(valueSource, expected, comparer, CollectionOrdering.Matching, doNotPopulateThisValue, doNotPopulateThisValue2);
+    }
+
+    public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEquivalentTo<  
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+        TInner>(this IValueSource<ImmutableArray<TInner>> valueSource, IEnumerable<TInner> expected, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
+    {
+        return IsNotEquivalentTo(valueSource, expected, new CollectionEquivalentToEqualityComparer<TInner>(), collectionOrdering, doNotPopulateThisValue, doNotPopulateThisValue2);
+    }
+    
+    public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEquivalentTo<TInner>(this IValueSource<ImmutableArray<TInner>> valueSource, IEnumerable<TInner> expected, IEqualityComparer<TInner> comparer, CollectionOrdering collectionOrdering, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null, [CallerArgumentExpression(nameof(collectionOrdering))] string doNotPopulateThisValue2 = null)
+    {
+        return valueSource.RegisterAssertion(
+            new EnumerableNotEquivalentToExpectedValueAssertCondition<ImmutableArray<TInner>, TInner>(expected,
+                comparer, collectionOrdering), [doNotPopulateThisValue, doNotPopulateThisValue2]);
     }
     
     public static InvokableValueAssertionBuilder<ImmutableArray<TInner>> IsNotEmpty<TInner>(this IValueSource<ImmutableArray<TInner>> valueSource)

--- a/TUnit.Assertions/Assertions/Generics/Conditions/EquivalentToExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/EquivalentToExpectedValueAssertCondition.cs
@@ -19,7 +19,13 @@ public class EquivalentToExpectedValueAssertCondition<
     public EquivalencyKind EquivalencyKind { get; set; } = EquivalencyKind.Full;
     
     protected override string GetExpectation()
-        => $"to be equivalent to {expectedExpression ?? "null"}";
+    {
+        var expectedMessage = typeof(TExpected).IsSimpleType() || typeof(IEnumerable).IsAssignableFrom(typeof(TExpected)) 
+            ? Formatter.Format(expected)
+            : expectedExpression;
+        
+        return $"to be equivalent to {expectedMessage ?? "null"}";
+    }
 
     protected override ValueTask<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
     {

--- a/TUnit.Assertions/Assertions/Generics/Conditions/NoOpAssertionCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/NoOpAssertionCondition.cs
@@ -2,9 +2,9 @@
 
 namespace TUnit.Assertions.Assertions.Generics.Conditions;
 
-public class NoOpAssertionCondition<TActual> : BaseAssertCondition<TActual>
+public class NoOpAssertionCondition<TActual>(string previousExpectation) : BaseAssertCondition<TActual>
 {
-    protected override string GetExpectation() => string.Empty;
+    protected override string GetExpectation() => previousExpectation;
 
     protected override ValueTask<AssertionResult> GetResult(
         TActual? actualValue, Exception? exception,

--- a/TUnit.Assertions/Extensions/StringExtensions.cs
+++ b/TUnit.Assertions/Extensions/StringExtensions.cs
@@ -26,6 +26,11 @@ public static class StringExtensions
 
     public static string TruncateWithEllipsis(this string value, int maxLength)
     {
+        if (Environment.GetEnvironmentVariable("TUNIT_ASSERTIONS_DISABLE_TRUNCATION") == "true")
+        {
+            return value;
+        }
+        
         if (value.Length <= maxLength)
         {
             return value;

--- a/TUnit.Assertions/Helpers/Formatter.cs
+++ b/TUnit.Assertions/Helpers/Formatter.cs
@@ -26,6 +26,7 @@ public abstract class Formatter
         new SimpleFormatter<string>(value => $"\"{value}\""),
         new SimpleFormatter<char>(value => $"'{value}'"),
         new SimpleFormatter<DateTime>(value => $"<{value:O}>"),
+        new SimpleFormatter<TimeSpan>(value => value.PrettyPrint()),
         new SimpleFormatter<DateTimeOffset>(value => value.ToString("<yyyy-MM-dd HH:mm:ss.fff tt>", CultureInfo.InvariantCulture)),
 #if NET
         new SimpleFormatter<DateOnly>(value => value.ToString("<yyyy-MM-dd>", CultureInfo.InvariantCulture)),


### PR DESCRIPTION
Fixes #2117

Also added equivalent overloads for IsNotEquivalentTo