### PR TITLE
Override Results from an `AfterTestContext` object

### DIFF
--- a/TUnit.Core.SourceGenerator.Tests/TUnit.Core.SourceGenerator.Tests.csproj
+++ b/TUnit.Core.SourceGenerator.Tests/TUnit.Core.SourceGenerator.Tests.csproj
@@ -4,7 +4,8 @@
   
   <ItemGroup>
     <ProjectReference Include="..\TUnit.Core.SourceGenerator\TUnit.Core.SourceGenerator.csproj" />
-    <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" />
+    <ProjectReference Include="..\TUnit.TestProject.Library\TUnit.TestProject.Library.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.SourceGenerators.Testing" />
@@ -16,9 +17,6 @@
 
   <ItemGroup>
     <None Include="..\TUnit.Core\bin\$(Configuration)\netstandard2.0\TUnit.Core.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\TUnit.TestProject.Library\bin\$(Configuration)\$(LibraryTargetFramework)\TUnit.TestProject.Library.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/TUnit.Core/AfterTestContext.cs
+++ b/TUnit.Core/AfterTestContext.cs
@@ -1,0 +1,63 @@
+﻿using TUnit.Core.Enums;
+
+namespace TUnit.Core;
+
+public class AfterTestContext
+{
+    internal readonly DiscoveredTest DiscoveredTest;
+
+    internal AfterTestContext(DiscoveredTest discoveredTest)
+    {
+        DiscoveredTest = discoveredTest;
+    }
+    
+    public TestContext TestContext => DiscoveredTest.TestContext;
+    public TestDetails TestDetails => TestContext.TestDetails;
+    
+    public void OverrideResult(Status status, string reason)
+    {
+        var testResult = TestContext.Result;
+
+        if (testResult is null)
+        {
+            throw new InvalidOperationException("There is no test result to override.");
+        }
+        
+        OverrideResult(testResult with
+        {
+            Status = status,
+            IsOverridden = true,
+            OverrideReason = reason
+        });
+
+        if(status == Status.Skipped)
+        {
+            TestContext.SkipReason = reason;
+        }
+    }
+    
+    public void OverrideResult(Exception exception, string reason)
+    {
+        var testResult = TestContext.Result;
+
+        if (testResult is null)
+        {
+            throw new InvalidOperationException("There is no test result to override.");
+        }
+        
+        OverrideResult(testResult with
+        {
+            Status = Status.Failed,
+            Exception = exception,
+            IsOverridden = true,
+            OverrideReason = reason,
+        });
+    }
+    
+    private void OverrideResult(TestResult result)
+    {
+        TestContext.Result = result;
+    }
+
+    public static implicit operator TestContext(AfterTestContext afterTestContext) => afterTestContext.TestContext;
+}

--- a/TUnit.Core/Attributes/TestData/ClassDataSources.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSources.cs
@@ -261,7 +261,7 @@ internal class ClassDataSources
         }
     }
     
-    public async Task OnTestEnd<T>(TestContext context, T item) where T : new()
+    public async Task OnTestEnd<T>(AfterTestContext context, T item) where T : new()
     {
         if (item is ITestEndEventReceiver testEndEventReceiver)
         {

--- a/TUnit.Core/BeforeTestContext.cs
+++ b/TUnit.Core/BeforeTestContext.cs
@@ -30,4 +30,6 @@ public class BeforeTestContext
     }
     
     public void AddAsyncLocalValues() => TestContext.AddAsyncLocalValues();
+    
+    public static implicit operator TestContext(BeforeTestContext beforeTestContext) => beforeTestContext.TestContext;
 }

--- a/TUnit.Core/Interfaces/ITestEndEventReceiver.cs
+++ b/TUnit.Core/Interfaces/ITestEndEventReceiver.cs
@@ -2,5 +2,5 @@
 
 public interface ITestEndEventReceiver : IEventReceiver
 {
-    ValueTask OnTestEnd(TestContext testContext);
+    ValueTask OnTestEnd(AfterTestContext afterTestContext);
 }

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -1,8 +1,11 @@
-﻿namespace TUnit.Core;
+﻿using System.Diagnostics;
+
+namespace TUnit.Core;
 
 /// <summary>
 /// Represents the context for a test.
 /// </summary>
