### PR TITLE
perf: remove closures in `GetOrAdd`

### DIFF
--- a/TUnit.Core/ContextProvider.cs
+++ b/TUnit.Core/ContextProvider.cs
@@ -51,13 +51,11 @@ public class ContextProvider(IServiceProvider serviceProvider, string testSessio
     /// </summary>
     public AssemblyHookContext GetOrCreateAssemblyContext(Assembly assembly)
     {
-        return _assemblyContexts.GetOrAdd(assembly, asm =>
-        {
-            return new AssemblyHookContext(TestSessionContext)
+        return _assemblyContexts.GetOrAdd(assembly, static (assembly, context) =>
+            new AssemblyHookContext(context)
             {
                 Assembly = assembly
-            };
-        });
+            }, TestSessionContext);
     }
 
     /// <summary>

--- a/TUnit.Core/ObjectInitializer.cs
+++ b/TUnit.Core/ObjectInitializer.cs
@@ -106,9 +106,10 @@ internal static class ObjectInitializer
         // is called exactly once, even under contention. GetOrAdd's factory may be
         // called multiple times, but Lazy ensures only one initialization runs.
         var lazyTask = InitializationTasks.GetOrAdd(obj,
-            _ => new Lazy<Task>(
+            static (_, asyncInitializer) => new Lazy<Task>(
                 asyncInitializer.InitializeAsync,
-                LazyThreadSafetyMode.ExecutionAndPublication));
+                LazyThreadSafetyMode.ExecutionAndPublication)
+            , asyncInitializer);
 
         try
         {

--- a/TUnit.Core/TestContext.StateBag.cs
+++ b/TUnit.Core/TestContext.StateBag.cs
@@ -25,7 +25,7 @@ public partial class TestContext
     /// <inheritdoc/>
     T ITestStateBag.GetOrAdd<T>(string key, Func<string, T> valueFactory)
     {
-        var value = ObjectBag.GetOrAdd(key, k => valueFactory(k)!);
+        var value = ObjectBag.GetOrAdd(key, static (k, valueFactory) => valueFactory(k)!, valueFactory);
 
         if (value is T typedValue)
         {


### PR DESCRIPTION
Use `GetOrAdd` overload and pass state in to avoid creating `Func` or closures

- I think it's possible to do this in `GetOrCreateClassContext`, but the trimmer analyser doesn't like this. I'd assume it's safe to allow this, but I'm not familiar with AOT requirements