### PR TITLE
perf: use `Lock` for small boost and declare intent

### DIFF
--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -21,7 +21,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
         new(Helpers.ReferenceEqualityComparer.Instance);
 
     // Lock for atomic decrement-check-dispose operations to prevent race conditions
-    private static readonly object s_disposalLock = new();
+    private static readonly Lock s_disposalLock = new();
 
     // Collects errors from async disposal callbacks for post-session review
     private static readonly ConcurrentBag<Exception> s_asyncCallbackErrors = new();

--- a/TUnit.Engine/Services/AfterHookPairTracker.cs
+++ b/TUnit.Engine/Services/AfterHookPairTracker.cs
@@ -17,8 +17,8 @@ internal sealed class AfterHookPairTracker
     private readonly ThreadSafeDictionary<Type, Task<List<Exception>>> _afterClassTasks = new();
     private readonly ThreadSafeDictionary<Assembly, Task<List<Exception>>> _afterAssemblyTasks = new();
     private Task<List<Exception>>? _afterTestSessionTask;
-    private readonly object _testSessionLock = new();
-    private readonly object _classLock = new();
+    private readonly Lock _testSessionLock = new();
+    private readonly Lock _classLock = new();
 
     // Track cancellation registrations for cleanup
     private readonly ConcurrentBag<CancellationTokenRegistration> _registrations = [];

--- a/TUnit.Engine/Services/BeforeHookTaskCache.cs
+++ b/TUnit.Engine/Services/BeforeHookTaskCache.cs
@@ -14,8 +14,8 @@ internal sealed class BeforeHookTaskCache
     private readonly ThreadSafeDictionary<Type, Task> _beforeClassTasks = new();
     private readonly ThreadSafeDictionary<Assembly, Task> _beforeAssemblyTasks = new();
     private Task? _beforeTestSessionTask;
-    private readonly object _testSessionLock = new();
-    private readonly object _classLock = new();
+    private readonly Lock _testSessionLock = new();
+    private readonly Lock _classLock = new();
 
     public ValueTask GetOrCreateBeforeTestSessionTask(Func<CancellationToken, ValueTask> taskFactory, CancellationToken cancellationToken)
     {

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -17,7 +17,7 @@ internal sealed class TestDependencyResolver
     private readonly HashSet<AbstractExecutableTest> _testsBeingResolved =
     [
     ];
-    private readonly object _resolutionLock = new();
+    private readonly Lock _resolutionLock = new();
 
     public void RegisterTest(AbstractExecutableTest test)
     {


### PR DESCRIPTION
Small change, `Lock` is slightly faster that using `object`, but the main advantage is that it declares intent.