### PR TITLE
feat: make `AotConverterGenerator` incremental and optimise

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
@@ -673,9 +673,9 @@ public class AotConverterGenerator : IIncrementalGenerator
         return new TypeMetadata(globallyQualified, type.ToDisplayString(), patternTypeName);
     }
 
-    private record TypeMetadata(string GloballyQualified, string DisplayString, string PatternTypeName);
+    public record TypeMetadata(string GloballyQualified, string DisplayString, string PatternTypeName);
 
-    private record ConversionMetadata
+    public record ConversionMetadata
     {
         public required TypeMetadata SourceType { get; init; }
         public required TypeMetadata TargetType { get; init; }

--- a/TUnit.SourceGenerator.IncrementalTests/AotConverterGeneratorIncrementalTests.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/AotConverterGeneratorIncrementalTests.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.Generators;
+using TUnit.Core.SourceGenerator.Models;
+
+namespace TUnit.Assertions.SourceGenerator.IncrementalTests;
+
+public class AotConverterGeneratorIncrementalTests
+{
+    private const string DefaultConverter =
+        """
+        using global::TUnit.Core;
+
+        #nullable enabled
+        public record Foo
+        {
+            public static implicit operator Foo((int Value1, int Value2) tuple) => new();
+        }
+
+        public class Tests
+        {
+            [Test]
+            [MethodDataSource(nameof(Data))]
+            public void Test1(Foo data)
+            {
+            }
+
+            public static IEnumerable<Foo> Data() => [new()];
+        }
+        """;
+
+    private const string SecondConverter =
+        """
+        using global::TUnit.Core;
+
+        #nullable enabled
+        public record FooBar
+        {
+            public static implicit operator FooBar((int Value1, int Value2) tuple) => new();
+        }
+
+        public class Tests1
+        {
+            [Test]
+            [MethodDataSource(nameof(Data))]
+            public void Test1(FooBar data)
+            {
+            }
+
+            public static IEnumerable<FooBar> Data() => [new()];
+        }
+        """;
+
+    [Fact]
+    public void AddUnrelatedType_MethodShouldNotRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultConverter, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<AotConverterGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New, 1);
+
+        var compilation2 = compilation1.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct MyValue {}"));
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Cached, 1);
+    }
+
+    [Fact]
+    public void AddNewConverterShouldRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultConverter, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<AotConverterGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New, 1);
+
+        var compilation2 = compilation1.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SecondConverter));
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Modified, 2);
+    }
+
+    [Fact]
+    public void ModifyOperatorShouldRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultConverter, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<AotConverterGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New, 1);
+
+        var compilation2 = TestHelper.ReplaceTypeDeclaration(compilation1, "Foo",
+            """
+            public record Foo
+            {
+                public static explicit operator Foo((int Value1, int Value2) tuple) => new();
+            }
+            """
+            );
+
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Modified, 1);
+    }
+
+    private static void AssertRunReasons(
+        GeneratorDriver driver,
+        IncrementalGeneratorRunReasons reasons,
+        int conversionMetadataLength,
+        int outputIndex = 0
+    )
+    {
+        var runResult = driver.GetRunResult().Results[0];
+        var runValue = runResult.TrackedSteps[AotConverterGenerator.ParseAotConverter][0].Outputs[0].Value;
+        var runState = (ValueTuple<EquatableArray<AotConverterGenerator.ConversionMetadata>, bool>)runValue;
+        Assert.That(runState.Item1.Length == conversionMetadataLength);
+
+        TestHelper.AssertRunReason(runResult, AotConverterGenerator.ParseAotConverter, reasons.BuildStep, outputIndex);
+    }
+}

--- a/TUnit.SourceGenerator.IncrementalTests/Fixture.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/Fixture.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using TUnit.Assertions.Attributes;
+using TUnit.Core;
 
 namespace TUnit.Assertions.SourceGenerator.IncrementalTests;
 
@@ -15,6 +16,7 @@ public static class Fixture
         typeof(GenerateAssertionAttribute).Assembly,
         typeof(MulticastDelegate).Assembly,
         typeof(IServiceProvider).Assembly,
+        typeof(TestAttribute).Assembly,
     };
 
     public static Assembly[] AssemblyReferencesForCodegen =>

--- a/TUnit.SourceGenerator.IncrementalTests/TUnit.SourceGenerator.IncrementalTests.csproj
+++ b/TUnit.SourceGenerator.IncrementalTests/TUnit.SourceGenerator.IncrementalTests.csproj
@@ -22,7 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\TUnit.Assertions.SourceGenerator\TUnit.Assertions.SourceGenerator.csproj" />
-      <ProjectReference Include="..\TUnit.Assertions\TUnit.Assertions.csproj" />
+        <ProjectReference Include="..\TUnit.Assertions.SourceGenerator\TUnit.Assertions.SourceGenerator.csproj" />
+        <ProjectReference Include="..\TUnit.Assertions\TUnit.Assertions.csproj" />
+        <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" />
+        <ProjectReference Include="..\TUnit.Core.SourceGenerator.Roslyn47\TUnit.Core.SourceGenerator.Roslyn47.csproj" />
     </ItemGroup>
 </Project>

--- a/TUnit.SourceGenerator.IncrementalTests/TestHelper.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/TestHelper.cs
@@ -23,9 +23,9 @@ internal static class TestHelper
         return driver.RunGenerators(compilation);
     }
 
-    internal static CSharpCompilation ReplaceMemberDeclaration(
+    internal static CSharpCompilation ReplaceTypeDeclaration(
         CSharpCompilation compilation,
-        string memberName,
+        string typeName,
         string newMember
     )
     {
@@ -34,7 +34,7 @@ internal static class TestHelper
             .GetCompilationUnitRoot()
             .DescendantNodes()
             .OfType<TypeDeclarationSyntax>()
-            .Single(x => x.Identifier.Text == memberName);
+            .Single(x => x.Identifier.Text == typeName);
         var updatedMemberDeclaration = SyntaxFactory.ParseMemberDeclaration(newMember)!;
 
         var newRoot = syntaxTree.GetCompilationUnitRoot().ReplaceNode(memberDeclaration, updatedMemberDeclaration);


### PR DESCRIPTION
- Add system to make `AotConverterGenerator` incremental
- Descend root node once instead of descending twice


### Before

| Method       | Mean     | Error    | StdDev  | Gen0       | Gen1      | Allocated |
|------------- |---------:|---------:|--------:|-----------:|----------:|----------:|
| RunGenerator | 576.4 ms | 10.45 ms | 8.72 ms | 11000.0000 | 3000.0000 | 101.98 MB |


### After

| Method       | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|------------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| RunGenerator | 329.8 ms | 5.83 ms | 13.04 ms | 325.1 ms | 11000.0000 | 3000.0000 | 101.19 MB |
