### PR TITLE
perf: remove `ReadOnlyDictionary` wrapper

### DIFF
--- a/TUnit.Core/Helpers/AttributeDictionaryHelper.cs
+++ b/TUnit.Core/Helpers/AttributeDictionaryHelper.cs
@@ -45,7 +45,7 @@ public static class AttributeDictionaryHelper
             }
         }
 
-        return new ReadOnlyDictionary<Type, IReadOnlyList<Attribute>>(result);
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
Remove `ReadOnlyDictionary` wrapper. IIRC `ReadOnlyDictionary` is a wrapper for `Dictionary` and only exists to make it slightly harder for people casting `IReadOnlyDictionary` back into a `Dictionary`


### Before
<img width="759" height="76" alt="image" src="https://github.com/user-attachments/assets/d3e5a8c9-13e4-4bb3-aaab-f386f5bf6708" />


### After
<img width="485" height="70" alt="image" src="https://github.com/user-attachments/assets/40de21fc-44f8-4b68-8ebf-dffe31db30c3" />

