### PR TITLE
perf: fix `_parallelConstraints` deferred initialisation

### DIFF
--- a/TUnit.Core/TestContext.Parallelization.cs
+++ b/TUnit.Core/TestContext.Parallelization.cs
@@ -5,7 +5,10 @@ namespace TUnit.Core;
 
 public partial class TestContext
 {
-    internal IReadOnlyList<IParallelConstraint> ParallelConstraints => _parallelConstraints ?? [];
+    internal IReadOnlyList<IParallelConstraint> ParallelConstraints => _parallelConstraints == null
+        ? Array.Empty<IParallelConstraint>()
+        : _parallelConstraints;
+
     internal Priority ExecutionPriority { get; set; } = Priority.Normal;
 
     IReadOnlyList<IParallelConstraint> ITestParallelization.Constraints => ParallelConstraints;


### PR DESCRIPTION
`[]` will usually default to a `List<T>` when it is ambiguous, this ensures that an empty array is used when possible.



### Before
<img width="575" height="133" alt="image" src="https://github.com/user-attachments/assets/ee158486-8082-43db-8efe-8d9ebe643d31" />

### After
<img width="589" height="135" alt="image" src="https://github.com/user-attachments/assets/cbcbf2b9-bc44-48ef-8854-74d67151de79" />
