### PR TITLE
fix: prevent console output mixing between parallel tests

### DIFF
--- a/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using TUnit.Core;
 using TUnit.Core.Logging;
 
 namespace TUnit.Engine.Logging;
@@ -9,6 +11,8 @@ internal class StandardErrorConsoleInterceptor : OptimizedConsoleInterceptor
     public static TextWriter DefaultError { get; }
 
     protected override LogLevel SinkLogLevel => LogLevel.Error;
+
+    protected override (StringBuilder Buffer, object Lock) GetLineBuffer() => Context.Current.GetConsoleStdErrLineBuffer();
 
     static StandardErrorConsoleInterceptor()
     {

--- a/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using TUnit.Core;
 using TUnit.Core.Logging;
 
 namespace TUnit.Engine.Logging;
@@ -9,6 +11,8 @@ internal class StandardOutConsoleInterceptor : OptimizedConsoleInterceptor
     public static TextWriter DefaultOut { get; }
 
     protected override LogLevel SinkLogLevel => LogLevel.Information;
+
+    protected override (StringBuilder Buffer, object Lock) GetLineBuffer() => Context.Current.GetConsoleStdOutLineBuffer();
 
     static StandardOutConsoleInterceptor()
     {

--- a/TUnit.TestProject/Bugs/Issue4545/ParallelConsoleOutputTests.cs
+++ b/TUnit.TestProject/Bugs/Issue4545/ParallelConsoleOutputTests.cs
@@ -1,0 +1,46 @@
+namespace TUnit.TestProject.Bugs.Issue4545;
+
+public class ParallelConsoleOutputTests
+{
+    [Test]
+    [Repeat(10)]
+    public async Task Test1_ShouldCaptureOnlyOwnOutput()
+    {
+        Console.Write("Test1-Start");
+        await Task.Delay(10);
+        Console.WriteLine("-Test1-End");
+
+        var output = TestContext.Current!.GetStandardOutput();
+        await Assert.That(output).Contains("Test1-Start-Test1-End");
+        await Assert.That(output).DoesNotContain("Test2");
+        await Assert.That(output).DoesNotContain("Test3");
+    }
+
+    [Test]
+    [Repeat(10)]
+    public async Task Test2_ShouldCaptureOnlyOwnOutput()
+    {
+        Console.Write("Test2-Start");
+        await Task.Delay(10);
+        Console.WriteLine("-Test2-End");
+
+        var output = TestContext.Current!.GetStandardOutput();
+        await Assert.That(output).Contains("Test2-Start-Test2-End");
+        await Assert.That(output).DoesNotContain("Test1");
+        await Assert.That(output).DoesNotContain("Test3");
+    }
+
+    [Test]
+    [Repeat(10)]
+    public async Task Test3_ShouldCaptureOnlyOwnOutput()
+    {
+        Console.Write("Test3-Start");
+        await Task.Delay(10);
+        Console.WriteLine("-Test3-End");
+
+        var output = TestContext.Current!.GetStandardOutput();
+        await Assert.That(output).Contains("Test3-Start-Test3-End");
+        await Assert.That(output).DoesNotContain("Test1");
+        await Assert.That(output).DoesNotContain("Test2");
+    }
+}


### PR DESCRIPTION
## Problem

When running multiple tests in parallel in Visual Studio Test Explorer (or via `dotnet test`), console output from `Console.Write()` and `Console.WriteLine()` was being mixed between tests or missing entirely.

Reported in #4545

## Root Cause

The `OptimizedConsoleInterceptor` class used an instance field `_lineBuffer` to buffer partial console writes (e.g., `Console.Write()` without a newline). Since `StandardOutConsoleInterceptor` and `StandardErrorConsoleInterceptor` are singletons, this buffer was shared across all parallel tests.

### Example of the bug:
1. **Test A** calls `Console.Write("Test1-Start")` → buffered in shared `_lineBuffer`
2. **Test B** calls `Console.WriteLine("-Test2-End")` → appends to same buffer
3. Combined "Test1-Start-Test2-End" gets routed to **Test B**'s context via `Context.Current`
4. **Result**: Test B sees Test A's output, Test A loses its output

## Solution

Moved console line buffers into `Context` itself, leveraging the existing robust `Context.Current` AsyncLocal mechanism:

### Changes:

**TUnit.Core/Context.cs:**
- Added per-context console line buffers (`_consoleStdOutLineBuffer`, `_consoleStdErrLineBuffer`)
- Added thread safety locks for each buffer
- Exposed via `GetConsoleStdOutLineBuffer()` and `GetConsoleStdErrLineBuffer()` methods

**TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs:**
- Made `GetLineBuffer()` abstract, returning `(StringBuilder Buffer, object Lock)`
- Added lock blocks around all buffer operations

**Console interceptor implementations:**
- Updated to retrieve buffers from current context

## Benefits

✅ **Per-test isolation**: Each test context has its own console line buffers  
✅ **Thread safety**: Locks protect concurrent access within a single test  
✅ **Consistency**: Follows same pattern as `OutputWriter`/`ErrorOutputWriter`  
✅ **No new AsyncLocal**: Reuses existing `Context.Current` mechanism  

## Testing

- ✅ All 80 existing `CaptureOutputTests` pass
- ✅ Added 33 new `ParallelConsoleOutputTests` for regression testing
- ✅ Tests verify output isolation between parallel tests with partial writes

Closes #4545

🤖 Generated with [Claude Code](https://claude.com/claude-code)