### PR TITLE
fix: correct xUnit Assert.Same/NotSame conversion method names

### DIFF
--- a/TUnit.Analyzers.CodeFixers/XUnitMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/XUnitMigrationCodeFixProvider.cs
@@ -569,9 +569,9 @@ public class XUnitMigrationCodeFixProvider : BaseMigrationCodeFixProvider
 
                 // Reference assertions
                 "Same" when arguments.Count >= 2 =>
-                    CreateTUnitAssertion("IsSameReference", arguments[1].Expression, arguments[0]),
+                    CreateTUnitAssertion("IsSameReferenceAs", arguments[1].Expression, arguments[0]),
                 "NotSame" when arguments.Count >= 2 =>
-                    CreateTUnitAssertion("IsNotSameReference", arguments[1].Expression, arguments[0]),
+                    CreateTUnitAssertion("IsNotSameReferenceAs", arguments[1].Expression, arguments[0]),
 
                 // String/Collection contains
                 "Contains" when arguments.Count >= 2 =>

--- a/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
@@ -861,6 +861,82 @@ public class XUnitMigrationAnalyzerTests
             );
     }
 
+    [Test]
+    public async Task Assert_Same_Can_Be_Converted()
+    {
+        await CodeFixer
+            .VerifyCodeFixAsync(
+                """
+                {|#0:using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Fact]
+                    public void MyTest()
+                    {
+                        var expected = new object();
+                        var actual = expected;
+                        Assert.Same(expected, actual);
+                    }
+                }|}
+                """,
+                Verifier.Diagnostic(Rules.XunitMigration).WithLocation(0),
+                """
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public async Task MyTest()
+                    {
+                        var expected = new object();
+                        var actual = expected;
+                        await Assert.That(actual).IsSameReferenceAs(expected);
+                    }
+                }
+                """,
+                ConfigureXUnitTest
+            );
+    }
+
+    [Test]
+    public async Task Assert_NotSame_Can_Be_Converted()
+    {
+        await CodeFixer
+            .VerifyCodeFixAsync(
+                """
+                {|#0:using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Fact]
+                    public void MyTest()
+                    {
+                        var obj1 = new object();
+                        var obj2 = new object();
+                        Assert.NotSame(obj1, obj2);
+                    }
+                }|}
+                """,
+                Verifier.Diagnostic(Rules.XunitMigration).WithLocation(0),
+                """
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public async Task MyTest()
+                    {
+                        var obj1 = new object();
+                        var obj2 = new object();
+                        await Assert.That(obj2).IsNotSameReferenceAs(obj1);
+                    }
+                }
+                """,
+                ConfigureXUnitTest
+            );
+    }
+
     private static void ConfigureXUnitTest(Verifier.Test test)
     {
         var globalUsings = ("GlobalUsings.cs", SourceText.From("global using Xunit;"));


### PR DESCRIPTION
## Summary
- Fixed xUnit migration code fixer generating incorrect method names for reference equality assertions
- Changed `IsSameReference` → `IsSameReferenceAs` and `IsNotSameReference` → `IsNotSameReferenceAs`
- Added tests for Assert.Same and Assert.NotSame conversion

## Test plan
- [x] Added `Assert_Same_Can_Be_Converted` test
- [x] Added `Assert_NotSame_Can_Be_Converted` test
- [x] All existing xUnit migration tests pass (41/41)

Fixes #4333

🤖 Generated with [Claude Code](https://claude.com/claude-code)