### PR TITLE
Use Lock class instead of object

### DIFF
--- a/TUnit.Engine/Events/EventReceiverRegistry.cs
+++ b/TUnit.Engine/Events/EventReceiverRegistry.cs
@@ -28,7 +28,7 @@ internal sealed class EventReceiverRegistry
     private volatile EventTypes _registeredEvents = EventTypes.None;
     private readonly Dictionary<Type, object[]> _receiversByType = new();
     private readonly ConcurrentDictionary<Type, Array> _cachedTypedReceivers = new();
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Register event receivers from a collection of objects

--- a/TUnit.TestProject/AdaptiveParallelismTests.cs
+++ b/TUnit.TestProject/AdaptiveParallelismTests.cs
@@ -8,7 +8,7 @@ public class AdaptiveParallelismTests
 {
     private static int _currentlyRunning;
     private static int _maxConcurrent;
-    private static readonly object _lock = new();
+    private static readonly Lock _lock = new();
 
     [Test]
     [Repeat(1000)]

--- a/TUnit.TestProject/Bugs/4032/NestedAsyncInitializerTests.cs
+++ b/TUnit.TestProject/Bugs/4032/NestedAsyncInitializerTests.cs
@@ -189,7 +189,7 @@ public class NestedAsyncInitializerOrderTests
 public static class DeepNestingInitializationTracker
 {
     private static readonly List<string> _initializationOrder = [];
-    private static readonly object _lock = new();
+    private static readonly Lock _lock = new();
 
     public static void RecordInitialization(string name)
     {

--- a/TUnit.TestProject/CombinedDataSourceTests.cs
+++ b/TUnit.TestProject/CombinedDataSourceTests.cs
@@ -256,7 +256,7 @@ public class CombinedDataSourceTests
     #region Verification Tests - Ensure Correct Combinations
 
     private static readonly HashSet<string> _seenCombinations = new();
-    private static readonly object _lock = new();
+    private static readonly Lock _lock = new();
 
     [Test]
     [CombinedDataSources]

--- a/TUnit.TestProject/ParallelismValidationTests.cs
+++ b/TUnit.TestProject/ParallelismValidationTests.cs
@@ -12,7 +12,7 @@ public class UnconstrainedParallelTests
         private static readonly ConcurrentBag<(string TestName, DateTimeOffset Start, DateTimeOffset End)> _executionTimes = [];
         private static int _concurrentCount = 0;
         private static int _maxConcurrent = 0;
-        private static readonly object _lock = new();
+        private static readonly Lock _lock = new();
 
         [After(Test)]
         public async Task RecordExecution()
@@ -114,7 +114,7 @@ public class LimitedParallelTests
         private static int _concurrentCount = 0;
         private static int _maxConcurrent = 0;
         private static int _exceededLimit = 0;
-        private static readonly object _lock = new();
+        private static readonly Lock _lock = new();
 
         [After(Test)]
         public async Task RecordExecution()
@@ -225,7 +225,7 @@ public class StrictlySerialTests
         private static int _concurrentCount = 0;
         private static int _maxConcurrent = 0;
         private static int _exceededLimit = 0;
-        private static readonly object _lock = new();
+        private static readonly Lock _lock = new();
 
         [After(Test)]
         public async Task RecordExecution()
@@ -333,7 +333,7 @@ public class HighParallelismTests
         private static readonly ConcurrentBag<(string TestName, DateTimeOffset Start, DateTimeOffset End)> _executionTimes = [];
         private static int _concurrentCount = 0;
         private static int _maxConcurrent = 0;
-        private static readonly object _lock = new();
+        private static readonly Lock _lock = new();
 
         [After(Test)]
         public async Task RecordExecution()

--- a/TUnit.TestProject/ScopedEventReceiverTests.cs
+++ b/TUnit.TestProject/ScopedEventReceiverTests.cs
@@ -7,7 +7,7 @@ namespace TUnit.TestProject;
 [TestEndLogger(source: "assembly")]
 public class ScopedEventReceiverTests
 {
-    internal static readonly object _lock = new();
+    internal static readonly Lock _lock = new();
     internal static readonly Dictionary<string, List<string>> _testStartEvents = new();
     internal static readonly Dictionary<string, List<string>> _testEndEvents = new();
 


### PR DESCRIPTION
Use Lock instead of object everywhere.
There is already a use of Lock here:

https://github.com/thomhurst/TUnit/blob/ec4f8400016269f97ee0f414e23e8532c1790079/TUnit.Core/Logging/TUnitLoggerFactory.cs#L63
