### PR TITLE
fix: prevent interface implementation methods from being converted to async

### DIFF
--- a/TUnit.Analyzers.CodeFixers/Base/AsyncMethodSignatureRewriter.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/AsyncMethodSignatureRewriter.cs
@@ -10,6 +10,84 @@ namespace TUnit.Analyzers.CodeFixers.Base;
 /// </summary>
 public class AsyncMethodSignatureRewriter : CSharpSyntaxRewriter
 {
+    private readonly HashSet<string> _interfaceImplementingMethods;
+
+    public AsyncMethodSignatureRewriter() : this(new HashSet<string>())
+    {
+    }
+
+    public AsyncMethodSignatureRewriter(HashSet<string> interfaceImplementingMethods)
+    {
+        _interfaceImplementingMethods = interfaceImplementingMethods;
+    }
+
+    /// <summary>
+    /// Collects method signatures that implement interface members.
+    /// This should be called BEFORE syntax modifications while the semantic model is still valid.
+    /// </summary>
+    public static HashSet<string> CollectInterfaceImplementingMethods(
+        CompilationUnitSyntax compilationUnit,
+        SemanticModel semanticModel)
+    {
+        var methods = new HashSet<string>();
+
+        foreach (var methodDecl in compilationUnit.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            // Check for explicit interface implementation syntax
+            if (methodDecl.ExplicitInterfaceSpecifier != null)
+            {
+                methods.Add(GetMethodKey(methodDecl));
+                continue;
+            }
+
+            var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl);
+            if (methodSymbol == null)
+            {
+                continue;
+            }
+
+            // Check if this method explicitly implements an interface
+            if (methodSymbol.ExplicitInterfaceImplementations.Length > 0)
+            {
+                methods.Add(GetMethodKey(methodDecl));
+                continue;
+            }
+
+            // Check if this method implicitly implements an interface member
+            var containingType = methodSymbol.ContainingType;
+            if (containingType != null)
+            {
+                foreach (var iface in containingType.AllInterfaces)
+                {
+                    foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+                    {
+                        var impl = containingType.FindImplementationForInterfaceMember(member);
+                        if (SymbolEqualityComparer.Default.Equals(impl, methodSymbol))
+                        {
+                            methods.Add(GetMethodKey(methodDecl));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return methods;
+    }
+
+    /// <summary>
+    /// Gets a unique key for a method declaration based on its signature.
+    /// This key is stable across syntax tree modifications.
+    /// </summary>
+    private static string GetMethodKey(MethodDeclarationSyntax node)
+    {
+        // Build a key from class name, method name, and parameter types
+        var className = node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault()?.Identifier.Text ?? "";
+        var methodName = node.Identifier.Text;
+        var parameters = string.Join(",", node.ParameterList.Parameters.Select(p => p.Type?.ToString() ?? ""));
+        return $"{className}.{methodName}({parameters})";
+    }
+
     public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
         // First, visit children to ensure nested content is processed
@@ -29,6 +107,21 @@ public class AsyncMethodSignatureRewriter : CSharpSyntaxRewriter
             return node;
         }
 
+        // Skip methods with ref/out/in parameters (they can't be async)
+        if (node.ParameterList.Parameters.Any(p =>
+            p.Modifiers.Any(SyntaxKind.RefKeyword) ||
+            p.Modifiers.Any(SyntaxKind.OutKeyword) ||
+            p.Modifiers.Any(SyntaxKind.InKeyword)))
+        {
+            return node;
+        }
+
+        // Skip if method implements an interface member (changing return type would break the implementation)
+        if (ImplementsInterfaceMember(node))
+        {
+            return node;
+        }
+
         // Convert the return type
         var newReturnType = ConvertReturnType(node.ReturnType);
 
@@ -38,6 +131,19 @@ public class AsyncMethodSignatureRewriter : CSharpSyntaxRewriter
         return node
             .WithReturnType(newReturnType)
             .WithModifiers(newModifiers);
+    }
+
+    private bool ImplementsInterfaceMember(MethodDeclarationSyntax node)
+    {
+        // Check for explicit interface implementation syntax (IFoo.Method)
+        if (node.ExplicitInterfaceSpecifier != null)
+        {
+            return true;
+        }
+
+        // Check if this method was identified as an interface implementation
+        var key = GetMethodKey(node);
+        return _interfaceImplementingMethods.Contains(key);
     }
 
     private static TypeSyntax ConvertReturnType(TypeSyntax returnType)


### PR DESCRIPTION
## Summary
Methods that implement interface members should NOT have their signatures converted to `async Task` because this would break the interface implementation contract. 

The fix uses a two-pass approach:
1. **Before syntax modifications**: Collect all methods that implement interface members using semantic analysis (via semantic model)
2. **During async signature rewriting**: Skip methods identified as interface implementations

Also adds `ref`/`out`/`in` parameter check to prevent async conversion of methods with those parameter types (which cannot be async).

## Changes
- Modified `AsyncMethodSignatureRewriter` to accept a set of interface-implementing method keys
- Added static method `CollectInterfaceImplementingMethods` that uses semantic analysis to identify interface implementations
- Updated `BaseMigrationCodeFixProvider` to collect interface-implementing methods before modifications
- Added test for interface implementation scenario

## Test plan
- [x] Run NUnit migration tests (66 passed)
- [x] Run xUnit migration tests (39 passed, 1 skipped)
- [x] Run MSTest migration tests (23 passed)

Fixes #4342

🤖 Generated with [Claude Code](https://claude.com/claude-code)