### PR TITLE
perf: make methods synchronous and defer `List` creation

### DIFF
--- a/TUnit.Engine/Services/HookExecutor.cs
+++ b/TUnit.Engine/Services/HookExecutor.cs
@@ -292,7 +292,7 @@ internal sealed class HookExecutor
         }
     }
 
-    public async ValueTask<List<Exception>> ExecuteAfterTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    public async ValueTask<IReadOnlyList<Exception>> ExecuteAfterTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         // Defer exception list allocation until actually needed
         List<Exception>? exceptions = null;
@@ -338,7 +338,7 @@ internal sealed class HookExecutor
             }
         }
 
-        return exceptions ?? [];
+        return exceptions == null ? Array.Empty<Exception>() : exceptions;
     }
 
     public async ValueTask ExecuteBeforeTestDiscoveryHooksAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
- Change method signature to `ValueTask<IReadOnlyList<Exception>>` and return an empty array when possible
- Make `EventReceiverOrchestrator` methods synchronous when possible to eliminate state machine creation
- Replace `ThreadSafeDictionary` with `ConcurrentDictionary` as the `valueFactory` doesn't need the run once guarantee

As usual I don't think the non-generic `ValueTask` are useful

### Before
<img width="593" height="385" alt="image" src="https://github.com/user-attachments/assets/f7ba94d9-4e09-417d-b40c-87afe7e06531" />

### After
<img width="604" height="203" alt="image" src="https://github.com/user-attachments/assets/b5c1cb06-c27b-467a-a616-95ab4746125b" />
