### PR TITLE
perf: avoid creating closure

### DIFF
--- a/TUnit.Core/Models/TestModels/AssemblyMetadata.cs
+++ b/TUnit.Core/Models/TestModels/AssemblyMetadata.cs
@@ -9,7 +9,7 @@ public record AssemblyMetadata
     private static readonly ConcurrentDictionary<string, AssemblyMetadata> Cache = [];
     public static AssemblyMetadata GetOrAdd(string name, Func<AssemblyMetadata> factory)
     {
-        return Cache.GetOrAdd(name, _ => factory());
+        return Cache.GetOrAdd(name, static (_, factory) => factory(), factory);
     }
 
     public virtual bool Equals(AssemblyMetadata? other)

--- a/TUnit.Core/Models/TestModels/ClassMetadata.cs
+++ b/TUnit.Core/Models/TestModels/ClassMetadata.cs
@@ -24,9 +24,9 @@ public record ClassMetadata : IMemberMetadata
             }
             return existing;
         }
-        
+
         // Otherwise add new value
-        return Cache.GetOrAdd(name, _ => factory());
+        return Cache.GetOrAdd(name, static (_, factory) => factory(), factory);
     }
 
     public virtual bool Equals(ClassMetadata? other)

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -967,7 +967,6 @@ internal sealed class TestBuilder : ITestBuilder
         return firstSkipAttribute?.Reason;
     }
 
-
     private async ValueTask<TestContext> CreateTestContextAsync(string testId, TestMetadata metadata, TestData testData, TestBuilderContext testBuilderContext)
     {
         // Use attributes from context if available, or create new ones


### PR DESCRIPTION
Prevent closure creation for `AssmeblyMetada` and `ClassMetadata`, using `GetOrAdd<TArg>(TKey, Func<TKey,TArg,TValue>, TArg)`
- Also removed an extra line 

Not a massive saving probably around 100KB on `TUnit.TestProject`