### PR TITLE
fix: session hooks in referenced library projects not executing

### DIFF
--- a/TUnit.TestProject.Library/Hooks.cs
+++ b/TUnit.TestProject.Library/Hooks.cs
@@ -14,3 +14,28 @@ public class Hooks
         testContext.StateBag.Items["AfterHit"] = true;
     }
 }
+
+/// <summary>
+/// Test session hook in a library project.
+/// This tests the fix for https://github.com/thomhurst/TUnit/issues/4583
+/// where hooks in referenced library projects don't execute.
+/// </summary>
+public static class LibraryTestSessionHooks
+{
+    public static bool BeforeTestSessionWasExecuted { get; private set; }
+    public static bool AfterTestSessionWasExecuted { get; private set; }
+
+    [Before(TestSession)]
+    public static Task BeforeTestSession()
+    {
+        BeforeTestSessionWasExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    [After(TestSession)]
+    public static Task AfterTestSession()
+    {
+        AfterTestSessionWasExecuted = true;
+        return Task.CompletedTask;
+    }
+}

--- a/TUnit.TestProject/Bugs/Issue4583/LibraryTestSessionHookTests.cs
+++ b/TUnit.TestProject/Bugs/Issue4583/LibraryTestSessionHookTests.cs
@@ -1,0 +1,20 @@
+using TUnit.TestProject.Attributes;
+using TUnit.TestProject.Library;
+
+namespace TUnit.TestProject.Bugs.Issue4583;
+
+/// <summary>
+/// Reproduction test for https://github.com/thomhurst/TUnit/issues/4583
+/// Tests that [Before(TestSession)] hooks in REFERENCED LIBRARY projects are executed.
+/// This is different from issue #4541 which tested hooks in the same project.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class LibraryTestSessionHookTests
+{
+    [Test]
+    public async Task Verify_TestSession_Hook_In_Referenced_Library_Executed()
+    {
+        await Assert.That(LibraryTestSessionHooks.BeforeTestSessionWasExecuted).IsTrue()
+            .Because("[Before(TestSession)] hook in referenced library project should have executed");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4583 - `[Before(TestSession)]` and `[After(TestSession)]` hooks defined in referenced library projects were not executing.

## Problem

The `InfrastructureGenerator` generates code to load referenced assemblies early (to trigger their module initializers which register hooks). However, the `HasPhysicalLocation` check was too restrictive:

```csharp
return correspondingReference is PortableExecutableReference { FilePath: not null and not "" };
```

This only accepted `PortableExecutableReference` objects. During IDE design-time builds, project-to-project references are represented as `CompilationReference` objects. The incremental generator may cache results from these builds, resulting in missing `Assembly.Load()` calls for library projects.

## Solution

- Renamed `HasPhysicalLocation` to `IsLoadableAtRuntime` to better reflect its purpose
- Simplified the logic to accept any assembly with a corresponding reference in the compilation
- Any referenced assembly will be available at runtime (either as a compiled DLL or NuGet package)

## Test Plan

- [x] Added `LibraryTestSessionHooks` class to `TUnit.TestProject.Library` with `[Before(TestSession)]` and `[After(TestSession)]` hooks
- [x] Added `LibraryTestSessionHookTests` in `TUnit.TestProject` to verify the library's hooks execute
- [x] Verified test passes with `dotnet run -- --treenode-filter "/*/*/LibraryTestSessionHookTests/*"`