### PR TITLE
fix: skip tests when transitive dependencies fail

### DIFF
--- a/TUnit.Engine.Tests/TransitiveDependenciesTests.cs
+++ b/TUnit.Engine.Tests/TransitiveDependenciesTests.cs
@@ -1,0 +1,25 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+/// <summary>
+/// Verifies that tests are correctly skipped when transitive dependencies fail.
+/// Tests the fix for GitHub issue #4643.
+/// </summary>
+public class TransitiveDependenciesTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/TransitiveDependenciesTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(3),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1), // Only Test1 should fail
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(2) // Test2 and Test3 should be skipped
+            ]);
+    }
+}

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -78,7 +78,7 @@ public sealed class TestRunner
             {
                 await ExecuteTestAsync(dependency.Test, cancellationToken).ConfigureAwait(false);
 
-                if (dependency.Test.State == TestState.Failed && !dependency.ProceedOnFailure)
+                if (dependency.Test.State != TestState.Passed && !dependency.ProceedOnFailure)
                 {
                     _testStateManager.MarkSkipped(test, "Skipped due to failed dependencies");
                     await _tunitMessageBus.Skipped(test.Context, "Skipped due to failed dependencies").ConfigureAwait(false);

--- a/TUnit.TestProject/TransitiveDependenciesTests.cs
+++ b/TUnit.TestProject/TransitiveDependenciesTests.cs
@@ -1,0 +1,35 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+/// <summary>
+/// Tests for transitive dependency handling when dependencies fail.
+/// Reproduces GitHub issue #4643: Tests not skipped when transitive dependencies fail
+/// </summary>
+[EngineTest(ExpectedResult.Failure)]
+public class TransitiveDependenciesTests
+{
+    [Test]
+    public async Task Test1()
+    {
+        // This test fails intentionally
+        await Assert.That(true).IsEqualTo(false);
+    }
+
+    [Test, DependsOn(nameof(Test1))]
+    public async Task Test2()
+    {
+        // Test2 depends on Test1, which fails
+        // Test2 should be skipped
+        await Assert.That(true).IsEqualTo(false);
+    }
+
+    [Test, DependsOn(nameof(Test2))]
+    public async Task Test3()
+    {
+        // Test3 depends on Test2, which depends on Test1
+        // When Test1 fails, Test2 is skipped
+        // Therefore Test3 should also be skipped (transitive dependency)
+        await Assert.That(true).IsEqualTo(false);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4643 - Tests are now correctly skipped when transitive dependencies fail.

## Problem

When using `DependsOn` attribute with transitive dependencies:
- Test1 fails
- Test2 depends on Test1 → correctly skipped
- Test3 depends on Test2 → **incorrectly runs and fails** (should be skipped)

## Root Cause

`TestRunner.cs:81` only checked if dependency state was `Failed`, but when Test2 is skipped due to Test1 failing, Test3 sees Test2 in `Skipped` state and proceeds to run.

## Solution

Changed condition from `State == TestState.Failed` to `State != TestState.Passed`, ensuring any non-successful dependency state (Skipped, Failed, Timeout, Cancelled) blocks execution.

## Changes

- **Fix**: `TUnit.Engine/Scheduling/TestRunner.cs` - Updated dependency check condition
- **Tests**: Added `TransitiveDependenciesTests` to reproduce and validate the fix

## Test Plan

- [x] New tests pass - Test3 is now correctly skipped
- [x] All existing DependsOn tests still pass
- [x] 304/310 engine tests pass (2 unrelated F#/VB failures)