### PR TITLE
`await Assert.That(...).IsNotNull()` returns a non-nullable annotated object

### DIFF
--- a/TUnit.Assertions.Tests/NullabilityInferenceTests.cs
+++ b/TUnit.Assertions.Tests/NullabilityInferenceTests.cs
@@ -1,0 +1,17 @@
+﻿namespace TUnit.Assertions.Tests;
+
+public class NullabilityInferenceTests
+{
+    [Test]
+    public async Task NotNull()
+    {
+        // ReSharper disable once SuggestVarOrType_BuiltInTypes
+        // ReSharper disable once ConvertToConstant.Local
+        // ReSharper disable once VariableCanBeNotNullable
+        string? nullableValue = "Hello World!";
+
+        var notNullValue = await Assert.That(nullableValue).IsNotNull();
+        
+        Console.WriteLine(notNullValue.Clone());
+    }
+}

--- a/TUnit.Assertions/AssertConditions/NotNullExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/AssertConditions/NotNullExpectedValueAssertCondition.cs
@@ -1,15 +1,18 @@
 namespace TUnit.Assertions.AssertConditions;
 
-public class NotNullExpectedValueAssertCondition<TActual> : BaseAssertCondition<TActual>
+public class NotNullExpectedValueAssertCondition<TActual> : ConvertToAssertCondition<TActual?, TActual>
 {
     protected override string GetExpectation()
         => "to not be null";
 
-    protected override ValueTask<AssertionResult> GetResult(
-        TActual? actualValue, Exception? exception,
-        AssertionMetadata assertionMetadata
-    )
-        => AssertionResult
-            .FailIf(actualValue is null,
-                "it was");
+    public override ValueTask<(AssertionResult, TActual?)> ConvertValue(TActual? value)
+    {
+        return new ValueTask<(AssertionResult, TActual?)>
+        (
+            (
+                AssertionResult.FailIf(value is null, "it was"),
+                value!
+            )
+        );
+    }
 }

--- a/TUnit.Assertions/AssertionBuilders/Wrappers/NotNullAssertionBuilderWrapper.cs
+++ b/TUnit.Assertions/AssertionBuilders/Wrappers/NotNullAssertionBuilderWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace TUnit.Assertions.AssertionBuilders.Wrappers;
+
+public class NotNullAssertionBuilderWrapper<TActual> : InvokableValueAssertionBuilder<TActual>
+{
+    internal NotNullAssertionBuilderWrapper(InvokableAssertionBuilder<TActual?> invokableAssertionBuilder) : base(invokableAssertionBuilder)
+    {
+    }
+    
+    public new TaskAwaiter<TActual> GetAwaiter()
+    {
+        return Process().GetAwaiter();
+    }
+    
+    private async Task<TActual> Process()
+    {
+        var data = await ProcessAssertionsAsync();
+
+        var tActual = data.Result is TActual actual ? actual : default;
+
+        return tActual!;
+    }
+}

--- a/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsNotExtensions.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertConditions;
 using TUnit.Assertions.AssertConditions.Interfaces;
 using TUnit.Assertions.AssertionBuilders;
@@ -11,7 +9,7 @@ namespace TUnit.Assertions.Extensions;
 
 public static class GenericIsNotExtensions
 {
-    public static GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null) 
+    public static GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string? doNotPopulateThisValue = null) 
     {
         var assertionBuilder = valueSource.RegisterAssertion(new NotEqualsExpectedValueAssertCondition<TActual>(expected)
             , [doNotPopulateThisValue]);
@@ -19,19 +17,18 @@ public static class GenericIsNotExtensions
         return new GenericNotEqualToAssertionBuilderWrapper<TActual>(assertionBuilder);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotNull<TActual>(this IValueSource<TActual> valueSource)
+    public static NotNullAssertionBuilderWrapper<TActual> IsNotNull<TActual>(this IValueSource<TActual?> valueSource) where TActual : class
     {
-        return valueSource!.RegisterAssertion(new NotNullExpectedValueAssertCondition<TActual>()
-            , []);
+        return new NotNullAssertionBuilderWrapper<TActual>(valueSource.RegisterConversionAssertion(new NotNullExpectedValueAssertCondition<TActual?>(), []));
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue = null)
+    public static InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string? doNotPopulateThisValue = null)
     {
         return valueSource.RegisterAssertion(new NotEqualsExpectedValueAssertCondition<TActual>(expected)
             , [doNotPopulateThisValue]);
     }
     
