### PR TITLE
Don't enumerate multiple times when using `Assert.That(collection).Contains(predicate)` and setting result to a variable

### DIFF
--- a/TUnit.Assertions/AssertionBuilders/MappableResultAssertionBuilder.cs
+++ b/TUnit.Assertions/AssertionBuilders/MappableResultAssertionBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using TUnit.Assertions.AssertConditions;
 
 namespace TUnit.Assertions.AssertionBuilders;
 
@@ -23,5 +24,32 @@ public class MappableResultAssertionBuilder<TActual, TExpected> : InvokableValue
         var tActual = data.Result is TActual actual ? actual : default;
         
         return _mapper(tActual);
+    }
+}
+
+public class MappableResultAssertionBuilder<TActual, TAssertCondition, TExpected> : InvokableValueAssertionBuilder<TActual> 
+    where TAssertCondition : BaseAssertCondition<TActual>
+{
+    private readonly TAssertCondition _assertCondition;
+    private readonly Func<TActual?, TAssertCondition, TExpected?> _mapper;
+
+    internal MappableResultAssertionBuilder(InvokableAssertionBuilder<TActual> assertionBuilder, TAssertCondition assertCondition, Func<TActual?, TAssertCondition, TExpected?> mapper) : base(assertionBuilder)
+    {
+        _assertCondition = assertCondition;
+        _mapper = mapper;
+    }
+
+    public new TaskAwaiter<TExpected?> GetAwaiter()
+    {
+        return Map().GetAwaiter();
+    }
+
+    private async Task<TExpected?> Map()
+    {
+        var data = await ProcessAssertionsAsync();
+
+        var tActual = data.Result is TActual actual ? actual : default;
+        
+        return _mapper(tActual, _assertCondition);
     }
 }

--- a/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedFuncAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Collections/Conditions/EnumerableContainsExpectedFuncAssertCondition.cs
@@ -12,10 +12,23 @@ public class EnumerableContainsExpectedFuncAssertCondition<TActual, TInner>(
         AssertionMetadata assertionMetadata
     )
     {
+        if (actualValue is null)
+        {
+            return FailWithMessage($"{ActualExpression ?? typeof(TActual).Name} is null");
+        }
+
+        foreach (var inner in actualValue)
+        {
+            if (matcher(inner))
+            {
+                FoundItem = inner;
+                break;
+            }
+        }
+        
         return AssertionResult
-            .FailIf(actualValue is null,
-                $"{ActualExpression ?? typeof(TActual).Name} is null")
-            .OrFailIf(!actualValue!.Any(matcher),
-                "there was no match found in the collection");
+            .FailIf(FoundItem is null, "there was no match found in the collection");
     }
+
+    public TInner? FoundItem { get; private set; }
 }

--- a/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
+++ b/TUnit.Assertions/Assertions/Generics/DoesExtensions_Generic.cs
@@ -16,10 +16,16 @@ public static partial class DoesExtensions
             , [doNotPopulateThisValue]);
     }
     
-    public static MappableResultAssertionBuilder<IEnumerable<TInner>, TInner> Contains<TInner>(this IValueSource<IEnumerable<TInner>> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = null)
+    public static MappableResultAssertionBuilder<IEnumerable<TInner>, EnumerableContainsExpectedFuncAssertCondition<IEnumerable<TInner>, TInner>, TInner> Contains<TInner>(this IValueSource<IEnumerable<TInner>> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = null)
     {
-        return new MappableResultAssertionBuilder<IEnumerable<TInner>, TInner>(valueSource.RegisterAssertion(new EnumerableContainsExpectedFuncAssertCondition<IEnumerable<TInner>, TInner>(matcher, doNotPopulateThisValue)
-            , [doNotPopulateThisValue]), enumerable => enumerable.FirstOrDefault(matcher));
+        var enumerableContainsExpectedFuncAssertCondition = new EnumerableContainsExpectedFuncAssertCondition<IEnumerable<TInner>, TInner>(matcher, doNotPopulateThisValue);
+
+        return new MappableResultAssertionBuilder<IEnumerable<TInner>,
+            EnumerableContainsExpectedFuncAssertCondition<IEnumerable<TInner>, TInner>, TInner>(
+            valueSource.RegisterAssertion(enumerableContainsExpectedFuncAssertCondition, [doNotPopulateThisValue]),
+            enumerableContainsExpectedFuncAssertCondition,
+            (_, assertCondition) => assertCondition.FoundItem
+        );
     }
 
     public static InvokableValueAssertionBuilder<IEnumerable<TInner>> ContainsOnly<TInner>(this IValueSource<IEnumerable<TInner>> valueSource, Func<TInner, bool> matcher, [CallerArgumentExpression(nameof(matcher))] string doNotPopulateThisValue = null)

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
@@ -303,6 +303,7 @@ namespace TUnit.Assertions.AssertConditions.Collections
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
         public EnumerableContainsExpectedFuncAssertCondition(System.Func<TInner, bool> matcher, string? matcherString) { }
