### PR TITLE
feat: add TUNIT_DISABLE_LOGO environment variable support

### DIFF
--- a/TUnit.Engine/Capabilities/BannerCapability.cs
+++ b/TUnit.Engine/Capabilities/BannerCapability.cs
@@ -23,6 +23,7 @@ internal class BannerCapability(IPlatformInformation platformInformation, IComma
     public Task<string?> GetBannerMessageAsync()
     {
         if (commandLineOptions.IsOptionSet(DisableLogoCommandProvider.DisableLogo)
+            || Environment.GetEnvironmentVariable("TUNIT_DISABLE_LOGO") is not null
             || loggerFactory.CreateLogger(nameof(BannerCapability)).IsEnabled(LogLevel.Information))
         {
             return Task.FromResult<string?>(GetRuntimeDetails());

--- a/docs/docs/reference/command-line-flags.md
+++ b/docs/docs/reference/command-line-flags.md
@@ -75,7 +75,8 @@ Please note that for the coverage and trx report, you need to install [additiona
         XML code coverage settings
 
     --disable-logo
-        Disables the TUnit logo when starting a test session
+        Disables the TUnit logo when starting a test session.
+        Can also be set via TUNIT_DISABLE_LOGO environment variable.
 
     --fail-fast
         Cancel the test run after the first test failure

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -1,0 +1,198 @@
+# Environment Variables
+
+TUnit supports configuration through environment variables, allowing you to set defaults without modifying command-line arguments. This is particularly useful for CI/CD pipelines and development environments.
+
+## TUnit-Specific Environment Variables
+
+### TUNIT_DISABLE_LOGO
+
+Disables the TUnit ASCII art logo when starting a test session.
+
+```bash
+# Bash/Linux/macOS
+export TUNIT_DISABLE_LOGO=true
+
+# PowerShell
+$env:TUNIT_DISABLE_LOGO = "true"
+
+# Windows Command Prompt
+set TUNIT_DISABLE_LOGO=true
+```
+
+**Equivalent to:** `--disable-logo`
+
+**Use case:** Reduces output noise in CI/CD logs or when using AI/LLM coding assistants that parse test output.
+
+### TUNIT_DISABLE_GITHUB_REPORTER
+
+Disables the automatic GitHub Actions test summary reporter.
+
+```bash
+export TUNIT_DISABLE_GITHUB_REPORTER=true
+```
+
+**Use case:** When you want to use a custom reporting solution instead of the built-in GitHub Actions integration.
+
+### TUNIT_GITHUB_REPORTER_STYLE
+
+Controls the style of the GitHub Actions test reporter output.
+
+```bash
+export TUNIT_GITHUB_REPORTER_STYLE=collapsible  # default
+export TUNIT_GITHUB_REPORTER_STYLE=full
+```
+
+**Values:**
+- `collapsible` (default): Wraps detailed test results in expandable HTML blocks
+- `full`: Displays all test details directly
+
+**Equivalent to:** `--github-reporter-style`
+
+### TUNIT_DISABLE_JUNIT_REPORTER
+
+Disables the JUnit XML reporter.
+
+```bash
+export TUNIT_DISABLE_JUNIT_REPORTER=true
+```
+
+### TUNIT_ENABLE_JUNIT_REPORTER
+
+Explicitly enables the JUnit XML reporter.
+
+```bash
+export TUNIT_ENABLE_JUNIT_REPORTER=true
+```
+
+### JUNIT_XML_OUTPUT_PATH
+
+Sets the output path for JUnit XML reports.
+
+```bash
+export JUNIT_XML_OUTPUT_PATH=/path/to/output.xml
+```
+
+### TUNIT_MAX_PARALLEL_TESTS
+
+Sets the maximum number of tests that can run in parallel.
+
+```bash
+export TUNIT_MAX_PARALLEL_TESTS=4    # Limit to 4 concurrent tests
+export TUNIT_MAX_PARALLEL_TESTS=0    # Unlimited parallelism
+```
+
+**Equivalent to:** `--maximum-parallel-tests`
+
+**Note:** Command-line arguments take precedence over environment variables.
+
+## Microsoft Testing Platform Environment Variables
+
+These environment variables are provided by the underlying Microsoft Testing Platform:
+
+### TESTINGPLATFORM_TELEMETRY_OPTOUT
+
+Disables telemetry collection.
+
+```bash
+export TESTINGPLATFORM_TELEMETRY_OPTOUT=1
+```
+
+### TESTINGPLATFORM_UI_LANGUAGE
+
+Sets the language for platform messages and logs.
+
+```bash
+export TESTINGPLATFORM_UI_LANGUAGE=en-us
+```
+
+## Platform-Level Flags
+
+Some command-line flags are handled by the Microsoft Testing Platform rather than TUnit directly. These flags currently do not have environment variable equivalents:
+
+- `--no-progress` - Disables progress reporting to screen
+- `--no-ansi` - Disables ANSI escape characters
+
+### Workarounds for --no-progress
+
+While there's no environment variable for `--no-progress`, you can use these alternatives:
+
+**1. MSBuild Property (with `dotnet test`):**
+
+```xml
+<PropertyGroup>
+  <TestingPlatformCommandLineArguments>--no-progress</TestingPlatformCommandLineArguments>
+</PropertyGroup>
+```
+
+**2. Shell Wrapper:**
+
+```bash
+#!/bin/bash
+# run-tests.sh
+./MyTestProject.exe --no-progress "$@"
+```
+
+**3. Direct Command Line:**
+
+```bash
+./MyTestProject.exe --no-progress
+```
+
+## CI/CD Examples
+
+### GitHub Actions
+
+```yaml
+- name: Run Tests
+  env:
+    TUNIT_DISABLE_LOGO: true
+    TUNIT_GITHUB_REPORTER_STYLE: collapsible
+  run: dotnet test
+```
+
+### Azure DevOps
+
+```yaml
+- task: DotNetCoreCLI@2
+  env:
+    TUNIT_DISABLE_LOGO: true
+  inputs:
+    command: 'test'
+```
+
+### GitLab CI
+
+```yaml
+test:
+  variables:
+    TUNIT_DISABLE_LOGO: "true"
+  script:
+    - dotnet test
+```
+
+### Docker
+
+```dockerfile
+ENV TUNIT_DISABLE_LOGO=true
+ENV TUNIT_MAX_PARALLEL_TESTS=4
+```
+
+## Priority Order
+
+When the same setting is configured in multiple places, TUnit follows this priority order (highest to lowest):
+
+1. **Command-line arguments** - Always take precedence
+2. **Environment variables** - Applied when command-line argument is not provided
+3. **Configuration files** - Applied as defaults
+
+## Summary Table
+
+| Environment Variable | Equivalent Flag | Description |
+|---------------------|-----------------|-------------|
+| `TUNIT_DISABLE_LOGO` | `--disable-logo` | Disables ASCII art logo |
+| `TUNIT_GITHUB_REPORTER_STYLE` | `--github-reporter-style` | GitHub reporter style |
+| `TUNIT_DISABLE_GITHUB_REPORTER` | - | Disables GitHub reporter |
+| `TUNIT_DISABLE_JUNIT_REPORTER` | - | Disables JUnit reporter |
+| `TUNIT_ENABLE_JUNIT_REPORTER` | - | Enables JUnit reporter |
+| `JUNIT_XML_OUTPUT_PATH` | - | JUnit output path |
+| `TUNIT_MAX_PARALLEL_TESTS` | `--maximum-parallel-tests` | Max parallel tests |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -279,6 +279,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'reference/command-line-flags',
+        'reference/environment-variables',
         'reference/test-configuration',
         'comparison/attributes',
       ],


### PR DESCRIPTION
## Summary

- Adds `TUNIT_DISABLE_LOGO` environment variable support to disable the ASCII art logo
- Updates command-line flags documentation to mention the new environment variable
- Adds comprehensive environment variables reference documentation

Closes #4574

## Changes

- **TUnit.Engine/Capabilities/BannerCapability.cs**: Check for `TUNIT_DISABLE_LOGO` environment variable alongside the `--disable-logo` command-line flag
- **docs/docs/reference/command-line-flags.md**: Note that `--disable-logo` can also be set via environment variable
- **docs/docs/reference/environment-variables.md**: New comprehensive documentation covering all TUnit environment variables
- **docs/sidebars.ts**: Add environment variables doc to sidebar

## Test plan

- [ ] Verify `TUNIT_DISABLE_LOGO=true` suppresses the ASCII logo
- [ ] Verify `--disable-logo` still works as before
- [ ] Verify command-line flag takes precedence over environment variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)