### PR TITLE
perf: use shared `Task.FromResult(Passed)`

### DIFF
--- a/TUnit.Assertions/Assertions/Enums/EnumAssertions.cs
+++ b/TUnit.Assertions/Assertions/Enums/EnumAssertions.cs
@@ -35,7 +35,7 @@ public class HasFlagAssertion<TEnum> : Assertion<TEnum>
 
         if (enumValue.HasFlag(enumFlag))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {value} does not have flag {_expectedFlag}"));
@@ -75,7 +75,7 @@ public class DoesNotHaveFlagAssertion<TEnum> : Assertion<TEnum>
 
         if (!enumValue.HasFlag(enumFlag))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {value} has flag {_unexpectedFlag}"));
@@ -112,7 +112,7 @@ public class IsDefinedAssertion<TEnum> : Assertion<TEnum>
         if (Enum.IsDefined(typeof(TEnum), value))
 #endif
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {value} is not defined in {typeof(TEnum).Name}"));
@@ -149,7 +149,7 @@ public class IsNotDefinedAssertion<TEnum> : Assertion<TEnum>
         if (!Enum.IsDefined(typeof(TEnum), value))
 #endif
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {value} is defined in {typeof(TEnum).Name}"));
@@ -189,7 +189,7 @@ public class HasSameNameAsAssertion<TEnum> : Assertion<TEnum>
 
         if (valueName == otherName)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value name \"{valueName}\" does not equal \"{otherName}\""));
@@ -230,7 +230,7 @@ public class HasSameValueAsAssertion<TEnum> : Assertion<TEnum>
 
         if (valueAsInt == otherAsInt)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {valueAsInt} does not equal {otherAsInt}"));
@@ -270,7 +270,7 @@ public class DoesNotHaveSameNameAsAssertion<TEnum> : Assertion<TEnum>
 
         if (valueName != otherName)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value name \"{valueName}\" equals \"{otherName}\""));
@@ -310,7 +310,7 @@ public class DoesNotHaveSameValueAsAssertion<TEnum> : Assertion<TEnum>
 
         if (valueAsInt != otherAsInt)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {valueAsInt} equals {otherAsInt}"));

--- a/TUnit.Assertions/Assertions/Regex/MatchIndexAssertion.cs
+++ b/TUnit.Assertions/Assertions/Regex/MatchIndexAssertion.cs
@@ -52,7 +52,7 @@ public class MatchIndexAssertion : Assertion<RegexMatch>
         }
 
         // If we have a match, the assertion passed
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => $"match at index {_index} to exist";

--- a/TUnit.Assertions/Assertions/Strings/ParseAssertions.cs
+++ b/TUnit.Assertions/Assertions/Strings/ParseAssertions.cs
@@ -47,7 +47,7 @@ public class IsParsableIntoAssertion<[DynamicallyAccessedMembers(DynamicallyAcce
 
         if (TryParse(value, _formatProvider, out _))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"\"{value}\" cannot be parsed into {typeof(T).Name}"));
@@ -146,12 +146,12 @@ public class IsNotParsableIntoAssertion<[DynamicallyAccessedMembers(DynamicallyA
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Passed); // null cannot be parsed
+            return AssertionResult._passedTask; // null cannot be parsed
         }
 
         if (!TryParse(value, _formatProvider, out _))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"\"{value}\" can be parsed into {typeof(T).Name}"));
