### PR TITLE
perf: eliminate `Func` and closure allocation in `DedicatedThreadExecutor`

### DIFF
--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -77,11 +77,11 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
 
             try
             {
-                var task = Task.Factory.StartNew(async () =>
+                var task = Task.Factory.StartNew(static async action =>
                 {
                     // Inside this task, TaskScheduler.Current will be our scheduler
-                    await action();
-                }, CancellationToken.None, TaskCreationOptions.None, taskScheduler).Unwrap();
+                    await ((Func<ValueTask>)action!)();
+                }, action, CancellationToken.None, TaskCreationOptions.None, taskScheduler).Unwrap();
 
                 // Try fast path first - many tests complete quickly
                 // Use IsCompleted to avoid synchronous wait


### PR DESCRIPTION
Pass `action` into `StartNew` eliminating allocation of `Func<TResult>` and associated closure

### Before
<img width="447" height="155" alt="image" src="https://github.com/user-attachments/assets/52d10970-25ab-42e1-a58d-61de1ac1ef9b" />


### After
<img width="443" height="158" alt="image" src="https://github.com/user-attachments/assets/e1042062-4909-423c-90aa-3d1a96a5208a" />
