### PR TITLE
perf: skip `List` creation in `GetDynamicTestAttributes`

### DIFF
--- a/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
+++ b/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
@@ -155,15 +155,17 @@ internal sealed class AotTestDataCollector : ITestDataCollector
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)
     {
+        if (result.TestClassType == null)
+        {
+            return result.Attributes.ToArray();
+        }
+
         // Merge explicitly provided attributes with inherited class/assembly attributes
         // Order matches GetAllAttributes: method-level first (explicit), then class, then assembly
         var attributes = new List<Attribute>(result.Attributes);
 
-        if (result.TestClassType != null)
-        {
-            attributes.AddRange(result.TestClassType.GetCustomAttributes().OfType<Attribute>());
-            attributes.AddRange(result.TestClassType.Assembly.GetCustomAttributes().OfType<Attribute>());
-        }
+        attributes.AddRange(result.TestClassType.GetCustomAttributes());
+        attributes.AddRange(result.TestClassType.Assembly.GetCustomAttributes());
 
         return attributes.ToArray();
     }

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -1932,15 +1932,17 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)
     {
+        if (result.TestClassType == null)
+        {
+            return result.Attributes.ToArray();
+        }
+
         // Merge explicitly provided attributes with inherited class/assembly attributes
         // Order matches GetAllAttributes: method-level first (explicit), then class, then assembly
         var attributes = new List<Attribute>(result.Attributes);
 
-        if (result.TestClassType != null)
-        {
-            attributes.AddRange(result.TestClassType.GetCustomAttributes().OfType<Attribute>());
-            attributes.AddRange(result.TestClassType.Assembly.GetCustomAttributes().OfType<Attribute>());
-        }
+        attributes.AddRange(result.TestClassType.GetCustomAttributes());
+        attributes.AddRange(result.TestClassType.Assembly.GetCustomAttributes());
 
         return attributes.ToArray();
     }


### PR DESCRIPTION
Skip `List` creation if `TestClassType` is `null`. 
- Would be a good candidate for `ValueListBuilder` if this is a hot path