### PR TITLE
Fix deadlock in BufferedTextWriter caused by nested locking

### DIFF
--- a/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
@@ -15,7 +15,12 @@ internal class StandardErrorConsoleInterceptor : OptimizedConsoleInterceptor
 
     static StandardErrorConsoleInterceptor()
     {
-        DefaultError = Console.Error;
+        // Get the raw stream without SyncTextWriter synchronization wrapper
+        // BufferedTextWriter already provides thread safety, so we avoid double-locking
+        DefaultError = new StreamWriter(Console.OpenStandardError())
+        {
+            AutoFlush = true
+        };
     }
 
     public StandardErrorConsoleInterceptor(VerbosityService verbosityService) : base(verbosityService)

--- a/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
@@ -15,7 +15,12 @@ internal class StandardOutConsoleInterceptor : OptimizedConsoleInterceptor
 
     static StandardOutConsoleInterceptor()
     {
-        DefaultOut = Console.Out;
+        // Get the raw stream without SyncTextWriter synchronization wrapper
+        // BufferedTextWriter already provides thread safety, so we avoid double-locking
+        DefaultOut = new StreamWriter(Console.OpenStandardOutput())
+        {
+            AutoFlush = true
+        };
     }
 
     public StandardOutConsoleInterceptor(VerbosityService verbosityService) : base(verbosityService)


### PR DESCRIPTION
The deadlock occurred due to double synchronization:
1. BufferedTextWriter uses ReaderWriterLockSlim for thread safety
2. Console.Out/Error are SyncTextWriter instances with their own locks

This created a lock ordering deadlock where:
- AutoFlush threads: BufferedTextWriter lock → SyncTextWriter lock
- Test threads: SyncTextWriter lock → BufferedTextWriter lock

Fixed by:
1. Modified BufferedTextWriter to release locks before calling external code
2. Used Console.OpenStandardOutput/Error() to bypass SyncTextWriter wrapper

These changes eliminate the deadlock by preventing nested lock acquisition and ensuring consistent lock ordering.
