### PR TITLE
fix: source generator benchmarks were running other generators

### DIFF
--- a/TUnit.SourceGenerator.Benchmarks/WorkspaceHelper.cs
+++ b/TUnit.SourceGenerator.Benchmarks/WorkspaceHelper.cs
@@ -34,6 +34,7 @@ public static class WorkspaceHelper
         {
             ConsoleLogger.Default.WriteLine("Loading project\n");
             project = await workspace.OpenProjectAsync(projectFile);
+            project = project.WithAnalyzerReferences([]);
             ConsoleLogger.Default.WriteLine("\nLoaded project");
         }
         catch (Exception ex)


### PR DESCRIPTION
Looks like when I'd run one benchmark it would run other source generators, giving a misleading time. For instance trying to benchmark `StaticPropertyInitializationGenerator` would also run `TestMetadataGenerator` and vice versa. You can prove this by changing all the predicates to false in `TestMetadataGenerator`, low and behold `StaticPropertyInitializationGenerator` would suddenly run much faster.

Strangely it doesn't happen to all generators, for instance `InfrastructureGenerator` only runs itself when benchmarked, making it harder for me to spot the issue 😠 

Should solve the issue in #4639 / #4624 - I suspect I was consistently getting a faster time on the benchmarks because I was experimenting with `TestMetadataGenerator`, not expecting it to affect an unrelated source generator



### StaticPropertyInitializationGenerator
| Method       | Mean     | Error    | StdDev   | Gen0     | Gen1     | Allocated |
|------------- |---------:|---------:|---------:|---------:|---------:|----------:|
| RunGenerator | 28.43 ms | 0.542 ms | 1.201 ms | 666.6667 | 333.3333 |      8 MB |


### TestMetadataGenerator
| Method       | Mean     | Error    | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|------------- |---------:|---------:|---------:|---------:|-----------:|----------:|----------:|
| RunGenerator | 201.6 ms | 12.64 ms | 36.28 ms | 191.5 ms | 10000.0000 | 4000.0000 |  97.07 MB |

### AotConverter
| Method       | Mean     | Error    | StdDev   | Gen0      | Allocated |
|------------- |---------:|---------:|---------:|----------:|----------:|
| RunGenerator | 60.76 ms | 1.212 ms | 2.761 ms | 1000.0000 |   9.29 MB |