@@ -330,7 +330,7 @@ public class WhenParsedIntoAssertion<[DynamicallyAccessedMembers(DynamicallyAcce
             return Task.FromResult(AssertionResult.Failed($"parsing failed: {exception.Message}"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => $"to be parsable into {typeof(T).Name}";

--- a/TUnit.Assertions/Collections/MemoryAssertions.cs
+++ b/TUnit.Assertions/Collections/MemoryAssertions.cs
@@ -565,7 +565,7 @@ public class MemoryCountEqualsAssertion<TMemory, TItem> : MemoryAssertionBase<TM
 
         if (passed)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {actualCount}"));

--- a/TUnit.Assertions/Conditions/BetweenAssertion.cs
+++ b/TUnit.Assertions/Conditions/BetweenAssertion.cs
@@ -89,7 +89,7 @@ public class BetweenAssertion<TValue> : Assertion<TValue>
 
         if (minOk && maxOk)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -702,7 +702,7 @@ public class CollectionIsOrderedByAssertion<TCollection, TItem, TKey> : Sources.
 
         if (enumerated.SequenceEqual(ordered))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         for (int i = 1; i < enumerated.Length; i++)
@@ -716,7 +716,7 @@ public class CollectionIsOrderedByAssertion<TCollection, TItem, TKey> : Sources.
             }
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to be ordered by key selector in ascending order";
@@ -764,7 +764,7 @@ public class CollectionIsOrderedByDescendingAssertion<TCollection, TItem, TKey> 
 
         if (enumerated.SequenceEqual(ordered))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         for (int i = 1; i < enumerated.Length; i++)
@@ -778,7 +778,7 @@ public class CollectionIsOrderedByDescendingAssertion<TCollection, TItem, TKey> 
             }
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to be ordered by key selector in descending order";

--- a/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
+++ b/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
@@ -22,7 +22,7 @@ public class CollectionNotNullAssertion<TCollection, TItem> : CollectionAssertio
 
         if (value != null)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed("value is null"));

--- a/TUnit.Assertions/Conditions/DateTimeSpecializedAssertions.cs
+++ b/TUnit.Assertions/Conditions/DateTimeSpecializedAssertions.cs
@@ -21,7 +21,7 @@ public class DateTimeEqualsExactAssertion : Assertion<DateTime>
     {
         if (metadata.Value == _expected)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed(

--- a/TUnit.Assertions/Conditions/DictionaryAssertions.cs
+++ b/TUnit.Assertions/Conditions/DictionaryAssertions.cs
@@ -67,7 +67,7 @@ public class DictionaryContainsKeyAssertion<TDictionary, TKey, TValue> : Sources
 
         if (found)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"key {_expectedKey} not found"));
@@ -112,7 +112,7 @@ public class DictionaryDoesNotContainKeyAssertion<TDictionary, TKey, TValue> : S
 
         if (!value.ContainsKey(_expectedKey))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"key {_expectedKey} was found"));

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -89,7 +89,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
             var result = DeepEquals(value, _expected, _ignoredTypes, visited);
             if (result.IsSuccess)
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             return Task.FromResult(AssertionResult.Failed(result.Message ?? $"found {value}"));
@@ -100,7 +100,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
 
         if (comparer.Equals(value!, _expected!))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/EquatableAssertion.cs
+++ b/TUnit.Assertions/Conditions/EquatableAssertion.cs
@@ -40,7 +40,7 @@ public class EquatableAssertion<TActual, TExpected> : Assertion<TActual>
         // Use IEquatable<TExpected>.Equals for comparison
         if (value.Equals(_expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));
@@ -85,7 +85,7 @@ public class NullableEquatableAssertion<TActual, TExpected> : Assertion<TActual?
         // Use IEquatable<TExpected>.Equals for comparison
         if (value.Value.Equals(_expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value.Value}"));

--- a/TUnit.Assertions/Conditions/ExceptionPropertyAssertions.cs
+++ b/TUnit.Assertions/Conditions/ExceptionPropertyAssertions.cs
@@ -45,7 +45,7 @@ public class ExceptionMessageContainsAssertion<TException> : Assertion<TExceptio
 
         if (exception.Message.Contains(_expectedSubstring, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"exception message was \"{exception.Message}\""));
@@ -91,7 +91,7 @@ public class ExceptionMessageEqualsAssertion<TException> : Assertion<TException>
 
         if (string.Equals(exception.Message, _expectedMessage, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"exception message was \"{exception.Message}\""));
@@ -141,7 +141,7 @@ public class ExceptionMessageNotContainsAssertion<TException> : Assertion<TExcep
                 $"exception message \"{exception.Message}\" should not contain \"{_notExpectedSubstring}\""));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() =>
