### PR TITLE
feat: add System.Threading.Tasks using and preserve TestCase properties

### DIFF
--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -114,6 +114,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -285,6 +286,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -326,6 +328,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -373,6 +376,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -419,6 +423,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -508,6 +513,7 @@ public class MSTestMigrationAnalyzerTests
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
                 using System;
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -608,6 +614,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -664,6 +671,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -708,6 +716,7 @@ public class MSTestMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -113,6 +113,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -290,6 +291,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -336,6 +338,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -378,6 +381,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -468,6 +472,7 @@ public class NUnitMigrationAnalyzerTests
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
                 using System;
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -558,6 +563,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -596,6 +602,7 @@ public class NUnitMigrationAnalyzerTests
             """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+            using System.Threading.Tasks;
             using TUnit.Core;
             using TUnit.Assertions;
             using static TUnit.Assertions.Assert;
@@ -632,6 +639,7 @@ public class NUnitMigrationAnalyzerTests
             """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+            using System.Threading.Tasks;
             using TUnit.Core;
             using TUnit.Assertions;
             using static TUnit.Assertions.Assert;
@@ -672,6 +680,7 @@ public class NUnitMigrationAnalyzerTests
             """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+            using System.Threading.Tasks;
             using TUnit.Core;
             using TUnit.Assertions;
             using static TUnit.Assertions.Assert;
@@ -708,6 +717,7 @@ public class NUnitMigrationAnalyzerTests
             """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+            using System.Threading.Tasks;
             using TUnit.Core;
             using TUnit.Assertions;
             using static TUnit.Assertions.Assert;
@@ -746,6 +756,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -782,6 +793,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -818,6 +830,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -854,6 +867,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -890,6 +904,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -926,6 +941,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -962,6 +978,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -999,6 +1016,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;
@@ -1038,6 +1056,7 @@ public class NUnitMigrationAnalyzerTests
                 """,
             Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
             """
+                using System.Threading.Tasks;
                 using TUnit.Core;
                 using TUnit.Assertions;
                 using static TUnit.Assertions.Assert;


### PR DESCRIPTION
## Summary

Follow-up improvements to the migration code fixers based on user feedback:

- Add `using System.Threading.Tasks;` when async code is present in migration
- Preserve NUnit TestCase named properties during migration:
  - Map `Ignore`/`IgnoreReason` to TUnit's `Skip` property
  - Add TODO comments for unsupported properties (`TestName`, `Category`, `Description`, `Author`, `Explicit`, `ExplicitReason`)

## Test plan

- [x] NUnit migration tests: 124/124 passed
- [x] MSTest migration tests: 84/84 passed  
- [x] xUnit migration tests: 131/132 passed (1 infrastructure failure on net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)