### PR TITLE
perf: make `StaticPropertyInitializationGenerator` incremental

### DIFF
--- a/TUnit.Core.SourceGenerator/Models/PropertyWithDataSource.cs
+++ b/TUnit.Core.SourceGenerator/Models/PropertyWithDataSource.cs
@@ -2,8 +2,22 @@ using Microsoft.CodeAnalysis;
 
 namespace TUnit.Core.SourceGenerator.Models;
 
-public struct PropertyWithDataSource
+public record PropertyWithDataSource
 {
-    public IPropertySymbol Property { get; init; }
-    public AttributeData DataSourceAttribute { get; init; }
+    public required IPropertySymbol Property { get; init; }
+    public required AttributeData DataSourceAttribute { get; init; }
+}
+
+public record PropertyWithDataSourceModel(PropertyType Property, DataSourceAttribute DataSourceAttribute);
+
+public record ContainingType(string GloballyQualified, string Name, string ContainingNamespace, string ContainingAssemblyName);
+
+public record PropertyType(string GloballyQualifiedType, string Name, ContainingType ContainingType);
+
+public abstract record DataSourceAttribute
+{
+    public record ArgumentsDataSource(string? FormattedValue) : DataSourceAttribute;
+    public record MethodDataSource(string? Data) : DataSourceAttribute;
+    public record AsyncDataSource(string GeneratedCode) : DataSourceAttribute;
+    public record Fallback : DataSourceAttribute;
 }

--- a/TUnit.SourceGenerator.IncrementalTests/AotConverterGeneratorIncrementalTests.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/AotConverterGeneratorIncrementalTests.cs
@@ -111,7 +111,7 @@ public class AotConverterGeneratorIncrementalTests
         var runResult = driver.GetRunResult().Results[0];
         var runValue = runResult.TrackedSteps[AotConverterGenerator.ParseAotConverter][0].Outputs[0].Value;
         var runState = (ValueTuple<EquatableArray<AotConverterGenerator.ConversionMetadata>, bool>)runValue;
-        Assert.That(runState.Item1.Length == conversionMetadataLength);
+        Xunit.Assert.Equal(conversionMetadataLength, runState.Item1.Length);
 
         TestHelper.AssertRunReason(runResult, AotConverterGenerator.ParseAotConverter, reasons.BuildStep, outputIndex);
     }

