### PR TITLE
Update command for generating TRX report 

### DIFF
--- a/docs/docs/extensions/extensions.md
+++ b/docs/docs/extensions/extensions.md
@@ -108,7 +108,7 @@ Run your tests with the `--report-trx` flag:
 dotnet run --configuration Release --report-trx
 
 # Specify output location
-dotnet dotnet run --configuration Release --results-directory ./reports --report-trx --report-trx-filename testresults.trx
+dotnet run --configuration Release --results-directory ./reports --report-trx --report-trx-filename testresults.trx
 ```
 
 **📚 More Resources:**


### PR DESCRIPTION
Previous command results in:

```
Option '--report-trx-filename' has invalid arguments:
file name argument must not contain path (e.g. --report-trx-filename myreport.trx)
```