### PR TITLE
fix: pass empty array to params parameter when [Arguments] has no values

### DIFF
--- a/TUnit.Core/Attributes/TestData/ArgumentsAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/ArgumentsAttribute.cs
@@ -62,9 +62,13 @@ public sealed class ArgumentsAttribute : Attribute, IDataSourceAttribute, ITestR
 
     public ArgumentsAttribute(params object?[]? values)
     {
-        if (values == null || values.Length == 0)
+        if (values == null)
         {
             Values = [null];
+        }
+        else if (values.Length == 0)
+        {
+            Values = [];
         }
         else
         {

--- a/TUnit.TestProject/ParamsArgumentsTests.cs
+++ b/TUnit.TestProject/ParamsArgumentsTests.cs
@@ -45,6 +45,17 @@ public class ParamsArgumentsTests
     }
 
     [Test]
+    [Arguments]
+    [Arguments("a")]
+    [Arguments("a", "b")]
+    [Arguments("a", "b", "c")]
+    public async Task ParamsOnlyWithEmptyArguments(params string[] args)
+    {
+        // When [Arguments] has no values, params should be an empty array, not null
+        await Assert.That(args).IsNotNull();
+    }
+
+    [Test]
     [Arguments(1, "single")]
     public async Task SingleStringInParamsArray(int id, params string[] values)
     {


### PR DESCRIPTION
## Summary

- Fixed bug where `[Arguments]` with no values passed `null` instead of an empty array to `params` parameters
- The `ArgumentsAttribute` constructor now distinguishes between empty arguments (`[]`) and explicit null (`[null]`)
- Added test case to verify the fix

Fixes #4561

## Test plan

- [x] Verified new test `ParamsOnlyWithEmptyArguments` passes with 4 test cases
- [x] Verified all 12 `ParamsArgumentsTests` pass
- [x] Verified 105 source generator tests pass
- [x] No snapshot test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)