### PR TITLE
Fix test discovery intermittent hanging issues in reflection mode

### DIFF
--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -30,9 +30,9 @@ internal sealed class TestBuilderPipeline
     public async Task<IEnumerable<AbstractExecutableTest>> BuildTestsAsync(string testSessionId, HashSet<Type>? filterTypes)
     {
         var dataCollector = _dataCollectorFactory(filterTypes);
-        var collectedMetadata = await dataCollector.CollectTestsAsync(testSessionId);
+        var collectedMetadata = await dataCollector.CollectTestsAsync(testSessionId).ConfigureAwait(false);
 
-        return await BuildTestsFromMetadataAsync(collectedMetadata);
+        return await BuildTestsFromMetadataAsync(collectedMetadata).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ internal sealed class TestBuilderPipeline
 
         // Get metadata streaming if supported
         // Fall back to non-streaming collection
-        var collectedMetadata = await dataCollector.CollectTestsAsync(testSessionId);
+        var collectedMetadata = await dataCollector.CollectTestsAsync(testSessionId).ConfigureAwait(false);
 
         return await collectedMetadata
             .SelectManyAsync(BuildTestsFromSingleMetadataAsync, cancellationToken: cancellationToken)
@@ -56,7 +56,7 @@ internal sealed class TestBuilderPipeline
 
     private async IAsyncEnumerable<TestMetadata> ToAsyncEnumerable(IEnumerable<TestMetadata> metadata)
     {
-        await Task.Yield(); // Yield control once at the start to maintain async context
+        await Task.Yield().ConfigureAwait(false); // Yield control once at the start to maintain async context
         foreach (var item in metadata)
         {
             yield return item;
@@ -72,10 +72,10 @@ internal sealed class TestBuilderPipeline
                     // Check if this is a dynamic test metadata that should bypass normal test building
                     if (metadata is IDynamicTestMetadata)
                     {
-                        return await GenerateDynamicTests(metadata);
+                        return await GenerateDynamicTests(metadata).ConfigureAwait(false);
                     }
 
-                    return await _testBuilder.BuildTestsFromMetadataAsync(metadata);
+                    return await _testBuilder.BuildTestsFromMetadataAsync(metadata).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -156,7 +156,7 @@ internal sealed class TestBuilderPipeline
             context.TestDetails = testDetails;
 
             // Invoke discovery event receivers to properly handle all attribute behaviors
-            await InvokeDiscoveryEventReceiversAsync(context);
+            await InvokeDiscoveryEventReceiversAsync(context).ConfigureAwait(false);
 
             var executableTestContext = new ExecutableTestCreationContext
             {
@@ -276,7 +276,7 @@ internal sealed class TestBuilderPipeline
                     context.TestDetails = testDetails;
 
                     // Invoke discovery event receivers to properly handle all attribute behaviors
-                    await InvokeDiscoveryEventReceiversAsync(context);
+                    await InvokeDiscoveryEventReceiversAsync(context).ConfigureAwait(false);
 
                     var executableTestContext = new ExecutableTestCreationContext
                     {
@@ -295,7 +295,7 @@ internal sealed class TestBuilderPipeline
             else
             {
                 // Normal test metadata goes through the standard test builder
-                var testsFromMetadata = await _testBuilder.BuildTestsFromMetadataAsync(resolvedMetadata);
+                var testsFromMetadata = await _testBuilder.BuildTestsFromMetadataAsync(resolvedMetadata).ConfigureAwait(false);
                 testsToYield = new List<AbstractExecutableTest>(testsFromMetadata);
             }
         }
@@ -436,7 +436,7 @@ internal sealed class TestBuilderPipeline
             context.TestDetails.TestName,
             context);
 
-        await _eventReceiverOrchestrator.InvokeTestDiscoveryEventReceiversAsync(context, discoveredContext, CancellationToken.None);
+        await _eventReceiverOrchestrator.InvokeTestDiscoveryEventReceiversAsync(context, discoveredContext, CancellationToken.None).ConfigureAwait(false);
     }
 
 }

--- a/TUnit.Engine/Services/HookOrchestrator.cs
+++ b/TUnit.Engine/Services/HookOrchestrator.cs
@@ -95,31 +95,31 @@ internal sealed class HookOrchestrator
         {
 #if NET
             var assemblyName = assembly.GetName().Name ?? "Unknown";
-            var assemblyContext = await GetOrCreateBeforeAssemblyTask(assemblyName, assembly, cancellationToken);
+            var assemblyContext = await GetOrCreateBeforeAssemblyTask(assemblyName, assembly, cancellationToken).ConfigureAwait(false);
             if (assemblyContext != null)
             {
                 ExecutionContext.Restore(assemblyContext);
             }
 #endif
             // Now run class hooks in the assembly context
-            return await ExecuteBeforeClassHooksAsync(testClassType, cancellationToken);
+            return await ExecuteBeforeClassHooksAsync(testClassType, cancellationToken).ConfigureAwait(false);
         });
     }
 
     public async Task<ExecutionContext?> ExecuteBeforeTestSessionHooksAsync(CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectBeforeTestSessionHooksAsync();
+        var hooks = await _hookCollectionService.CollectBeforeTestSessionHooksAsync().ConfigureAwait(false);
 
         foreach (var hook in hooks)
         {
             try
             {
                 _contextProvider.TestSessionContext.RestoreExecutionContext();
-                await hook(_contextProvider.TestSessionContext, cancellationToken);
+                await hook(_contextProvider.TestSessionContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeTestSession hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeTestSession hook failed: {ex.Message}").ConfigureAwait(false);
                 throw; // Before hooks should prevent execution on failure
             }
         }
@@ -135,7 +135,7 @@ internal sealed class HookOrchestrator
 
     public async Task<ExecutionContext?> ExecuteAfterTestSessionHooksAsync(CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectAfterTestSessionHooksAsync();
+        var hooks = await _hookCollectionService.CollectAfterTestSessionHooksAsync().ConfigureAwait(false);
         var exceptions = new List<Exception>();
 
         foreach (var hook in hooks)
@@ -143,11 +143,11 @@ internal sealed class HookOrchestrator
             try
             {
                 _contextProvider.TestSessionContext.RestoreExecutionContext();
-                await hook(_contextProvider.TestSessionContext, cancellationToken);
+                await hook(_contextProvider.TestSessionContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterTestSession hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterTestSession hook failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -169,18 +169,18 @@ internal sealed class HookOrchestrator
 
     public async Task<ExecutionContext?> ExecuteBeforeTestDiscoveryHooksAsync(CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectBeforeTestDiscoveryHooksAsync();
+        var hooks = await _hookCollectionService.CollectBeforeTestDiscoveryHooksAsync().ConfigureAwait(false);
 
         foreach (var hook in hooks)
         {
             try
             {
                 _contextProvider.BeforeTestDiscoveryContext.RestoreExecutionContext();
-                await hook(_contextProvider.BeforeTestDiscoveryContext, cancellationToken);
+                await hook(_contextProvider.BeforeTestDiscoveryContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeTestDiscovery hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeTestDiscovery hook failed: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
@@ -195,7 +195,7 @@ internal sealed class HookOrchestrator
 
     public async Task<ExecutionContext?> ExecuteAfterTestDiscoveryHooksAsync(CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectAfterTestDiscoveryHooksAsync();
+        var hooks = await _hookCollectionService.CollectAfterTestDiscoveryHooksAsync().ConfigureAwait(false);
         var exceptions = new List<Exception>();
 
         foreach (var hook in hooks)
@@ -203,11 +203,11 @@ internal sealed class HookOrchestrator
             try
             {
                 _contextProvider.TestDiscoveryContext.RestoreExecutionContext();
-                await hook(_contextProvider.TestDiscoveryContext, cancellationToken);
+                await hook(_contextProvider.TestDiscoveryContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterTestDiscovery hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterTestDiscovery hook failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -242,14 +242,14 @@ internal sealed class HookOrchestrator
         // Fast path: check if we need to run hooks at all
         var hasHooks = await _hasBeforeEveryTestHooks.GetOrAdd(testClassType, async _ => 
         {
-            var hooks = await _hookCollectionService.CollectBeforeEveryTestHooksAsync(testClassType);
+            var hooks = await _hookCollectionService.CollectBeforeEveryTestHooksAsync(testClassType).ConfigureAwait(false);
             return hooks.Count > 0;
         });
 
-        await GetOrCreateBeforeAssemblyTask(assemblyName, testClassType.Assembly, cancellationToken);
+        await GetOrCreateBeforeAssemblyTask(assemblyName, testClassType.Assembly, cancellationToken).ConfigureAwait(false);
 
         // Get the cached class context (includes assembly context)
-        var classContext = await GetOrCreateBeforeClassTask(testClassType, testClassType.Assembly, cancellationToken);
+        var classContext = await GetOrCreateBeforeClassTask(testClassType, testClassType.Assembly, cancellationToken).ConfigureAwait(false);
 
 #if NET
         // Batch context restoration - only restore once if we have hooks to run
@@ -264,7 +264,7 @@ internal sealed class HookOrchestrator
         // Execute BeforeEveryTest hooks only if they exist
         if (hasHooks)
         {
-            await ExecuteBeforeEveryTestHooksAsync(testClassType, test.Context, cancellationToken);
+            await ExecuteBeforeEveryTestHooksAsync(testClassType, test.Context, cancellationToken).ConfigureAwait(false);
         }
 
         // Return whichever context has AsyncLocal values:
@@ -292,7 +292,7 @@ internal sealed class HookOrchestrator
         // Fast path: check if we have hooks to execute
         var hasHooks = await _hasAfterEveryTestHooks.GetOrAdd(testClassType, async _ =>
         {
-            var hooks = await _hookCollectionService.CollectAfterEveryTestHooksAsync(testClassType);
+            var hooks = await _hookCollectionService.CollectAfterEveryTestHooksAsync(testClassType).ConfigureAwait(false);
             return hooks.Count > 0;
         });
 
@@ -301,11 +301,11 @@ internal sealed class HookOrchestrator
         {
             try
             {
-                await ExecuteAfterEveryTestHooksAsync(testClassType, test.Context, cancellationToken);
+                await ExecuteAfterEveryTestHooksAsync(testClassType, test.Context, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterEveryTest hooks failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterEveryTest hooks failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -321,11 +321,11 @@ internal sealed class HookOrchestrator
         {
             try
             {
-                await ExecuteAfterClassHooksAsync(testClassType, cancellationToken);
+                await ExecuteAfterClassHooksAsync(testClassType, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterClass hooks failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterClass hooks failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
             finally
@@ -340,11 +340,11 @@ internal sealed class HookOrchestrator
         {
             try
             {
-                await ExecuteAfterAssemblyHooksAsync(test.Context.ClassContext.AssemblyContext.Assembly, cancellationToken);
+                await ExecuteAfterAssemblyHooksAsync(test.Context.ClassContext.AssemblyContext.Assembly, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterAssembly hooks failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterAssembly hooks failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
             finally
@@ -365,7 +365,7 @@ internal sealed class HookOrchestrator
 
     private async Task<ExecutionContext?> ExecuteBeforeAssemblyHooksAsync(Assembly assembly, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectBeforeAssemblyHooksAsync(assembly);
+        var hooks = await _hookCollectionService.CollectBeforeAssemblyHooksAsync(assembly).ConfigureAwait(false);
 
         var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
 
@@ -382,27 +382,27 @@ internal sealed class HookOrchestrator
             try
             {
                 assemblyContext.RestoreExecutionContext();
-                await hook(assemblyContext, cancellationToken);
+                await hook(assemblyContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeAssembly hook failed for {assembly}: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeAssembly hook failed for {assembly}: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
 
         // Execute global BeforeEveryAssembly hooks
-        var everyHooks = await _hookCollectionService.CollectBeforeEveryAssemblyHooksAsync();
+        var everyHooks = await _hookCollectionService.CollectBeforeEveryAssemblyHooksAsync().ConfigureAwait(false);
         foreach (var hook in everyHooks)
         {
             try
             {
                 assemblyContext.RestoreExecutionContext();
-                await hook(assemblyContext, cancellationToken);
+                await hook(assemblyContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeEveryAssembly hook failed for {assembly}: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeEveryAssembly hook failed for {assembly}: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
@@ -417,22 +417,22 @@ internal sealed class HookOrchestrator
 
     private async Task<ExecutionContext?> ExecuteAfterAssemblyHooksAsync(Assembly assembly, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectAfterAssemblyHooksAsync(assembly);
+        var hooks = await _hookCollectionService.CollectAfterAssemblyHooksAsync(assembly).ConfigureAwait(false);
         var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
         var exceptions = new List<Exception>();
 
         // Execute global AfterEveryAssembly hooks first
-        var everyHooks = await _hookCollectionService.CollectAfterEveryAssemblyHooksAsync();
+        var everyHooks = await _hookCollectionService.CollectAfterEveryAssemblyHooksAsync().ConfigureAwait(false);
         foreach (var hook in everyHooks)
         {
             try
             {
                 assemblyContext.RestoreExecutionContext();
-                await hook(assemblyContext, cancellationToken);
+                await hook(assemblyContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterEveryAssembly hook failed for {assembly.GetName().Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterEveryAssembly hook failed for {assembly.GetName().Name}: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -442,11 +442,11 @@ internal sealed class HookOrchestrator
             try
             {
                 assemblyContext.RestoreExecutionContext();
-                await hook(assemblyContext, cancellationToken);
+                await hook(assemblyContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterAssembly hook failed for {assembly.GetName().Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterAssembly hook failed for {assembly.GetName().Name}: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -470,7 +470,7 @@ internal sealed class HookOrchestrator
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClassType, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectBeforeClassHooksAsync(testClassType);
+        var hooks = await _hookCollectionService.CollectBeforeClassHooksAsync(testClassType).ConfigureAwait(false);
 
         var classContext = _contextProvider.GetOrCreateClassContext(testClassType);
 
@@ -479,27 +479,27 @@ internal sealed class HookOrchestrator
             try
             {
                 classContext.RestoreExecutionContext();
-                await hook(classContext, cancellationToken);
+                await hook(classContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeClass hook failed for {testClassType.Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeClass hook failed for {testClassType.Name}: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
 
         // Execute global BeforeEveryClass hooks
-        var everyHooks = await _hookCollectionService.CollectBeforeEveryClassHooksAsync();
+        var everyHooks = await _hookCollectionService.CollectBeforeEveryClassHooksAsync().ConfigureAwait(false);
         foreach (var hook in everyHooks)
         {
             try
             {
                 classContext.RestoreExecutionContext();
-                await hook(classContext, cancellationToken);
+                await hook(classContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeEveryClass hook failed for {testClassType.Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeEveryClass hook failed for {testClassType.Name}: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
@@ -516,22 +516,22 @@ internal sealed class HookOrchestrator
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClassType, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectAfterClassHooksAsync(testClassType);
+        var hooks = await _hookCollectionService.CollectAfterClassHooksAsync(testClassType).ConfigureAwait(false);
         var classContext = _contextProvider.GetOrCreateClassContext(testClassType);
         var exceptions = new List<Exception>();
 
         // Execute global AfterEveryClass hooks first
-        var everyHooks = await _hookCollectionService.CollectAfterEveryClassHooksAsync();
+        var everyHooks = await _hookCollectionService.CollectAfterEveryClassHooksAsync().ConfigureAwait(false);
         foreach (var hook in everyHooks)
         {
             try
             {
                 classContext.RestoreExecutionContext();
-                await hook(classContext, cancellationToken);
+                await hook(classContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterEveryClass hook failed for {testClassType.Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterEveryClass hook failed for {testClassType.Name}: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -541,11 +541,11 @@ internal sealed class HookOrchestrator
             try
             {
                 classContext.RestoreExecutionContext();
-                await hook(classContext, cancellationToken);
+                await hook(classContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterClass hook failed for {testClassType.Name}: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterClass hook failed for {testClassType.Name}: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }
@@ -567,18 +567,18 @@ internal sealed class HookOrchestrator
 
     private async Task ExecuteBeforeEveryTestHooksAsync(Type testClassType, TestContext testContext, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectBeforeEveryTestHooksAsync(testClassType);
+        var hooks = await _hookCollectionService.CollectBeforeEveryTestHooksAsync(testClassType).ConfigureAwait(false);
 
         foreach (var hook in hooks)
         {
             try
             {
                 testContext.RestoreExecutionContext();
-                await hook(testContext, cancellationToken);
+                await hook(testContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"BeforeEveryTest hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"BeforeEveryTest hook failed: {ex.Message}").ConfigureAwait(false);
                 throw;
             }
         }
@@ -586,7 +586,7 @@ internal sealed class HookOrchestrator
 
     private async Task ExecuteAfterEveryTestHooksAsync(Type testClassType, TestContext testContext, CancellationToken cancellationToken)
     {
-        var hooks = await _hookCollectionService.CollectAfterEveryTestHooksAsync(testClassType);
+        var hooks = await _hookCollectionService.CollectAfterEveryTestHooksAsync(testClassType).ConfigureAwait(false);
         var exceptions = new List<Exception>();
 
         foreach (var hook in hooks)
@@ -594,11 +594,11 @@ internal sealed class HookOrchestrator
             try
             {
                 testContext.RestoreExecutionContext();
-                await hook(testContext, cancellationToken);
+                await hook(testContext, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                await _logger.LogErrorAsync($"AfterEveryTest hook failed: {ex.Message}");
+                await _logger.LogErrorAsync($"AfterEveryTest hook failed: {ex.Message}").ConfigureAwait(false);
                 exceptions.Add(ex);
             }
         }


### PR DESCRIPTION
This commit addresses multiple critical deadlock scenarios that could cause test discovery to hang intermittently:

1. Missing ConfigureAwait(false) calls (40+ locations fixed)
   - Added to all await calls in TestDiscoveryService, HookOrchestrator, and TestBuilderPipeline
   - Prevents SynchronizationContext capture that causes deadlocks in UI/ASP.NET environments

2. Thread pool exhaustion from unbounded parallelism
   - Added SemaphoreSlim throttling to limit concurrent assembly discovery to ProcessorCount * 2
   - Prevents thread pool starvation when discovering tests in solutions with many assemblies

3. Static lock bottleneck causing serialization
   - Replaced HashSet<Assembly> with ConcurrentDictionary<Assembly, bool>
   - Replaced List<TestMetadata> with ConcurrentBag<TestMetadata>
   - Eliminated global lock that was serializing all parallel discovery operations