+        public TInner FoundItem { get; }
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
@@ -662,6 +663,11 @@ namespace TUnit.Assertions.AssertionBuilders
         public TUnit.Assertions.AssertConditions.Operators.ValueDelegateOr<TActual> Or { get; }
     }
     public class MappableResultAssertionBuilder<TActual, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
+    }
+    public class MappableResultAssertionBuilder<TActual, TAssertCondition, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+        where TAssertCondition : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
         public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
     }
@@ -1188,7 +1194,7 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, System.StringComparison stringComparison, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null, [System.Runtime.CompilerServices.CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = null) { }
-        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TUnit.Assertions.AssertConditions.Collections.EnumerableContainsExpectedFuncAssertCondition<System.Collections.Generic.IEnumerable<TInner>, TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TInner expected, System.Collections.Generic.IEqualityComparer<TInner> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)
             where TActual : System.Collections.Generic.IEnumerable<TInner> { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TDictionary> valueSource, TKey expected, System.Collections.Generic.IEqualityComparer<TKey> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -326,6 +326,7 @@ namespace TUnit.Assertions.AssertConditions.Collections
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
         public EnumerableContainsExpectedFuncAssertCondition(System.Func<TInner, bool> matcher, string? matcherString) { }
+        public TInner FoundItem { get; }
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
@@ -685,6 +686,11 @@ namespace TUnit.Assertions.AssertionBuilders
         public TUnit.Assertions.AssertConditions.Operators.ValueDelegateOr<TActual> Or { get; }
     }
     public class MappableResultAssertionBuilder<TActual, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
+    }
+    public class MappableResultAssertionBuilder<TActual, TAssertCondition, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+        where TAssertCondition : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
         public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
     }
@@ -1227,7 +1233,7 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, System.StringComparison stringComparison, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null, [System.Runtime.CompilerServices.CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = null) { }
-        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TUnit.Assertions.AssertConditions.Collections.EnumerableContainsExpectedFuncAssertCondition<System.Collections.Generic.IEnumerable<TInner>, TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TInner expected, System.Collections.Generic.IEqualityComparer<TInner> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)
             where TActual : System.Collections.Generic.IEnumerable<TInner> { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TDictionary> valueSource, TKey expected, System.Collections.Generic.IEqualityComparer<TKey> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -326,6 +326,7 @@ namespace TUnit.Assertions.AssertConditions.Collections
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
         public EnumerableContainsExpectedFuncAssertCondition(System.Func<TInner, bool> matcher, string? matcherString) { }
+        public TInner FoundItem { get; }
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
@@ -685,6 +686,11 @@ namespace TUnit.Assertions.AssertionBuilders
         public TUnit.Assertions.AssertConditions.Operators.ValueDelegateOr<TActual> Or { get; }
     }
     public class MappableResultAssertionBuilder<TActual, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
+    }
+    public class MappableResultAssertionBuilder<TActual, TAssertCondition, TExpected> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+        where TAssertCondition : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
         public new System.Runtime.CompilerServices.TaskAwaiter<TExpected?> GetAwaiter() { }
     }
@@ -1227,7 +1233,7 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.Wrappers.StringContainsAssertionBuilderWrapper Contains(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<string> valueSource, string expected, System.StringComparison stringComparison, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null, [System.Runtime.CompilerServices.CallerArgumentExpression("stringComparison")] string doNotPopulateThisValue2 = null) { }
-        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.MappableResultAssertionBuilder<System.Collections.Generic.IEnumerable<TInner>, TUnit.Assertions.AssertConditions.Collections.EnumerableContainsExpectedFuncAssertCondition<System.Collections.Generic.IEnumerable<TInner>, TInner>, TInner> Contains<TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<System.Collections.Generic.IEnumerable<TInner>> valueSource, System.Func<TInner, bool> matcher, [System.Runtime.CompilerServices.CallerArgumentExpression("matcher")] string doNotPopulateThisValue = null) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> Contains<TActual, TInner>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TInner expected, System.Collections.Generic.IEqualityComparer<TInner> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)
             where TActual : System.Collections.Generic.IEnumerable<TInner> { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TDictionary> ContainsKey<TDictionary, TKey>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TDictionary> valueSource, TKey expected, System.Collections.Generic.IEqualityComparer<TKey> equalityComparer = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null)


### PR DESCRIPTION
@hartmair This should sort it.