### PR TITLE
perf: use `WellKnownTypes` in `AttributeWriter`

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -31,10 +31,14 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         var compilationContext = context
             .CompilationProvider
             .Select(static (c, _) =>
-                new CompilationContext(
+            {
+                var wellKnownTypes = new WellKnownTypes(c);
+                return new CompilationContext(
                     (CSharpCompilation)c,
-                    new AttributeWriter(c)
-                    ));
+                    new AttributeWriter(c, wellKnownTypes),
+                    wellKnownTypes
+                );
+            });
 
         var testMethodsProvider = context.SyntaxProvider
             .ForAttributeWithMetadataName(

--- a/TUnit.Core.SourceGenerator/Helpers/WellKnownTypes.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/WellKnownTypes.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace TUnit.Core.SourceGenerator.Helpers;
+
+public class WellKnownTypes(Compilation compilation)
+{
+    private readonly Dictionary<string, INamedTypeSymbol?> _cachedTypes = new();
+    private readonly Dictionary<INamedTypeSymbol, string> _cachedToDisplayString = new(SymbolEqualityComparer.Default);
+
+    public string GetDisplayString(INamedTypeSymbol type)
+    {
+        if (_cachedToDisplayString.TryGetValue(type, out var displayString))
+        {
+            return displayString;
+        }
+
+        displayString = type.ToDisplayString();
+        _cachedToDisplayString.Add(type, displayString);
+
+        return displayString;
+    }
+
+    public INamedTypeSymbol Get<T>() => Get(typeof(T));
+
+    public INamedTypeSymbol Get(Type type)
+    {
+        if (type.IsConstructedGenericType)
+        {
+            type = type.GetGenericTypeDefinition();
+        }
+
+        return Get(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type));
+    }
+
+    public INamedTypeSymbol? TryGet(string typeFullName)
+    {
+        if (_cachedTypes.TryGetValue(typeFullName, out var typeSymbol))
+        {
+            return typeSymbol;
+        }
+
+        typeSymbol = compilation.GetTypeByMetadataName(typeFullName);
+        _cachedTypes.Add(typeFullName, typeSymbol);
+
+        return typeSymbol;
+    }
+
+    private INamedTypeSymbol Get(string typeFullName) =>
+        TryGet(typeFullName) ?? throw new InvalidOperationException("Could not get type " + typeFullName);
+}

--- a/TUnit.Core.SourceGenerator/Models/TestMethodMetadata.cs
+++ b/TUnit.Core.SourceGenerator/Models/TestMethodMetadata.cs
@@ -3,10 +3,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TUnit.Core.SourceGenerator.CodeGenerators.Writers;
+using TUnit.Core.SourceGenerator.Helpers;
 
 namespace TUnit.Core.SourceGenerator.Models;
 
-public record CompilationContext(CSharpCompilation Compilation, AttributeWriter AttributeWriter);
+public record CompilationContext(CSharpCompilation Compilation, AttributeWriter AttributeWriter, WellKnownTypes WellKnownTypes);
 
 /// <summary>
 /// Contains all the metadata about a test method discovered by the source generator.


### PR DESCRIPTION
Use `WellKnownTypes` to cache `ToDisplayName` and `GetTypeByMetadataName` calls in `AttributeWriter`





### Before
| Method  | Mean     | Error    | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|-------- |---------:|---------:|---------:|---------:|-----------:|----------:|----------:|
| Compile | 225.6 ms | 10.50 ms | 29.45 ms | 210.0 ms | 11000.0000 | 4000.0000 | 104.79 MB |



### After

| Method  | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|-------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| Compile | 201.8 ms | 8.24 ms | 22.97 ms | 191.4 ms | 10000.0000 | 4000.0000 |  99.34 MB |
