### PR TITLE
docs: fix incorrect OR operator syntax in test-filters documentation

### DIFF
--- a/docs/docs/execution/test-filters.md
+++ b/docs/docs/execution/test-filters.md
@@ -23,7 +23,7 @@ TUnit supports several operators for building complex filters:
 - **Equality:** Use `=` for exact match (e.g., `[Category=Unit]`)
 - **Negation:** Use `!=` for excluding values (e.g., `[Category!=Performance]`)
 - **AND operator:** Use `&` to combine conditions (e.g., `[Category=Unit]&[Priority=High]`)
-- **OR operator:** Use `|` to match either condition - requires parentheses (e.g., `(/*/*/Class1/*)|(/*/*/Class2/*)`)
+- **OR operator:** Use `|` to match either condition within a single path segment - requires parentheses (e.g., `/*/*/(Class1)|(Class2)/*`)
 
 For full information on the treenode filters, see [Microsoft's documentation](https://github.com/microsoft/testfx/blob/main/docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md)
 


### PR DESCRIPTION
## Summary

The documentation showed an invalid OR operator syntax that causes errors with Microsoft.Testing.Platform's TreeNodeFilter.

**Invalid syntax (old):**
```
(/*/*/Class1/*)|(/*/*/Class2/*)
```

This throws: `A filter '/.*/.*/Class1/.*' should not contain a '/' character`

**Valid syntax (new):**
```
/*/*/(Class1)|(Class2)/*
```

### Root Cause

Microsoft.Testing.Platform's TreeNodeFilter validates that expressions being combined with operators (`|`, `&`) cannot contain the `/` path separator character. OR operations must occur **within a single path segment**, not across full paths.

From the [TreeNodeFilter source](https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs):
```csharp
case ValueExpression vExpr when vExpr.Value.Contains(PathSeparator):
    throw new ArgumentException(...);
```

## Test plan

- [ ] Verify documentation renders correctly
- [ ] Test that the new example syntax works: `dotnet run -- --treenode-filter "/*/*/(Class1)|(Class2)/*"`