### PR TITLE
perf: `TestExtensions` eliminate closure with equality

### DIFF
--- a/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/TUnit.Engine/Extensions/TestExtensions.cs
@@ -41,11 +41,12 @@ internal static class TestExtensions
 
     private static CachedTestNodeProperties GetOrCreateCachedProperties(TestContext testContext)
     {
-        var testDetails = testContext.Metadata.TestDetails;
-        var testId = testDetails.TestId;
+        var testId = testContext.Metadata.TestDetails.TestId;
 
-        return TestNodePropertiesCache.GetOrAdd(testId, _ =>
+        return TestNodePropertiesCache.GetOrAdd(testId, static (_, testContext) =>
         {
+            var testDetails = testContext.Metadata.TestDetails;
+
             var fileLocation = new TestFileLocationProperty(testDetails.TestFilePath, new LinePositionSpan(
                 new LinePosition(testDetails.TestLineNumber, 0),
                 new LinePosition(testDetails.TestLineNumber, 0)
@@ -108,7 +109,7 @@ internal static class TestExtensions
                 TrxFullyQualifiedTypeName = trxTypeName,
                 TrxCategories = trxCategories
             };
-        });
+        }, testContext);
     }
 
     internal static TestNode ToTestNode(this TestContext testContext, TestNodeStateProperty stateProperty)


### PR DESCRIPTION
Each time `GetOrCreateCachedProperties` is called a `Func<string, CachedTestNodeProperties>` and display class would be created for `GetOrAdd` function.

I changed `TestNodePropertiesCache` to `ConcurrentDictionary<TestContext, CachedTestNodeProperties>` and used a custom `IEqualityComparer` to use `TestId` as the actual key. This way the `testContext` would be passed to the `valueFactory` and no closure would be created.


### Before
<img width="538" height="149" alt="image" src="https://github.com/user-attachments/assets/cab4a0e0-ca2e-4a45-8b3a-720a447fc01c" />

### After
<img width="375" height="159" alt="image" src="https://github.com/user-attachments/assets/802188d1-3828-4cd5-b0e6-187f9793b792" />


This trick can probably be used in a lot of other places