### PR TITLE
perf: `AssertAsync` return synchronous  `Task`

### DIFF
--- a/TUnit.Assertions/Core/Assertion.cs
+++ b/TUnit.Assertions/Core/Assertion.cs
@@ -105,15 +105,15 @@ public abstract class Assertion<TValue> : IAssertion
     /// and throws if the assertion fails (or adds to AssertionScope if within Assert.Multiple).
     /// If this assertion is part of an And/Or chain, delegates to the wrapper.
     /// </summary>
-    public virtual async Task<TValue?> AssertAsync()
+    public virtual Task<TValue?> AssertAsync()
     {
         // If part of an And/Or chain, delegate to the wrapper
         if (_wrappedExecution != null)
         {
-            return await _wrappedExecution.AssertAsync();
+            return _wrappedExecution.AssertAsync();
         }
 
-        return await ExecuteCoreAsync();
+        return ExecuteCoreAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
Make `AssertAsync` synchronous  return a `Task` without awaiting. 

- As usual this will mean stack traces thrown by the returned task won't include this method.

### Before
<img width="512" height="156" alt="image" src="https://github.com/user-attachments/assets/65bee1a9-5050-476b-929a-16b4862ad312" />

### After
No longer creating a state machine or allocating
<img width="544" height="136" alt="image" src="https://github.com/user-attachments/assets/67b37b6a-8f22-48ee-9c28-80ef13a76903" />
