### PR TITLE
fix: Dispose SharedType.PerClass and PerAssembly instances after test…

### DIFF
--- a/TUnit.Core/Data/GetOnlyDictionary.cs
+++ b/TUnit.Core/Data/GetOnlyDictionary.cs
@@ -50,6 +50,18 @@ public class GetOnlyDictionary<TKey,
         return default(TValue?);
     }
 
+    public bool TryRemove(TKey key, [NotNullWhen(true)] out TValue? value)
+    {
+        if (_innerDictionary.TryRemove(key, out var lazy))
+        {
+            value = lazy.Value!;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
     public TValue this[TKey key] => _innerDictionary.TryGetValue(key, out var lazy) 
         ? lazy.Value 
         : throw new KeyNotFoundException($"Key '{key}' not found in dictionary");

--- a/TUnit.Core/Data/ScopedContainer.cs
+++ b/TUnit.Core/Data/ScopedContainer.cs
@@ -34,4 +34,26 @@ internal class ScopedContainer<TKey> where TKey : notnull
         return _containers.TryGetValue(key, out var container) &&
                container.TryGetValue(type, out instance);
     }
+
+    /// <summary>
+    /// Disposes and removes all instances for the specified key.
+    /// </summary>
+    /// <param name="key">The scoping key.</param>
+    public async Task DisposeAndRemoveAsync(TKey key)
+    {
+        if (_containers.TryRemove(key, out var container))
+        {
+            foreach (var instance in container.Values)
+            {
+                if (instance is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else if (instance is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+        }
+    }
 }

--- a/TUnit.Core/TestDataContainer.cs
+++ b/TUnit.Core/TestDataContainer.cs
@@ -29,4 +29,14 @@ internal static class TestDataContainer
     {
         return _keyContainer.GetOrCreate(key, type, func);
     }
+
+    public static async Task CleanupClassAsync(Type testClass)
+    {
+        await _classContainer.DisposeAndRemoveAsync(testClass);
+    }
+
+    public static async Task CleanupAssemblyAsync(Assembly assembly)
+    {
+        await _assemblyContainer.DisposeAndRemoveAsync(assembly);
+    }
 }

--- a/TUnit.Engine/Services/HookOrchestrator.cs
+++ b/TUnit.Engine/Services/HookOrchestrator.cs
@@ -458,6 +458,9 @@ internal sealed class HookOrchestrator
                 : new HookFailedException("Multiple AfterAssembly hooks failed", new AggregateException(exceptions));
         }
 
+        // Clean up SharedType.PerAssembly instances
+        await TestDataContainer.CleanupAssemblyAsync(assembly);
+
         // Return the context's ExecutionContext if user called AddAsyncLocalValues, otherwise null
 #if NET
         return assemblyContext.ExecutionContext;
@@ -556,6 +559,9 @@ internal sealed class HookOrchestrator
                 ? new HookFailedException(exceptions[0])
                 : new HookFailedException("Multiple AfterClass hooks failed", new AggregateException(exceptions));
         }
+
+        // Clean up SharedType.PerClass instances
+        await TestDataContainer.CleanupClassAsync(testClassType);
 
         // Return the context's ExecutionContext if user called AddAsyncLocalValues, otherwise null
 #if NET


### PR DESCRIPTION
…s complete (#2867)

When using ClassDataSource with SharedType.PerClass or PerAssembly, instances were never disposed after test execution completed, causing resource leaks.

- Added DisposeAndRemoveAsync to ScopedContainer to properly dispose instances
- Added cleanup methods to TestDataContainer for class and assembly scopes
- Integrated cleanup calls in HookOrchestrator after AfterClass/AfterAssembly hooks
- Added TryRemove method to GetOnlyDictionary for safe removal

Fixes #2867