+[DebuggerDisplay("{TestDetails.TestClass.Name}.{TestDetails.TestName}")]
 public partial class TestContext : Context
 {
     private readonly IServiceProvider _serviceProvider;

--- a/TUnit.Core/TestContextEvents.cs
+++ b/TUnit.Core/TestContextEvents.cs
@@ -23,7 +23,7 @@ public record TestContextEvents :
     public AsyncEvent<TestRegisteredContext>? OnTestRegistered { get; set; }
     public AsyncEvent<TestContext>? OnInitialize { get; set; }
     public AsyncEvent<BeforeTestContext>? OnTestStart { get; set; }
-    public AsyncEvent<TestContext>? OnTestEnd { get; set; }
+    public AsyncEvent<AfterTestContext>? OnTestEnd { get; set; }
     public AsyncEvent<TestContext>? OnTestSkipped { get; set; }
     public AsyncEvent<(ClassHookContext, TestContext)>? OnLastTestInClass { get; set; }
     public AsyncEvent<(AssemblyHookContext, TestContext)>? OnLastTestInAssembly { get; set; }
@@ -40,7 +40,7 @@ public record TestContextEvents :
         return OnTestStart?.InvokeAsync(this, beforeTestContext) ?? default;
     }
 
-    ValueTask ITestEndEventReceiver.OnTestEnd(TestContext testContext)
+    ValueTask ITestEndEventReceiver.OnTestEnd(AfterTestContext testContext)
     {
         return OnTestEnd?.InvokeAsync(this, testContext) ?? default;
     }

--- a/TUnit.Core/TestResult.cs
+++ b/TUnit.Core/TestResult.cs
@@ -48,4 +48,7 @@ public record TestResult
     /// </summary>
     [JsonIgnore]
     internal TestContext? TestContext { get; init; }
+    
+    public string? OverrideReason { get; set; }
+    public bool IsOverridden { get; set; }
 }

