### PR TITLE
fix: Nested class test filtering in VS and Test Explorer

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/Writers/SourceInformationWriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Writers/SourceInformationWriter.cs
@@ -9,8 +9,7 @@ public static class SourceInformationWriter
 {
     public static void GenerateClassInformation(ICodeWriter sourceCodeWriter, Compilation compilation, INamedTypeSymbol namedTypeSymbol)
     {
-        var parent = namedTypeSymbol.ContainingType;
-        var parentExpression = parent != null ? MetadataGenerationHelper.GenerateClassMetadataGetOrAdd(parent, null, sourceCodeWriter.IndentLevel) : null;
+        var parentExpression = GenerateParentClassMetadataExpression(namedTypeSymbol, sourceCodeWriter.IndentLevel);
         var classMetadata = MetadataGenerationHelper.GenerateClassMetadataGetOrAdd(namedTypeSymbol, parentExpression, sourceCodeWriter.IndentLevel);
 
         // Handle multi-line class metadata similar to method metadata
@@ -97,5 +96,21 @@ public static class SourceInformationWriter
         // For now, use the generic version since it's what the existing code was doing
         MetadataGenerationHelper.WriteParameterMetadataGeneric(sourceCodeWriter, parameter);
         sourceCodeWriter.Append(",");
+    }
+
+    /// <summary>
+    /// Recursively generates parent ClassMetadata expression for nested types.
+    /// Returns null if the type has no containing type.
+    /// </summary>
+    private static string? GenerateParentClassMetadataExpression(INamedTypeSymbol typeSymbol, int indentLevel)
+    {
+        var parent = typeSymbol.ContainingType;
+        if (parent == null)
+        {
+            return null;
+        }
+
+        var grandparentExpression = GenerateParentClassMetadataExpression(parent, indentLevel);
+        return MetadataGenerationHelper.GenerateClassMetadataGetOrAdd(parent, grandparentExpression, indentLevel);
     }
 }

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -1934,7 +1934,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
     {
         var methodName = testMethod.MethodSymbol.Name;
         var namespaceName = testMethod.TypeSymbol.ContainingNamespace?.ToDisplayString() ?? "";
-        var simpleClassName = testMethod.TypeSymbol.Name;
+        var simpleClassName = testMethod.TypeSymbol.GetNestedClassName();
         var fullyQualifiedName = string.IsNullOrEmpty(namespaceName)
             ? $"{simpleClassName}.{methodName}"
             : $"{namespaceName}.{simpleClassName}.{methodName}";

--- a/TUnit.Core.SourceGenerator/Utilities/MetadataGenerationHelper.cs
+++ b/TUnit.Core.SourceGenerator/Utilities/MetadataGenerationHelper.cs
@@ -34,7 +34,7 @@ internal static class MetadataGenerationHelper
         WriteParameterMetadataArrayForMethod(writer, methodSymbol);
         writer.AppendLine(",");
         writer.Append("Class = ");
-        WriteClassMetadataGetOrAdd(writer, namedTypeSymbol);
+        WriteClassMetadataGetOrAddWithParent(writer, namedTypeSymbol);
 
         // Manually restore indent level
         writer.SetIndentLevel(currentIndent);
@@ -145,6 +145,24 @@ internal static class MetadataGenerationHelper
         writer.SetIndentLevel(currentIndent);
         writer.AppendLine();
         writer.Append("})");
+    }
+
+    /// <summary>
+    /// Writes ClassMetadata with recursive parent generation for nested types
+    /// </summary>
+    private static void WriteClassMetadataGetOrAddWithParent(ICodeWriter writer, INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.ContainingType != null)
+        {
+            // Generate the parent expression as a string, then pass it
+            var parentWriter = new CodeWriter("", includeHeader: false).SetIndentLevel(writer.IndentLevel);
+            WriteClassMetadataGetOrAddWithParent(parentWriter, typeSymbol.ContainingType);
+            WriteClassMetadataGetOrAdd(writer, typeSymbol, parentWriter.ToString());
+        }
+        else
+        {
+            WriteClassMetadataGetOrAdd(writer, typeSymbol);
+        }
     }
 
     /// <summary>

