### PR TITLE
perf: parallelize dependency resolution after registration

### DIFF
--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -103,10 +103,9 @@ internal sealed class TestDiscoveryService : IDataProducer
             _dependencyResolver.RegisterTest(test);
         }
 
-        foreach (var test in allTests.Where(t => t.Metadata.Dependencies.Length > 0))
-        {
-            _dependencyResolver.TryResolveDependencies(test);
-        }
+        // Resolve dependencies in parallel — registration is complete so lookup dictionaries
+        // are effectively read-only, and each test's Dependencies are written independently.
+        _dependencyResolver.BatchResolveDependencies(allTests);
 
         // Populate TestContext._dependencies for ALL tests before After(TestDiscovery) hooks run.
         // This ensures hooks can access dependency information on any TestContext (including focused tests).
@@ -187,10 +186,9 @@ internal sealed class TestDiscoveryService : IDataProducer
             allTests.Add(test);
         }
 
-        foreach (var test in allTests)
-        {
-            _dependencyResolver.TryResolveDependencies(test);
-        }
+        // Resolve dependencies in parallel — registration is complete so lookup dictionaries
+        // are effectively read-only, and each test's Dependencies are written independently.
+        _dependencyResolver.BatchResolveDependencies(allTests);
 
         // Populate TestContext._dependencies for ALL tests before After(TestDiscovery) hooks run.
         // This ensures hooks can access dependency information on any TestContext (including focused tests).


### PR DESCRIPTION
## Summary
- Add \`BatchResolveDependencies\` method using \`Parallel.ForEach\` for the resolution phase
- Safe to parallelize because after registration completes, lookup dictionaries (\`_testsByType\`, \`_testsByMethodName\`, \`_allTests\`) are effectively read-only
- Each test's \`Dependencies\` field is only written by its own resolution (no cross-test writes)
- Replaces sequential \`foreach\` + \`TryResolveDependencies\` in both discovery paths

## Test plan
- [ ] Verify test dependencies resolve correctly (same-class and cross-class)
- [ ] Verify transitive dependencies work
- [ ] Verify DependsOn attribute behavior is preserved
- [ ] Run full engine test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)