### PR TITLE
perf: reduce allocations with `Span.Split` and `VSB`

### DIFF
--- a/TUnit.Engine/Exceptions/TUnitFailedException.cs
+++ b/TUnit.Engine/Exceptions/TUnitFailedException.cs
@@ -1,4 +1,5 @@
 ﻿using TUnit.Core.Exceptions;
+using TUnit.Core.Helpers;
 
 namespace TUnit.Engine.Exceptions;
 
@@ -23,9 +24,21 @@ public abstract class TUnitFailedException : TUnitException
             return string.Empty;
         }
 
-        var lines = stackTrace!.Split([Environment.NewLine], StringSplitOptions.None);
+        var vsb = new ValueStringBuilder(stackalloc char[256]);
 
-        return string.Join(Environment.NewLine,
-            lines.TakeWhile(x => !x.Trim().StartsWith("at TUnit")));
+        var added = false;
+        foreach(var range in stackTrace.AsSpan().Split(Environment.NewLine))
+        {
+            var slice = stackTrace.AsSpan()[range];
+            if (slice.Trim().StartsWith("at TUnit"))
+            {
+                break;
+            }
+            vsb.Append(added ? Environment.NewLine : "");
+            vsb.Append(slice);
+            added = true;
+        }
+
+        return vsb.ToString();
     }
 }


### PR DESCRIPTION
Use `ValueStringBuilder` and `Span.Split` to avoid allocating `string[]` and `string.Substring`

Note that while the savings are small for modern versions of .NET - 2.5MB, this represents a substantial speedup for .NET framework where `string.Split` would allocate 60MB of `int[]`

### Before
<img width="399" height="152" alt="image" src="https://github.com/user-attachments/assets/876c75a2-69d9-4880-b036-f409509d52d2" />


### After
<img width="391" height="158" alt="image" src="https://github.com/user-attachments/assets/a9523588-8b13-48b4-b924-0a7e43da391d" />

