### PR TITLE
feat: confirm `InterfaceCache` memory leak

### DIFF
--- a/TUnit.Core.SourceGenerator/Helpers/InterfaceCache.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/InterfaceCache.cs
@@ -7,9 +7,9 @@ namespace TUnit.Core.SourceGenerator.Helpers;
 /// <summary>
 /// Caches interface implementation checks to avoid repeated AllInterfaces traversals
 /// </summary>
-internal static class InterfaceCache
+public static class InterfaceCache
 {
-    private static readonly ConcurrentDictionary<(ITypeSymbol Type, string InterfaceName), bool> _implementsCache = new(TypeStringTupleComparer.Default);
+    public static readonly ConcurrentDictionary<(ITypeSymbol Type, string InterfaceName), bool> _implementsCache = new(TypeStringTupleComparer.Default);
     private static readonly ConcurrentDictionary<(ITypeSymbol Type, string GenericInterfacePattern), INamedTypeSymbol?> _genericInterfaceCache = new(TypeStringTupleComparer.Default);
 
     /// <summary>

--- a/TUnit.SourceGenerator.Benchmarks/Program.cs
+++ b/TUnit.SourceGenerator.Benchmarks/Program.cs
@@ -10,7 +10,17 @@ if (args is { Length: > 0 })
 }
 else
 {
-    BenchmarkRunner.Run<TestMetadataGeneratorBenchmarks>();
+    var bench  = new TestMetadataGeneratorBenchmarks();
+    bench.SetupRunGenerator();
+    for (int i = 0; i < 100; i++)
+    {
+        bench.RunGenerator();
+        var count = TUnit.Core.SourceGenerator.Helpers.InterfaceCache._implementsCache.Count;
+        Console.WriteLine($"{count} references to stale compilations. Total {GC.GetTotalMemory(true)/1_000_000} MB");
+    }
+
+    bench.Cleanup();
+    // BenchmarkRunner.Run<TestMetadataGeneratorBenchmarks>();
     // BenchmarkRunner.Run<AotConverterGeneratorBenchmarks>();
     // BenchmarkRunner.Run<StaticPropertyInitializationGeneratorBenchmarks>();
 }

--- a/TUnit.SourceGenerator.Benchmarks/TestMetadataGeneratorBenchmarks.cs
+++ b/TUnit.SourceGenerator.Benchmarks/TestMetadataGeneratorBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.MSBuild;
 using TUnit.Core.SourceGenerator.Generators;
 using TUnit.SourceGenerator.Benchmarks;
@@ -23,8 +24,25 @@ public class TestMetadataGeneratorBenchmarks
             .GetAwaiter()
             .GetResult();
 
+    // [IterationSetup(Target = nameof(RunGenerator))]
+    // public void Setup()
+    // {
+    //     _sampleCompilation = _sampleCompilation!.AddSyntaxTrees([CSharpSyntaxTree.ParseText($"struct MyValue{Random.Shared.Next()} {{}}", options: (CSharpParseOptions)_sampleCompilation.SyntaxTrees.First().Options)]);
+    //
+    // }
+
+    // [Benchmark]
+    // public GeneratorDriver RunGenerator() => _sampleDriver!.RunGeneratorsAndUpdateCompilation(_sampleCompilation!, out _, out _);
+
     [Benchmark]
-    public GeneratorDriver RunGenerator() => _sampleDriver!.RunGeneratorsAndUpdateCompilation(_sampleCompilation!, out _, out _);
+    public GeneratorDriver RunGenerator()
+    {
+        var driver = _sampleDriver!.RunGeneratorsAndUpdateCompilation(_sampleCompilation!, out _, out _);
+
+        // add a random type to create a new compilation.
+        _sampleCompilation = _sampleCompilation.AddSyntaxTrees([CSharpSyntaxTree.ParseText($"struct MyValue{Random.Shared.Next()} {{}}", options: (CSharpParseOptions)_sampleCompilation.SyntaxTrees.First().Options)]);
+        return driver;
+    }
 
     [GlobalCleanup]
     public void Cleanup()


### PR DESCRIPTION
The `public static readonly ConcurrentDictionary` are permanently keeping references to outdated `Compilations` causing a memory leak

### Current
340 references to stale compilations. Total 123 MB
573 references to stale compilations. Total 127 MB
806 references to stale compilations. Total 134 MB
1039 references to stale compilations. Total 135 MB
1272 references to stale compilations. Total 142 MB
1505 references to stale compilations. Total 149 MB
1738 references to stale compilations. Total 156 MB
1971 references to stale compilations. Total 163 MB
2204 references to stale compilations. Total 171 MB
2437 references to stale compilations. Total 178 MB
2670 references to stale compilations. Total 185 MB
2903 references to stale compilations. Total 192 MB
3136 references to stale compilations. Total 199 MB
3369 references to stale compilations. Total 206 MB
3602 references to stale compilations. Total 213 MB
3835 references to stale compilations. Total 220 MB
4068 references to stale compilations. Total 227 MB

### With #4645
0 references to stale compilations. Total 116 MB
0 references to stale compilations. Total 116 MB
0 references to stale compilations. Total 116 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 110 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB
0 references to stale compilations. Total 111 MB