### PR TITLE
perf: remove unnecessary loop

### DIFF
--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -60,23 +60,8 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
             return ImmutableHashSet<object>.Empty;
         }
 
-#if NETSTANDARD2_0
-        // .NET Standard 2.0 doesn't support HashSet capacity constructor
         var result = new HashSet<object>(Helpers.ReferenceEqualityComparer.Instance);
-#else
-        // First pass: calculate total capacity to avoid resizing
-        var totalCapacity = 0;
-        foreach (var kvp in trackedObjects)
-        {
-            lock (kvp.Value)
-            {
-                totalCapacity += kvp.Value.Count;
-            }
-        }
 
-        // Second pass: populate with pre-sized HashSet
-        var result = new HashSet<object>(totalCapacity, Helpers.ReferenceEqualityComparer.Instance);
-#endif
         foreach (var kvp in trackedObjects)
         {
             lock (kvp.Value)


### PR DESCRIPTION
Removes unnecessary loop to calculate `HashSet` capacity. I haven't benchmarked this, but I really doubt the savings from preallocating a `Hashset` outways the cost of allocating a second `ConcurrentDictionary.Enumerator` and `locking` and looping the dictionary a second time.

I'll close this PR if this was added to address a legitimate issue