### PR TITLE
docs: fix FsCheck custom generators example for FsCheck 3.x API

### DIFF
--- a/TUnit.Example.FsCheck.TestProject/PropertyTests.cs
+++ b/TUnit.Example.FsCheck.TestProject/PropertyTests.cs
@@ -4,6 +4,19 @@ using TUnit.FsCheck;
 
 namespace TUnit.Example.FsCheck.TestProject;
 
+/// <summary>
+/// Custom arbitrary that generates positive integers only.
+/// </summary>
+public class PositiveIntArbitrary
+{
+    public static Arbitrary<int> PositiveInt()
+    {
+        return ArbMap.Default.GeneratorFor<int>()
+            .Where(x => x > 0)
+            .ToArbitrary();
+    }
+}
+
 public class PropertyTests
 {
     [Test, FsCheckProperty]
@@ -88,4 +101,9 @@ public class PropertyTests
         });
     }
 
+    [Test, FsCheckProperty(Arbitrary = new[] { typeof(PositiveIntArbitrary) })]
+    public bool PositiveNumbersArePositive(int value)
+    {
+        return value > 0;
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed the FsCheck custom generators documentation example which used the deprecated FsCheck 2.x API (`Arb.Default.Int32().Filter()`)
- Updated to use the correct FsCheck 3.x Fluent API with `ArbMap.Default.GeneratorFor<T>()`
- Added alternative examples and test coverage

## Problem
The documentation example at https://tunit.dev/docs/examples/fscheck/#custom-generators didn't compile because `Arb.Default` is internal in FsCheck 3.x (the version used by TUnit.FsCheck).

## Changes
- Use `ArbMap.Default.GeneratorFor<T>()` instead of `Arb.Default`
- Use `.Where()` for filtering and `.ToArbitrary()` to convert generators
- Added alternative example using `Gen.Choose` for simple ranges
- Added custom types example showing LINQ composition
- Added test coverage in `TUnit.Example.FsCheck.TestProject` to verify the documented pattern works

## Test plan
- [x] Build succeeded
- [x] New `PositiveNumbersArePositive` test passes with custom arbitrary

Fixes #4619