### PR TITLE
fix: ensure thread-safe initialization of console line buffers

### DIFF
--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -29,8 +29,9 @@ public abstract class Context : IContext, IDisposable
 
     // Console interceptor line buffers for partial writes (Console.Write without newline)
     // These are stored per-context to prevent output mixing between parallel tests
-    private StringBuilder? _consoleStdOutLineBuffer;
-    private StringBuilder? _consoleStdErrLineBuffer;
+    // Using Lazy<T> for thread-safe initialization
+    private readonly Lazy<StringBuilder> _consoleStdOutLineBuffer = new(() => new StringBuilder());
+    private readonly Lazy<StringBuilder> _consoleStdErrLineBuffer = new(() => new StringBuilder());
     private readonly object _consoleStdOutBufferLock = new();
     private readonly object _consoleStdErrBufferLock = new();
 
@@ -43,12 +44,12 @@ public abstract class Context : IContext, IDisposable
     // Internal accessors for console interceptor line buffers with thread safety
     internal (StringBuilder Buffer, object Lock) GetConsoleStdOutLineBuffer()
     {
-        return (_consoleStdOutLineBuffer ??= new StringBuilder(), _consoleStdOutBufferLock);
+        return (_consoleStdOutLineBuffer.Value, _consoleStdOutBufferLock);
     }
 
     internal (StringBuilder Buffer, object Lock) GetConsoleStdErrLineBuffer()
     {
-        return (_consoleStdErrLineBuffer ??= new StringBuilder(), _consoleStdErrBufferLock);
+        return (_consoleStdErrLineBuffer.Value, _consoleStdErrBufferLock);
     }
 
     internal Context(Context? parent)


### PR DESCRIPTION
## Problem

PR #4549 introduced per-context console line buffers to prevent output mixing between parallel tests. However, a post-merge review comment identified a thread-safety issue with the lazy initialization in `Context.cs`:

```csharp
// NOT thread-safe
internal (StringBuilder Buffer, object Lock) GetConsoleStdOutLineBuffer()
{
    return (_consoleStdOutLineBuffer ??= new StringBuilder(), _consoleStdOutBufferLock);
}
```

**Race condition:** Multiple threads calling `GetConsoleStdOutLineBuffer()` simultaneously could each create their own `StringBuilder` before the null-coalescing assignment completes, undermining the per-context buffer isolation that #4549 was designed to provide.

## Solution

Replace nullable `StringBuilder?` fields with `Lazy<StringBuilder>` for guaranteed thread-safe initialization:

**TUnit.Core/Context.cs:**
- Changed `StringBuilder? _consoleStdOutLineBuffer` → `Lazy<StringBuilder> _consoleStdOutLineBuffer = new(() => new StringBuilder())`
- Changed `StringBuilder? _consoleStdErrLineBuffer` → `Lazy<StringBuilder> _consoleStdErrLineBuffer = new(() => new StringBuilder())`
- Updated accessors to use `.Value` instead of `??=` operator

## Benefits

✅ **Thread-safe by default** - `Lazy<T>` guarantees single initialization even under concurrent access  
✅ **No manual locking** - No need for double-checked locking pattern  
✅ **Idiomatic C#** - Standard approach for lazy initialization  
✅ **AOT-compatible** - Works with Native AOT compilation  
✅ **Zero behavior change** - Transparent fix maintaining all existing functionality

## Testing

- ✅ Builds successfully across all target frameworks (netstandard2.0, net8.0, net9.0, net10.0)
- ✅ No build warnings
- ✅ Existing `ParallelConsoleOutputTests` from #4549 continue to validate correct behavior

Addresses feedback from: https://github.com/thomhurst/TUnit/pull/4549#issuecomment-3794570788

🤖 Generated with [Claude Code](https://claude.com/claude-code)