### PR TITLE
docs: fix delegate example

### DIFF
--- a/docs/docs/tutorial-assertions/delegates.md
+++ b/docs/docs/tutorial-assertions/delegates.md
@@ -24,7 +24,7 @@ TUnit can execute your delegates for you, and this allows you to assert on the d
         await Assert.That(() =>
         {
             // Do something here
-        }).ThrowsException().OfType<ArgumentNullException>();
+        }).Throws<ArgumentNullException>();
     }
 
     // or 


### PR DESCRIPTION
### Please check the following before creating a Pull Request

- If this is a new feature or piece of functionality, have you started a discussion and gotten agreement on it?
- If it fixes a bug or problem, is there an issue to track it? If not, create one first and link it please so there's clear visibility.
- Did you write tests to ensure you code works properly?

👋 Hello, I was playing around with this great library, and I came across an example that doesn't compile. I think it's documenting an older version of the API as I couldn't find any examples of it in the codebase.


The error that I encountered is the following:

```
'ThrowsException<object?, Exception>' does not contain a definition for 'OfType'
and the best extension method overload 'Queryable.OfType<ArgumentNullException>(IQueryable)' 
requires a receiver of type 'System.Linq.IQueryable`.
```