### PR TITLE
fix: enable Windows long path support in GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -100,6 +100,12 @@ jobs:
         run: npx playwright install
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
+      - name: Enable Long Paths on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+        shell: pwsh
+
       - name: Build
         run: dotnet build -c Release
 


### PR DESCRIPTION
## Summary
Fixes PathTooLongException errors on Windows CI by enabling long path support (>260 characters) via registry setting.

## Problem
Windows CI was failing with:
```
System.IO.PathTooLongException: The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
```

This occurred during source generation for test methods with complex generic signatures like `GenericMethodTests.AggregateBy_HasExpectedOutput<TSource, TKey, TAccumulate>(...)`.

## Solution
Enable Windows long path support in GitHub Actions by setting the `LongPathsEnabled` registry key before building. This is a cleaner solution than modifying source generator code to hash long filenames.

## Test Plan
- [x] Windows CI should pass without PathTooLongException
- [x] Source generator tests with long method names should work

Fixes: https://github.com/thomhurst/TUnit/actions/runs/21610514651