### PR TITLE
perf: add capacity to `StringBuilder` in `ValueAssertion`

### DIFF
--- a/TUnit.Assertions/Sources/ValueAssertion.cs
+++ b/TUnit.Assertions/Sources/ValueAssertion.cs
@@ -15,7 +15,8 @@ public class ValueAssertion<TValue> : IAssertionSource<TValue>
 
     public ValueAssertion(TValue? value, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
+        // Initialize StringBuilder with enough space for expression and text
+        var expressionBuilder = new StringBuilder((expression?.Length ?? 1) + 32);
         expressionBuilder.Append($"Assert.That({expression ?? "?"})");
         Context = new AssertionContext<TValue>(value, expressionBuilder);
     }


### PR DESCRIPTION
By default `StringBuilder` starts with a capacity of 16. This is a problem in `ValueAssertion` as it initialises `Context`  with a `StringBuilder` before appending `$"Assert.That({expression ?? "?"})"`, at a minimum this is 14 characters which is fine, but in the common case where the expression is not null, it will exceed the default of 16 and immediately have to add another `StringBuilder`. 
This pretty much guaranteed that any instance of `ValueAssertion` would allocate 2 `StringBuilder` and 2 `char[]` on initialisation.


I solved this by initialising the `StringBuilder` with `13 + expression.Length`.

The question is: how much additional capacity should be given? Too small and you frequently pay the cost to create a new `StringBuilder` and `char[]`, too large and you over allocate a `char[]`. Making this decision based too much on the benchmarks would be optimising for the benchmarks and not real life. WDYT


### Before
<img width="306" height="151" alt="image" src="https://github.com/user-attachments/assets/196d47f7-77e3-407a-abc4-d2da054ff3ac" />


### `(expression?.Length ?? 1) + 13` no unused space, the follwing assertion will have to create a new `StringBuilder`
<img width="305" height="148" alt="image" src="https://github.com/user-attachments/assets/5f9234d1-8108-4eaa-a712-51b60a507105" />

### `(expression?.Length ?? 1) + 24` aka unused length of 11
<img width="312" height="153" alt="image" src="https://github.com/user-attachments/assets/91bcfa84-6db1-412a-b66c-cc15750e6cc1" />

### ### `(expression?.Length ?? 1) + 32` aka unused length of 19
<img width="306" height="151" alt="image" src="https://github.com/user-attachments/assets/de1f86ef-7db7-4f0c-9d0a-0d42ee1ecacd" />

Note that the benchmarks give a general idea 