### PR TITLE
feat: add `StaticPropertyInitializationGeneratorBenchmarks`

### DIFF
--- a/TUnit.SourceGenerator.Benchmarks/Program.cs
+++ b/TUnit.SourceGenerator.Benchmarks/Program.cs
@@ -12,4 +12,5 @@ else
 {
     BenchmarkRunner.Run<TestMetadataGeneratorBenchmarks>();
     // BenchmarkRunner.Run<AotConverterGeneratorBenchmarks>();
+    // BenchmarkRunner.Run<StaticPropertyInitializationGeneratorBenchmarks>();
 }

--- a/TUnit.SourceGenerator.Benchmarks/StaticPropertyInitializationGeneratorBenchmarks.cs
+++ b/TUnit.SourceGenerator.Benchmarks/StaticPropertyInitializationGeneratorBenchmarks.cs
@@ -1,0 +1,33 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using TUnit.Core.SourceGenerator.CodeGenerators;
+
+namespace TUnit.SourceGenerator.Benchmarks;
+
+[MemoryDiagnoser]
+[InProcess]
+public class StaticPropertyInitializationGeneratorBenchmarks
+{
+    private const string SampleProjectPath = "../TUnit.TestProject/TUnit.TestProject.csproj";
+
+    private MSBuildWorkspace? _workspace;
+    private GeneratorDriver? _sampleDriver;
+    private Compilation? _sampleCompilation;
+
+    [GlobalSetup(Target = nameof(RunGenerator))]
+    public void SetupRunGenerator() =>
+        (_sampleCompilation, _sampleDriver, _workspace) =
+        WorkspaceHelper.SetupAsync<StaticPropertyInitializationGenerator>(SampleProjectPath)
+            .GetAwaiter()
+            .GetResult();
+
+    [Benchmark]
+    public GeneratorDriver RunGenerator() => _sampleDriver!.RunGeneratorsAndUpdateCompilation(_sampleCompilation!, out _, out _);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _workspace?.Dispose();
+    }
+}


### PR DESCRIPTION
Add `StaticPropertyInitializationGeneratorBenchmarks`

| Method       | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|------------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| RunGenerator | 183.7 ms | 6.12 ms | 16.66 ms | 176.5 ms | 10000.0000 | 4000.0000 |  99.35 MB |



