### PR TITLE
perf: use static `Task` in `MethodAssertionGenerator` generated code

### DIFF
--- a/TUnit.Assertions.SourceGenerator/Generators/MethodAssertionGenerator.cs
+++ b/TUnit.Assertions.SourceGenerator/Generators/MethodAssertionGenerator.cs
@@ -569,6 +569,13 @@ public sealed class MethodAssertionGenerator : IIncrementalGenerator
 
         sb.AppendLine("{");
 
+        if (data.ReturnTypeInfo.Kind is ReturnTypeKind.Bool)
+        {
+            sb.AppendLine(
+                "    private static readonly Task<AssertionResult> _passedTask = Task.FromResult(AssertionResult.Passed);");
+            sb.AppendLine();
+        }
+
         // Private fields for additional parameters
         // Note: Ref struct types (like DefaultInterpolatedStringHandler) are stored as string
         foreach (var param in data.AdditionalParameters)
@@ -702,9 +709,9 @@ public sealed class MethodAssertionGenerator : IIncrementalGenerator
         {
             case ReturnTypeKind.Bool:
                 sb.AppendLine($"        var result = {methodCall};");
-                sb.AppendLine("        return Task.FromResult(result");
-                sb.AppendLine("            ? AssertionResult.Passed");
-                sb.AppendLine("            : AssertionResult.Failed($\"found {value}\"));");
+                sb.AppendLine("        return result");
+                sb.AppendLine("            ? _passedTask");
+                sb.AppendLine("            : Task.FromResult(AssertionResult.Failed($\"found {value}\"));");
                 break;
 
             case ReturnTypeKind.AssertionResult:


### PR DESCRIPTION
Improve generated code by `MethodAssertionGenerator` to sometimes emit `private static readonly Task<AssertionResult> _passedTask = Task.FromResult(AssertionResult.Passed);` and return it.


- This could be a `protected static readonly Task<AssertionResult> _passedTask` inherited from `Assertion<T>`, but I didn't want to change the existing api.
- It's been a while since I've worked on a source generator, but could this one use caching?

Again I'll ask you to update the snapshot tests, I've rebased and I still get the Sourcy error 😅 


### Before
<img width="595" height="82" alt="image" src="https://github.com/user-attachments/assets/0e3e37d7-0357-47fe-a375-02a77cf8c84b" />


### After
<img width="598" height="83" alt="image" src="https://github.com/user-attachments/assets/6e766e76-3881-4fbc-9141-6edb7e1ca87f" />
