### PR TITLE
perf: replace collection duplication with `RemoveWhere`

### DIFF
--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -176,16 +176,9 @@ internal sealed class TestDependencyResolver
 
     private void ResolvePendingDependencies()
     {
-        var pendingTests = _testsWithPendingDependencies.ToList();
-
-        foreach (var test in pendingTests)
+        _testsWithPendingDependencies.RemoveWhere(static test => test.Dependencies.Length > 0);
+        foreach (var test in _testsWithPendingDependencies)
         {
-            if (test.Dependencies.Length > 0)
-            {
-                _testsWithPendingDependencies.Remove(test);
-                continue;
-            }
-
             ResolveDependenciesForTest(test);
         }
     }


### PR DESCRIPTION
`ToList` call was used to iterate the `Hashset` while removing items. This PR uses `RemoveWhere` to remove items and then iterates it. 

- Eliminates most `List<AbstractExecutableTest>` and `AbstractExecutableTest[]` allocations from `TestDependencyResolver`


### Before
<img width="607" height="164" alt="image" src="https://github.com/user-attachments/assets/33c04853-cd08-4c65-b414-ad4704fd3704" />

### After
<img width="619" height="167" alt="image" src="https://github.com/user-attachments/assets/edb9d4c6-debd-404f-9230-7ba9d3ebbaaa" />
