### PR TITLE
chore: Extended `Assert.Throw` and `Assert.ThrowAsync` with ParameterName Overload

### DIFF
--- a/TUnit.Assertions/Assert.cs
+++ b/TUnit.Assertions/Assert.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.AssertionBuilders;
 using TUnit.Assertions.Extensions;
+using TUnit.Assertions.Helpers;
 using TUnit.Assertions.Wrappers;
 
 namespace TUnit.Assertions;
@@ -13,47 +14,47 @@ public static class Assert
     {
         return new ValueAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
-    
+
     public static ValueAssertionBuilder<IEnumerable<object>> That(IEnumerable enumerable, [CallerArgumentExpression(nameof(enumerable))] string? doNotPopulateThisValue = null)
     {
         return new ValueAssertionBuilder<IEnumerable<object>>(new UnTypedEnumerableWrapper(enumerable), doNotPopulateThisValue);
     }
-    
+
     public static DelegateAssertionBuilder That(Action value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new DelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
-    
+
     public static ValueDelegateAssertionBuilder<TActual> That<TActual>(Func<TActual> value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new ValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncDelegateAssertionBuilder That(Func<Task> value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncDelegateAssertionBuilder(value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Func<Task<TActual>> value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncDelegateAssertionBuilder That(Task value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncDelegateAssertionBuilder(async () => await value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(Task<TActual> value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(async () => await value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncDelegateAssertionBuilder That(ValueTask value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncDelegateAssertionBuilder(async () => await value, doNotPopulateThisValue);
     }
-    
+
     public static AsyncValueDelegateAssertionBuilder<TActual> That<TActual>(ValueTask<TActual> value, [CallerArgumentExpression(nameof(value))] string? doNotPopulateThisValue = null)
     {
         return new AsyncValueDelegateAssertionBuilder<TActual>(async () => await value, doNotPopulateThisValue);
@@ -71,32 +72,56 @@ public static class Assert
     public static Task<Exception> ThrowsAsync(Task @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static Task<Exception> ThrowsAsync(ValueTask @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static Task<TException> ThrowsAsync<TException>(Task @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static Task<TException> ThrowsAsync<TException>(ValueTask @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
         => ThrowsAsync<TException>(async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static async Task<TException> ThrowsAsync<TException>(Func<Task> @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
-        return (TException) await ThrowsAsync(typeof(TException), @delegate, doNotPopulateThisValue);
+        return (TException)await ThrowsAsync(typeof(TException), @delegate, doNotPopulateThisValue);
     }
-    
+
+    public static Task<TException> ThrowsAsync<TException>(string parameterName,
+        Task @delegate,
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : ArgumentException
+        => ThrowsAsync<TException>(parameterName, async () => await @delegate, doNotPopulateThisValue);
+
+    public static Task<TException> ThrowsAsync<TException>(string parameterName,
+        ValueTask @delegate,
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : ArgumentException
+        => ThrowsAsync<TException>(parameterName, async () => await @delegate, doNotPopulateThisValue);
+
+    public static async Task<TException> ThrowsAsync<TException>(string parameterName,
+        Func<Task> @delegate,
+        [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : ArgumentException
+    {
+        var ex = (TException)await ThrowsAsync(typeof(TException), @delegate, doNotPopulateThisValue);
+
+        if (ex.ParamName?.Equals(parameterName, StringComparison.Ordinal) == false)
+        {
+            Fail($"Incorrect parameter name {new StringDifference(ex.ParamName, parameterName).ToString("it differs at index")}");
+        }
+
+        return ex;
+    }
+
     public static Task<Exception> ThrowsAsync(Type type, Task @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(type, async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static Task<Exception> ThrowsAsync(Type type, ValueTask @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => ThrowsAsync(type, async () => await @delegate, doNotPopulateThisValue);
-    
+
     public static async Task<Exception> ThrowsAsync(Type type, Func<Task> @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
     {
         try
@@ -113,14 +138,14 @@ public static class Assert
         }
 
         Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
-        
+
         return null;
     }
 
     public static Exception Throws(Action @delegate,
         [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
         => Throws<Exception>(@delegate, doNotPopulateThisValue);
-    
+
     public static Exception Throws(Type type, Action @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null)
     {
         try
@@ -135,15 +160,27 @@ public static class Assert
         {
             Fail($"Exception is of type {e.GetType().Name} instead of {type.Name} for {doNotPopulateThisValue.GetStringOr("the delegate")}");
         }
-        
+
         Fail($"No exception was thrown by {doNotPopulateThisValue.GetStringOr("the delegate")}");
 
         return null;
     }
-    
+
     public static TException Throws<TException>(Action @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : Exception
     {
-        return (TException) Throws(typeof(TException), @delegate, doNotPopulateThisValue);
+        return (TException)Throws(typeof(TException), @delegate, doNotPopulateThisValue);
+    }
+
+    public static TException Throws<TException>(string parameterName, Action @delegate, [CallerArgumentExpression(nameof(@delegate))] string? doNotPopulateThisValue = null) where TException : ArgumentException
+    {
+        var ex = Throws<TException>(@delegate, doNotPopulateThisValue);
+
+        if (ex.ParamName?.Equals(parameterName, StringComparison.Ordinal) == false)
+        {
+            Fail($"Incorrect parameter name {new StringDifference(ex.ParamName, parameterName).ToString("it differs at index")}");
+        }
+
+        return ex;
     }
 
     [DoesNotReturn]

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet2_0.verified.txt
@@ -20,6 +20,8 @@ namespace TUnit.Assertions
         public static System.Exception Throws(System.Type type, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static TException Throws<TException>(System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static TException Throws<TException>(string parameterName, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
@@ -32,6 +34,12 @@ namespace TUnit.Assertions
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
     }
     public readonly struct AssertionData : System.IEquatable<TUnit.Assertions.AssertionData>
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -20,6 +20,8 @@ namespace TUnit.Assertions
         public static System.Exception Throws(System.Type type, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static TException Throws<TException>(System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static TException Throws<TException>(string parameterName, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
@@ -32,6 +34,12 @@ namespace TUnit.Assertions
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
     }
     public readonly struct AssertionData : System.IEquatable<TUnit.Assertions.AssertionData>
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -20,6 +20,8 @@ namespace TUnit.Assertions
         public static System.Exception Throws(System.Type type, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static TException Throws<TException>(System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static TException Throws<TException>(string parameterName, System.Action @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null) { }
@@ -32,6 +34,12 @@ namespace TUnit.Assertions
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
             where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Func<System.Threading.Tasks.Task> @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.Task @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<TException> ThrowsAsync<TException>(string parameterName, System.Threading.Tasks.ValueTask @delegate, [System.Runtime.CompilerServices.CallerArgumentExpression("delegate")] string? doNotPopulateThisValue = null)
+            where TException : System.ArgumentException { }
     }
     public readonly struct AssertionData : System.IEquatable<TUnit.Assertions.AssertionData>
     {


### PR DESCRIPTION
Closed: #2470