### PR TITLE
fix: correct Windows path scrubbing regex in snapshot tests

### DIFF
--- a/TUnit.Core.SourceGenerator.Tests/Verify.cs
+++ b/TUnit.Core.SourceGenerator.Tests/Verify.cs
@@ -70,7 +70,7 @@ public sealed class VerifySettingsTask
     {
         // Scrub Windows-style paths (e.g., C:\Users\... or D:\git\TUnit\)
         ScrubLinesWithReplace(line => System.Text.RegularExpressions.Regex.Replace(line,
-            @"[A-Za-z]:\\\\[^""\s,)]+",
+            @"[A-Za-z]:\\[^""\s,)]+",
             "PATH_SCRUBBED"));
 
         // Scrub Unix-style paths (e.g., /home/user/... or /var/lib/...)


### PR DESCRIPTION
## Problem

Windows CI was failing on .NET Framework 4.7.2 in `TUnit.Core.SourceGenerator.Tests`, specifically the `BasicTests.Test()` method and other snapshot tests.

## Root Cause

The regex pattern used to scrub Windows file paths in snapshot tests was incorrect:

```csharp
@"[A-Za-z]:\\\\[^""\s,)]+"
```

In a C# verbatim string (`@"..."`), `\\` represents **one literal backslash**. The pattern `\\\\` therefore matches **two literal backslashes**, but Windows paths like `C:\Users\...` only contain **single backslashes** between path segments.

This meant file paths weren't being scrubbed on Windows, causing snapshot mismatches when the actual output contained machine-specific paths.

## Solution

Fixed the regex to correctly match single backslashes:

```csharp
@"[A-Za-z]:\\[^""\s,)]+"
```

Now Windows paths are properly replaced with `"PATH_SCRUBBED"` in snapshot tests, making them platform-independent.

## Testing

- Build succeeds on .NET Framework 4.7.2
- Test passes locally on Linux with Mono (which was already passing)
- Should fix Windows CI failures

Fixes the Windows CI failures observed in recent runs.