### PR TITLE
fix: TUnit0059 false positive when no subclasses exist in assembly

### DIFF
--- a/TUnit.Analyzers.Tests/AbstractTestClassWithDataSourcesAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/AbstractTestClassWithDataSourcesAnalyzerTests.cs
@@ -65,15 +65,17 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
     }
 
     [Test]
-    public async Task Warning_For_Abstract_Class_With_MethodDataSource()
+    public async Task No_Warning_For_Abstract_Class_With_MethodDataSource_When_No_Subclasses()
     {
+        // No warning when there are no subclasses - the abstract class may be in a library
+        // meant to be subclassed by consuming assemblies
         await Verifier
             .VerifyAnalyzerAsync(
                 """
                 using TUnit.Core;
                 using System.Collections.Generic;
 
-                public abstract class {|#0:AbstractTestBase|}
+                public abstract class AbstractTestBase
                 {
                     public static IEnumerable<int> TestData() => new[] { 1, 2, 3 };
 
@@ -83,24 +85,22 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
                     {
                     }
                 }
-                """,
-
-                Verifier.Diagnostic(Rules.AbstractTestClassWithDataSources)
-                    .WithLocation(0)
-                    .WithArguments("AbstractTestBase")
+                """
             );
     }
 
     [Test]
-    public async Task Warning_For_Abstract_Class_With_InstanceMethodDataSource()
+    public async Task No_Warning_For_Abstract_Class_With_InstanceMethodDataSource_When_No_Subclasses()
     {
+        // No warning when there are no subclasses - the abstract class may be in a library
+        // meant to be subclassed by consuming assemblies
         await Verifier
             .VerifyAnalyzerAsync(
                 """
                 using TUnit.Core;
                 using System.Collections.Generic;
 
-                public abstract class {|#0:ServiceCollectionTest|}
+                public abstract class ServiceCollectionTest
                 {
                     public IEnumerable<int> SingletonServices() => new[] { 1, 2, 3 };
 
@@ -110,23 +110,21 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
                     {
                     }
                 }
-                """,
-
-                Verifier.Diagnostic(Rules.AbstractTestClassWithDataSources)
-                    .WithLocation(0)
-                    .WithArguments("ServiceCollectionTest")
+                """
             );
     }
 
     [Test]
-    public async Task Warning_For_Abstract_Class_With_Arguments()
+    public async Task No_Warning_For_Abstract_Class_With_Arguments_When_No_Subclasses()
     {
+        // No warning when there are no subclasses - the abstract class may be in a library
+        // meant to be subclassed by consuming assemblies
         await Verifier
             .VerifyAnalyzerAsync(
                 """
                 using TUnit.Core;
 
-                public abstract class {|#0:AbstractTestBase|}
+                public abstract class AbstractTestBase
                 {
                     [Test]
                     [Arguments(1)]
@@ -135,17 +133,15 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
                     {
                     }
                 }
-                """,
-
-                Verifier.Diagnostic(Rules.AbstractTestClassWithDataSources)
-                    .WithLocation(0)
-                    .WithArguments("AbstractTestBase")
+                """
             );
     }
 
     [Test]
-    public async Task Warning_For_Abstract_Class_With_ClassDataSource()
+    public async Task No_Warning_For_Abstract_Class_With_ClassDataSource_When_No_Subclasses()
     {
+        // No warning when there are no subclasses - the abstract class may be in a library
+        // meant to be subclassed by consuming assemblies
         await Verifier
             .VerifyAnalyzerAsync(
                 """
@@ -155,7 +151,7 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
                 {
                 }
 
-                public abstract class {|#0:AbstractTestBase|}
+                public abstract class AbstractTestBase
                 {
                     [Test]
                     [ClassDataSource<TestData>]
@@ -163,11 +159,7 @@ public class AbstractTestClassWithDataSourcesAnalyzerTests
                     {
                     }
                 }
-                """,
-
-                Verifier.Diagnostic(Rules.AbstractTestClassWithDataSources)
-                    .WithLocation(0)
-                    .WithArguments("AbstractTestBase")
+                """
             );
     }
 


### PR DESCRIPTION
## Summary

- Fix false positive TUnit0059 warning when an abstract test class with data sources has no concrete subclasses in the same assembly
- This supports the "testing library" pattern where abstract test classes are defined in a library meant to be subclassed by consuming assemblies

## Changes

- Modified `AbstractTestClassWithDataSourcesAnalyzer` to track whether any concrete subclasses exist
- Added filter to only consider source-defined types (not from referenced assemblies)
- Updated diagnostic logic to only warn when there ARE concrete subclasses that are missing `[InheritsTests]`
- Updated tests to reflect the new expected behavior

## Behavior

| Scenario | Old Behavior | New Behavior |
|----------|--------------|--------------|
| Abstract class with no subclasses | ⚠️ Warning | ✅ No warning |
| Abstract class with subclass missing `[InheritsTests]` | ⚠️ Warning | ⚠️ Warning |
| Abstract class with subclass having `[InheritsTests]` | ✅ No warning | ✅ No warning |

Fixes #4607

## Test plan

- [x] Updated existing analyzer tests
- [x] All `AbstractTestClassWithDataSourcesAnalyzerTests` pass