### PR TITLE
feat: add SharedDataSources helper for custom data source attributes

### DIFF
--- a/TUnit.Core/SharedDataSources.cs
+++ b/TUnit.Core/SharedDataSources.cs
@@ -22,7 +22,7 @@ public static class SharedDataSources
     /// Thrown when <paramref name="key"/> is null/empty and <paramref name="sharedType"/> is <see cref="SharedType.Keyed"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sharedType"/> is not a valid value.</exception>
-    public static T GetOrCreate<T>(SharedType sharedType, DataGeneratorMetadata dataGeneratorMetadata, string? key) where T : new()
+    public static T GetOrCreate<T>(SharedType sharedType, DataGeneratorMetadata dataGeneratorMetadata, string? key = null) where T : new()
     {
         return GetOrCreate(sharedType, dataGeneratorMetadata, key, static () => new T());
     }
@@ -40,7 +40,7 @@ public static class SharedDataSources
     /// or when <paramref name="key"/> is null/empty and <paramref name="sharedType"/> is <see cref="SharedType.Keyed"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sharedType"/> is not a valid value.</exception>
-    public static T GetOrCreate<T>(SharedType sharedType, Type? testClassType, string? key) where T : new()
+    public static T GetOrCreate<T>(SharedType sharedType, Type? testClassType = null, string? key = null) where T : new()
     {
         return GetOrCreate(sharedType, testClassType, key, static () => new T());
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1202,9 +1202,9 @@ namespace
     {
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, ? testClassType, string? key, <object?> factory) { }
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <object?> factory) { }
-        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType = null, string? key = null)
             where T : new() { }
-        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key = null)
             where T : new() { }
         public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key, <T> factory) { }
         public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <T> factory) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1202,9 +1202,9 @@ namespace
     {
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, ? testClassType, string? key, <object?> factory) { }
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <object?> factory) { }
-        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType = null, string? key = null)
             where T : new() { }
-        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key = null)
             where T : new() { }
         public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key, <T> factory) { }
         public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <T> factory) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1202,9 +1202,9 @@ namespace
     {
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, ? testClassType, string? key, <object?> factory) { }
         public static object? GetOrCreate(.SharedType sharedType, [.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..NonPublicConstructors)]  type, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <object?> factory) { }
-        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType = null, string? key = null)
             where T : new() { }
-        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key = null)
             where T : new() { }
         public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key, <T> factory) { }
         public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <T> factory) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1160,9 +1160,9 @@ namespace
     {
         public static object? GetOrCreate(.SharedType sharedType,  type, ? testClassType, string? key, <object?> factory) { }
         public static object? GetOrCreate(.SharedType sharedType,  type, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <object?> factory) { }
-        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType = null, string? key = null)
             where T : new() { }
-        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key)
+        public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key = null)
             where T : new() { }
         public static T GetOrCreate<T>(.SharedType sharedType, ? testClassType, string? key, <T> factory) { }
         public static T GetOrCreate<T>(.SharedType sharedType, .DataGeneratorMetadata dataGeneratorMetadata, string? key, <T> factory) { }


### PR DESCRIPTION
## Summary

- Adds a new public `SharedDataSources` class that allows users to implement custom data source attributes with the same sharing behavior (`SharedType` and `Key`) as `ClassDataSourceAttribute`
- Provides a clean public API without exposing internal implementation details (`ClassDataSources`, `TestDataContainer`)
- Addresses the feature request in discussion #4536

## API

```csharp
// Simplest - generic with new() constraint (no factory needed)
public static T GetOrCreate<T>(SharedType sharedType, DataGeneratorMetadata metadata, string? key) where T : new()
public static T GetOrCreate<T>(SharedType sharedType, Type? testClassType, string? key) where T : new()

// Generic with custom factory
public static T GetOrCreate<T>(SharedType sharedType, DataGeneratorMetadata metadata, string? key, Func<T> factory)
public static T GetOrCreate<T>(SharedType sharedType, Type? testClassType, string? key, Func<T> factory)

// Non-generic (runtime types, factory required)
public static object? GetOrCreate(SharedType sharedType, Type type, DataGeneratorMetadata metadata, string? key, Func<object?> factory)
public static object? GetOrCreate(SharedType sharedType, Type type, Type? testClassType, string? key, Func<object?> factory)
```

## Usage Example

```csharp
public class MyCustomDataSourceAttribute<T> : DataSourceGeneratorAttribute<T> where T : new()
{
    public SharedType Shared { get; set; } = SharedType.None;
    public string Key { get; set; } = "";

    protected override IEnumerable<Func<T>> GenerateDataSources(DataGeneratorMetadata metadata)
    {
        yield return () => SharedDataSources.GetOrCreate<T>(Shared, metadata, Key);
    }
}
```

## Test plan

- [ ] Verify TUnit.Core builds successfully
- [ ] Verify API is accessible from test projects
- [ ] Test custom data source implementation using the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)