### PR TITLE
perf: prevent `Func` allocation with method group

### DIFF
--- a/TUnit.Core/PropertyInjection/PropertyInjectionCache.cs
+++ b/TUnit.Core/PropertyInjection/PropertyInjectionCache.cs
@@ -25,7 +25,7 @@ internal static class PropertyInjectionCache
     /// </summary>
     public static PropertyInjectionPlan GetOrCreatePlan(Type type)
     {
-        return _injectionPlans.GetOrAdd(type, _ => PropertyInjectionPlanBuilder.Build(type));
+        return _injectionPlans.GetOrAdd(type, PropertyInjectionPlanBuilder.Build);
     }
 
     /// <summary>


### PR DESCRIPTION
Uses method group to avoid allocating a new `Func` and closure whenever `GetOrCreatePlan` is called.

I'm assuming `PropertyInjectionPlanBuilder.Build` is extremely expensive to run hence this code? Was the thread safe caching added for safety reasons or just performance?

### Before
<img width="630" height="164" alt="image" src="https://github.com/user-attachments/assets/bfa5141e-f57e-4f7e-ab6e-2711513f0673" />


### After
<img width="633" height="168" alt="image" src="https://github.com/user-attachments/assets/2d5e3c20-0d11-4b3e-9199-13e496fb1d55" />
