### PR TITLE
perf: replace redundant allocations with `Linq`

### DIFF
--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -503,7 +503,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
                 continue;
             }
 
-            MethodInfo[] testMethods;
+            IEnumerable<MethodInfo> testMethods;
             try
             {
                 // Check if this class inherits tests from base classes
@@ -513,15 +513,14 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
                 {
                     // Get all test methods including inherited ones
                     testMethods = GetAllTestMethods(type)
-                        .Where(static m => m.IsDefined(typeof(TestAttribute), inherit: false) && !m.IsAbstract)
-                        .ToArray();
+                        .Where(static m => m.IsDefined(typeof(TestAttribute), inherit: false) && !m.IsAbstract);
                 }
                 else
                 {
                     // Only get declared test methods
-                    testMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
-                        .Where(static m => m.IsDefined(typeof(TestAttribute), inherit: false) && !m.IsAbstract)
-                        .ToArray();
+                    testMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                                  BindingFlags.DeclaredOnly)
+                        .Where(static m => m.IsDefined(typeof(TestAttribute), inherit: false) && !m.IsAbstract);
                 }
             }
             catch (Exception)

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -261,7 +261,9 @@ internal sealed class TestRegistry : ITestRegistry
             TestName = testName,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = GetDependenciesOptimized(result.Attributes),
+            Dependencies = result.Attributes.OfType<DependsOnAttribute>()
+                .Select(x => x.ToTestDependency())
+                .ToArray(),
             DataSources = [],
             ClassDataSources = [],
             PropertyDataSources = [],
@@ -338,25 +340,6 @@ internal sealed class TestRegistry : ITestRegistry
         public required TestContext SourceContext { get; init; }
         public required Type TestClassType { get; init; }
     }
-
-
-    /// <summary>
-    /// Optimized method to get dependencies without LINQ allocations
-    /// </summary>
-    private static TestDependency[] GetDependenciesOptimized(ICollection<Attribute> attributes)
-    {
-        var dependencies = new List<TestDependency>(attributes.Count);
-        foreach (var attr in attributes)
-        {
-            if (attr is DependsOnAttribute dependsOn)
-            {
-                dependencies.Add(dependsOn.ToTestDependency());
-            }
-        }
-        return dependencies.ToArray();
-    }
-
-
 
     /// <summary>
     /// Optimized method to convert attributes to array without LINQ allocations


### PR DESCRIPTION
Replace redundant repeat allocations with `Linq`. TUnit has a lot of code that replaces a 24 byte `Linq` allocation (sometimes Linq doesn't even allocate) with a `O(n)` temporary collection allocation.


There are way more of these for instance 0b1df1a7a7cf433c072a2b20088c5c3992b4d2eb, I don't think the AI understand `Linq`, as a rule of thumb, any comment starting with the word `Optimize` or mentions the word `Linq` is suspect