### PR TITLE
fix: don't initialize test arguments before test session hooks

### DIFF
--- a/TUnit.Engine/Services/TestArgumentTrackingService.cs
+++ b/TUnit.Engine/Services/TestArgumentTrackingService.cs
@@ -30,20 +30,21 @@ internal sealed class TestArgumentTrackingService : ITestRegisteredEventReceiver
         var classArguments = testContext.TestDetails.TestClassArguments;
         var methodArguments = testContext.TestDetails.TestMethodArguments;
         
-        // Use centralized TestObjectInitializer for all initialization
-        // Initialize class arguments
+        // Initialize class arguments (registration phase)
         await _testObjectInitializer.InitializeArgumentsAsync(
             classArguments,
             testContext.ObjectBag,
             testContext.TestDetails.MethodMetadata,
-            testContext.Events);
-        
-        // Initialize method arguments
+            testContext.Events,
+            isRegistrationPhase: true);
+
+        // Initialize method arguments (registration phase)
         await _testObjectInitializer.InitializeArgumentsAsync(
             methodArguments,
             testContext.ObjectBag,
             testContext.TestDetails.MethodMetadata,
-            testContext.Events);
+            testContext.Events,
+            isRegistrationPhase: true);
         
         // Track all constructor and method arguments
         // Note: TestObjectInitializer already handles tracking, but we ensure it here for clarity

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -69,6 +69,9 @@ internal sealed class TestCoordinator : ITestCoordinator
                 test.Context.Dependencies.Add(dependency);
             }
             
+            // Ensure TestSession hooks run before creating test instances
+            await _testExecutor.EnsureTestSessionHooksExecutedAsync();
+
             test.Context.TestDetails.ClassInstance = await test.CreateInstanceAsync();
 
             // Check if this test should be skipped (after creating instance)


### PR DESCRIPTION
Fixes #3199