### PR TITLE
perf: remove `List` usage from `AttributeWriter`

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/Writers/AttributeWriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Writers/AttributeWriter.cs
@@ -13,50 +13,46 @@ public class AttributeWriter(Compilation compilation, TUnit.Core.SourceGenerator
     public void WriteAttributes(ICodeWriter sourceCodeWriter,
         IEnumerable<AttributeData> attributeDatas)
     {
-        var attributesToWrite = new List<AttributeData>();
+        var first = true;
 
         // Filter out attributes that we can write
         foreach (var attributeData in attributeDatas)
         {
             // Include attributes with syntax reference (from current compilation)
             // Include attributes without syntax reference (from other assemblies) as long as they have an AttributeClass
-            if (attributeData.ApplicationSyntaxReference is not null || attributeData.AttributeClass is not null)
+            if (attributeData.ApplicationSyntaxReference is null && attributeData.AttributeClass is null)
             {
-                // Skip compiler-internal and assembly-level attributes
-                if (ShouldSkipCompilerInternalAttribute(attributeData))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                // Skip framework-specific attributes when targeting older frameworks
-                // We determine this by checking if we can compile the attribute
-                if (ShouldSkipFrameworkSpecificAttribute(attributeData))
-                {
-                    continue;
-                }
+            // Skip compiler-internal and assembly-level attributes
+            if (ShouldSkipCompilerInternalAttribute(attributeData))
+            {
+                continue;
+            }
 
-                // Skip attributes with compiler-generated type arguments
-                if (attributeData.ConstructorArguments.Any(arg =>
+            // Skip framework-specific attributes when targeting older frameworks
+            // We determine this by checking if we can compile the attribute
+            if (ShouldSkipFrameworkSpecificAttribute(attributeData))
+            {
+                continue;
+            }
+
+            // Skip attributes with compiler-generated type arguments
+            if (attributeData.ConstructorArguments.Any(arg =>
                     arg is { Kind: TypedConstantKind.Type, Value: ITypeSymbol typeSymbol } &&
                     typeSymbol.IsCompilerGeneratedType()))
-                {
-                    continue;
-                }
-
-                attributesToWrite.Add(attributeData);
+            {
+                continue;
             }
-        }
 
-        for (var index = 0; index < attributesToWrite.Count; index++)
-        {
-            var attributeData = attributesToWrite[index];
-
-            WriteAttribute(sourceCodeWriter, attributeData);
-
-            if (index != attributesToWrite.Count - 1)
+            if (!first)
             {
                 sourceCodeWriter.AppendLine(",");
             }
+
+            WriteAttribute(sourceCodeWriter, attributeData);
+            first = false;
         }
     }
 


### PR DESCRIPTION
Remove `List<AttributeData>` usage in `AttributeWriter.WriteAttributes`


## Benchmarks
Note that timing is inaccurate, I didn't bother running them under benchmark conditions
### Before

| Method       | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|------------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| RunGenerator | 187.1 ms | 5.75 ms | 16.97 ms | 178.6 ms | 11000.0000 | 4000.0000 | 101.25 MB |

### After

| Method       | Mean     | Error   | StdDev   | Median   | Gen0       | Gen1      | Allocated |
|------------- |---------:|--------:|---------:|---------:|-----------:|----------:|----------:|
| RunGenerator | 203.4 ms | 6.20 ms | 17.99 ms | 194.7 ms | 11000.0000 | 4000.0000 | 100.62 MB |
