### PR TITLE
perf: guard debug logging to avoid string allocations

### DIFF
--- a/TUnit.Engine/Logging/TUnitFrameworkLogger.cs
+++ b/TUnit.Engine/Logging/TUnitFrameworkLogger.cs
@@ -93,6 +93,8 @@ public class TUnitFrameworkLogger(IExtension extension, IOutputDevice outputDevi
         return logLevel >= _minimumLogLevel;
     }
 
+    public bool IsDebugEnabled => _minimumLogLevel <= LogLevel.Debug;
+
     public async Task LogErrorAsync(string message)
     {
         await LogAsync(LogLevel.Error, message, null, (s, _) => s);

--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -80,7 +80,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             if (canStart)
             {
                 // Start the test immediately
-                await _logger.LogDebugAsync($"Starting test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsDebugEnabled)
+                    await _logger.LogDebugAsync($"Starting test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
                 startSignal.SetResult(true);
 
                 var testTask = ExecuteTestAndReleaseKeysAsync(test, constraintKeys, lockedKeys, lockObject, waitingTests, cancellationToken);
@@ -90,7 +91,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             else
             {
                 // Queue the test to wait for its keys
-                await _logger.LogDebugAsync($"Queueing test {test.TestId} waiting for constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsDebugEnabled)
+                    await _logger.LogDebugAsync($"Queueing test {test.TestId} waiting for constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
                 waitingTests.Enqueue((test, constraintKeys, startSignal));
 
                 var testTask = WaitAndExecuteTestAsync(test, constraintKeys, startSignal, lockedKeys, lockObject, waitingTests, cancellationToken);
@@ -118,7 +120,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         // Wait for signal to start
         await startSignal.Task.ConfigureAwait(false);
 
-        await _logger.LogDebugAsync($"Starting previously queued test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+        if (_logger.IsDebugEnabled)
+            await _logger.LogDebugAsync($"Starting previously queued test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
 
         await ExecuteTestAndReleaseKeysAsync(test, constraintKeys, lockedKeys, lockObject, waitingTests, cancellationToken).ConfigureAwait(false);
     }
@@ -209,11 +212,13 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             }
 
             // Log and signal tests to start outside the lock
-            await _logger.LogDebugAsync($"Released constraint keys for test {test.TestId}: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Released constraint keys for test {test.TestId}: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
 
             foreach (var testToStart in testsToStart)
             {
-                await _logger.LogDebugAsync($"Unblocking waiting test {testToStart.Test.TestId} with constraint keys: {string.Join(", ", testToStart.ConstraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsDebugEnabled)
+                    await _logger.LogDebugAsync($"Unblocking waiting test {testToStart.Test.TestId} with constraint keys: {string.Join(", ", testToStart.ConstraintKeys)}").ConfigureAwait(false);
                 testToStart.StartSignal.SetResult(true);
             }
         }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -79,7 +79,8 @@ internal sealed class TestScheduler : ITestScheduler
             return true;
         }
 
-        await _logger.LogDebugAsync($"Scheduling execution of {testList.Count} tests").ConfigureAwait(false);
+        if (_logger.IsDebugEnabled)
+            await _logger.LogDebugAsync($"Scheduling execution of {testList.Count} tests").ConfigureAwait(false);
 
         var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(testList);
 
@@ -163,7 +164,8 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (groupedTests.Parallel.Length > 0)
         {
-            await _logger.LogDebugAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
             await ExecuteTestsAsync(groupedTests.Parallel, cancellationToken).ConfigureAwait(false);
         }
 
@@ -176,14 +178,16 @@ internal sealed class TestScheduler : ITestScheduler
             }
             var orderedTestsArray = orderedTests.ToArray();
 
-            await _logger.LogDebugAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);
             await ExecuteTestsAsync(orderedTestsArray, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var kvp in groupedTests.ConstrainedParallelGroups)
         {
             var constrainedTests = kvp.Value;
-            await _logger.LogDebugAsync($"Starting constrained parallel group '{kvp.Key}' with {constrainedTests.UnconstrainedTests.Length} unconstrained and {constrainedTests.KeyedTests.Length} keyed tests").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Starting constrained parallel group '{kvp.Key}' with {constrainedTests.UnconstrainedTests.Length} unconstrained and {constrainedTests.KeyedTests.Length} keyed tests").ConfigureAwait(false);
 
             var tasks = new List<Task>();
             if (constrainedTests.UnconstrainedTests.Length > 0)
@@ -202,13 +206,15 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (groupedTests.KeyedNotInParallel.Length > 0)
         {
-            await _logger.LogDebugAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
             await _constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).ConfigureAwait(false);
         }
 
         if (groupedTests.NotInParallel.Length > 0)
         {
-            await _logger.LogDebugAsync($"Starting {groupedTests.NotInParallel.Length} global NotInParallel tests").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Starting {groupedTests.NotInParallel.Length} global NotInParallel tests").ConfigureAwait(false);
             await ExecuteSequentiallyAsync(groupedTests.NotInParallel, cancellationToken).ConfigureAwait(false);
         }
 
@@ -239,7 +245,8 @@ internal sealed class TestScheduler : ITestScheduler
             // Execute the batch of dynamic tests if any were found
             if (dynamicTests.Count > 0)
             {
-                await _logger.LogDebugAsync($"Executing {dynamicTests.Count} dynamic test(s)").ConfigureAwait(false);
+                if (_logger.IsDebugEnabled)
+                    await _logger.LogDebugAsync($"Executing {dynamicTests.Count} dynamic test(s)").ConfigureAwait(false);
 
                 // Group and execute just like regular tests
                 var dynamicTestsArray = dynamicTests.ToArray();
@@ -271,7 +278,8 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (dynamicTests.Count > 0)
         {
-            await _logger.LogDebugAsync($"Executing {dynamicTests.Count} remaining dynamic test(s)").ConfigureAwait(false);
+            if (_logger.IsDebugEnabled)
+                await _logger.LogDebugAsync($"Executing {dynamicTests.Count} remaining dynamic test(s)").ConfigureAwait(false);
 
             var dynamicTestsArray = dynamicTests.ToArray();
             var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTestsArray).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Add \`IsDebugEnabled\` property to \`TUnitFrameworkLogger\`
- Wrap all \`LogDebugAsync\` calls in hot paths (ConstraintKeyScheduler, TestScheduler) with \`if (_logger.IsDebugEnabled)\` guards
- Prevents interpolated string allocations when debug logging is disabled (the common case)
- For 10,000+ tests, this avoids 20,000+ unnecessary string allocations in the scheduler alone

## Test plan
- [ ] Verify debug logging still works when enabled
- [ ] Verify no functional changes when logging is disabled
- [ ] Run full engine test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)