### PR TITLE
fix: JUnit reporter was encoding xml files in UTF-16 instead of UTF-8

### DIFF
--- a/TUnit.Engine/Xml/JUnitXmlWriter.cs
+++ b/TUnit.Engine/Xml/JUnitXmlWriter.cs
@@ -33,7 +33,7 @@ internal static class JUnitXmlWriter
                 ?.FrameworkDisplayName
             ?? RuntimeInformation.FrameworkDescription;
 
-        using var stringWriter = new StringWriter();
+        using var stringWriter = new Utf8StringWriter();
         var settings = new XmlWriterSettings
         {
             Indent = true,
@@ -339,6 +339,11 @@ internal static class JUnitXmlWriter
 
         return summary;
     }
+}
+
+file sealed class Utf8StringWriter : StringWriter
+{
+    public override Encoding Encoding => Encoding.UTF8;
 }
 
 internal sealed class TestSummary


### PR DESCRIPTION
Unfortunately the JUnit Reporter is encoding theX XML files in UTF-16 which is not supported by GitLab
<img width="792" height="100" alt="image" src="https://github.com/user-attachments/assets/d4075d40-97a8-4f53-b043-c5531b4c644e" />
Opening the file, i'm seeing that the header contains the wrong encoding: `<?xml version="1.0" encoding="utf-16"?>`

This fix will force the XML files to be encoded in UTF-8: `<?xml version="1.0" encoding="utf-8"?>` 

Fixes https://github.com/thomhurst/TUnit/issues/3985