### PR TITLE
feat: comprehensive migration code fixer improvements

### DIFF
--- a/TUnit.Analyzers.CodeFixers/Base/AsyncMethodSignatureRewriter.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/AsyncMethodSignatureRewriter.cs
@@ -1,0 +1,85 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace TUnit.Analyzers.CodeFixers.Base;
+
+/// <summary>
+/// Transforms method signatures that contain await expressions but are not marked as async.
+/// Converts void methods to async Task and T-returning methods to async Task&lt;T&gt;.
+/// </summary>
+public class AsyncMethodSignatureRewriter : CSharpSyntaxRewriter
+{
+    public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        // First, visit children to ensure nested content is processed
+        node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
+
+        // Skip if already async or abstract
+        if (node.Modifiers.Any(SyntaxKind.AsyncKeyword) ||
+            node.Modifiers.Any(SyntaxKind.AbstractKeyword))
+        {
+            return node;
+        }
+
+        // Check if method contains await expressions
+        bool hasAwait = node.DescendantNodes().OfType<AwaitExpressionSyntax>().Any();
+        if (!hasAwait)
+        {
+            return node;
+        }
+
+        // Convert the return type
+        var newReturnType = ConvertReturnType(node.ReturnType);
+
+        // Add async modifier after access modifiers but before other modifiers (like static)
+        var newModifiers = InsertAsyncModifier(node.Modifiers);
+
+        return node
+            .WithReturnType(newReturnType)
+            .WithModifiers(newModifiers);
+    }
+
+    private static TypeSyntax ConvertReturnType(TypeSyntax returnType)
+    {
+        // void -> Task
+        if (returnType is PredefinedTypeSyntax predefined && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword))
+        {
+            return SyntaxFactory.ParseTypeName("Task")
+                .WithLeadingTrivia(returnType.GetLeadingTrivia())
+                .WithTrailingTrivia(returnType.GetTrailingTrivia());
+        }
+
+        // T -> Task<T>
+        var innerType = returnType.WithoutTrivia();
+        return SyntaxFactory.GenericName("Task")
+            .WithTypeArgumentList(
+                SyntaxFactory.TypeArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(innerType)))
+            .WithLeadingTrivia(returnType.GetLeadingTrivia())
+            .WithTrailingTrivia(returnType.GetTrailingTrivia());
+    }
+
+    private static SyntaxTokenList InsertAsyncModifier(SyntaxTokenList modifiers)
+    {
+        // Find the right position for async (after public/private/etc, before static/virtual/etc)
+        int insertIndex = 0;
+
+        for (int i = 0; i < modifiers.Count; i++)
+        {
+            var modifier = modifiers[i];
+            if (modifier.IsKind(SyntaxKind.PublicKeyword) ||
+                modifier.IsKind(SyntaxKind.PrivateKeyword) ||
+                modifier.IsKind(SyntaxKind.ProtectedKeyword) ||
+                modifier.IsKind(SyntaxKind.InternalKeyword))
+            {
+                insertIndex = i + 1;
+            }
+        }
+
+        var asyncModifier = SyntaxFactory.Token(SyntaxKind.AsyncKeyword)
+            .WithTrailingTrivia(SyntaxFactory.Space);
+
+        return modifiers.Insert(insertIndex, asyncModifier);
+    }
+}

