### PR TITLE
perf: cache `GetAttributeObjectInitializer`

### DIFF
--- a/TUnit.Core.SourceGenerator/Models/TestMethodMetadata.cs
+++ b/TUnit.Core.SourceGenerator/Models/TestMethodMetadata.cs
@@ -1,8 +1,12 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using TUnit.Core.SourceGenerator.CodeGenerators.Writers;
 
 namespace TUnit.Core.SourceGenerator.Models;
+
+public record CompilationContext(CSharpCompilation Compilation, AttributeWriter AttributeWriter);
 
 /// <summary>
 /// Contains all the metadata about a test method discovered by the source generator.
@@ -15,6 +19,7 @@ public class TestMethodMetadata : IEquatable<TestMethodMetadata>
     public required int LineNumber { get; init; }
     public required AttributeData TestAttribute { get; init; }
     public GeneratorAttributeSyntaxContext? Context { get; init; }
+    public required CompilationContext CompilationContext { get; init; }
     public required MethodDeclarationSyntax? MethodSyntax { get; init; }
     public bool IsGenericType { get; init; }
     public bool IsGenericMethod { get; init; }
@@ -23,7 +28,7 @@ public class TestMethodMetadata : IEquatable<TestMethodMetadata>
     /// All attributes on the method, stored for later use during data combination generation
     /// </summary>
     public ImmutableArray<AttributeData> MethodAttributes { get; init; } = ImmutableArray<AttributeData>.Empty;
-    
+
     /// <summary>
     /// The inheritance depth of this test method.
     /// 0 = method is declared directly in the test class


### PR DESCRIPTION
Use `ConditionalWeakTable` to cache `GetAttributeObjectInitializer`. `ConditionalWeakTable` uses `Object.ReferenceEquals` for equality and does not count as a reference to the `AttributeData`, therefore it won't keep the object or attached compilation alive after it becomes stale.

<img width="879" height="444" alt="image" src="https://github.com/user-attachments/assets/563035ee-62d9-47e8-880a-be085c01de34" />


- On a related note, I'm pretty sure `InterfaceCache` should be causing a memory leak by keeping most stale `Compilation` objects alive. I have no idea why this hasn't become an issue.

- Note that the benchmarks aren't completely accurate for real world scenarios. While `GetAttributeObjectInitializer` is slow, I suspect the main issue is each method in `TUnit.TestProject` has at least 8 identical licensing attributes, making this a slightly misleading benchmark

### Before


| Method  | Mean     | Error    | StdDev   | Gen0       | Gen1      | Allocated |
|-------- |---------:|---------:|---------:|-----------:|----------:|----------:|
| Compile | 499.5 ms | 19.50 ms | 57.48 ms | 18000.0000 | 4000.0000 | 165.61 MB |


### After
| Method  | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|-------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| Compile | 174.6 ms | 6.29 ms | 17.96 ms | 166.6 ms | 10000.0000 | 3000.0000 |  96.14 MB |


#### Attribute bloat
<img width="1283" height="654" alt="image" src="https://github.com/user-attachments/assets/6cb1b19d-e5cc-48c0-b629-559baa089ffe" />
