### PR TITLE
Fix matrix example syntax in troubleshooting docs

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1939,16 +1939,19 @@ public static IEnumerable<User> GetUsers()
 ```csharp
 // ❌ Explosive combination
 [Test]
-[Arguments(1, 2, 3, 4, 5)]
-[Arguments("a", "b", "c", "d", "e")]
-[Arguments(true, false)]
+[MatrixDataSource]
+public void Test(
+    [Matrix(1, 2, 3, 4, 5)] int x,
+    [Matrix("a", "b", "c", "d", "e")] string y,
+    [Matrix(true, false)] bool z)
 // Creates 5 × 5 × 2 = 50 combinations!
 
-// ✅ Use specific combinations
+// ✅ Use specific combinations instead
 [Test]
 [Arguments(1, "a", true)]
 [Arguments(2, "b", false)]
 [Arguments(3, "c", true)]
+public void Test(int x, string y, bool z)
 // Only 3 specific test cases
 ```
 


### PR DESCRIPTION
Fixes the matrix test explosion example to use the actual `[MatrixDataSource]` and `[Matrix]` syntax instead of `[Arguments]`.

Closes #4590

🤖 Generated with [Claude Code](https://claude.ai/code)