@@ -187,7 +187,7 @@ public class ExceptionMessageMatchesPatternAssertion<TException> : Assertion<TEx
 
         if (MatchesPattern(exception.Message, _pattern))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed(
@@ -249,7 +249,7 @@ public class ExceptionMessageMatchesAssertion<TException> : Assertion<TException
 
         if (_matcher.IsMatch(exception.Message))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed(
@@ -305,7 +305,7 @@ public class ExceptionParameterNameAssertion<TException> : Assertion<TException>
         {
             if (argumentException.ParamName == _expectedParameterName)
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             return Task.FromResult(AssertionResult.Failed(

--- a/TUnit.Assertions/Conditions/FileSystemAssertions.cs
+++ b/TUnit.Assertions/Conditions/FileSystemAssertions.cs
@@ -42,7 +42,7 @@ public class DirectoryHasFilesAssertion : Assertion<DirectoryInfo>
             return Task.FromResult(AssertionResult.Failed($"directory '{value.FullName}' has no files"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to have files";
@@ -84,7 +84,7 @@ public class DirectoryHasNoSubdirectoriesAssertion : Assertion<DirectoryInfo>
             return Task.FromResult(AssertionResult.Failed($"directory '{value.FullName}' has {subdirectories.Length} subdirectories"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to have no subdirectories";
@@ -126,7 +126,7 @@ public class FileIsNotSystemAssertion : Assertion<FileInfo>
             return Task.FromResult(AssertionResult.Failed($"file '{value.FullName}' is a system file"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to not be a system file";
@@ -170,7 +170,7 @@ public class FileIsNotExecutableAssertion : Assertion<FileInfo>
             return Task.FromResult(AssertionResult.Failed($"file '{value.FullName}' is executable (extension: {value.Extension})"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to not be executable";

--- a/TUnit.Assertions/Conditions/GreaterThanAssertion.cs
+++ b/TUnit.Assertions/Conditions/GreaterThanAssertion.cs
@@ -34,7 +34,7 @@ public class GreaterThanAssertion<TValue> : Assertion<TValue>
 
         if (value.CompareTo(_minimum) > 0)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));
@@ -72,7 +72,7 @@ public class GreaterThanOrEqualAssertion<TValue> : Assertion<TValue>
 
         if (value.CompareTo(_minimum) >= 0)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/LessThanAssertion.cs
+++ b/TUnit.Assertions/Conditions/LessThanAssertion.cs
@@ -33,7 +33,7 @@ public class LessThanAssertion<TValue> : Assertion<TValue>
 
         if (value.CompareTo(_maximum) < 0)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));
@@ -71,7 +71,7 @@ public class LessThanOrEqualAssertion<TValue> : Assertion<TValue>
 
         if (value.CompareTo(_maximum) <= 0)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/ListAssertions.cs
+++ b/TUnit.Assertions/Conditions/ListAssertions.cs
@@ -48,7 +48,7 @@ public class ListHasItemAtAssertion<TList, TItem> : ListAssertionBase<TList, TIt
 
         if (comparer.Equals(actualItem, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
@@ -309,12 +309,12 @@ public class ListItemAtEqualsAssertion<TList, TItem> : ListAssertionBase<TList, 
         {
             return areEqual
                 ? Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
         else
         {
             return areEqual
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
         }
     }
@@ -368,14 +368,14 @@ public class ListItemAtNullAssertion<TList, TItem> : ListAssertionBase<TList, TI
         if (_expectNull)
         {
             return isNull
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
         }
         else
         {
             return isNull
                 ? Task.FromResult(AssertionResult.Failed($"item at index {_index} was null"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
     }
 
@@ -489,12 +489,12 @@ public class ListLastItemEqualsAssertion<TList, TItem> : ListAssertionBase<TList
         {
             return areEqual
                 ? Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
         else
         {
             return areEqual
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"));
         }
     }
@@ -544,14 +544,14 @@ public class ListLastItemNullAssertion<TList, TItem> : ListAssertionBase<TList, 
         if (_expectNull)
         {
             return isNull
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"));
         }
         else
         {
             return isNull
                 ? Task.FromResult(AssertionResult.Failed("last item was null"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
     }
 

--- a/TUnit.Assertions/Conditions/MutableDictionaryAssertions.cs
+++ b/TUnit.Assertions/Conditions/MutableDictionaryAssertions.cs
@@ -59,7 +59,7 @@ public class MutableDictionaryContainsKeyAssertion<TDictionary, TKey, TValue> : 
 
         if (found)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"key {_expectedKey} not found"));
@@ -100,7 +100,7 @@ public class MutableDictionaryDoesNotContainKeyAssertion<TDictionary, TKey, TVal
             return Task.FromResult(AssertionResult.Failed($"key {_expectedKey} was found"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 }
 
@@ -138,7 +138,7 @@ public class MutableDictionaryContainsValueAssertion<TDictionary, TKey, TValue> 
         {
             if (comparer.Equals(v, _expectedValue))
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
         }
 
@@ -184,7 +184,7 @@ public class MutableDictionaryDoesNotContainValueAssertion<TDictionary, TKey, TV
             }
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 }
 
@@ -227,7 +227,7 @@ public class MutableDictionaryContainsKeyWithValueAssertion<TDictionary, TKey, T
         var comparer = EqualityComparer<TValue>.Default;
         if (comparer.Equals(actualValue, _expectedValue))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"key {_expectedKey} has value {actualValue}, not {_expectedValue}"));
@@ -271,7 +271,7 @@ public class MutableDictionaryAllKeysAssertion<TDictionary, TKey, TValue> : Muta
             }
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 }
 
@@ -312,7 +312,7 @@ public class MutableDictionaryAllValuesAssertion<TDictionary, TKey, TValue> : Mu
             }
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 }
 
@@ -349,7 +349,7 @@ public class MutableDictionaryAnyKeyAssertion<TDictionary, TKey, TValue> : Mutab
         {
             if (_predicate(key))
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
         }
 
@@ -390,7 +390,7 @@ public class MutableDictionaryAnyValueAssertion<TDictionary, TKey, TValue> : Mut
         {
             if (_predicate(value))
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
         }
 

--- a/TUnit.Assertions/Conditions/NotEqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/NotEqualsAssertion.cs
@@ -64,7 +64,7 @@ public class NotEqualsAssertion<TValue> : Assertion<TValue>
             var result = DeepEquals(value, _notExpected, _ignoredTypes);
             if (!result.IsSuccess)
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             return Task.FromResult(AssertionResult.Failed($"both values are equivalent"));
@@ -74,7 +74,7 @@ public class NotEqualsAssertion<TValue> : Assertion<TValue>
 
         if (!comparer.Equals(value!, _notExpected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"both values are {value}"));

--- a/TUnit.Assertions/Conditions/NotStructuralEquivalencyAssertion.cs
+++ b/TUnit.Assertions/Conditions/NotStructuralEquivalencyAssertion.cs
@@ -104,7 +104,7 @@ public class NotStructuralEquivalencyAssertion<TValue> : Assertion<TValue>
             return Task.FromResult(AssertionResult.Failed("objects are equivalent but should not be"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation()

--- a/TUnit.Assertions/Conditions/NullAssertion.cs
+++ b/TUnit.Assertions/Conditions/NullAssertion.cs
@@ -24,7 +24,7 @@ public class NullAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));
@@ -50,7 +50,7 @@ public class NotNullAssertion<TValue> : Assertion<TValue>
 
         if (value != null)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed("value is null"));
@@ -95,7 +95,7 @@ public class IsDefaultAssertion<TValue> : Assertion<TValue> where TValue : struc
 
         if (EqualityComparer<TValue>.Default.Equals(value!, default!))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is {value}"));
@@ -128,7 +128,7 @@ public class IsNotDefaultAssertion<TValue> : Assertion<TValue> where TValue : st
 
         if (!EqualityComparer<TValue>.Default.Equals(value!, default!))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name})"));
@@ -162,7 +162,7 @@ public class IsDefaultNullableAssertion<TValue> : Assertion<TValue?> where TValu
 
         if (!value.HasValue)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is {value}"));
@@ -196,7 +196,7 @@ public class IsNotDefaultNullableAssertion<TValue> : Assertion<TValue?> where TV
 
         if (value.HasValue)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name}?)"));
@@ -230,7 +230,7 @@ public class IsDefaultReferenceAssertion<TValue> : Assertion<TValue> where TValu
 
         if (EqualityComparer<TValue>.Default.Equals(value!, default!))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is {value}"));
@@ -264,7 +264,7 @@ public class IsNotDefaultReferenceAssertion<TValue> : Assertion<TValue> where TV
 
         if (!EqualityComparer<TValue>.Default.Equals(value!, default!))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name})"));

