### PR TITLE
perf: `IReadOnlyList<Artifact>` call `ToArray`

### DIFF
--- a/TUnit.Core/TestContext.Output.cs
+++ b/TUnit.Core/TestContext.Output.cs
@@ -14,7 +14,7 @@ public partial class TestContext
     internal ConcurrentBag<Timing> Timings { get; } = [];
     private readonly ConcurrentBag<Artifact> _artifactsBag = new();
 
-    internal IReadOnlyList<Artifact> Artifacts => _artifactsBag.ToList();
+    internal IReadOnlyList<Artifact> Artifacts => _artifactsBag.ToArray();
 
     // Explicit interface implementations for ITestOutput
     TextWriter ITestOutput.StandardOutput => OutputWriter;


### PR DESCRIPTION
Call `ToArray` instead of `ToList`, most of the time the underlying collection contains zero items so it will return an empty array.



### Before
<img width="618" height="84" alt="image" src="https://github.com/user-attachments/assets/716f404c-52e1-44e9-8044-3723c5736b2f" />


### After
<img width="594" height="136" alt="image" src="https://github.com/user-attachments/assets/f1c6c3f6-5247-4478-9db3-b400f36849c8" />
<img width="603" height="77" alt="image" src="https://github.com/user-attachments/assets/0758faf3-9a52-4a6d-b00c-dedafe27dec5" />