--- a/TUnit.SourceGenerator.IncrementalTests/StaticPropertyInitializationGeneratorIncrementalTests.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/StaticPropertyInitializationGeneratorIncrementalTests.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.CodeGenerators;
+using TUnit.Core.SourceGenerator.Models;
+
+namespace TUnit.Assertions.SourceGenerator.IncrementalTests;
+
+public class StaticPropertyInitializationGeneratorIncrementalTests
+{
+    private const string DefaultProperties =
+        """
+        #nullable enabled
+        using System.ComponentModel;
+        using TUnit.Assertions.Attributes;
+        using TUnit.Core;
+
+        public class StaticPropertyDataSourceTests
+        {
+            // Static property with Arguments attribute
+            [Arguments("static injected value")]
+            public static string? StaticStringProperty { get; set; }
+
+            // Static property with MethodDataSource
+            [MethodDataSource(nameof(GetStaticTestData))]
+            public static string? StaticDataProperty { get; set; }
+
+            public static IStaticTestDataProvider? StaticDataProviderProperty { get; set; }
+        }
+        """;
+
+    [Fact]
+    public void AddUnrelatedMethodShouldNotRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultProperties, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<StaticPropertyInitializationGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New);
+
+        var compilation2 = compilation1.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct MyValue {}"));
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunParseLength(driver2,2);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Unchanged);
+    }
+
+    [Fact]
+    public void AddClassWithValidPropertyShouldRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultProperties, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<StaticPropertyInitializationGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New);
+
+        var compilation2 = compilation1.AddSyntaxTrees(CSharpSyntaxTree.ParseText(
+            """
+            using TUnit.Assertions.Attributes;
+            using TUnit.Core;
+
+            public class ExtraStaticProperty
+            {
+                // Static property with ClassDataSource
+                [ClassDataSource<StaticTestDataProvider>]
+                public static IStaticTestDataProvider? StaticDataProviderProperty { get; set; }
+            }
+            """));
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunParseLength(driver2,3);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.ModifiedSource);
+    }
+
+    [Fact]
+    public void ModifyPropertyAttributeShouldRegenerate()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(DefaultProperties, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked<StaticPropertyInitializationGenerator>(compilation1);
+        AssertRunReasons(driver1, IncrementalGeneratorRunReasons.New);
+
+        var compilation2 = compilation1.AddSyntaxTrees(CSharpSyntaxTree.ParseText(
+            """
+            using TUnit.Assertions.Attributes;
+            using TUnit.Core;
+
+            public class ExtraStaticProperty
+            {
+                // Static property with ClassDataSource
+                [ClassDataSource<StaticTestDataProvider>]
+                public static IStaticTestDataProvider? StaticDataProviderProperty { get; set; }
+            }
+            """));
+        var driver2 = driver1.RunGenerators(compilation2);
+        AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Modified);
+    }
+
+    private static void AssertRunReasons(
+        GeneratorDriver driver,
+        IncrementalGeneratorRunReasons reasons,
+        int outputIndex = 0
+    )
+    {
+        var runResult = driver.GetRunResult().Results[0];
+        TestHelper.AssertRunReason(runResult, StaticPropertyInitializationGenerator.ParseStaticProperties, reasons.BuildStep, outputIndex);
+    }
+
+    private static void AssertRunParseLength(
+        GeneratorDriver driver,
+        int staticPropertyModelCount
+    )
+    {
+        var runResult = driver.GetRunResult().Results[0];
+        var runValue = runResult.TrackedSteps[StaticPropertyInitializationGenerator.ParseStaticProperties][0].Outputs[0].Value;
+        var runState = (EquatableArray<PropertyWithDataSourceModel>)runValue;
+        Xunit.Assert.Equal(staticPropertyModelCount, runState.Length);
+    }
+}

--- a/TUnit.SourceGenerator.IncrementalTests/TestHelper.cs
+++ b/TUnit.SourceGenerator.IncrementalTests/TestHelper.cs
@@ -85,6 +85,27 @@ internal static class TestHelper
         return compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), newTree);
     }
 
+    internal static CSharpCompilation ReplacePropertyDeclaration(
+        CSharpCompilation compilation,
+        string propertyName,
+        string newDeclaration
+    )
+    {
+        var syntaxTree = compilation.SyntaxTrees.Single();
+
+        var memberDeclaration = syntaxTree
+            .GetCompilationUnitRoot()
+            .DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .First(x => x.Identifier.Text == propertyName);
+        var updatedMemberDeclaration = SyntaxFactory.ParseMemberDeclaration(newDeclaration)!;
+
+        var newRoot = syntaxTree.GetCompilationUnitRoot().ReplaceNode(memberDeclaration, updatedMemberDeclaration);
+        var newTree = syntaxTree.WithRootAndOptions(newRoot, syntaxTree.Options);
+
+        return compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), newTree);
+    }
+
     public static void AssertRunReason(
         GeneratorRunResult runResult,
         string stepName,
@@ -119,6 +140,11 @@ internal record IncrementalGeneratorRunReasons(
     public static readonly IncrementalGeneratorRunReasons Cached = new(
         // compilation step should always be modified as each time a new compilation is passed
         IncrementalStepRunReason.Cached,
+        IncrementalStepRunReason.Cached
+    );
+
+    public static readonly IncrementalGeneratorRunReasons Unchanged = new(
+        IncrementalStepRunReason.Unchanged,
         IncrementalStepRunReason.Cached
     );
 


### PR DESCRIPTION
- Add `PropertyWithDataSourceModel` and associated types
- Return `ImmutableArray<PropertyWithDataSource>` from `GetSemanticTargetForGeneration`
- Move `enabledProvider` check to earlier in pipeline to reduce work
- `ToUniquePropertyModels` ensures that only distinct properties are converter into `PropertyWithDataSourceModel`
- Only call `GetStaticPropertyDataSources` instead of doing a unnecessary call in `GenerateStaticPropertyInitialization`