### PR TITLE
perf: change `TrackedObjects` to `Dictionary`

### DIFF
--- a/TUnit.Core/Interfaces/IObjectGraphDiscoverer.cs
+++ b/TUnit.Core/Interfaces/IObjectGraphDiscoverer.cs
@@ -64,7 +64,7 @@ internal interface IObjectGraphDiscoverer
     /// This method modifies testContext.TrackedObjects directly. For pure query operations,
     /// use <see cref="DiscoverObjectGraph"/> instead.
     /// </remarks>
-    ConcurrentDictionary<int, HashSet<object>> DiscoverAndTrackObjects(TestContext testContext, CancellationToken cancellationToken = default);
+    Dictionary<int, HashSet<object>> DiscoverAndTrackObjects(TestContext testContext, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -222,20 +222,11 @@ public partial class TestContext : Context,
         CachedClassInstance = null;
     }
 
-
     internal ConcurrentDictionary<string, object?> ObjectBag => _testBuilderContext.StateBag;
-
 
     internal AbstractExecutableTest InternalExecutableTest { get; set; } = null!;
 
-    private ConcurrentDictionary<int, HashSet<object>>? _trackedObjects;
-
-    /// <summary>
-    /// Thread-safe lazy initialization of TrackedObjects using LazyInitializer
-    /// to prevent race conditions when multiple threads access this property simultaneously.
-    /// </summary>
-    internal ConcurrentDictionary<int, HashSet<object>> TrackedObjects =>
-        LazyInitializer.EnsureInitialized(ref _trackedObjects)!;
+    internal Dictionary<int, HashSet<object>> TrackedObjects { get; } = new();
 
     /// <summary>
     /// Sets the output captured during test building phase.

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -53,9 +53,9 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     /// Thread-safe: locks each HashSet while copying.
     /// Pre-calculates capacity to avoid HashSet resizing during population.
     /// </summary>
-    private static ISet<object> FlattenTrackedObjects(ConcurrentDictionary<int, HashSet<object>> trackedObjects)
+    private static ISet<object> FlattenTrackedObjects(Dictionary<int, HashSet<object>> trackedObjects)
     {
-        if (trackedObjects.IsEmpty)
+        if (trackedObjects.Count == 0)
         {
             return ImmutableHashSet<object>.Empty;
         }
@@ -64,12 +64,9 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
 
         foreach (var kvp in trackedObjects)
         {
-            lock (kvp.Value)
+            foreach (var obj in kvp.Value)
             {
-                foreach (var obj in kvp.Value)
-                {
-                    result.Add(obj);
-                }
+                result.Add(obj);
             }
         }
 
@@ -83,7 +80,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
 
         // Get new trackable objects
         var trackableDict = trackableObjectGraphProvider.GetTrackableObjects(testContext);
-        if (trackableDict.IsEmpty && alreadyTracked.Count == 0)
+        if (trackableDict.Count == 0 && alreadyTracked.Count == 0)
         {
             return;
         }

--- a/TUnit.Core/Tracking/TrackableObjectGraphProvider.cs
+++ b/TUnit.Core/Tracking/TrackableObjectGraphProvider.cs
@@ -34,7 +34,7 @@ internal class TrackableObjectGraphProvider
     /// </summary>
     /// <param name="testContext">The test context to get trackable objects from.</param>
     /// <param name="cancellationToken">Optional cancellation token for long-running discovery.</param>
-    public ConcurrentDictionary<int, HashSet<object>> GetTrackableObjects(TestContext testContext, CancellationToken cancellationToken = default)
+    public Dictionary<int, HashSet<object>> GetTrackableObjects(TestContext testContext, CancellationToken cancellationToken = default)
     {
         // OCP-compliant: Use the interface method directly instead of type-checking
         return _discoverer.DiscoverAndTrackObjects(testContext, cancellationToken);

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -235,17 +235,9 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
                     continue;
                 }
 
-                // Copy to array under lock to prevent concurrent modification
-                object[] objectsCopy;
-                lock (objectsAtLevel)
-                {
-                    objectsCopy = new object[objectsAtLevel.Count];
-                    objectsAtLevel.CopyTo(objectsCopy);
-                }
-
                 // Initialize all objects at this level in parallel
-                var tasks = new List<Task>(objectsCopy.Length);
-                foreach (var obj in objectsCopy)
+                var tasks = new List<Task>(objectsAtLevel.Count);
+                foreach (var obj in objectsAtLevel)
                 {
                     tasks.Add(InitializeObjectWithNestedAsync(obj, cancellationToken));
                 }


### PR DESCRIPTION
Change `TrackedObjects` to `Dictionary` 


### Why I think this is safe
The only function that mutates `TrackedObjects` is `ObjectTracker.TrackObjects` which is in turn called by the following methods:

- `TestArgumentRegistrationService.RegisterTestArgumentsAsync` 
	- `TestBuilder.InvokeTestRegisteredEventReceiversAsync`
		- `TestBuilder.BuildTestAsync` * 4
	- `TestFilterService.RegisterTest`
		- `TestDiscoveryService.DiscoverTests` * 2
			- Both go to both branches of `TestRequestHandler.HandleRequestAsync`

Note that when a method only has 1 caller I skip it. To my knowledge `TrackedObjects` is only ever mutated by one thread at a time and usually only once.


### Before
<img width="595" height="94" alt="image" src="https://github.com/user-attachments/assets/95acdafe-947e-42b8-8337-c093c4108819" />
<img width="612" height="89" alt="image" src="https://github.com/user-attachments/assets/44ec7229-fff1-49f9-aef1-182d09270389" />


### After
<img width="609" height="88" alt="image" src="https://github.com/user-attachments/assets/425c07e6-0c0d-4a9f-a4f2-6ddd4e1cb203" />
<img width="610" height="90" alt="image" src="https://github.com/user-attachments/assets/1eca6c73-48a0-4793-bfe4-6151575fdc33" />

I'm pretty sure I can simplify a lot of logic in `ObjectGraphDiscoverer` as the function signatures are similar now