### PR TITLE
perf: reduce allocations in generated code

### DIFF
--- a/TUnit.Assertions.SourceGenerator/Generators/AssertionExtensionGenerator.cs
+++ b/TUnit.Assertions.SourceGenerator/Generators/AssertionExtensionGenerator.cs
@@ -439,10 +439,17 @@ public sealed class AssertionExtensionGenerator : IIncrementalGenerator
         else if (additionalParams.Length > 0)
         {
             sourceBuilder.AppendLine();
-            sourceBuilder.Append("        source.Context.ExpressionBuilder.Append(string.Join(\", \", new[] { ");
-            var expressionParts = additionalParams.Select(p => $"{p.Name}Expression");
-            sourceBuilder.Append(string.Join(", ", expressionParts));
-            sourceBuilder.AppendLine(" }.Where(e => e != null)));");
+            sourceBuilder.AppendLine("        var added = false;");
+            foreach (var param in additionalParams)
+            {
+                sourceBuilder.AppendLine($"        if ({param.Name}Expression != null)");
+                sourceBuilder.AppendLine("        {");
+                sourceBuilder.AppendLine("            source.Context.ExpressionBuilder.Append(added ? \", \" : \"\");");
+                sourceBuilder.AppendLine($"            source.Context.ExpressionBuilder.Append({param.Name}Expression);");
+                sourceBuilder.AppendLine($"            added = true;");
+                sourceBuilder.AppendLine("        }");
+
+            }
         }
         sourceBuilder.AppendLine("        source.Context.ExpressionBuilder.Append(\")\");");
 


### PR DESCRIPTION
Modify generated code to avoid allocations.
- Removes `string[]` allocation, `ArrayWhereIterator` and string concatenation.
- Does `TUnit` have tests for generated assertion code? Most of the tests for `TUnit` usually fail for me so I don't bother using them 😅 
    - Does the CI run unit tests or does it only try to run claude?

Note that there is a lot of room for improvement with the `additionalParams.Length > 0` case. I can think of a couple of approaches if you'd like to try them

### Before
<img width="451" height="154" alt="image" src="https://github.com/user-attachments/assets/4ab7e781-4e7a-41e9-81c4-a20d936aca3f" />
<img width="433" height="167" alt="image" src="https://github.com/user-attachments/assets/3209321a-f51a-4830-8a1d-4cc864935d6c" />

### After
<img width="479" height="158" alt="image" src="https://github.com/user-attachments/assets/c5bb4d2a-b4f7-4552-86dd-aa9a07974ea5" />
<img width="423" height="174" alt="image" src="https://github.com/user-attachments/assets/50fe5205-b9f0-4e8b-9778-0b667bd2221c" />


Note