### PR TITLE
perf: reuse no data array and empty task

### DIFF
--- a/TUnit.Core/Attributes/TestData/NoDataSource.cs
+++ b/TUnit.Core/Attributes/TestData/NoDataSource.cs
@@ -2,6 +2,7 @@
 
 internal class NoDataSource : IDataSourceAttribute
 {
+    private static readonly Task<object?[]?> _emptyRowTask = Task.FromResult<object?[]?>([]);
     public static readonly NoDataSource Instance = new();
 
     /// <inheritdoc />
@@ -9,7 +10,7 @@ internal class NoDataSource : IDataSourceAttribute
 
     public async IAsyncEnumerable<Func<Task<object?[]?>>> GetDataRowsAsync(DataGeneratorMetadata dataGeneratorMetadata)
     {
-        yield return () => Task.FromResult<object?[]?>([]);
+        yield return static () => _emptyRowTask;
         await default(ValueTask);
     }
 }

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -812,11 +812,13 @@ internal sealed class TestBuilder : ITestBuilder
         return resolvedTypes;
     }
 
+    private static readonly IDataSourceAttribute[] _dataSourceArray = [NoDataSource.Instance];
+
     private async Task<IDataSourceAttribute[]> GetDataSourcesAsync(IDataSourceAttribute[] dataSources)
     {
         if (dataSources.Length == 0)
         {
-            return [NoDataSource.Instance];
+            return _dataSourceArray;
         }
 
         // Inject properties into data sources during discovery (IAsyncInitializer deferred to execution)


### PR DESCRIPTION
- Return the same `static readonly` array containing `[NoDataSource.Instance]`
- Return cached `Task<object[]>` in `GetDataRowsAsync`
 

### Before
<img width="604" height="90" alt="image" src="https://github.com/user-attachments/assets/2e35bb86-0854-439d-9036-dfafc47708f8" />


### After
<img width="595" height="80" alt="image" src="https://github.com/user-attachments/assets/eea72941-4f17-4563-9eff-6d6ef742a79b" />

