### PR TITLE
Add a simple retry to the GithubReporter to prevent crashing on file locks

### DIFF
--- a/TUnit.Engine/Helpers/EnvironmentVariableCache.cs
+++ b/TUnit.Engine/Helpers/EnvironmentVariableCache.cs
@@ -27,6 +27,7 @@ internal static class EnvironmentVariableCache
         "TUNIT_ADAPTIVE_MAX_PARALLELISM", 
         "TUNIT_ADAPTIVE_METRICS",
         "TUNIT_DISABLE_GITHUB_REPORTER",
+        "TUNIT_GITHUB_ACTIONS_REPORTER_RETRY_COUNT",
         
         // CI environment detection variables
         "CI",


### PR DESCRIPTION
Fixes #3022 with a simple delay-based retry loop.

Sorry if this is a bit presumptuous - it was a quick thing to add and so I figured I'd send it up. 