### PR TITLE
feat: add class name to GitHub Reporter test output

### DIFF
--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -178,7 +178,13 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         foreach (var testNodeUpdateMessage in last.Values)
         {
-            var name = testNodeUpdateMessage.TestNode.DisplayName;
+            var testMethodIdentifier = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
+                .OfType<TestMethodIdentifierProperty>()
+                .FirstOrDefault();
+
+            var className = testMethodIdentifier?.TypeName;
+            var displayName = testNodeUpdateMessage.TestNode.DisplayName;
+            var name = string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
 
             var passedProperty = testNodeUpdateMessage.TestNode.Properties.OfType<PassedTestNodeStateProperty>().FirstOrDefault();
 


### PR DESCRIPTION
## Summary

- Adds the class name to the Test column in the GitHub Reporter Details table
- Format changed from `MethodName(args)` to `ClassName.MethodName(args)`
- Makes it easier to identify which specific test is being referenced

Fixes #4323

## Test plan

- [x] Verified build compiles successfully
- [x] Ran GitHubReporter unit tests - all 4 pass
- [ ] Verify on a real GitHub Actions run that the format looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)