### PR TITLE
perf: eliminate closure and `Func` creation

### DIFF
--- a/TUnit.Core/ContextProvider.cs
+++ b/TUnit.Core/ContextProvider.cs
@@ -61,17 +61,20 @@ public class ContextProvider(IServiceProvider serviceProvider, string testSessio
     /// <summary>
     /// Gets or creates a class context
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2111",
+        Justification = "Type parameter is annotated at the method boundary.")]
     public ClassHookContext GetOrCreateClassContext(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type classType)
     {
-        return _classContexts.GetOrAdd(classType, type =>
+        return _classContexts.GetOrAdd(classType, static ([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+            type, state) =>
         {
-            return new ClassHookContext(GetOrCreateAssemblyContext(classType.Assembly))
+            return new ClassHookContext(state.GetOrCreateAssemblyContext(type.Assembly))
             {
-                ClassType = classType
+                ClassType = type
             };
-        });
+        }, this);
     }
 
     /// <summary>

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -170,7 +170,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
             // Stream tests from this assembly
             await foreach (var test in DiscoverTestsInAssemblyStreamingAsync(assembly, cancellationToken))
             {
-                ImmutableInterlocked.Update(ref _discoveredTests, list => list.Add(test));
+                ImmutableInterlocked.Update(ref _discoveredTests, static (list, test) => list.Add(test), test);
                 yield return test;
             }
         }
@@ -178,7 +178,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
         // Stream dynamic tests
         await foreach (var dynamicTest in DiscoverDynamicTestsStreamingAsync(testSessionId, cancellationToken))
         {
-            ImmutableInterlocked.Update(ref _discoveredTests, list => list.Add(dynamicTest));
+            ImmutableInterlocked.Update(ref _discoveredTests, static (list, dynamicTest) => list.Add(dynamicTest), dynamicTest);
             yield return dynamicTest;
         }
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -419,6 +419,7 @@ namespace
         public .TestSessionContext TestSessionContext { get; }
         public .TestContext CreateTestContext(string testName, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public .AssemblyHookContext GetOrCreateAssemblyContext(.Assembly assembly) { }
+        [.("Trimming", "IL2111", Justification="Type parameter is annotated at the method boundary.")]
         public .ClassHookContext GetOrCreateClassContext([.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType) { }
     }
     public class CultureExecutor : .DedicatedThreadExecutor

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -419,6 +419,7 @@ namespace
         public .TestSessionContext TestSessionContext { get; }
         public .TestContext CreateTestContext(string testName, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public .AssemblyHookContext GetOrCreateAssemblyContext(.Assembly assembly) { }
+        [.("Trimming", "IL2111", Justification="Type parameter is annotated at the method boundary.")]
         public .ClassHookContext GetOrCreateClassContext([.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType) { }
     }
     public class CultureExecutor : .DedicatedThreadExecutor

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -419,6 +419,7 @@ namespace
         public .TestSessionContext TestSessionContext { get; }
         public .TestContext CreateTestContext(string testName, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public .AssemblyHookContext GetOrCreateAssemblyContext(.Assembly assembly) { }
+        [.("Trimming", "IL2111", Justification="Type parameter is annotated at the method boundary.")]
         public .ClassHookContext GetOrCreateClassContext([.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  classType) { }
     }
     public class CultureExecutor : .DedicatedThreadExecutor


### PR DESCRIPTION
Following on from #4479

Use function overloads to pass state into update methods.

I've used `UnconditionalSuppressMessage` to suppress the following error,
`IL2111` - ```Method with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.```


### Before
<img width="1087" height="161" alt="image" src="https://github.com/user-attachments/assets/111fb3ef-07fb-49cb-9ab6-82b9a3cf1982" />


### After
<img width="619" height="90" alt="image" src="https://github.com/user-attachments/assets/a7ddd821-2ba6-4d74-a714-add7f685be17" />


