### PR TITLE
Enable parallelism for MSTest benchmark

### DIFF
--- a/tools/speed-comparison/MSTestTimer/MSTestTimer/AssemblyInfo.cs
+++ b/tools/speed-comparison/MSTestTimer/MSTestTimer/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+ [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
+ 


### PR DESCRIPTION
I feel it's a bit unfair to do the comparison without parallelization enabled for MSTest.