### PR TITLE
fix: add disk space cleanup step for Ubuntu runners

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Adds a disk space cleanup step at the start of the `.NET` workflow for Ubuntu runners
- Removes unused pre-installed software (Android SDK, pre-installed .NET, Haskell) to free ~15-25GB
- Fixes disk space exhaustion issue seen in CI (e.g., #4373 dependency update)

## Context
The `ubuntu-latest` runner was failing with:
```
No space left on device: '/home/runner/actions-runner/cached/_diag/Worker_*.log'
```

## Test plan
- [ ] Verify the workflow runs successfully on `ubuntu-latest` without disk space errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)