### PR TITLE
perf: use `Attribute[]` then `List` in `ToAttributeDictionary`

### DIFF
--- a/TUnit.Core/Helpers/AttributeDictionaryHelper.cs
+++ b/TUnit.Core/Helpers/AttributeDictionaryHelper.cs
@@ -27,12 +27,21 @@ public static class AttributeDictionaryHelper
             var type = attr.GetType();
             if (!result.TryGetValue(type, out var list))
             {
-                var newList = new List<Attribute> { attr };
-                result[type] = newList;
+                var newCollection = new [] { attr };
+                result[type] = newCollection;
             }
             else
             {
-                ((List<Attribute>)list).Add(attr);
+                // first attribute is added to an array, move to a list for addtional values
+                if (list is Attribute[])
+                {
+                    var newlist = new List<Attribute> { list[0], attr };
+                    result[type] = newlist;
+                }
+                else
+                {
+                    ((List<Attribute>)list).Add(attr);
+                }
             }
         }
 


### PR DESCRIPTION
Most attributes types are unique in `ToAttributeDictionary` so we default to a single array and then switch to a `List<Attribute>` when a type has more that one attributes. Lists with 1 element added are 32 bytes with an additional 4 element, 56 byte `Attribute[]`.

Might be able to pre size the dictionary by using an average of all previous final dictionaries, It might be as easy as a static `long Accumulator` and `long Count` and the average is inital capacity for `Dictionary`

- Were you aware that the attributes in `Playground.AssemblyInfo` were appearing in every tests `AttributeFactory`
    - I assume all global assemblies are added to each tests `AttributeFactory`, Is this in case the attribute is needed in the test or some AOT thing?
- Is it necessary to wrap the dictionary in `ReadOnlyDictionary`?



### Before
<img width="598" height="86" alt="image" src="https://github.com/user-attachments/assets/a6240744-03f0-4a15-bf33-72c4a43f427f" />


### After

<img width="566" height="159" alt="image" src="https://github.com/user-attachments/assets/ad84d31c-a69a-47b8-93f2-8454509eeabb" />
