### PR TITLE
feat: make `MethodAssertionGenerator` incremental

### DIFF
--- a/TUnit.Assertions.SourceGenerator/Models/ImmutableEquatableArray.cs
+++ b/TUnit.Assertions.SourceGenerator/Models/ImmutableEquatableArray.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections;
+
+namespace TUnit.Assertions.SourceGenerator.Models;
+
+// From https://github.com/dotnet/runtime/blob/6316c17c26c7ad25bd3449ce477a0882a48916dd/src/libraries/Common/src/SourceGenerators/ImmutableEquatableArray.cs#L15
+/// <summary>
+/// Provides an immutable list implementation which implements sequence equality.
+/// </summary>
+public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableArray<T>>, IReadOnlyList<T>
+    where T : IEquatable<T>
+{
+    public static ImmutableEquatableArray<T> Empty { get; } = new ImmutableEquatableArray<T>(Array.Empty<T>());
+
+    private readonly T[] _values;
+    public T this[int index] => _values[index];
+    public int Count => _values.Length;
+
+    public ImmutableEquatableArray(IEnumerable<T> values)
+        => _values = values.ToArray();
+
+    public bool Equals(ImmutableEquatableArray<T>? other)
+        => other != null && ((ReadOnlySpan<T>)_values).SequenceEqual(other._values);
+
+    public override bool Equals(object? obj)
+        => obj is ImmutableEquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = 0;
+        foreach (T value in _values)
+        {
+            hash = Combine(hash, value.GetHashCode());
+        }
+
+        static int Combine(int h1, int h2)
+        {
+            // RyuJIT optimizes this to use the ROL instruction
+            // Related GitHub pull request: https://github.com/dotnet/coreclr/pull/1830
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
+        }
+
+        return hash;
+    }
+
+    public Enumerator GetEnumerator() => new Enumerator(_values);
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)_values).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+
+    public struct Enumerator
+    {
+        private readonly T[] _values;
+        private int _index;
+
+        internal Enumerator(T[] values)
+        {
+            _values = values;
+            _index = -1;
+        }
+
+        public bool MoveNext()
+        {
+            int newIndex = _index + 1;
+
+            if ((uint)newIndex < (uint)_values.Length)
+            {
+                _index = newIndex;
+                return true;
+            }
+
+            return false;
+        }
+
+        public readonly T Current => _values[_index];
+    }
+}
+
+internal static class ImmutableEquatableArray
+{
+    public static ImmutableEquatableArray<T> Empty<T>()
+        where T : IEquatable<T> => ImmutableEquatableArray<T>.Empty;
+
+    public static ImmutableEquatableArray<T> ToImmutableEquatableArray<T>(this IEnumerable<T> values) where T : IEquatable<T>
+        => new(values);
+}


### PR DESCRIPTION
Add incremental caching for `MethodAssertionGenerator`.


- Uses `ImmutableEquatableArray` for structural equality on collections
- I have created tests to verify this, as usual I can't run any projects with `Sourcy` so I created a new test project see #4565
- Plan is to do this for all generators to improve ide responsiveness, should help with repeated build times 👍 