-    public static InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this IValueSource<TActual> valueSource, TExpected expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = null)
+    public static InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this IValueSource<TActual> valueSource, TExpected expected, [CallerArgumentExpression(nameof(expected))] string? doNotPopulateThisValue1 = null)
     {
         return valueSource.RegisterAssertion(new NotSameReferenceExpectedValueAssertCondition<TActual, TExpected>(expected)
             , [doNotPopulateThisValue1]);

--- a/TUnit.Assertions/Extensions/SourceExtensions.cs
+++ b/TUnit.Assertions/Extensions/SourceExtensions.cs
@@ -13,7 +13,7 @@ public static class SourceExtensions
     {
         if (!string.IsNullOrEmpty(caller))
         {
-            source.AppendExpression(BuildExpression(caller!, argumentExpressions));
+            source.AppendExpression(BuildExpression(caller, argumentExpressions));
         }
         
         var invokeableAssertionBuilder = source.WithAssertion(assertCondition);
@@ -42,7 +42,7 @@ public static class SourceExtensions
     {
         if (!string.IsNullOrEmpty(caller))
         {
-            delegateSource.AppendExpression(BuildExpression(caller!, argumentExpressions));
+            delegateSource.AppendExpression(BuildExpression(caller, argumentExpressions));
         }
         
         var source = delegateSource.WithAssertion(assertCondition);
@@ -60,14 +60,18 @@ public static class SourceExtensions
         return new InvokableDelegateAssertionBuilder(new InvokableAssertionBuilder<object?>(source));
     }
 
-    private static string BuildExpression(string caller, string?[] argumentExpressions)
+    private static string BuildExpression(string? caller, string?[] argumentExpressions)
     {
         var assertionBuilder = new StringBuilder();
 
         argumentExpressions = argumentExpressions.OfType<string>().ToArray();
         
-        assertionBuilder.Append(caller)
-            .Append('(');
+        if(caller is not null)
+        {
+            assertionBuilder.Append(caller);
+        }
+
+        assertionBuilder.Append('(');
         
         for (var index = 0; index < argumentExpressions.Length; index++)
         {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
@@ -204,11 +204,11 @@ namespace TUnit.Assertions.AssertConditions
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue) { }
     }
-    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
+    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.ConvertToAssertCondition<TActual?, TActual>
     {
         public NotNullExpectedValueAssertCondition() { }
+        public override System.Threading.Tasks.ValueTask<System.ValueTuple<TUnit.Assertions.AssertConditions.AssertionResult, TActual?>> ConvertValue(TActual? value) { }
         protected override string GetExpectation() { }
-        protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
     public class NullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
@@ -787,6 +787,10 @@ namespace TUnit.Assertions.AssertionBuilders.Wrappers
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithExclusiveBounds() { }
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithInclusiveBounds() { }
     }
+    public class NotNullAssertionBuilderWrapper<TActual> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TActual> GetAwaiter() { }
+    }
     public class SingleItemAssertionBuilderWrapper<TActual, TInner> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
@@ -1265,10 +1269,11 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.NotNullAssertionBuilderWrapper<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual?> valueSource)
+            where TActual :  class { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue1 = null) { }
     }
     public static class GenericSatisfiesExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -213,11 +213,11 @@ namespace TUnit.Assertions.AssertConditions
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue) { }
     }
-    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
+    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.ConvertToAssertCondition<TActual?, TActual>
     {
         public NotNullExpectedValueAssertCondition() { }
+        public override System.Threading.Tasks.ValueTask<System.ValueTuple<TUnit.Assertions.AssertConditions.AssertionResult, TActual?>> ConvertValue(TActual? value) { }
         protected override string GetExpectation() { }
-        protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
     public class NullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
@@ -814,6 +814,10 @@ namespace TUnit.Assertions.AssertionBuilders.Wrappers
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithExclusiveBounds() { }
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithInclusiveBounds() { }
     }
+    public class NotNullAssertionBuilderWrapper<TActual> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TActual> GetAwaiter() { }
+    }
     public class SingleItemAssertionBuilderWrapper<TActual, TInner> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
@@ -1304,10 +1308,11 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.NotNullAssertionBuilderWrapper<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual?> valueSource)
+            where TActual :  class { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue1 = null) { }
     }
     public static class GenericSatisfiesExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -213,11 +213,11 @@ namespace TUnit.Assertions.AssertConditions
         protected override string GetExpectation() { }
         protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue) { }
     }
-    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
+    public class NotNullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.ConvertToAssertCondition<TActual?, TActual>
     {
         public NotNullExpectedValueAssertCondition() { }
+        public override System.Threading.Tasks.ValueTask<System.ValueTuple<TUnit.Assertions.AssertConditions.AssertionResult, TActual?>> ConvertValue(TActual? value) { }
         protected override string GetExpectation() { }
-        protected override System.Threading.Tasks.ValueTask<TUnit.Assertions.AssertConditions.AssertionResult> GetResult(TActual? actualValue, System.Exception? exception, TUnit.Assertions.AssertionMetadata assertionMetadata) { }
     }
     public class NullExpectedValueAssertCondition<TActual> : TUnit.Assertions.AssertConditions.BaseAssertCondition<TActual>
     {
@@ -814,6 +814,10 @@ namespace TUnit.Assertions.AssertionBuilders.Wrappers
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithExclusiveBounds() { }
         public TUnit.Assertions.AssertionBuilders.Wrappers.NotBetweenAssertionBuilderWrapper<TActual> WithInclusiveBounds() { }
     }
+    public class NotNullAssertionBuilderWrapper<TActual> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
+    {
+        public new System.Runtime.CompilerServices.TaskAwaiter<TActual> GetAwaiter() { }
+    }
     public class SingleItemAssertionBuilderWrapper<TActual, TInner> : TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual>
         where TActual : System.Collections.Generic.IEnumerable<TInner>
     {
@@ -1304,10 +1308,11 @@ namespace TUnit.Assertions.Extensions
     {
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
         public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotDefault<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue = null) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource) { }
-        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string doNotPopulateThisValue1 = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.GenericNotEqualToAssertionBuilderWrapper<TActual> IsNotEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotEquatableOrEqualTo<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TActual expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue = null) { }
+        public static TUnit.Assertions.AssertionBuilders.Wrappers.NotNullAssertionBuilderWrapper<TActual> IsNotNull<TActual>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual?> valueSource)
+            where TActual :  class { }
+        public static TUnit.Assertions.AssertionBuilders.InvokableValueAssertionBuilder<TActual> IsNotSameReferenceAs<TActual, TExpected>(this TUnit.Assertions.AssertConditions.Interfaces.IValueSource<TActual> valueSource, TExpected expected, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? doNotPopulateThisValue1 = null) { }
     }
     public static class GenericSatisfiesExtensions
     {


### PR DESCRIPTION
Fixes #2138 