--- a/TUnit.Engine.Tests/OverrideResultsTests.cs
+++ b/TUnit.Engine.Tests/OverrideResultsTests.cs
@@ -1,0 +1,21 @@
+﻿using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class OverrideResultsTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/OverrideResultsTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -112,7 +112,8 @@ internal class SingleTestExecutor(
             }
             catch (Exception e)
             {
-                if (testContext.Result?.IsOverridden is false
+                if (testContext.Result is null
+                    || testContext.Result?.IsOverridden is false
                     || testContext.Result?.Status is Status.Failed or Status.Cancelled)
                 {
                     await logger.LogDebugAsync($"Error in test {testContext.TestDetails.TestClass.Type.FullName}.{testContext.GetTestDisplayName()}: {e}");

--- a/TUnit.Engine/Services/SingleTestExecutor.cs
+++ b/TUnit.Engine/Services/SingleTestExecutor.cs
@@ -109,14 +109,16 @@ internal class SingleTestExecutor(
                 await logger.LogInformationAsync($"Skipping {testContext.GetClassTypeName()}.{testContext.GetTestDisplayName()}...");
                 
                 testContext.SetResult(skipTestException);
-                
-                await messageBus.Skipped(testContext, skipTestException.Reason);
             }
             catch (Exception e)
             {
-                await logger.LogDebugAsync($"Error in test {testContext.TestDetails.TestClass.Type.FullName}.{testContext.GetTestDisplayName()}: {e}");
-                testContext.SetResult(e);
-                throw;
+                if (testContext.Result?.IsOverridden is false
+                    || testContext.Result?.Status is Status.Failed or Status.Cancelled)
+                {
+                    await logger.LogDebugAsync($"Error in test {testContext.TestDetails.TestClass.Type.FullName}.{testContext.GetTestDisplayName()}: {e}");
+                    testContext.SetResult(e);
+                    throw;
+                }
             }
             finally
             {
@@ -134,27 +136,12 @@ internal class SingleTestExecutor(
                 Status.Passed => messageBus.Passed(test.TestContext, start.GetValueOrDefault()),
                 Status.Failed => messageBus.Failed(test.TestContext, result.Exception!, start.GetValueOrDefault()),
                 Status.Cancelled => messageBus.Cancelled(test.TestContext, start.GetValueOrDefault()),
+                Status.Skipped => messageBus.Skipped(test.TestContext, test.TestContext.SkipReason!),
                 _ => default,
             };
 
             await task;
         }
-    }
-
-    private bool IsCancelled(Exception ex)
-    {
-        if (ex is TestRunCanceledException)
-        {
-            return true;
-        }
-
-        if (ex is TaskCanceledException or OperationCanceledException
-            && engineCancellationToken.Token.IsCancellationRequested)
-        {
-            return true;
-        }
-
-        return false;
     }
 
     private async Task RunFirstTestEventReceivers(TestContext testContext)

--- a/TUnit.Engine/Services/TestInvoker.cs
+++ b/TUnit.Engine/Services/TestInvoker.cs
@@ -67,7 +67,7 @@ internal class TestInvoker(TestHookOrchestrator testHookOrchestrator, Disposer d
         
         foreach (var testEndEventsObject in testContext.GetTestEndEventObjects())
         {
-            await RunHelpers.RunValueTaskSafelyAsync(() => testEndEventsObject.OnTestEnd(testContext),
+            await RunHelpers.RunValueTaskSafelyAsync(() => testEndEventsObject.OnTestEnd(new AfterTestContext(testContext.InternalDiscoveredTest)),
                 cleanUpExceptions);
         }
         

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet2_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet2_0.verified.txt
@@ -13,6 +13,14 @@ namespace TUnit.Core
     {
         public AfterEveryAttribute(TUnit.Core.HookType hookType, [System.Runtime.CompilerServices.CallerFilePath] string file = "", [System.Runtime.CompilerServices.CallerLineNumber] int line = 0) { }
     }
+    public class AfterTestContext
+    {
+        public TUnit.Core.TestContext TestContext { get; }
+        public TUnit.Core.TestDetails TestDetails { get; }
+        public void OverrideResult(System.Exception exception, string reason) { }
+        public void OverrideResult(TUnit.Core.Enums.Status status, string reason) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.AfterTestContext afterTestContext) { }
+    }
     public abstract class ArgumentDisplayFormatter
     {
         protected ArgumentDisplayFormatter() { }
@@ -93,6 +101,7 @@ namespace TUnit.Core
         public void AddLinkedCancellationToken(System.Threading.CancellationToken cancellationToken) { }
         public void SetHookExecutor(TUnit.Core.Interfaces.IHookExecutor hookExecutor) { }
         public void SetTestExecutor(TUnit.Core.Interfaces.ITestExecutor testExecutor) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.BeforeTestContext beforeTestContext) { }
     }
     public class BeforeTestDiscoveryContext : TUnit.Core.Context
     {
@@ -797,7 +806,7 @@ namespace TUnit.Core
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.AssemblyHookContext, TUnit.Core.TestContext>>? OnLastTestInAssembly { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.ClassHookContext, TUnit.Core.TestContext>>? OnLastTestInClass { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.TestSessionContext, TUnit.Core.TestContext>>? OnLastTestInTestSession { get; set; }
-        public TUnit.Core.AsyncEvent<TUnit.Core.TestContext>? OnTestEnd { get; set; }
+        public TUnit.Core.AsyncEvent<TUnit.Core.AfterTestContext>? OnTestEnd { get; set; }
         public TUnit.Core.AsyncEvent<TUnit.Core.TestRegisteredContext>? OnTestRegistered { get; set; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 null,
@@ -908,7 +917,9 @@ namespace TUnit.Core
         public required System.TimeSpan? Duration { get; init; }
         public required System.DateTimeOffset? End { get; init; }
         public required System.Exception? Exception { get; init; }
+        public bool IsOverridden { get; set; }
         public string? Output { get; }
+        public string? OverrideReason { get; set; }
         public required System.DateTimeOffset? Start { get; init; }
         public required TUnit.Core.Enums.Status Status { get; init; }
     }
@@ -1392,7 +1403,7 @@ namespace TUnit.Core.Interfaces
     }
     public interface ITestEndEventReceiver : TUnit.Core.Interfaces.IEventReceiver
     {
-        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.TestContext testContext);
+        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.AfterTestContext afterTestContext);
     }
     public interface ITestExecutor
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet2_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet2_0.verified.txt
@@ -777,6 +777,7 @@ namespace TUnit.Core
         public TestBuilderContextAccessor(TUnit.Core.TestBuilderContext context) { }
         public TUnit.Core.TestBuilderContext Current { get; set; }
     }
+    [System.Diagnostics.DebuggerDisplay("{TestDetails.TestClass.Name}.{TestDetails.TestName}")]
     public class TestContext : TUnit.Core.Context
     {
         public readonly object Lock;

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -13,6 +13,14 @@ namespace TUnit.Core
     {
         public AfterEveryAttribute(TUnit.Core.HookType hookType, [System.Runtime.CompilerServices.CallerFilePath] string file = "", [System.Runtime.CompilerServices.CallerLineNumber] int line = 0) { }
     }
+    public class AfterTestContext
+    {
+        public TUnit.Core.TestContext TestContext { get; }
+        public TUnit.Core.TestDetails TestDetails { get; }
+        public void OverrideResult(System.Exception exception, string reason) { }
+        public void OverrideResult(TUnit.Core.Enums.Status status, string reason) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.AfterTestContext afterTestContext) { }
+    }
     public abstract class ArgumentDisplayFormatter
     {
         protected ArgumentDisplayFormatter() { }
@@ -93,6 +101,7 @@ namespace TUnit.Core
         public void AddLinkedCancellationToken(System.Threading.CancellationToken cancellationToken) { }
         public void SetHookExecutor(TUnit.Core.Interfaces.IHookExecutor hookExecutor) { }
         public void SetTestExecutor(TUnit.Core.Interfaces.ITestExecutor testExecutor) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.BeforeTestContext beforeTestContext) { }
     }
     public class BeforeTestDiscoveryContext : TUnit.Core.Context
     {
@@ -844,7 +853,7 @@ namespace TUnit.Core
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.AssemblyHookContext, TUnit.Core.TestContext>>? OnLastTestInAssembly { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.ClassHookContext, TUnit.Core.TestContext>>? OnLastTestInClass { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.TestSessionContext, TUnit.Core.TestContext>>? OnLastTestInTestSession { get; set; }
-        public TUnit.Core.AsyncEvent<TUnit.Core.TestContext>? OnTestEnd { get; set; }
+        public TUnit.Core.AsyncEvent<TUnit.Core.AfterTestContext>? OnTestEnd { get; set; }
         public TUnit.Core.AsyncEvent<TUnit.Core.TestRegisteredContext>? OnTestRegistered { get; set; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 null,
@@ -957,7 +966,9 @@ namespace TUnit.Core
         public required System.TimeSpan? Duration { get; init; }
         public required System.DateTimeOffset? End { get; init; }
         public required System.Exception? Exception { get; init; }
+        public bool IsOverridden { get; set; }
         public string? Output { get; }
+        public string? OverrideReason { get; set; }
         public required System.DateTimeOffset? Start { get; init; }
         public required TUnit.Core.Enums.Status Status { get; init; }
     }
@@ -1455,7 +1466,7 @@ namespace TUnit.Core.Interfaces
     }
     public interface ITestEndEventReceiver : TUnit.Core.Interfaces.IEventReceiver
     {
-        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.TestContext testContext);
+        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.AfterTestContext afterTestContext);
     }
     public interface ITestExecutor
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -823,6 +823,7 @@ namespace TUnit.Core
         public TestBuilderContextAccessor(TUnit.Core.TestBuilderContext context) { }
         public TUnit.Core.TestBuilderContext Current { get; set; }
     }
