### PR TITLE
perf: lazy initialization for TestBuilderContext properties

### DIFF
--- a/TUnit.Core/TestBuilderContext.cs
+++ b/TUnit.Core/TestBuilderContext.cs
@@ -9,6 +9,7 @@ namespace TUnit.Core;
 public record TestBuilderContext
 {
     private static readonly AsyncLocal<TestBuilderContext?> BuilderContexts = new();
+    private string? _definitionId;
 
     /// <summary>
     /// Gets the current test builder context.
@@ -19,17 +20,31 @@ public record TestBuilderContext
         internal set => BuilderContexts.Value = value;
     }
 
-    public string DefinitionId { get; } = Guid.NewGuid().ToString();
+    /// <summary>
+    /// Gets the unique definition ID for this context. Generated lazily on first access.
+    /// </summary>
+    public string DefinitionId => _definitionId ??= Guid.NewGuid().ToString();
 
      [Obsolete("Use StateBag property instead.")]
      public ConcurrentDictionary<string, object?> ObjectBag => StateBag;
 
+    private ConcurrentDictionary<string, object?>? _stateBag;
+    private TestContextEvents? _events;
+
     /// <summary>
     /// Gets the state bag for storing arbitrary data during test building.
     /// </summary>
-    public ConcurrentDictionary<string, object?> StateBag { get; set; } = new();
+    public ConcurrentDictionary<string, object?> StateBag
+    {
+        get => _stateBag ??= new ConcurrentDictionary<string, object?>();
+        set => _stateBag = value;
+    }
 
-    public TestContextEvents Events { get; set; } = new();
+    public TestContextEvents Events
+    {
+        get => _events ??= new TestContextEvents();
+        set => _events = value;
+    }
 
     public IDataSourceAttribute? DataSourceAttribute { get; set; }
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -162,11 +162,10 @@ internal sealed class TestBuilder : ITestBuilder
             }
 
             // Create a single context accessor that we'll reuse, updating its Current property for each test
+            // StateBag and Events are lazy-initialized, so we don't need to pre-allocate them
             var testBuilderContext = new TestBuilderContext
             {
                 TestMetadata = metadata.MethodMetadata,
-                Events = new TestContextEvents(),
-                StateBag = new ConcurrentDictionary<string, object?>(),
                 InitializedAttributes = attributes  // Store the initialized attributes
             };
 
@@ -309,11 +308,10 @@ internal sealed class TestBuilder : ITestBuilder
                             for (var i = 0; i < repeatCount + 1; i++)
                             {
                                 // Update context BEFORE calling data factories so they track objects in the right context
+                                // StateBag and Events are lazy-initialized for performance
                                 contextAccessor.Current = new TestBuilderContext
                                 {
                                     TestMetadata = metadata.MethodMetadata,
-                                    Events = new TestContextEvents(),
-                                    StateBag = new ConcurrentDictionary<string, object?>(),
                                     DataSourceAttribute = methodDataSource,
                                     InitializedAttributes = testBuilderContext.InitializedAttributes,  // Preserve attributes from parent context
                                     ClassConstructor = testBuilderContext.ClassConstructor  // Preserve ClassConstructor for instance creation
@@ -443,10 +441,10 @@ internal sealed class TestBuilder : ITestBuilder
                                     Metadata = finalMetadata
                                 };
 
+                                // Events is lazy-initialized; explicitly share StateBag from per-iteration context
                                 var testSpecificContext = new TestBuilderContext
                                 {
                                     TestMetadata = metadata.MethodMetadata,
-                                    Events = new TestContextEvents(),
                                     StateBag = contextAccessor.Current.StateBag,
                                     ClassConstructor = testBuilderContext.ClassConstructor,
                                     DataSourceAttribute = contextAccessor.Current.DataSourceAttribute,
@@ -508,11 +506,10 @@ internal sealed class TestBuilder : ITestBuilder
                                     ResolvedMethodGenericArguments = Type.EmptyTypes
                                 };
 
+                                // StateBag and Events are lazy-initialized
                                 var testSpecificContext = new TestBuilderContext
                                 {
                                     TestMetadata = metadata.MethodMetadata,
-                                    Events = new TestContextEvents(),
-                                    StateBag = new ConcurrentDictionary<string, object?>(),
                                     ClassConstructor = testBuilderContext.ClassConstructor,
                                     DataSourceAttribute = methodDataSource,
                                     InitializedAttributes = attributes
@@ -568,11 +565,10 @@ internal sealed class TestBuilder : ITestBuilder
                             ResolvedMethodGenericArguments = Type.EmptyTypes
                         };
 
+                        // StateBag and Events are lazy-initialized
                         var testSpecificContext = new TestBuilderContext
                         {
                             TestMetadata = metadata.MethodMetadata,
-                            Events = new TestContextEvents(),
-                            StateBag = new ConcurrentDictionary<string, object?>(),
                             ClassConstructor = testBuilderContext.ClassConstructor,
                             DataSourceAttribute = classDataSource,
                             InitializedAttributes = attributes
@@ -1428,11 +1424,10 @@ internal sealed class TestBuilder : ITestBuilder
         var attributes = await InitializeAttributesAsync(metadata.AttributeFactory.Invoke());
 
         // Create base context with ClassConstructor if present
+        // StateBag and Events are lazy-initialized for performance
         var baseContext = new TestBuilderContext
         {
             TestMetadata = metadata.MethodMetadata,
-            Events = new TestContextEvents(),
-            StateBag = new ConcurrentDictionary<string, object?>(),
             InitializedAttributes = attributes  // Store the initialized attributes
         };
 
@@ -1732,10 +1727,10 @@ internal sealed class TestBuilder : ITestBuilder
                 Metadata = finalMetadata
             };
 
+            // Events is lazy-initialized; explicitly share StateBag from per-iteration context
             var testSpecificContext = new TestBuilderContext
             {
                 TestMetadata = metadata.MethodMetadata,
-                Events = new TestContextEvents(),
                 StateBag = contextAccessor.Current.StateBag,
                 ClassConstructor = contextAccessor.Current.ClassConstructor,
                 DataSourceAttribute = contextAccessor.Current.DataSourceAttribute,


### PR DESCRIPTION
## Summary
- Reduce allocations in test building hot path by making `TestBuilderContext` properties lazy-initialized
- Remove pre-allocations in `TestBuilder.cs` that were eagerly creating `StateBag` and `Events` instances

## Changes

### TestBuilderContext.cs
Made three properties lazy-initialized:

| Property | Before | After |
|----------|--------|-------|
| `DefinitionId` | `= Guid.NewGuid().ToString()` (eager) | Lazy - only generated on first access |
| `StateBag` | `= new ConcurrentDictionary<>()` (eager) | Lazy - only allocated when accessed |
| `Events` | `= new TestContextEvents()` (eager) | Lazy - only allocated when accessed |

### TestBuilder.cs
Removed pre-allocations in 7 locations that were explicitly passing `new ConcurrentDictionary<>()` and `new TestContextEvents()` when creating contexts.

## Why This Matters

Before these changes, for **every test iteration** during building:
- `new ConcurrentDictionary<string, object?>()` - Very expensive due to internal lock arrays
- `new TestContextEvents()` - 7 nullable event delegate slots
- `Guid.NewGuid().ToString()` - GUID generation + string allocation

Now these allocations only happen **when the properties are actually accessed**, which for many tests during the build phase, may not happen at all.

## Test plan
- [x] `TUnit.Engine.Tests` - 290 tests pass (270 succeeded, 20 skipped)
- [x] `TUnit.PerformanceBenchmarks` - 60 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)