### PR TITLE
perf: replace `SubsString` with alternative lookup

### DIFF
--- a/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
+++ b/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
@@ -651,8 +651,13 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
             return true; // Malformed key, treat as direct
         }
 
+#if NET9_0_OR_GREATER
+        var declaringTypeName = cacheKey.AsSpan()[..lastDotIndex];
+        return hierarchyTypes.GetAlternateLookup<ReadOnlySpan<char>>().Contains(declaringTypeName);
+#else
         var declaringTypeName = cacheKey.Substring(0, lastDotIndex);
         return hierarchyTypes.Contains(declaringTypeName);
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
Use `GetAlternateLookup` to avoid allocaing a `string` via `SubString`. 

Edit: use preprocessor directive, apparently you can't polyfill `GetAlternativeLookup`

Small improvement saves around 200KB