--- a/TUnit.Analyzers.CodeFixers/Base/TestAttributeEnsurer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TestAttributeEnsurer.cs
@@ -1,0 +1,136 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace TUnit.Analyzers.CodeFixers.Base;
+
+/// <summary>
+/// Ensures that methods with data attributes (like [Arguments]) also have a [Test] attribute.
+/// This handles the case where NUnit allows [TestCase] alone, but TUnit requires [Test] + [Arguments].
+/// </summary>
+public class TestAttributeEnsurer : CSharpSyntaxRewriter
+{
+    private static readonly string[] DataAttributeNames =
+    [
+        "Arguments",
+        "MethodDataSource",
+        "ClassDataSource",
+        "MatrixDataSource"
+    ];
+
+    public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        // First, visit children
+        node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
+
+        // Check if method has any data attributes
+        bool hasDataAttribute = HasAnyDataAttribute(node);
+        if (!hasDataAttribute)
+        {
+            return node;
+        }
+
+        // Check if method already has [Test] attribute
+        bool hasTestAttribute = HasTestAttribute(node);
+        if (hasTestAttribute)
+        {
+            return node;
+        }
+
+        // Add [Test] attribute before the first attribute list
+        return AddTestAttribute(node);
+    }
+
+    private static bool HasAnyDataAttribute(MethodDeclarationSyntax method)
+    {
+        foreach (var attributeList in method.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                var name = GetAttributeName(attribute);
+                if (DataAttributeNames.Contains(name))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static bool HasTestAttribute(MethodDeclarationSyntax method)
+    {
+        foreach (var attributeList in method.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                var name = GetAttributeName(attribute);
+                if (name == "Test")
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static string GetAttributeName(AttributeSyntax attribute)
+    {
+        var name = attribute.Name.ToString();
+
+        // Remove "Attribute" suffix if present
+        if (name.EndsWith("Attribute"))
+        {
+            name = name[..^9];
+        }
+
+        // Handle fully qualified names (take the last part)
+        var lastDot = name.LastIndexOf('.');
+        if (lastDot >= 0)
+        {
+            name = name[(lastDot + 1)..];
+        }
+
+        return name;
+    }
+
+    private static MethodDeclarationSyntax AddTestAttribute(MethodDeclarationSyntax method)
+    {
+        if (method.AttributeLists.Count == 0)
+        {
+            // No existing attributes - add [Test] with proper formatting
+            var testAttribute = SyntaxFactory.Attribute(SyntaxFactory.IdentifierName("Test"));
+            var testAttributeList = SyntaxFactory.AttributeList(
+                SyntaxFactory.SingletonSeparatedList(testAttribute))
+                .WithTrailingTrivia(SyntaxFactory.EndOfLine("\n"));
+
+            return method.WithAttributeLists(
+                SyntaxFactory.SingletonList(testAttributeList));
+        }
+
+        // Get the leading trivia (indentation) from the first attribute list
+        var firstAttributeList = method.AttributeLists[0];
+        var leadingTrivia = firstAttributeList.GetLeadingTrivia();
+
+        // Create [Test] attribute list with same indentation
+        var testAttr = SyntaxFactory.Attribute(SyntaxFactory.IdentifierName("Test"));
+        var newTestAttrList = SyntaxFactory.AttributeList(
+            SyntaxFactory.SingletonSeparatedList(testAttr))
+            .WithLeadingTrivia(leadingTrivia)
+            .WithTrailingTrivia(SyntaxFactory.EndOfLine("\n"));
+
+        // Strip newlines from first attribute's leading trivia, keep only indentation
+        // This prevents double newlines when we insert [Test] before it
+        var strippedTrivia = firstAttributeList.GetLeadingTrivia()
+            .Where(t => !t.IsKind(SyntaxKind.EndOfLineTrivia))
+            .ToList();
+        var updatedFirstAttr = firstAttributeList.WithLeadingTrivia(strippedTrivia);
+
+        // Build new attribute list: [Test], then updated first attr (with stripped trivia), then rest
+        var newAttributeLists = new SyntaxList<AttributeListSyntax>()
+            .Add(newTestAttrList)
+            .Add(updatedFirstAttr)
+            .AddRange(method.AttributeLists.Skip(1));
+
+        return method.WithAttributeLists(newAttributeLists);
+    }
+}


### PR DESCRIPTION
## Summary

- Add extensive assertion conversion support for NUnit, MSTest, and xUnit migration code fixers
- Add format string message preservation (`Assert.AreEqual(5, x, "Expected {0}", x)` → `string.Format()`)
- Add custom comparer detection using semantic model (generates TODO comments instead of misinterpreting as message)
- Add `AsyncMethodSignatureRewriter` to convert void test methods to async Task when assertions are converted
- Add `TestAttributeEnsurer` to add [Test] attribute when data attributes exist (NUnit → TUnit migration)

### NUnit Additions
- `Assert.Throws<T>()` / `Assert.ThrowsAsync<T>()` → `Throws.InstanceOf<T>()`
- `Assert.Pass()`, `Assert.Fail()`, `Assert.Inconclusive()`, `Assert.Ignore()`
- `Is.SubsetOf()`, `Is.SupersetOf()`, `Is.EquivalentTo()`
- `Is.Unique` → `HasDistinctItems()`
- `Is.Ordered` → `IsInAscendingOrder()`
- `Is.InRange()` → `IsBetween()`

### MSTest Additions
- `Assert.Inconclusive()` → `Assert.Skip()`
- `CollectionAssert.AreEquivalent()` / `AreNotEquivalent()`
- `CollectionAssert.AllItemsAreUnique()` → `HasDistinctItems()`
- `CollectionAssert.IsSubsetOf()` / `IsNotSubsetOf()`
- `CollectionAssert.AllItemsAreInstancesOfType()`

### xUnit Additions
- `Assert.ThrowsAny<T>()` / `ThrowsAnyAsync<T>()`
- `Assert.Single()` → `HasSingleItem()`
- `Assert.Distinct()` → `HasDistinctItems()`
- `Assert.Subset()` / `Assert.Superset()`
- `Assert.Equivalent()` → `IsEquivalentTo()`
- `Assert.All()` → `AllSatisfy()`

## Test plan

- [x] NUnit migration tests: 124/124 passed
- [x] MSTest migration tests: 84/84 passed
- [x] xUnit migration tests: 131/132 passed (1 infrastructure failure on net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)