### PR TITLE
feat: reorder After(TestDiscovery) hooks to run before event receivers

### DIFF
--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -957,10 +957,13 @@ internal sealed class TestBuilder : ITestBuilder
         TestContext.Current = context;
 
         // Populate TestContext._dependencies from resolved test.Dependencies
-        // This makes dependencies available to ITestRegisteredEventReceiver
+        // This makes dependencies available to event receivers
         PopulateDependencies(test, context._dependencies);
 
-        // Invoke test registered event receivers
+        // Invoke discovery event receivers first (discovery phase)
+        await InvokeDiscoveryEventReceiversAsync(context);
+
+        // Invoke test registered event receivers (registration phase)
         try
         {
             await InvokeTestRegisteredReceiversAsync(context);
@@ -971,10 +974,7 @@ internal sealed class TestBuilder : ITestBuilder
             test.SetResult(TestState.Failed, ex);
         }
 
-        // Invoke discovery event receivers
-        await InvokeDiscoveryEventReceiversAsync(context);
-
-        // Clear the cached display name after discovery events
+        // Clear the cached display name after registration events
         // This ensures that ArgumentDisplayFormatterAttribute and similar attributes
         // have a chance to register their formatters before the display name is finalized
         context.InvalidateDisplayNameCache();


### PR DESCRIPTION
## Summary

- Moves `After(TestDiscovery)` hooks to run after dependency resolution but before `ITestRegisteredEventReceiver` and `ITestDiscoveryEventReceiver` are invoked
- Reorders `ITestDiscoveryEventReceiver` to fire before `ITestRegisteredEventReceiver` for semantic clarity
- Adds the missing `ExecuteAfterTestDiscoveryHooksAsync` call to `DiscoverTestsFullyStreamingAsync`

This allows `After(TestDiscovery)` hooks to set up state that event receivers can use during the registration phase.

### New execution order:
1. `Before(TestDiscovery)` hooks
2. Test discovery & building
3. Dependency resolution
4. `After(TestDiscovery)` hooks (discovery phase complete)
5. `ITestDiscoveryEventReceiver.OnTestDiscovered()`
6. `ITestRegisteredEventReceiver.OnTestRegistered()` (registration phase)

## Test plan

- [x] Verified `DependenciesAvailableInEventReceiverTests` pass
- [x] Verified `TransitiveDependenciesInEventReceiverTests` pass
- [x] Verified `CrossClassDependenciesInEventReceiverTests` pass
- [x] Build succeeds with no errors