### PR TITLE
perf: convert `AfterHookExecutionFlags` to `struct`

### DIFF
--- a/TUnit.Engine/Services/TestLifecycleCoordinator.cs
+++ b/TUnit.Engine/Services/TestLifecycleCoordinator.cs
@@ -92,7 +92,7 @@ internal sealed class TestLifecycleCoordinator
 /// <summary>
 /// Flags indicating which After hooks should be executed based on test completion counts.
 /// </summary>
-internal sealed class AfterHookExecutionFlags
+internal struct AfterHookExecutionFlags
 {
     public bool ShouldExecuteAfterClass { get; set; }
     public bool ShouldExecuteAfterAssembly { get; set; }


### PR DESCRIPTION
Convert `AfterHookExecutionFlags` to `struct`,


### Before
<img width="616" height="83" alt="image" src="https://github.com/user-attachments/assets/a01fe78f-b965-4e2b-8cba-dfbd46b420f8" />


### After
<img width="620" height="99" alt="image" src="https://github.com/user-attachments/assets/2ca09453-fb0c-4067-b018-922db28040f8" />