+    [System.Diagnostics.DebuggerDisplay("{TestDetails.TestClass.Name}.{TestDetails.TestName}")]
     public class TestContext : TUnit.Core.Context
     {
         public readonly object Lock;

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -823,6 +823,7 @@ namespace TUnit.Core
         public TestBuilderContextAccessor(TUnit.Core.TestBuilderContext context) { }
         public TUnit.Core.TestBuilderContext Current { get; set; }
     }
+    [System.Diagnostics.DebuggerDisplay("{TestDetails.TestClass.Name}.{TestDetails.TestName}")]
     public class TestContext : TUnit.Core.Context
     {
         public readonly System.Threading.Lock Lock;

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -13,6 +13,14 @@ namespace TUnit.Core
     {
         public AfterEveryAttribute(TUnit.Core.HookType hookType, [System.Runtime.CompilerServices.CallerFilePath] string file = "", [System.Runtime.CompilerServices.CallerLineNumber] int line = 0) { }
     }
+    public class AfterTestContext
+    {
+        public TUnit.Core.TestContext TestContext { get; }
+        public TUnit.Core.TestDetails TestDetails { get; }
+        public void OverrideResult(System.Exception exception, string reason) { }
+        public void OverrideResult(TUnit.Core.Enums.Status status, string reason) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.AfterTestContext afterTestContext) { }
+    }
     public abstract class ArgumentDisplayFormatter
     {
         protected ArgumentDisplayFormatter() { }
@@ -93,6 +101,7 @@ namespace TUnit.Core
         public void AddLinkedCancellationToken(System.Threading.CancellationToken cancellationToken) { }
         public void SetHookExecutor(TUnit.Core.Interfaces.IHookExecutor hookExecutor) { }
         public void SetTestExecutor(TUnit.Core.Interfaces.ITestExecutor testExecutor) { }
+        public static TUnit.Core.TestContext op_Implicit(TUnit.Core.BeforeTestContext beforeTestContext) { }
     }
     public class BeforeTestDiscoveryContext : TUnit.Core.Context
     {
@@ -844,7 +853,7 @@ namespace TUnit.Core
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.AssemblyHookContext, TUnit.Core.TestContext>>? OnLastTestInAssembly { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.ClassHookContext, TUnit.Core.TestContext>>? OnLastTestInClass { get; set; }
         public TUnit.Core.AsyncEvent<System.ValueTuple<TUnit.Core.TestSessionContext, TUnit.Core.TestContext>>? OnLastTestInTestSession { get; set; }
-        public TUnit.Core.AsyncEvent<TUnit.Core.TestContext>? OnTestEnd { get; set; }
+        public TUnit.Core.AsyncEvent<TUnit.Core.AfterTestContext>? OnTestEnd { get; set; }
         public TUnit.Core.AsyncEvent<TUnit.Core.TestRegisteredContext>? OnTestRegistered { get; set; }
         [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 null,
@@ -957,7 +966,9 @@ namespace TUnit.Core
         public required System.TimeSpan? Duration { get; init; }
         public required System.DateTimeOffset? End { get; init; }
         public required System.Exception? Exception { get; init; }
+        public bool IsOverridden { get; set; }
         public string? Output { get; }
+        public string? OverrideReason { get; set; }
         public required System.DateTimeOffset? Start { get; init; }
         public required TUnit.Core.Enums.Status Status { get; init; }
     }
@@ -1455,7 +1466,7 @@ namespace TUnit.Core.Interfaces
     }
     public interface ITestEndEventReceiver : TUnit.Core.Interfaces.IEventReceiver
     {
-        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.TestContext testContext);
+        System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.AfterTestContext afterTestContext);
     }
     public interface ITestExecutor
     {

--- a/TUnit.TestProject/AfterTestAttributeTests.cs
+++ b/TUnit.TestProject/AfterTestAttributeTests.cs
@@ -18,7 +18,7 @@ public class AfterTestAttributeTests
 
     public class WriteFileAfterTestAttribute : Attribute, ITestEndEventReceiver
     {
-        public async ValueTask OnTestEnd(TestContext testContext)
+        public async ValueTask OnTestEnd(AfterTestContext testContext)
         {
             Console.WriteLine(@"Writing file inside WriteFileAfterTestAttribute!");
 

--- a/TUnit.TestProject/Bugs/1836/Tests.cs
+++ b/TUnit.TestProject/Bugs/1836/Tests.cs
@@ -26,7 +26,7 @@ public class TestDbContext : IAsyncInitializer, IAsyncDisposable, ITestEndEventR
         return Task.CompletedTask;
     }
 
-    public ValueTask OnTestEnd(TestContext testContext)
+    public ValueTask OnTestEnd(AfterTestContext testContext)
     {
         if (!_isConnectionOpen)
         {

--- a/TUnit.TestProject/Bugs/2067/DataClass.cs
+++ b/TUnit.TestProject/Bugs/2067/DataClass.cs
@@ -35,7 +35,7 @@ public class DataClass :
     }
 
 
-    public ValueTask OnTestEnd(TestContext testContext)
+    public ValueTask OnTestEnd(AfterTestContext testContext)
     {
         IsEnded = true;
         return default;

--- a/TUnit.TestProject/DependencyInjectionClassConstructor.cs
+++ b/TUnit.TestProject/DependencyInjectionClassConstructor.cs
@@ -16,7 +16,7 @@ public class DependencyInjectionClassConstructor : IClassConstructor, ITestEndEv
         return ActivatorUtilities.GetServiceOrCreateInstance(_scope!.Value.ServiceProvider, type);
     }
 
-    public ValueTask OnTestEnd(TestContext testContext)
+    public ValueTask OnTestEnd(AfterTestContext testContext)
     {
         return _scope!.Value.DisposeAsync();
     }

--- a/TUnit.TestProject/DynamicallyRegisteredTests.cs
+++ b/TUnit.TestProject/DynamicallyRegisteredTests.cs
@@ -39,8 +39,10 @@ public class DynamicDataGenerator : DataSourceGeneratorAttribute<int>, ITestStar
 
     [Experimental("WIP")]
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Dynamic Code Only attribute on test")]
-    public async ValueTask OnTestEnd(TestContext testContext)
+    public async ValueTask OnTestEnd(AfterTestContext afterTestContext)
     {
+        var testContext = afterTestContext.TestContext;
+        
         if (testContext.Result?.Status == Status.Failed)
         {
             await _cancellationTokenSource.CancelAsync();

--- a/TUnit.TestProject/ExampleTestFixture.cs
+++ b/TUnit.TestProject/ExampleTestFixture.cs
@@ -38,7 +38,7 @@ public class DependencyInjectionClassConstructor2 : IClassConstructor, ITestEndE
         return ActivatorUtilities.GetServiceOrCreateInstance(_scope.ServiceProvider, type);
     }
 
-    public ValueTask OnTestEnd(TestContext testContext)
+    public ValueTask OnTestEnd(AfterTestContext testContext)
     {
         return _scope.DisposeAsync();
     }

--- a/TUnit.TestProject/OverrideResultsTests.cs
+++ b/TUnit.TestProject/OverrideResultsTests.cs
@@ -27,5 +27,7 @@ public class OverrideResultsTests
             afterTestContext.OverrideResult(Status.Passed, "Because I said so");
             return default;
         }
+
+        public int Order => 0;
     }
 }

--- a/TUnit.TestProject/OverrideResultsTests.cs
+++ b/TUnit.TestProject/OverrideResultsTests.cs
@@ -1,0 +1,31 @@
+﻿using TUnit.Core.Enums;
+using TUnit.Core.Interfaces;
+
+namespace TUnit.TestProject;
+
+public class OverrideResultsTests
+{
+    [Test, OverridePass]
+    public void OverrideResult_Throws_When_TestResult_Is_Null()
+    {
+        throw new InvalidOperationException();
+    }
+
+    [After(Class)]
+    public static async Task AfterClass(ClassHookContext classHookContext)
+    {
+        await Assert.That(classHookContext.Tests)
+            .HasSingleItem()
+            .And
+            .ContainsOnly(t => t.Result?.Status == Status.Passed);
+    }
+    
+    public class OverridePassAttribute : Attribute, ITestEndEventReceiver
+    {
+        public ValueTask OnTestEnd(AfterTestContext afterTestContext)
+        {
+            afterTestContext.OverrideResult(Status.Passed, "Because I said so");
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2357 