### PR TITLE
Expose CurrentRetryAttempt on TestContext

### DIFF
--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -320,6 +320,8 @@ public class TestContext : Context
 
     public DateTimeOffset? TestEnd { get; set; }
 
+    public int CurrentRetryAttempt { get; internal set; }
+
 
     public IEnumerable<TestContext> GetTests(Func<TestContext, bool> predicate)
     {

--- a/TUnit.Engine/Services/TestExecution/RetryHelper.cs
+++ b/TUnit.Engine/Services/TestExecution/RetryHelper.cs
@@ -10,6 +10,8 @@ internal static class RetryHelper
 
         for (var attempt = 0; attempt < maxRetries + 1; attempt++)
         {
+            testContext.CurrentRetryAttempt = attempt;
+
             try
             {
                 await action();
@@ -42,13 +44,13 @@ internal static class RetryHelper
         {
             return false;
         }
-        
+
         if (testContext.RetryFunc == null)
         {
             // Default behavior: retry on any exception if within retry limit
             return true;
         }
-        
+
         return await testContext.RetryFunc(testContext, ex, attempt + 1).ConfigureAwait(false);
     }
 }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1269,6 +1269,7 @@ namespace
         public .<.Artifact> Artifacts { get; }
         public .CancellationToken CancellationToken { get; set; }
         public .ClassHookContext ClassContext { get; }
+        public int CurrentRetryAttempt { get; }
         public .<.TestDetails> Dependencies { get; }
         public ? DisplayNameFormatter { get; set; }
         public .TestContextEvents Events { get; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1269,6 +1269,7 @@ namespace
         public .<.Artifact> Artifacts { get; }
         public .CancellationToken CancellationToken { get; set; }
         public .ClassHookContext ClassContext { get; }
+        public int CurrentRetryAttempt { get; }
         public .<.TestDetails> Dependencies { get; }
         public ? DisplayNameFormatter { get; set; }
         public .TestContextEvents Events { get; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1170,6 +1170,7 @@ namespace
         public .<.Artifact> Artifacts { get; }
         public .CancellationToken CancellationToken { get; set; }
         public .ClassHookContext ClassContext { get; }
+        public int CurrentRetryAttempt { get; }
         public .<.TestDetails> Dependencies { get; }
         public ? DisplayNameFormatter { get; set; }
         public .TestContextEvents Events { get; }


### PR DESCRIPTION
* Added a new property `CurrentRetryAttempt` to the `TestContext` class to record the current retry attempt for each test execution.
* Updated the `ExecuteWithRetry` method in `RetryHelper.cs` to set the `CurrentRetryAttempt` property on each retry loop iteration.