### PR TITLE
Fix inconsistent hook execution logic

### DIFF
--- a/TUnit.Engine/Services/TestsExecutor.cs
+++ b/TUnit.Engine/Services/TestsExecutor.cs
@@ -160,7 +160,7 @@ internal class TestsExecutor
         await queue
             .ForEachAsync(async test =>
             {
-                if (test.TestContext.SkipReason != null)
+                if (test.TestContext.SkipReason == null)
                 {
                     await _assemblyHookOrchestrator.ExecuteBeforeAssemblyHooks(test.TestContext);
 


### PR DESCRIPTION
## .NET Framework behaviour issue.

In .NET Framework (net48), the `[Before(Class)]` hook was not executing due to an inverted if condition. This PR fixes the logic to ensure hooks run consistently across .NET and .NET Framework.

Fixed `if (test.TestContext.SkipReason != null)` → now checks `SkipReason == null` (matching .NET behavior).