### PR TITLE
fix: Include class-level DependsOn attributes in generated test metadata

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -2478,6 +2478,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
     private static void GenerateDependencies(CodeWriter writer, Compilation compilation, IMethodSymbol methodSymbol)
     {
         var dependsOnAttributes = methodSymbol.GetAttributes()
+            .Concat(methodSymbol.ContainingType.GetAttributes())
             .Where(attr => attr.AttributeClass?.Name == "DependsOnAttribute" &&
                           attr.AttributeClass.ContainingNamespace?.ToDisplayString() == "TUnit.Core")
             .ToList();

--- a/TUnit.TestProject/DependsOnTests.cs
+++ b/TUnit.TestProject/DependsOnTests.cs
@@ -28,3 +28,31 @@ public class DependsOnTests
         await Assert.That(_test2Start).IsAfterOrEqualTo(_test1Start.AddSeconds(4.9));
     }
 }
+
+public sealed class MyAsyncTest
+{
+    public static int NumberOfInvocations = 0;
+
+    [Test]
+    public async Task Test()
+    {
+        NumberOfInvocations += 1;
+        await Assert.That(NumberOfInvocations).IsEqualTo(1);
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[DependsOn(typeof(MyAsyncTest), nameof(Test))]
+public sealed class DependsOn_AsyncTest
+{
+    [Test]
+    public async Task Test() => await Assert.That(MyAsyncTest.NumberOfInvocations).IsEqualTo(1);
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[DependsOn(typeof(MyAsyncTest), nameof(Test))]
+public sealed class DependsOn_AsyncTest_Two
+{
+    [Test]
+    public async Task Test() => await Assert.That(MyAsyncTest.NumberOfInvocations).IsEqualTo(1);
+}


### PR DESCRIPTION
## Summary
- Fixed `GenerateDependencies` in `TestMetadataGenerator` to also check class-level `[DependsOn]` attributes
- Added test cases for class-level `[DependsOn]` dependencies

## Problem
When using `[DependsOn]` at the class level (rather than method level), the dependency was not being captured in the generated test metadata. This meant that when filtering tests, the dependencies declared at class level were not being pulled in.

For example:
```csharp
[DependsOn(typeof(MyAsyncTest), nameof(Test))]  // Class-level - was being ignored!
public sealed class DependsOn_AsyncTest
{
    [Test]
    public async Task Test() => ...
}
```

## Root Cause
The `GenerateDependencies` method only collected `[DependsOn]` attributes from `methodSymbol.GetAttributes()`, missing attributes on the containing type.

## Fix
Added `.Concat(methodSymbol.ContainingType.GetAttributes())` to also capture class-level attributes.

## Test plan
- [x] Existing source generator tests pass (424 tests)
- [x] Manual test with filter `/*/*/*DependsOn_AsyncTest*/*` now correctly pulls in `MyAsyncTest.Test` dependency