### PR TITLE
Adding F# and VB.NET Basic template

### DIFF
--- a/TUnit.Templates/content/TUnit.FSharp/.template.config/template.json
+++ b/TUnit.Templates/content/TUnit.FSharp/.template.config/template.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "Tom Longhurst",
+    "description": "Templates for getting started with TUnit",
+    "classifications": [
+      "Test",
+      "TUnit"
+    ],
+    "name": "TUnit Mixed Test Project",
+    "identity": "TUnit.Test.Mixed",
+    "groupIdentity": "TUnit",
+    "shortName": "TUnit",
+    "tags": {
+      "language": "F#",
+      "type": "project"
+    },
+    "sourceName": "TestProject",
+    "preferNameDirectory": true
+  }
+  

--- a/TUnit.Templates/content/TUnit.FSharp/Data/DataClass.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Data/DataClass.fs
@@ -1,0 +1,15 @@
+﻿namespace TestProject
+
+open System
+open System.Threading.Tasks
+open TUnit.Core.Interfaces
+
+type DataClass() =
+    interface IAsyncInitializer with
+        member _.InitializeAsync() : Task =
+            Console.Out.WriteLineAsync("Classes can be injected into tests, and they can perform some initialisation logic such as starting an in-memory server or a test container.")
+
+    interface IAsyncDisposable with
+        member _.DisposeAsync() : ValueTask =
+            ValueTask(Console.Out.WriteLineAsync("And when the class is finished with, we can clean up any resources."))
+

--- a/TUnit.Templates/content/TUnit.FSharp/Data/DataGenerator.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Data/DataGenerator.fs
@@ -1,0 +1,16 @@
+﻿namespace TestProject.Data
+
+open System
+open System.Collections.Generic
+open TUnit.Core
+
+type DataGenerator() =
+    inherit DataSourceGeneratorAttribute<int, int, int>()
+
+    override _.GenerateDataSources(_: DataGeneratorMetadata) : IEnumerable<Func<struct (int * int * int)>> =
+        seq {
+            yield Func<struct (int * int * int)>(fun () -> struct (1, 1, 2))
+            yield Func<struct (int * int * int)>(fun () -> struct (1, 2, 3))
+            yield Func<struct (int * int * int)>(fun () -> struct (4, 5, 9))
+        }
+

--- a/TUnit.Templates/content/TUnit.FSharp/Data/DependencyInjectionClassConstructor.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Data/DependencyInjectionClassConstructor.fs
@@ -1,0 +1,14 @@
+﻿namespace TestProject
+
+open System
+open TUnit.Core.Interfaces
+open TUnit.Core
+
+type DependencyInjectionClassConstructor() =
+    interface IClassConstructor with
+        member _.Create(typ: System.Type, classConstructorMetadata: ClassConstructorMetadata) : obj =
+            Console.WriteLine("You can also control how your test classes are new'd up, giving you lots of power and the ability to utilise tools such as dependency injection")
+            //if typ = typeof<AndEvenMoreTests> then
+            //    AndEvenMoreTests(DataClass()) :> obj
+            //else
+            //    raise (NotImplementedException())

--- a/TUnit.Templates/content/TUnit.FSharp/GlobalSetup.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/GlobalSetup.fs
@@ -1,0 +1,22 @@
+﻿module TestProject
+
+// Here you could define global logic that would affect all tests
+
+// You can use attributes at the assembly level to apply to all tests in the assembly
+open System
+open System.Diagnostics.CodeAnalysis
+open TUnit.Core
+
+[<assembly: Retry(3)>]
+[<assembly: ExcludeFromCodeCoverage>]
+do ()
+
+type GlobalHooks() =
+    [<Before(HookType.TestSession)>]
+    static member SetUp() =
+        Console.WriteLine("Or you can define methods that do stuff before...")
+
+    [<After(HookType.TestSession)>]
+    static member CleanUp() =
+        Console.WriteLine("...and after!")
+

--- a/TUnit.Templates/content/TUnit.FSharp/GlobalSetup.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/GlobalSetup.fs
@@ -1,4 +1,4 @@
-﻿module TestProject
+﻿namespace TestProject
 
 // Here you could define global logic that would affect all tests
 

--- a/TUnit.Templates/content/TUnit.FSharp/Test1.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Test1.fs
@@ -1,1 +1,71 @@
 ﻿namespace TestProject