--- a/TUnit.Assertions/Conditions/PredicateAssertions.cs
+++ b/TUnit.Assertions/Conditions/PredicateAssertions.cs
@@ -35,7 +35,7 @@ public class SatisfiesAssertion<TValue> : Assertion<TValue>
 
         if (_predicate(value))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"value {value} does not satisfy predicate"));
@@ -87,7 +87,7 @@ public class IsEquatableOrEqualToAssertion<TValue> : ComparerBasedAssertion<TVal
 
         if (comparer.Equals(value!, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/ReadOnlyListAssertions.cs
+++ b/TUnit.Assertions/Conditions/ReadOnlyListAssertions.cs
@@ -50,7 +50,7 @@ public class ReadOnlyListHasItemAtAssertion<TList, TItem> : ReadOnlyListAssertio
 
         if (comparer.Equals(actualItem, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
@@ -311,12 +311,12 @@ public class ReadOnlyListItemAtEqualsAssertion<TList, TItem> : ReadOnlyListAsser
         {
             return areEqual
                 ? Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
         else
         {
             return areEqual
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
         }
     }
@@ -370,14 +370,14 @@ public class ReadOnlyListItemAtNullAssertion<TList, TItem> : ReadOnlyListAsserti
         if (_expectNull)
         {
             return isNull
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"item at index {_index} was {actualItem}"));
         }
         else
         {
             return isNull
                 ? Task.FromResult(AssertionResult.Failed($"item at index {_index} was null"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
     }
 
@@ -491,12 +491,12 @@ public class ReadOnlyListLastItemEqualsAssertion<TList, TItem> : ReadOnlyListAss
         {
             return areEqual
                 ? Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
         else
         {
             return areEqual
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"));
         }
     }
@@ -546,14 +546,14 @@ public class ReadOnlyListLastItemNullAssertion<TList, TItem> : ReadOnlyListAsser
         if (_expectNull)
         {
             return isNull
-                ? Task.FromResult(AssertionResult.Passed)
+                ? AssertionResult._passedTask
                 : Task.FromResult(AssertionResult.Failed($"last item was {lastItem}"));
         }
         else
         {
             return isNull
                 ? Task.FromResult(AssertionResult.Failed("last item was null"))
-                : Task.FromResult(AssertionResult.Passed);
+                : AssertionResult._passedTask;
         }
     }
 

--- a/TUnit.Assertions/Conditions/ReferenceEqualityAssertions.cs
+++ b/TUnit.Assertions/Conditions/ReferenceEqualityAssertions.cs
@@ -32,7 +32,7 @@ public class SameReferenceAssertion<TValue> : Assertion<TValue>
 
         if (ReferenceEquals(value, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed("references are different"));
@@ -69,7 +69,7 @@ public class NotSameReferenceAssertion<TValue> : Assertion<TValue>
 
         if (!ReferenceEquals(value, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed("references are the same"));

--- a/TUnit.Assertions/Conditions/SpecializedEqualityAssertions.cs
+++ b/TUnit.Assertions/Conditions/SpecializedEqualityAssertions.cs
@@ -254,7 +254,7 @@ public class IntEqualsAssertion : Assertion<int>
             var diff = Math.Abs(value - _expected);
             if (diff <= _tolerance.Value)
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             return Task.FromResult(AssertionResult.Failed($"found {value}, which differs by {diff}"));
@@ -262,7 +262,7 @@ public class IntEqualsAssertion : Assertion<int>
 
         if (value == _expected)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));
@@ -418,7 +418,7 @@ public class TimeSpanEqualsAssertion : Assertion<TimeSpan>
             var diff = value > _expected ? value - _expected : _expected - value;
             if (diff <= _tolerance.Value)
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             return Task.FromResult(AssertionResult.Failed($"found {value}, which differs by {diff}"));
@@ -426,7 +426,7 @@ public class TimeSpanEqualsAssertion : Assertion<TimeSpan>
 
         if (value == _expected)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/StringAssertions.cs
+++ b/TUnit.Assertions/Conditions/StringAssertions.cs
@@ -95,7 +95,7 @@ public class StringContainsAssertion : Assertion<string>
 
         if (actualValue.Contains(expectedValue, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -199,7 +199,7 @@ public class StringDoesNotContainAssertion : Assertion<string>
 
         if (!value.Contains(_expected, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{_expected}\" in \"{value}\""));
@@ -266,7 +266,7 @@ public class StringStartsWithAssertion : Assertion<string>
 
         if (value.StartsWith(_expected, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -333,7 +333,7 @@ public class StringEndsWithAssertion : Assertion<string>
 
         if (value.EndsWith(_expected, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -400,7 +400,7 @@ public class StringDoesNotStartWithAssertion : Assertion<string>
 
         if (!value.StartsWith(_expected, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -467,7 +467,7 @@ public class StringDoesNotEndWithAssertion : Assertion<string>
 
         if (!value.EndsWith(_expected, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -505,7 +505,7 @@ public class StringIsNotEmptyAssertion : Assertion<string>
 
         if (!string.IsNullOrEmpty(value))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -543,7 +543,7 @@ public class StringIsEmptyAssertion : Assertion<string>
 
         if (value == string.Empty)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
@@ -584,7 +584,7 @@ public class StringLengthAssertion : Assertion<string>
 
         if (value.Length == _expectedLength)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found length {value.Length}"));
@@ -694,7 +694,7 @@ public class StringMatchesAssertion : Assertion<RegexMatchCollection>
         }
 
         // If we have a RegexMatchCollection, at least one match succeeded
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation()
@@ -776,7 +776,7 @@ public class StringDoesNotMatchAssertion : Assertion<string>
 
         if (!isMatch)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"The regex \"{_pattern}\" matches with \"{value}\""));

--- a/TUnit.Assertions/Conditions/StringEqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/StringEqualsAssertion.cs
@@ -113,7 +113,7 @@ public class StringEqualsAssertion<TActual> : Assertion<TActual>
 
         if (string.Equals(actualValue, expectedValue, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         // Build detailed error message for string comparison failures

--- a/TUnit.Assertions/Conditions/ThrowsAssertion.cs
+++ b/TUnit.Assertions/Conditions/ThrowsAssertion.cs
@@ -53,7 +53,7 @@ public abstract class BaseThrowsAssertion<TException, TSelf> : Assertion<TExcept
             return Task.FromResult(AssertionResult.Failed(typeErrorMessage!));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() =>
@@ -366,7 +366,7 @@ public class ThrowsNothingAssertion<TValue> : Assertion<TValue>
                 $"threw {exception.GetType().FullName}: {exception.Message}"));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => "to not throw any exception";
@@ -419,7 +419,7 @@ public class HasMessageEqualToAssertion<TValue> : Assertion<TValue>
 
         if (string.Equals(exceptionToCheck.Message, _expectedMessage, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"message was \"{exceptionToCheck.Message}\""));
@@ -475,7 +475,7 @@ public class HasMessageStartingWithAssertion<TValue> : Assertion<TValue>
 
         if (exceptionToCheck.Message.StartsWith(_expectedPrefix, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"message was \"{exceptionToCheck.Message}\""));
@@ -531,7 +531,7 @@ public class HasMessageContainingAssertion<TValue> : Assertion<TValue>
 
         if (exceptionToCheck.Message.Contains(_expectedSubstring, _comparison))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"message was \"{exceptionToCheck.Message}\""));

--- a/TUnit.Assertions/Conditions/ToleranceBasedEqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/ToleranceBasedEqualsAssertion.cs
@@ -46,7 +46,7 @@ public abstract class ToleranceBasedEqualsAssertion<TValue, TTolerance> : Assert
         {
             if (IsWithinTolerance(value!, _expected, _tolerance))
             {
-                return Task.FromResult(AssertionResult.Passed);
+                return AssertionResult._passedTask;
             }
 
             var difference = CalculateDifference(value!, _expected);
@@ -56,7 +56,7 @@ public abstract class ToleranceBasedEqualsAssertion<TValue, TTolerance> : Assert
         // No tolerance - exact equality check
         if (AreExactlyEqual(value!, _expected))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"found {value}"));

--- a/TUnit.Assertions/Conditions/TypeOfAssertion.cs
+++ b/TUnit.Assertions/Conditions/TypeOfAssertion.cs
@@ -42,7 +42,7 @@ public class TypeOfAssertion<TFrom, TTo> : Assertion<TTo>
             return Task.FromResult(AssertionResult.Failed(exception.Message));
         }
 
-        return Task.FromResult(AssertionResult.Passed);
+        return AssertionResult._passedTask;
     }
 
     protected override string GetExpectation() => $"to be of type {_expectedType.Name}";
@@ -81,7 +81,7 @@ public class IsNotTypeOfAssertion<TValue, TExpected> : Assertion<TValue>
 
         if (actualType != _expectedType)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"type was {actualType.Name}"));
@@ -131,7 +131,7 @@ public class IsAssignableToAssertion<TTarget, TValue> : Assertion<TValue>
 
         if (_targetType.IsAssignableFrom(actualType))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"type {actualType.Name} is not assignable to {_targetType.Name}"));
@@ -181,7 +181,7 @@ public class IsNotAssignableToAssertion<TTarget, TValue> : Assertion<TValue>
 
         if (!_targetType.IsAssignableFrom(actualType))
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"type {actualType.Name} is assignable to {_targetType.Name}"));
@@ -224,7 +224,7 @@ public class IsTypeOfRuntimeAssertion<TValue> : Assertion<TValue>
 
         if (actualType == _expectedType)
         {
-            return Task.FromResult(AssertionResult.Passed);
+            return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed($"type was {actualType.Name}"));

--- a/TUnit.Assertions/Core/AssertionResult.cs
+++ b/TUnit.Assertions/Core/AssertionResult.cs
@@ -5,6 +5,8 @@ namespace TUnit.Assertions.Core;
 /// </summary>
 public readonly struct AssertionResult
 {
+    internal static readonly Task<AssertionResult> _passedTask = Task.FromResult(Passed);
+
     public bool IsPassed { get; }
     public string Message { get; }
 


### PR DESCRIPTION
Use return a shared static `Task.FromResult(Passed)` for successful assertions. This should be safe because `AssertionResult` is a `readonly struct`


### Before
<img width="634" height="255" alt="image" src="https://github.com/user-attachments/assets/a9b9cf07-fb13-4ef9-9736-676e075bcd83" />


### After
<img width="616" height="145" alt="image" src="https://github.com/user-attachments/assets/53a75bb2-671b-4a23-8239-71b7dd2582b2" />
