### PR TITLE
fix: prevent tests hanging when InitializeAsync throws (#4715)

### DIFF
--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -158,7 +158,7 @@ internal sealed class TestDiscoveryService : IDataProducer
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(5));
 
-        var tests = await _testBuilderPipeline.BuildTestsStreamingAsync(testSessionId, buildingContext, metadataFilter: null, cancellationToken).ConfigureAwait(false);
+        var tests = await _testBuilderPipeline.BuildTestsStreamingAsync(testSessionId, buildingContext, metadataFilter: null, cts.Token).ConfigureAwait(false);
 
         foreach (var test in tests)
         {


### PR DESCRIPTION
## Summary
- **Bug 1 (PRIMARY)**: `CreateFailedTestDetails` called `InitializeAttributesAsync()` — the exact method that caused the original exception — re-triggering the failure inside the `catch` block. Made it synchronous with empty attributes, matching the safe `TestBuilderPipeline` pattern.
- **Bug 2**: `FailedExecutableTest` in `TestBuilder` was missing `State = TestState.Failed` and `Result`, so failed tests didn't get the early-exit in `TestCoordinator.ExecuteTestInternalAsync`. Added both to match the `TestBuilderPipeline` version.
- **Bug 3**: The 5-minute discovery timeout CTS in `TestDiscoveryService.DiscoverTestsStreamAsync` was created but the original `cancellationToken` was passed to `BuildTestsStreamingAsync` instead of `cts.Token`, so the timeout was never applied.

Closes #4715

## Test plan
- [x] Verify TUnit.Engine compiles with no errors or warnings
- [ ] Run existing engine tests to check for regressions
- [ ] Verify tests with failing `InitializeAsync` now report as failed instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)