--- a/TUnit.Engine.Tests/NestedClassFilteringTests.cs
+++ b/TUnit.Engine.Tests/NestedClassFilteringTests.cs
@@ -1,0 +1,46 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class NestedClassFilteringTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Filter_NestedClass_ByFullNestedName()
+    {
+        await RunTestsWithFilter(
+            "/*/*/NestedTestClassTests+NestedClass/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+
+    [Test]
+    public async Task Filter_NestedClass_SpecificMethod()
+    {
+        await RunTestsWithFilter(
+            "/*/*/NestedTestClassTests+NestedClass/Inner",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+
+    [Test]
+    public async Task Filter_OuterClass_StillWorks()
+    {
+        await RunTestsWithFilter(
+            "/*/*/NestedTestClassTests/Outer",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+}

--- a/TUnit.Engine.Tests/UidFilterMatchingTests.cs
+++ b/TUnit.Engine.Tests/UidFilterMatchingTests.cs
@@ -15,11 +15,11 @@ public class UidFilterMatchingTests(TestMode testMode) : InvokableTestBase(testM
     [Test]
     public async Task Filter_NestedClass_ShouldMatchOnlyNestedClass()
     {
-        // Filter for the nested class InnerClass
-        // Tree node paths use just the innermost class name (Type.Name)
+        // Filter for the nested class InnerClass using full nested path
+        // Tree node paths now use OuterClass+InnerClass format for nested types
         // Should only run tests from InnerClass, not OuterClass
         await RunTestsWithFilter(
-            "/*/TUnit.TestProject.Bugs._4656/InnerClass/InnerMethod",
+            "/*/TUnit.TestProject.Bugs._4656/OuterClass+InnerClass/InnerMethod",
             [
                 result => result.ResultSummary.Outcome.ShouldBe("Completed"),
                 result => result.ResultSummary.Counters.Total.ShouldBe(1,

--- a/TUnit.Engine/Building/ReflectionMetadataBuilder.cs
+++ b/TUnit.Engine/Building/ReflectionMetadataBuilder.cs
@@ -90,7 +90,7 @@ internal static class ReflectionMetadataBuilder
                 }),
                 Parameters = constructorParameters,
                 Properties = [],
-                Parent = null
+                Parent = type.DeclaringType != null ? CreateClassMetadata(type.DeclaringType) : null
             };
         });
     }

--- a/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
+++ b/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
@@ -167,7 +167,7 @@ internal static class ReflectionInstanceFactory
             }),
             Properties = [],
             Parameters = [],
-            Parent = null
+            Parent = type.DeclaringType != null ? CreateClassMetadata(type.DeclaringType) : null
         });
     }
 

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -2497,10 +2497,11 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
                     var capturedType = type;
                     var capturedMethod = method;
 
+                    var nestedClassName = TUnit.Core.Extensions.TestContextExtensions.GetNestedTypeName(type);
                     yield return new TestDescriptor
                     {
                         TestId = $"{type.FullName}.{method.Name}",
-                        ClassName = type.Name,
+                        ClassName = nestedClassName,
                         MethodName = method.Name,
                         FullyQualifiedName = $"{type.FullName}.{method.Name}",
                         FilePath = ExtractFilePath(method) ?? "Unknown",

--- a/TUnit.Engine/Services/TestFilterService.cs
+++ b/TUnit.Engine/Services/TestFilterService.cs
@@ -140,7 +140,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         var classMetadata = test.Context.Metadata.TestDetails.MethodMetadata.Class;
         var assemblyName = classMetadata.Assembly.Name ?? metadata.TestClassType.Assembly.GetName().Name ?? "*";
         var namespaceName = classMetadata.Namespace ?? "*";
-        var classTypeName = classMetadata.Name;
+        var classTypeName = GetNestedClassName(classMetadata);
 
         var path = $"/{assemblyName}/{namespaceName}/{classTypeName}/{metadata.TestMethodName}";
 
@@ -242,5 +242,28 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         }
 
         return filteredTests;
+    }
+
+    /// <summary>
+    /// Builds the nested class name from ClassMetadata by walking the Parent chain.
+    /// Returns names joined with '+' (e.g., "OuterClass+InnerClass").
+    /// </summary>
+    internal static string GetNestedClassName(ClassMetadata classMetadata)
+    {
+        if (classMetadata.Parent == null)
+        {
+            return classMetadata.Name;
+        }
+
+        var hierarchy = new List<string>();
+        var current = classMetadata;
+        while (current != null)
+        {
+            hierarchy.Add(current.Name);
+            current = current.Parent;
+        }
+
+        hierarchy.Reverse();
+        return string.Join("+", hierarchy);
     }
 }

--- a/TUnit.TestProject/NestedTestClassTests.cs
+++ b/TUnit.TestProject/NestedTestClassTests.cs
@@ -1,0 +1,20 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Pass)]
+public class NestedTestClassTests
+{
+    [Test]
+    public void Outer()
+    {
+    }
+
+    public class NestedClass
+    {
+        [Test]
+        public void Inner()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes nested class tests being invisible to VS Test Explorer's "Run Tests" command and appearing as flat siblings without outer class context
- Tree node filter paths now use full `OuterClass+InnerClass` hierarchy instead of just `InnerClass`
- `ClassMetadata.Parent` is now recursively populated in both source-gen and reflection modes
- Filter matching (`CouldDescriptorMatch`, `CouldTypeMatch`) handles both full nested paths and partial names

Closes #4144

## Test plan

- [x] New `NestedClassFilteringTests` engine tests verify:
  - `/*/*/NestedTestClassTests+NestedClass/*` finds 1 nested test
  - `/*/*/NestedTestClassTests+NestedClass/Inner` finds specific nested test
  - `/*/*/NestedTestClassTests/Outer` still finds outer class test
- [x] All 448 source generator snapshot tests pass
- [x] `ExpectedStateTests` pass (comprehensive pass/fail validation across all modes)
- [x] `UidFilterMatchingTests` pass (28 tests, updated to use new nested format)
- [x] `OverlappingClassNameFilterTests` pass (no regression in substring matching fix)
- [x] Both source-gen and reflection modes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)