### PR TITLE
fix: always include StandardOutputProperty in test nodes for IDE support

### DIFF
--- a/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/TUnit.Engine/Extensions/TestExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using TUnit.Core;
 using TUnit.Core.Extensions;
 using TUnit.Engine.Capabilities;
-using TUnit.Engine.Services;
 #pragma warning disable TPEXP
 
 namespace TUnit.Engine.Extensions;
@@ -14,7 +13,6 @@ namespace TUnit.Engine.Extensions;
 internal static class TestExtensions
 {
     private static bool? _cachedIsTrxEnabled;
-    private static bool? _cachedIsDetailedOutput;
 
     private static readonly ConcurrentDictionary<Assembly, string> AssemblyFullNameCache = new();
     private static readonly ConcurrentDictionary<string, CachedTestNodeProperties> TestNodePropertiesCache = new();
@@ -34,7 +32,6 @@ internal static class TestExtensions
         AssemblyFullNameCache.Clear();
         TestNodePropertiesCache.Clear();
         _cachedIsTrxEnabled = null;
-        _cachedIsDetailedOutput = null;
     }
 
     private static string GetCachedAssemblyFullName(Assembly assembly)
@@ -159,17 +156,14 @@ internal static class TestExtensions
             output = testContext.GetStandardOutput();
             error = testContext.GetErrorOutput();
 
-            if (!IsDetailedOutput(testContext))
+            if (!string.IsNullOrEmpty(output))
             {
-                if (!string.IsNullOrEmpty(output))
-                {
-                    properties.Add(new StandardOutputProperty(output));
-                }
+                properties.Add(new StandardOutputProperty(output));
+            }
 
-                if (!string.IsNullOrEmpty(error))
-                {
-                    properties.Add(new StandardErrorProperty(error));
-                }
+            if (!string.IsNullOrEmpty(error))
+            {
+                properties.Add(new StandardErrorProperty(error));
             }
         }
 
@@ -292,23 +286,6 @@ internal static class TestExtensions
 
         _cachedIsTrxEnabled = trxCapability.IsTrxEnabled;
         return _cachedIsTrxEnabled.Value;
-    }
-
-    private static bool IsDetailedOutput(TestContext testContext)
-    {
-        if (_cachedIsDetailedOutput.HasValue)
-        {
-            return _cachedIsDetailedOutput.Value;
-        }
-
-        if (testContext.Services.GetService<VerbosityService>() is not {} verbosityService)
-        {
-            _cachedIsDetailedOutput = false;
-            return false;
-        }
-
-        _cachedIsDetailedOutput = verbosityService.IsDetailedOutput;
-        return _cachedIsDetailedOutput.Value;
     }
 
     private static TimingProperty GetTimingProperty(TestContext testContext, DateTimeOffset overallStart)


### PR DESCRIPTION
## Summary

- Fixes #4325 - Console.WriteLine output not visible in Rider since v1.9.42
- Always adds `StandardOutputProperty` and `StandardErrorProperty` to test nodes regardless of output mode
- Removes the unused `IsDetailedOutput` check that was preventing IDE test output display

## Root Cause

PR #4257 fixed duplicate output in "Detailed" mode by skipping `StandardOutputProperty` when `IsDetailedOutput` was true. However, IDEs like Rider are detected as "detailed" mode (because their client ID doesn't contain "console") but still need these properties to display test output in their results panel.

The real-time console output duplication is already handled separately by `HideTestOutput` in `OptimizedConsoleInterceptor`, so `StandardOutputProperty` should always be included for IDE consumption.

## Test plan

- [x] Build succeeds
- [x] `ConsoleTests` pass and show output in "Standard output" section
- [x] `CaptureOutputTests` pass with correct output capture
- [ ] Manual verification in Rider that Console.WriteLine output appears in test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)