### PR TITLE
perf: manually iterate `OfType`

### DIFF
--- a/TUnit.Core/Helpers/ClassConstructorHelper.cs
+++ b/TUnit.Core/Helpers/ClassConstructorHelper.cs
@@ -43,7 +43,7 @@ public static class ClassConstructorHelper
         TestBuilderContext testBuilderContext,
         string testSessionId)
     {
-        var classConstructorAttribute = attributes.OfType<ClassConstructorAttribute>().FirstOrDefault();
+        var classConstructorAttribute = GetClassConstructorAttribute(attributes);
 
         if (classConstructorAttribute == null)
         {
@@ -78,6 +78,21 @@ public static class ClassConstructorHelper
     /// </summary>
     public static ClassConstructorAttribute? GetClassConstructorAttribute(Attribute[] attributes)
     {
-        return attributes.OfType<ClassConstructorAttribute>().FirstOrDefault();
+        return GetClassConstructorAttribute((IReadOnlyList<ClassConstructorAttribute>)attributes);
+    }
+
+    private static ClassConstructorAttribute? GetClassConstructorAttribute(IReadOnlyList<Attribute> attributes)
+    {
+        ClassConstructorAttribute? classConstructorAttribute = null;
+        foreach (Attribute attribute in attributes)
+        {
+            if (attribute is ClassConstructorAttribute classAttribute)
+            {
+                classConstructorAttribute = classAttribute;
+                break;
+            }
+        }
+
+        return classConstructorAttribute;
     }
 }

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -947,13 +947,17 @@ internal sealed class TestBuilder : ITestBuilder
     private static string? GetBasicSkipReason(TestMetadata metadata, Attribute[]? cachedAttributes = null)
     {
         var attributes = cachedAttributes ?? metadata.AttributeFactory();
-        var skipAttributes = attributes.OfType<SkipAttribute>();
 
         SkipAttribute? firstSkipAttribute = null;
 
         // Check if all skip attributes are basic (non-derived) SkipAttribute instances
-        foreach (var skipAttribute in skipAttributes)
+        foreach (var attribute in attributes)
         {
+            if (attribute is not SkipAttribute skipAttribute)
+            {
+                continue;
+            }
+
             firstSkipAttribute ??= skipAttribute;
 
             var attributeType = skipAttribute.GetType();


### PR DESCRIPTION
Manually iterate collection to avoid allocating `OfType`


### Before
<img width="574" height="78" alt="image" src="https://github.com/user-attachments/assets/63a7ab4c-c178-4684-89e5-e0ca1dcb3be1" />

### After
<img width="566" height="23" alt="image" src="https://github.com/user-attachments/assets/f3f9ad6b-fe86-4f83-8b11-db931e196610" />


