### PR TITLE
perf: `ThreadSafeDict` extract slow logic

### DIFF
--- a/TUnit.Core/Data/ThreadSafeDictionary.cs
+++ b/TUnit.Core/Data/ThreadSafeDictionary.cs
@@ -81,6 +81,11 @@ public class ThreadSafeDictionary<TKey,
             return existingLazy.Value;
         }
 
+        return GetOrAddSlow(key, func);
+    }
+
+    private TValue GetOrAddSlow(TKey key, Func<TKey, TValue> func)
+    {
         // Slow path: Key not found, need to create
         // Create Lazy instance OUTSIDE of GetOrAdd to prevent factory from running during race
         var newLazy = new Lazy<TValue>(() => func(key), LazyThreadSafetyMode.ExecutionAndPublication);


### PR DESCRIPTION
C# compiler like to eagerly initialise closures at the start of the method, so even on fast paths the display class for `valueFactory` was being created. Extracting the slow code to a new method solves this issue. 

I have no idea why the .NET compiler does this, I assume it's a correctness thing (sometimes due `if` `else` usage). I really wish it didn't do this.

### Before
<img width="582" height="369" alt="image" src="https://github.com/user-attachments/assets/adb2911d-d088-4a0a-b8bc-0edf83e5cd54" />


### After
<img width="579" height="214" alt="image" src="https://github.com/user-attachments/assets/867eb84c-33db-4ba7-aae1-55254247d897" />

