### PR TITLE
chore: Add ExcludeFromCodeCoverage to generated classes

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/AssemblyLoaderGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/AssemblyLoaderGenerator.cs
@@ -70,6 +70,8 @@ public class AssemblyLoaderGenerator : IIncrementalGenerator
         }
 
         var sourceBuilder = new CodeWriter();
+
+        sourceBuilder.AppendLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]");
         sourceBuilder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"TUnit\", \"{typeof(AssemblyLoaderGenerator).Assembly.GetName().Version}\")]");
         using (sourceBuilder.BeginBlock("file static class AssemblyLoader" + Guid.NewGuid().ToString("N")))
         {

--- a/TUnit.Core.SourceGenerator/CodeGenerators/DisableReflectionScannerGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/DisableReflectionScannerGenerator.cs
@@ -36,6 +36,7 @@ public class DisableReflectionScannerGenerator : IIncrementalGenerator
     {
         var sourceBuilder = new CodeWriter();
 
+        sourceBuilder.AppendLine("[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]");
         sourceBuilder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"TUnit\", \"{typeof(DisableReflectionScannerGenerator).Assembly.GetName().Version}\")]");
         using (sourceBuilder.BeginBlock("file static class DisableReflectionScanner_" + Guid.NewGuid().ToString("N")))
         {


### PR DESCRIPTION
Generated classes in AssemblyLoaderGenerator and DisableReflectionScannerGenerator now include the [ExcludeFromCodeCoverage] attribute. This ensures that code coverage tools ignore these auto-generated files, resulting in more accurate coverage metrics for user-written code.