+
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+open TestProject.Data
+open TUnit
+open TUnit.Core
+open TUnit.Assertions
+open TUnit.Assertions.Extensions
+open TUnit.Assertions.AssertionBuilders
+
+type Tests() =
+
+    [<Test>]
+    member _.Basic() =
+        Console.WriteLine("This is a basic test")
+
+    [<Test>]
+    [<Arguments(1, 2, 3)>]
+    [<Arguments(2, 3, 5)>]
+    member _.DataDrivenArguments(a: int, b: int, c: int): Task =
+        task {
+            Console.WriteLine("This one can accept arguments from an attribute")
+            let result = a + b
+            // Properly await the assertion`
+            let assertion = Assert.That(result).IsEqualTo(c)
+            let awaiter = (assertion :> InvokableValueAssertionBuilder<int>).GetAwaiter()
+            awaiter.GetResult() |> ignore
+        }
+
+
+    [<Test>]
+    [<MethodDataSource("DataSource")>]
+    member _.MethodDataSource(a: int, b: int, c: int) : Task =
+        task {
+            Console.WriteLine("This one can accept arguments from a method")
+            let result = a + b
+            // Properly await the assertion`
+            let assertion = Assert.That(result).IsEqualTo(c)
+            let awaiter = (assertion :> InvokableValueAssertionBuilder<int>).GetAwaiter()
+            awaiter.GetResult() |> ignore
+        }
+
+    //[<Test>]
+    //[<ClassDataSource(typeof<TestProject.DataClass>)>]
+    //[<ClassDataSource(typeof<DataClass>, Shared = SharedType.PerClass)>]
+    //[<ClassDataSource(typeof<DataClass>, Shared = SharedType.PerAssembly)>]
+    //[<ClassDataSource(typeof<DataClass>, Shared = SharedType.PerTestSession)>]
+    //member _.ClassDataSource(dataClass: DataClass) =
+    //    Console.WriteLine("This test can accept a class, which can also be pre-initialised before being injected in")
+    //    Console.WriteLine("These can also be shared among other tests, or new'd up each time, by using the `Shared` property on the attribute")
+
+    [<Test>]
+    [<DataGenerator>]
+    member _.CustomDataGenerator(a: int, b: int, c: int) : Task =
+        task {
+            Console.WriteLine("You can even define your own custom data generators")
+            let result = a + b
+            // Properly await the assertion`
+            let assertion = Assert.That(result).IsEqualTo(c)
+            let awaiter = (assertion :> InvokableValueAssertionBuilder<int>).GetAwaiter()
+            awaiter.GetResult() |> ignore
+        }
+
+    static member DataSource() : IEnumerable<struct (int * int * int)> =
+        seq {
+            yield struct (1, 1, 2)
+            yield struct (2, 1, 3)
+            yield struct (3, 1, 4)
+        }

--- a/TUnit.Templates/content/TUnit.FSharp/Test1.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Test1.fs
@@ -1,0 +1,1 @@
+﻿namespace TestProject

--- a/TUnit.Templates/content/TUnit.FSharp/TestProject.FSharp.fsproj
+++ b/TUnit.Templates/content/TUnit.FSharp/TestProject.FSharp.fsproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputType>Exe</OutputType>
@@ -12,6 +13,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Compile Include="Data\DataClass.fs" />
+		<Compile Include="Data\DataGenerator.fs" />
+		<Compile Include="Data\DependencyInjectionClassConstructor.fs" />
 		<Compile Include="GlobalSetup.fs" />
 		<Compile Include="Test1.fs" />
 	</ItemGroup>

--- a/TUnit.Templates/content/TUnit.FSharp/TestProject.FSharp.fsproj
+++ b/TUnit.Templates/content/TUnit.FSharp/TestProject.FSharp.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="TUnit" Version="0.20.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="GlobalSetup.fs" />
+		<Compile Include="Test1.fs" />
+	</ItemGroup>
+
+</Project>

--- a/TUnit.sln
+++ b/TUnit.sln
@@ -113,6 +113,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TUnit.TestProject.FSharp", 
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "TUnit.TestProject.VB.NET", "TUnit.TestProject.VB.NET\TUnit.TestProject.VB.NET.vbproj", "{E0F6713B-3F3E-4335-B65F-69C9DE8FBA7C}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestProject.FSharp", "TUnit.Templates\content\TUnit.FSharp\TestProject.FSharp.fsproj", "{18DFAD44-97DA-9C91-D654-05B5CC055775}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -291,6 +293,10 @@ Global
 		{E0F6713B-3F3E-4335-B65F-69C9DE8FBA7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0F6713B-3F3E-4335-B65F-69C9DE8FBA7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0F6713B-3F3E-4335-B65F-69C9DE8FBA7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18DFAD44-97DA-9C91-D654-05B5CC055775}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18DFAD44-97DA-9C91-D654-05B5CC055775}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18DFAD44-97DA-9C91-D654-05B5CC055775}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18DFAD44-97DA-9C91-D654-05B5CC055775}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -340,6 +346,7 @@ Global
 		{73EC87A5-577E-4149-B3B9-1C386AFBA2B1} = {0BA988BF-ADCE-4343-9098-B4EF65C43709}
 		{9058BBB1-4561-4BBC-9BED-7075A50AFC14} = {0BA988BF-ADCE-4343-9098-B4EF65C43709}
 		{E0F6713B-3F3E-4335-B65F-69C9DE8FBA7C} = {0BA988BF-ADCE-4343-9098-B4EF65C43709}
+		{18DFAD44-97DA-9C91-D654-05B5CC055775} = {1CE32FD7-4B3B-4639-B88F-67FB339461F2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {109D285A-36B3-4503-BCDF-8E26FB0E2C5B}


### PR DESCRIPTION
This PR will allow people to create the TUnit project in either VB.NET or F#. The goal is for these not to be separate template listings in Visual Studio or dotnet cli. But instead, utilise the language option in the templating engine