### PR TITLE
Updated TUnit.Assertions.FSharp.Operations check function to support assertions with Throw Type

### DIFF
--- a/TUnit.Assertions.FSharp/Extensions.fs
+++ b/TUnit.Assertions.FSharp/Extensions.fs
@@ -2,8 +2,6 @@
 
 open TUnit.Assertions.AssertionBuilders
 open TUnit.Assertions.AssertConditions.Throws
-open System.Threading.Tasks
-open System.Reflection
 
 module Operations =
     [<CustomOperation(MaintainsVariableSpaceUsingBind = true)>]

--- a/TUnit.Assertions.FSharp/Extensions.fs
+++ b/TUnit.Assertions.FSharp/Extensions.fs
@@ -1,18 +1,36 @@
 ﻿namespace TUnit.Assertions.FSharp
 
 open TUnit.Assertions.AssertionBuilders
+open TUnit.Assertions.AssertConditions.Throws
+open System.Threading.Tasks
+open System.Reflection
 
 module Operations =
     [<CustomOperation(MaintainsVariableSpaceUsingBind = true)>]
-    let check (assertion: IInvokableAssertionBuilder) =
+    let check (assertion: 'T) =
         Async.FromContinuations(fun (cont, econt, ccont) ->
-            let awaiter = assertion.GetAwaiter()
-
-            awaiter.OnCompleted(fun () ->
-                try
-                    if awaiter.IsCompleted then
-                        cont(awaiter.GetResult())
-                    else
-                        ccont (System.OperationCanceledException())
-                with ex ->
-                    econt ex))
+            match box assertion with
+            | :? IInvokableAssertionBuilder as invokable ->
+                let awaiter = invokable.GetAwaiter()
+                awaiter.OnCompleted(fun () ->
+                    try
+                        if awaiter.IsCompleted then
+                            cont(awaiter.GetResult())
+                        else
+                            ccont (System.OperationCanceledException())
+                    with ex ->
+                        econt ex)
+            | :? ThrowsException<obj, exn> as throwsExn ->
+                let awaiter = throwsExn.GetAwaiter()
+                awaiter.OnCompleted(fun () ->
+                    try
+                        if awaiter.IsCompleted then
+                            let _ = awaiter.GetResult() // ignore the exn result
+                            cont ()
+                        else
+                            ccont (System.OperationCanceledException())
+                    with ex ->
+                        econt ex)
+            | _ ->
+                invalidOp $"Unsupported assertion type: We currently don't support Assertion Type {assertion.GetType()}"
+        )

--- a/docs/docs/tutorial-assertions/fsharp.md
+++ b/docs/docs/tutorial-assertions/fsharp.md
@@ -18,3 +18,29 @@ member this.CheckPositive() = async {
             do! check (Assert.That(result).IsPositive())
         }
 ```
+
+F# is a lot more strict with type resolution when it comes to extension methods and method overloads. Because of that you may need to annotate the type for the assertions.
+
+For example,
+
+```fsharp
+    [<Test>]
+    [<Category("Pass")>]
+    member _.Test3() = async {
+        let value = "1"
+        do! check (Assert.That<string>(value).IsEqualTo("1"))
+    }
+
+    [<Test>]
+    [<Category("Fail")>]
+    member _.Throws1() = async {
+        do! check (Assert.That<string>(fun () -> task { return new string([||]) }).ThrowsException())
+    }
+
+    [<Test>]
+    [<Category("Pass")>]
+    member _.Throws4() = async {
+        do! check (Assert.That<bool>(fun () -> Task.FromResult(true)).ThrowsNothing())
+    }
+
+```    


### PR DESCRIPTION
Added support for the Throw assertion type in the check function. 

To keep syntax and utilisation simple. I had to use pattern matching inside the check.  Good old fashion Functional paradimes.

Fortunately we can add to it later on. I would have liked to have made reusable code, but I think it is best we resolve the types in this way to ensure of type safety, and avoid surprise F# type conversions later on