### PR TITLE
perf: `ObjectGraph` switch `ConcurrentDictionary` to `Dictionary`

### DIFF
--- a/TUnit.Core/Discovery/ObjectGraph.cs
+++ b/TUnit.Core/Discovery/ObjectGraph.cs
@@ -13,7 +13,7 @@ namespace TUnit.Core.Discovery;
 /// </remarks>
 internal readonly struct ObjectGraph
 {
-    private readonly ConcurrentDictionary<int, HashSet<object>> _objectsByDepth;
+    private readonly Dictionary<int, HashSet<object>> _objectsByDepth;
 
     // Cached sorted depths (computed once in constructor)
     private readonly int[] _sortedDepthsDescending;
@@ -22,8 +22,7 @@ internal readonly struct ObjectGraph
     /// Creates a new object graph from the discovered objects.
     /// </summary>
     /// <param name="objectsByDepth">Objects organized by depth level.</param>
-    /// <param name="allObjects">All unique objects in the graph.</param>
-    public ObjectGraph(ConcurrentDictionary<int, HashSet<object>> objectsByDepth)
+    public ObjectGraph(Dictionary<int, HashSet<object>> objectsByDepth)
     {
         _objectsByDepth = objectsByDepth;
 

--- a/TUnit.Core/Extensions/DictionaryExtensions.cs
+++ b/TUnit.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace TUnit.Core.Extensions;
+
+internal static class DictionaryExtensions
+{
+    public static TValue GetOrAdd<TKey, TValue>(
+        this IDictionary<TKey, TValue> dictionary,
+        TKey key,
+        Func<TKey, TValue> valueFactory)
+    {
+        if (!dictionary.TryGetValue(key, out TValue? value))
+        {
+            value = valueFactory(key);
+            dictionary.Add(key, value);
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Follow up to #4415 

- Replace `ConcurrentDictionary` with `Dictionary` in `ObjectGraph` and `ObjectGraphDiscoverer`.
- Remove `allObjects` and its respective lock.

I believe that using non thread safe collections is safe here, because they are never pass to any externals methods that use concurrency. All logic within `ObjectGraphDiscoverer` is single threaded therefore it is safe to do so.



In a future PR I will look into preventing delegate and `DisplayClass` creation. I am also considering the possibility of converting `testContext.TrackedObjects` into a `Dictionary` and in turn updating `DiscoverAndTrackObjects`. I am pretty confident that it is never written to in a concurrent setting, I need to verify this completely by looking at the method call order.



### Before
<img width="576" height="150" alt="image" src="https://github.com/user-attachments/assets/181ca956-9b1b-43ed-b1aa-572c2b5a10d6" />


### After
<img width="457" height="151" alt="image" src="https://github.com/user-attachments/assets/0a189585-58c7-49e7-89a9-fb9400409f7a" />

