### PR TITLE
fix: handle ref struct parameters in [GenerateAssertion] source generator

### DIFF
--- a/TUnit.Assertions.SourceGenerator.Tests/TestData/RefStructParameterAssertion.cs
+++ b/TUnit.Assertions.SourceGenerator.Tests/TestData/RefStructParameterAssertion.cs
@@ -1,0 +1,30 @@
+#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using TUnit.Assertions.Attributes;
+
+namespace TUnit.Assertions.Tests.TestData;
+
+/// <summary>
+/// Test case: Method with ref struct parameter (DefaultInterpolatedStringHandler)
+/// The generator should convert the ref struct to string before storing it
+/// </summary>
+public static class RefStructParameterAssertions
+{
+    /// <summary>
+    /// Test that interpolated string handlers are properly converted to strings
+    /// </summary>
+    [GenerateAssertion(ExpectationMessage = "to contain {message}", InlineMethodBody = true)]
+    public static bool ContainsMessage(this string value, ref DefaultInterpolatedStringHandler message)
+    {
+        var stringMessage = message.ToStringAndClear();
+        return value.Contains(stringMessage);
+    }
+
+    /// <summary>
+    /// Test with a simpler expression body
+    /// </summary>
+    [GenerateAssertion(ExpectationMessage = "to end with {suffix}", InlineMethodBody = true)]
+    public static bool EndsWithMessage(this string value, ref DefaultInterpolatedStringHandler suffix)
+        => value.EndsWith(suffix.ToStringAndClear());
+}
+#endif


### PR DESCRIPTION
## Summary

Fixes #4192

The source generator was failing when encountering methods with `ref struct` parameters (like `DefaultInterpolatedStringHandler`) because it tried to store them as class fields, which is illegal in C#.

### Changes

- **Add ref struct detection methods**: `IsRefStruct()` and `IsInterpolatedStringHandler()` to detect ref-like types using the `IsRefLikeType` property and fallback pattern matching
- **Store ref struct parameters as string**: Fields for ref struct parameters now use `string` type instead of the original type
- **Convert in extension method**: Interpolated string handlers are converted to string via `.ToStringAndClear()` before passing to the assertion constructor; other ref structs use `.ToString()`
- **Fix inlined method bodies**: Remove redundant `.ToStringAndClear()`/`.ToString()` calls in inlined method bodies since the field is already a string
- **Add diagnostic TUNITGEN004**: Error when methods with ref struct parameters don't use `InlineMethodBody = true` (required because we can't call the original method with a string when it expects a ref struct)

### Example

For a method like:
```csharp
[GenerateAssertion(ExpectationMessage = "to contain {message}", InlineMethodBody = true)]
public static bool ContainsMessage(this string value, ref DefaultInterpolatedStringHandler message)
{
    var stringMessage = message.ToStringAndClear();
    return value.Contains(stringMessage);
}
```

The generator now produces:
1. A field: `private readonly string _message;` (instead of storing the handler)
2. Extension method converts: `message.ToStringAndClear()` before passing to constructor
3. Inlined body: `value!.Contains(_message)` (with `.ToStringAndClear()` removed since it's already a string)

## Test plan

- [x] Added test data file `RefStructParameterAssertion.cs` with interpolated string handler parameter examples
- [x] Added test case `RefStructParameter()` to verify the generated code
- [x] Full solution builds successfully
- [ ] Run source generator tests when test infrastructure version mismatch is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)