### PR TITLE
perf: replace fixed length `List` with `Span`

### DIFF
--- a/TUnit.Core/Helpers/ArgumentFormatter.cs
+++ b/TUnit.Core/Helpers/ArgumentFormatter.cs
@@ -135,19 +135,19 @@ public static class ArgumentFormatter
     private static string FormatEnumerable(IEnumerable enumerable)
     {
         const int maxElements = 10;
-        var elements = new List<string>(maxElements + 1);
-        var count = 0;
+        Span<string?> elements = [null, null, null, null, null, null, null, null, null, null, null];
 
+        var count = 0;
         try
         {
             foreach (var element in enumerable)
             {
                 if (count >= maxElements)
                 {
-                    elements.Add("...");
+                    elements[count] ="...";
                     break;
                 }
-                elements.Add(FormatDefault(element));
+                elements[count] = FormatDefault(element);
                 count++;
             }
         }
@@ -157,6 +157,6 @@ public static class ArgumentFormatter
             return enumerable.GetType().Name;
         }
 
-        return string.Join(", ", elements);
+        return string.Join(", ", elements[..count]);
     }
 }


### PR DESCRIPTION
Replaces `List<string>` with `Span<string?>`, modern collection expressions will generate a fixed length `struct`, `null` initialise it and then cast into `Span<string?>`.

This trick could probably be used in other areas, along with `ValueListBuilder` and `ValueStringBuilder`.

Not sure if it's worth using `Debug.Assert` to ensure that `elements` contains `maxElements + 1` values, I don't see `TUnit` using it very much.