### PR TITLE
perf: make methods synchronous and prevent closure creation

### DIFF
--- a/TUnit.Engine/Services/HookCollectionService.cs
+++ b/TUnit.Engine/Services/HookCollectionService.cs
@@ -704,27 +704,20 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
-        {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
-                hook,
-                context,
-                cancellationToken);
-
-            await timeoutAction();
-        };
+        return (context, cancellationToken) => HookTimeoutHelper.CreateTimeoutHookAction(
+            hook,
+            context,
+            cancellationToken);
     }
 
     private static Func<ClassHookContext, CancellationToken, Task> CreateClassHookDelegate(StaticHookMethod<ClassHookContext> hook)
     {
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
@@ -733,27 +726,23 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
     private static Func<AssemblyHookContext, CancellationToken, Task> CreateAssemblyHookDelegate(StaticHookMethod<AssemblyHookContext> hook)
     {
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
@@ -762,27 +751,23 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
     private static Func<TestSessionContext, CancellationToken, Task> CreateTestSessionHookDelegate(StaticHookMethod<TestSessionContext> hook)
     {
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
@@ -791,27 +776,23 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
     private static Func<BeforeTestDiscoveryContext, CancellationToken, Task> CreateBeforeTestDiscoveryHookDelegate(StaticHookMethod<BeforeTestDiscoveryContext> hook)
     {
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
@@ -820,27 +801,23 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
     private static Func<TestDiscoveryContext, CancellationToken, Task> CreateTestDiscoveryHookDelegate(StaticHookMethod<TestDiscoveryContext> hook)
     {
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 
@@ -849,14 +826,12 @@ internal sealed class HookCollectionService : IHookCollectionService
         // Process hook registration event receivers
         await ProcessHookRegistrationAsync(hook);
 
-        return async (context, cancellationToken) =>
+        return (context, cancellationToken) =>
         {
-            var timeoutAction = HookTimeoutHelper.CreateTimeoutHookAction(
+            return HookTimeoutHelper.CreateTimeoutHookAction(
                 hook,
                 context,
                 cancellationToken);
-
-            await timeoutAction();
         };
     }
 


### PR DESCRIPTION
Largest memory saving, I reckon I'll be able to make by eliding state machines and removing redundant closures.

- Directly return a task and remove the async keyword to avoid allocating a state machine
    - Note that the stack trace from invoked methods which throw will no longer include this function. IMO this won't affect debugging as these methods are pretty linear 🤷 
- Methods like `CreateStaticHookDelegateAsync` were creating a `Func<Task>` via `CreateTimeoutHookAction` before immediately invoking and awaiting it. I changed it to directly return a `Task` as the defered execution was never used.
	- This would allocate an unneeded state machine and there was no reason to create a delegate if you are immediately going to invoke it

- Get `int timoutMs` before passing it into `CreateTimeoutHookActionAsync`, this makes the resulting state machine 8 bytes smaller because it can pack the 4 byte integer with the state machine `state` integer. 
- Move `HookTimeoutHelper.ExecuteHookWithPotentialCustomExecutor` to a different method to prevent closure creation.
	- Even though 99% of method calls end up using the default hook executor via `hook.ExecuteAsync`, the compiler will still eagerly generate and allocate the closures even when they aren't needed. 

This saves around 180MB on `TUnit.TestProject` around 10% of total memory usage. 


### Before
<img width="807" height="308" alt="image" src="https://github.com/user-attachments/assets/9356221f-9df0-403e-b3c4-91858251c00d" />


<img width="570" height="214" alt="image" src="https://github.com/user-attachments/assets/78ce401c-1216-4a24-acfd-200f12e4aeb2" />


### After
<img width="802" height="282" alt="image" src="https://github.com/user-attachments/assets/fbe9fd4c-4531-4647-aa9d-80c00b5febfb" />


<img width="577" height="182" alt="image" src="https://github.com/user-attachments/assets/0d8dac65-1fb7-449a-bfc1-0a60d8fba22d" />

Note that `TUnit.Engine.Helpers.HookTimeoutHelper+<<CreateTimeoutHookAction>g__CreateTimeoutHookActionAsync|0_0>d<TestContext>` is large because it replaces a `Func<Task>`, a closure for `CreateTimeoutHookAction` and an async state machine costing around 150MB total.