### PR TITLE
feat: improve error handling in setup methods for Browser, Context, and Page for TUnit.Playwright

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,8 +57,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-docker-action@v4.3.0
 
-      - name: Install PlaywrightDependencies
+      - name: Install Playwright Dependencies
         run: npx playwright install-deps
+
+      - name: Install Playwright Browsers
+        run: npx playwright install
 
       - name: Build
         run: dotnet build -c Release

--- a/TUnit.Playwright/BrowserTest.cs
+++ b/TUnit.Playwright/BrowserTest.cs
@@ -29,6 +29,11 @@ public class BrowserTest : PlaywrightTest
     [Before(HookType.Test, "", 0)]
     public async Task BrowserSetup()
     {
+        if (BrowserType == null)
+        {
+            throw new InvalidOperationException($"BrowserType is not initialized. This may indicate that {nameof(PlaywrightTest)}.{nameof(Playwright)} is not initialized or {nameof(PlaywrightTest)}.{nameof(PlaywrightSetup)} did not execute properly.");
+        }
+        
         var service = await BrowserService.Register(this, BrowserType, _options).ConfigureAwait(false);
         Browser = service.Browser;
     }

--- a/TUnit.Playwright/ContextTest.cs
+++ b/TUnit.Playwright/ContextTest.cs
@@ -19,6 +19,11 @@ public class ContextTest : BrowserTest
     [Before(HookType.Test, "", 0)]
     public async Task ContextSetup(TestContext testContext)
     {
+        if (Browser == null)
+        {
+            throw new InvalidOperationException($"Browser is not initialized. This may indicate that {nameof(BrowserTest)}.{nameof(BrowserSetup)} did not execute properly.");
+        }
+        
         Context = await NewContext(ContextOptions(testContext)).ConfigureAwait(false);
     }
 }

--- a/TUnit.Playwright/PageTest.cs
+++ b/TUnit.Playwright/PageTest.cs
@@ -10,6 +10,11 @@ public class PageTest : ContextTest
     [Before(HookType.Test, "", 0)]
     public async Task PageSetup()
     {
+        if (Context == null)
+        {
+            throw new InvalidOperationException($"Browser context is not initialized. This may indicate that {nameof(ContextTest)}.{nameof(ContextSetup)} did not execute properly.");
+        }
+        
         Page = await Context.NewPageAsync().ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling in Playwright test setup and updates the GitHub Actions workflow to ensure Playwright dependencies and browsers are correctly installed. The key changes include adding validation checks to prevent uninitialized objects during test setup and enhancing the CI configuration for Playwright.

### Improvements to error handling in Playwright test setup:

* [`TUnit.Playwright/BrowserTest.cs`](diffhunk://#diff-8fe53969c771db0908dd1e7df3ab296cb6171e228742cfdc8b96ed04510c472bR32-R36): Added a validation check in `BrowserSetup` to throw an `InvalidOperationException` if `BrowserType` is not initialized, ensuring proper setup of the Playwright environment.
* [`TUnit.Playwright/ContextTest.cs`](diffhunk://#diff-346b3e02c9882efd2caef33aebd04c1971b4ef56da45a5a386e4d5b103e6e6b8R22-R26): Added a validation check in `ContextSetup` to throw an `InvalidOperationException` if `Browser` is not initialized, preventing issues when creating a new browser context.
* [`TUnit.Playwright/PageTest.cs`](diffhunk://#diff-620b65e9dfdde41d38454b222c5befdb9697c05f92e76dc1bac62749e5b9bd0cR13-R17): Added a validation check in `PageSetup` to throw an `InvalidOperationException` if `Context` is not initialized, ensuring a valid browser context is available before creating a new page.

### Enhancements to GitHub Actions workflow:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R63-R65): Added a step to install Playwright browsers (`npx playwright install`) after installing Playwright dependencies, ensuring the required browsers are available during CI runs.