### PR TITLE
Experimental implementation of suggestion made in #2972.

### DIFF
--- a/TUnit.Assertions.Tests/Old/EqualsAssertionTests.cs
+++ b/TUnit.Assertions.Tests/Old/EqualsAssertionTests.cs
@@ -48,4 +48,17 @@ public class EqualsAssertionTests
         short zero = 1;
         await TUnitAssert.ThrowsAsync<TUnitAssertionException>(async () => await TUnitAssert.That<long>(zero).IsEqualTo(0));
     }
+
+    [Test]
+    public async Task IEquatable()
+    {
+        var value = new TestItem(0);
+
+        await TUnitAssert.That(value).IsEquatableTo(0);
+    }
+
+    public record TestItem(int Value) : IEquatable<int>
+    {
+        public bool Equals(int other) => Value == other;
+    }
 }

--- a/TUnit.Assertions/Assertions/Generics/Conditions/GenericEqualsExpectedValueAssertCondition.cs
+++ b/TUnit.Assertions/Assertions/Generics/Conditions/GenericEqualsExpectedValueAssertCondition.cs
@@ -1,0 +1,20 @@
+﻿#if !NET
+#pragma warning disable CS8604 // Possible null reference argument.
+#endif
+using TUnit.Assertions.AssertConditions;
+
+namespace TUnit.Assertions.Assertions.Generics.Conditions;
+
+public class GenericEqualsExpectedValueAssertCondition<TActual, TExpected>(TExpected expected) : ExpectedValueAssertCondition<TActual, TExpected>(expected)
+    where TActual : IEquatable<TExpected>
+{
+    protected internal override string GetExpectation()
+        => $"to be equal to {ExpectedValue}";
+
+    protected override ValueTask<AssertionResult> GetResult(TActual? actualValue, TExpected? expectedValue)
+    {
+        return AssertionResult
+            .FailIf(!(actualValue?.Equals(expectedValue) ?? expectedValue == null),
+                $"found {actualValue}");
+    }
+}

--- a/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
+++ b/TUnit.Assertions/Assertions/Generics/GenericIsExtensions.cs
@@ -81,6 +81,16 @@ public static class GenericIsExtensions
         return valueSource.RegisterAssertion(new AssignableFromExpectedValueAssertCondition<object>(typeof(TExpected))
             , [typeof(TExpected).Name]);
     }
+
+    public static GenericEqualToAssertionBuilderWrapper<TActual> IsEquatableTo<TActual, TExpected>(this IValueSource<TActual> valueSource, TExpected expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = null)
+        where TActual : IEquatable<TExpected>
+    {
+        var assertionBuilder = valueSource
+            .RegisterAssertion(new GenericEqualsExpectedValueAssertCondition<TActual, TExpected>(expected), [doNotPopulateThisValue1]);
+
+        return new GenericEqualToAssertionBuilderWrapper<TActual>(assertionBuilder);
+    }
+
     public static GenericEqualToAssertionBuilderWrapper<TActual> IsEqualTo<TActual>(this IValueSource<TActual> valueSource, TActual expected, [CallerArgumentExpression(nameof(expected))] string doNotPopulateThisValue1 = null)
     {
         return IsEqualTo(valueSource, expected, EqualityComparer<TActual>.Default, doNotPopulateThisValue1);


### PR DESCRIPTION
I wasn't sure where to put the test, but the concept of permitting assertions on IEquatable<TOther> seems reasonable, so here is a simple implementation of the suggestion made in #2972 .

Using `IsEqualTo` results in overload resolution failure, so I used `IsEquatableTo`. (I note that `IsEquatableOrEqualTo` already exists - not sure if the naming should be tidied up here.)