### PR TITLE
perf: skip Discovered messages during test execution

### DIFF
--- a/TUnit.Engine/Framework/TestRequestHandler.cs
+++ b/TUnit.Engine/Framework/TestRequestHandler.cs
@@ -65,11 +65,8 @@ internal sealed class TestRequestHandler : IRequestHandler
 
         var allTests = discoveryResult.Tests.ToArray();
 
-        foreach (var test in allTests)
-        {
-            context.CancellationToken.ThrowIfCancellationRequested();
-            await serviceProvider.MessageBus.Discovered(test.Context);
-        }
+        // Skip sending Discovered messages during execution - they're only needed for discovery requests
+        // This saves significant time and allocations when running tests
 
         await serviceProvider.TestSessionCoordinator.ExecuteTests(
             allTests,

--- a/TUnit.Engine/Interfaces/IDynamicTestQueue.cs
+++ b/TUnit.Engine/Interfaces/IDynamicTestQueue.cs
@@ -10,11 +10,10 @@ namespace TUnit.Engine.Interfaces;
 internal interface IDynamicTestQueue
 {
     /// <summary>
-    /// Enqueues a test for execution and notifies the message bus. Thread-safe.
+    /// Enqueues a test for execution. Thread-safe.
     /// </summary>
     /// <param name="test">The test to enqueue</param>
-    /// <returns>Task that completes when the test is enqueued and discovery is notified</returns>
-    Task EnqueueAsync(AbstractExecutableTest test);
+    void Enqueue(AbstractExecutableTest test);
 
     /// <summary>
     /// Attempts to dequeue the next test. Thread-safe.

--- a/TUnit.Engine/Services/DynamicTestQueue.cs
+++ b/TUnit.Engine/Services/DynamicTestQueue.cs
@@ -29,7 +29,7 @@ internal sealed class DynamicTestQueue : IDynamicTestQueue
         });
     }
 
-    public async Task EnqueueAsync(AbstractExecutableTest test)
+    public void Enqueue(AbstractExecutableTest test)
     {
         Interlocked.Increment(ref _pendingCount);
 
@@ -39,7 +39,8 @@ internal sealed class DynamicTestQueue : IDynamicTestQueue
             throw new InvalidOperationException("Failed to enqueue test to dynamic test queue.");
         }
 
-        await _messageBus.Discovered(test.Context);
+        // Skip sending Discovered message - dynamic tests are created during execution,
+        // and Discovered messages are only needed for discovery requests
     }
 
     public bool TryDequeue(out AbstractExecutableTest? test)

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -101,7 +101,7 @@ internal sealed class TestRegistry : ITestRegistry
 
         foreach (var test in builtTests)
         {
-            await _dynamicTestQueue.EnqueueAsync(test);
+            _dynamicTestQueue.Enqueue(test);
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove Discovered message loop from `HandleRunRequestAsync` during test execution
- Only send Discovered messages during discovery requests (for test explorers)
- Change `DynamicTestQueue.EnqueueAsync` to synchronous `Enqueue` method
- Dynamic tests created at runtime don't need discovery notifications since they're created during execution

## Rationale

Discovered messages are used by test explorers to populate their UI during test discovery. When actually running tests, these messages are unnecessary overhead since:
1. The tests have already been discovered
2. The test session is in execution mode, not discovery mode
3. Dynamic tests (created via `CreateTestVariant` or `AddDynamicTest`) are created during execution, not discovery

## Test plan

- [x] Build succeeds with no errors
- [x] Ran 10,218+ tests successfully
- [x] Verified discovery requests still send Discovered messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)