### PR TITLE
docs: add telemetry documentation to extensions page

### DIFF
--- a/docs/docs/extensions/extensions.md
+++ b/docs/docs/extensions/extensions.md
@@ -4,7 +4,21 @@ As TUnit is built on top of Microsoft.Testing.Platform, it can tap into generic 
 
 ## Built-In Extensions
 
-The following extensions are **automatically included** when you install the **TUnit** meta package. You don't need to install them separately!
+The following extensions are **automatically included** when you install the **TUnit** meta package:
+
+- **Code Coverage** - via `Microsoft.Testing.Extensions.CodeCoverage`
+- **TRX Test Reports** - via `Microsoft.Testing.Extensions.TrxReport`
+- **Telemetry** - via `Microsoft.Testing.Extensions.Telemetry`
+
+:::tip Opting Out of Built-In Extensions
+If you don't want these extensions, you can reference `TUnit.Engine` and `TUnit.Assertions` packages separately instead of the `TUnit` meta package.
+
+```xml
+<!-- Instead of the TUnit meta package -->
+<PackageReference Include="TUnit.Engine" Version="x.x.x" />
+<PackageReference Include="TUnit.Assertions" Version="x.x.x" />
+```
+:::
 
 ### Code Coverage
 
@@ -113,6 +127,33 @@ dotnet run --configuration Release --results-directory ./reports --report-trx --
 
 **📚 More Resources:**
 - [Microsoft's TRX Report Documentation](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-extensions-test-reports)
+
+---
+
+### Telemetry
+
+Telemetry is provided via the `Microsoft.Testing.Extensions.Telemetry` NuGet package.
+
+**✅ Included automatically with the TUnit package**
+
+This extension enables Microsoft to collect anonymous usage metrics to help improve the testing platform. No personal data or source code is collected.
+
+#### Opting Out
+
+You can disable telemetry by setting an environment variable:
+
+```bash
+# Linux/macOS
+export TESTINGPLATFORM_TELEMETRY_OPTOUT=1
+
+# Windows
+set TESTINGPLATFORM_TELEMETRY_OPTOUT=1
+```
+
+Alternatively, you can use `DOTNET_CLI_TELEMETRY_OPTOUT=1` which also disables .NET SDK telemetry.
+
+**📚 More Resources:**
+- [Microsoft.Testing.Platform Telemetry Documentation](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-telemetry)
 
 ---
 


### PR DESCRIPTION
## Summary

- List all built-in extensions (Code Coverage, TRX Reports, Telemetry) at the top of the extensions page
- Add tip explaining how to opt out of built-in extensions by using `TUnit.Engine` and `TUnit.Assertions` packages separately
- Add Telemetry section with environment variable opt-out instructions
- Link to Microsoft's official telemetry documentation

Closes #4424

🤖 Generated with [Claude Code](https://claude.com/claude-code)