### PR TITLE
fix: consistent test time tracking

### DIFF
--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -119,7 +119,7 @@ public sealed class TestRunner
         }
         finally
         {
-            test.EndTime = DateTimeOffset.UtcNow;
+            test.EndTime ??= DateTimeOffset.UtcNow;
         }
     }
 

--- a/TUnit.Engine/Services/TestExecution/RetryHelper.cs
+++ b/TUnit.Engine/Services/TestExecution/RetryHelper.cs
@@ -30,6 +30,7 @@ internal static class RetryHelper
                     testContext.Execution.Result = null;
                     testContext.TestStart = null;
                     testContext.Execution.TestEnd = null;
+                    testContext.Timings.Clear();
                     continue;
                 }
 

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -78,6 +78,7 @@ internal sealed class TestCoordinator : ITestCoordinator
             test.Context.Execution.Result = null;
             test.Context.TestStart = null;
             test.Context.Execution.TestEnd = null;
+            test.Context.Timings.Clear();
 
             TestContext.Current = test.Context;
 

--- a/TUnit.Engine/Services/TestExecution/TestStateManager.cs
+++ b/TUnit.Engine/Services/TestExecution/TestStateManager.cs
@@ -31,7 +31,7 @@ internal sealed class TestStateManager
         };
 
         test.State = test.Result.State;
-        test.EndTime = now;
+        test.EndTime ??= now;
     }
 
     public void MarkFailed(AbstractExecutableTest test, Exception exception)
@@ -45,7 +45,7 @@ internal sealed class TestStateManager
         else
         {
             test.State = TestState.Failed;
-            test.EndTime = DateTimeOffset.UtcNow;
+            test.EndTime ??= DateTimeOffset.UtcNow;
             test.Result = new TestResult
             {
                 State = TestState.Failed,


### PR DESCRIPTION
## Summary

- **Exclude both Before and After hooks from headline test duration** — `TestEnd` is now set immediately after the test body finishes (before After hooks run), matching `TestStart` which is already set after Before hooks complete
- **Record Before/After test-level hooks as step timings** via `Timings.Record("BeforeTest"/"AfterTest", ...)` for granular visibility in test reports
- **Guard `EndTime` assignments** with `??=` in `TestRunner`, `TestStateManager.MarkCompleted`, and `TestStateManager.MarkFailed` to respect the body-level `TestEnd`
- **Clear `Timings` on retry/re-execution** in `RetryHelper` and `TestCoordinator` alongside existing `TestStart`/`TestEnd` resets

Closes #4711

## Test plan

- [ ] Verify build succeeds across all target frameworks
- [ ] Run existing engine tests to check for regressions
- [ ] Verify headline duration reflects only test body time (not Before/After hooks)
- [ ] Verify step timings include "BeforeTest" and "AfterTest" entries
- [ ] Verify retry and re-execution properly clear timings

🤖 Generated with [Claude Code](https://claude.com/claude-code)