### PR TITLE
fix: correct usage of multiple assertions

### DIFF
--- a/docs/docs/assertions/boolean.md
+++ b/docs/docs/assertions/boolean.md
@@ -248,7 +248,7 @@ public async Task Complex_Expression_Broken_Down()
 {
     var user = GetUser();
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         await Assert.That(user.IsActive).IsTrue();
         await Assert.That(user.IsBanned).IsFalse();
@@ -445,7 +445,7 @@ public async Task Multiple_Validations()
         Age = 25
     };
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         await Assert.That(form.IsEmailValid()).IsTrue();
         await Assert.That(form.IsPasswordStrong()).IsTrue();

--- a/docs/docs/assertions/collections.md
+++ b/docs/docs/assertions/collections.md
@@ -893,7 +893,7 @@ public async Task Validate_Each_Item()
 {
     var users = GetUsers();
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         foreach (var user in users)
         {

--- a/docs/docs/assertions/dictionaries.md
+++ b/docs/docs/assertions/dictionaries.md
@@ -182,7 +182,7 @@ public async Task Configuration_Has_Required_Keys()
 {
     var config = LoadConfiguration();
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         await Assert.That(config).ContainsKey("DatabaseConnection");
         await Assert.That(config).ContainsKey("ApiKey");
@@ -492,7 +492,7 @@ public async Task All_Required_Keys_Present_Multiple()
     var config = LoadConfiguration();
     var requiredKeys = new[] { "ApiKey", "Database", "Environment" };
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         foreach (var key in requiredKeys)
         {

--- a/docs/docs/assertions/exceptions.md
+++ b/docs/docs/assertions/exceptions.md
@@ -422,7 +422,7 @@ public async Task Custom_Exception_With_Properties()
 [Test]
 public async Task Multiple_Exception_Scenarios()
 {
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         await Assert.That(() => int.Parse("abc"))
             .Throws<FormatException>();

--- a/docs/docs/assertions/getting-started.md
+++ b/docs/docs/assertions/getting-started.md
@@ -117,7 +117,7 @@ await Assert.That(statusCode)
 Group related assertions together so all failures are reported:
 
 ```csharp
-await using (Assert.Multiple())
+using (Assert.Multiple())
 {
     await Assert.That(user.FirstName).IsEqualTo("John");
     await Assert.That(user.LastName).IsEqualTo("Doe");
@@ -364,7 +364,7 @@ await Assert.That(user.Age).IsGreaterThan(18);
   <TabItem value="good" label="✅ Good - Assert.Multiple">
 
 ```csharp
-await using (Assert.Multiple())
+using (Assert.Multiple())
 {
     await Assert.That(user.FirstName).IsEqualTo("John");
     await Assert.That(user.LastName).IsEqualTo("Doe");

--- a/docs/docs/assertions/null-and-default.md
+++ b/docs/docs/assertions/null-and-default.md
@@ -269,7 +269,7 @@ public async Task Validate_All_Required_Fields()
 {
     var user = CreateUser();
 
-    await using (Assert.Multiple())
+    using (Assert.Multiple())
     {
         await Assert.That(user).IsNotNull();
         await Assert.That(user.FirstName).IsNotNull();


### PR DESCRIPTION
## Description

See https://github.com/thomhurst/TUnit/issues/4584#issuecomment-3820148667

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [ ] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [ ] All existing tests pass (`dotnet test`)
- [ ] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
