### PR TITLE
Fix #4715: Propagate CancellationToken through property injection to prevent hangs

### DIFF
--- a/TUnit.Engine.Tests/PropertyInjectionInitFailureTests.cs
+++ b/TUnit.Engine.Tests/PropertyInjectionInitFailureTests.cs
@@ -1,0 +1,21 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class PropertyInjectionInitFailureTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/PropertyInjectionInitFailureTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}

--- a/TUnit.Engine/Building/Interfaces/ITestBuilder.cs
+++ b/TUnit.Engine/Building/Interfaces/ITestBuilder.cs
@@ -16,7 +16,7 @@ internal interface ITestBuilder
     /// <param name="testBuilderContext"></param>
     /// <param name="isReusingDiscoveryInstance">Whether this test is reusing the discovery instance</param>
     /// <returns>An executable test ready for execution</returns>
-    Task<AbstractExecutableTest> BuildTestAsync(TestMetadata metadata, TestBuilder.TestData testData, TestBuilderContext testBuilderContext, bool isReusingDiscoveryInstance = false);
+    Task<AbstractExecutableTest> BuildTestAsync(TestMetadata metadata, TestBuilder.TestData testData, TestBuilderContext testBuilderContext, bool isReusingDiscoveryInstance = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Builds all executable tests from a single TestMetadata using its DataCombinationGenerator delegate.
@@ -28,7 +28,7 @@ internal interface ITestBuilder
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
-    Task<IEnumerable<AbstractExecutableTest>> BuildTestsFromMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext);
+    Task<IEnumerable<AbstractExecutableTest>> BuildTestsFromMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Streaming version that yields tests as they're built without buffering

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -126,7 +126,7 @@ internal sealed class TestBuilderPipeline
         }
 
         return await collectedMetadata
-            .SelectManyAsync(metadata => BuildTestsFromSingleMetadataAsync(metadata, buildingContext), cancellationToken: cancellationToken)
+            .SelectManyAsync(metadata => BuildTestsFromSingleMetadataAsync(metadata, buildingContext, cancellationToken), cancellationToken: cancellationToken)
             .ProcessInParallel(cancellationToken: cancellationToken);
     }
 
@@ -170,7 +170,7 @@ internal sealed class TestBuilderPipeline
                     }
                     else
                     {
-                        results.Add(await _testBuilder.BuildTestsFromMetadataAsync(metadata, buildingContext).ConfigureAwait(false));
+                        results.Add(await _testBuilder.BuildTestsFromMetadataAsync(metadata, buildingContext, cancellationToken).ConfigureAwait(false));
                     }
                 }
                 catch (Exception ex)
@@ -194,7 +194,7 @@ internal sealed class TestBuilderPipeline
                             return await GenerateDynamicTests(metadata).ConfigureAwait(false);
                         }
 
-                        return await _testBuilder.BuildTestsFromMetadataAsync(metadata, buildingContext).ConfigureAwait(false);
+                        return await _testBuilder.BuildTestsFromMetadataAsync(metadata, buildingContext, cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -308,7 +308,7 @@ internal sealed class TestBuilderPipeline
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
-    private async IAsyncEnumerable<AbstractExecutableTest> BuildTestsFromSingleMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext)
+    private async IAsyncEnumerable<AbstractExecutableTest> BuildTestsFromSingleMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         TestMetadata resolvedMetadata;
         Exception? resolutionError = null;
@@ -430,7 +430,7 @@ internal sealed class TestBuilderPipeline
             else
             {
                 // Normal test metadata goes through the standard test builder
-                var testsFromMetadata = await _testBuilder.BuildTestsFromMetadataAsync(resolvedMetadata, buildingContext).ConfigureAwait(false);
+                var testsFromMetadata = await _testBuilder.BuildTestsFromMetadataAsync(resolvedMetadata, buildingContext, cancellationToken).ConfigureAwait(false);
                 testsToYield = new List<AbstractExecutableTest>(testsFromMetadata);
             }
         }

--- a/TUnit.Engine/Services/IObjectRegistry.cs
+++ b/TUnit.Engine/Services/IObjectRegistry.cs
@@ -22,7 +22,8 @@ internal interface IObjectRegistry
         object instance,
         ConcurrentDictionary<string, object?> objectBag,
         MethodMetadata? methodMetadata,
-        TestContextEvents events);
+        TestContextEvents events,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Registers multiple argument objects during the registration phase.
@@ -31,5 +32,6 @@ internal interface IObjectRegistry
         object?[] arguments,
         ConcurrentDictionary<string, object?> objectBag,
         MethodMetadata? methodMetadata,
-        TestContextEvents events);
+        TestContextEvents events,
+        CancellationToken cancellationToken = default);
 }

--- a/TUnit.Engine/Services/TestArgumentRegistrationService.cs
+++ b/TUnit.Engine/Services/TestArgumentRegistrationService.cs
@@ -21,7 +21,7 @@ internal sealed class TestArgumentRegistrationService
     /// for proper reference counting and disposal tracking.
     /// Property values are resolved lazily during test execution (not during discovery).
     /// </summary>
-    public async ValueTask RegisterTestArgumentsAsync(TestContext testContext)
+    public async ValueTask RegisterTestArgumentsAsync(TestContext testContext, CancellationToken cancellationToken = default)
     {
         TestContext.Current = testContext;
 
@@ -33,16 +33,18 @@ internal sealed class TestArgumentRegistrationService
             classArguments,
             testContext.StateBag.Items,
             testContext.Metadata.TestDetails.MethodMetadata,
-            testContext.InternalEvents);
+            testContext.InternalEvents,
+            cancellationToken);
 
         // Register method arguments
         await _objectLifecycleService.RegisterArgumentsAsync(
             methodArguments,
             testContext.StateBag.Items,
             testContext.Metadata.TestDetails.MethodMetadata,
-            testContext.InternalEvents);
+            testContext.InternalEvents,
+            cancellationToken);
 
         // Register the test for tracking (inject properties and track objects for disposal)
-        await _objectLifecycleService.RegisterTestAsync(testContext);
+        await _objectLifecycleService.RegisterTestAsync(testContext, cancellationToken);
     }
 }

--- a/TUnit.TestProject/Bugs/4715/AttributePropertyInjectionTests.cs
+++ b/TUnit.TestProject/Bugs/4715/AttributePropertyInjectionTests.cs
@@ -1,0 +1,63 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._4715;
+
+/// <summary>
+/// Closest reproduction to issue #4715: A DI data source attribute with
+/// [ClassDataSource] property pointing to a factory that has a nested
+/// IAsyncDiscoveryInitializer that throws during InitializeAsync.
+///
+/// Pattern from the issue:
+///   [AspireDataSource] on test class →
+///   AspireDataSourceAttribute has [ClassDataSource&lt;TestWebApplicationFactory&gt;] property →
+///   TestWebApplicationFactory has [ClassDataSource&lt;TestAppHost&gt;] property →
+///   TestAppHost : IAsyncDiscoveryInitializer → InitializeAsync() throws TimeoutException
+/// </summary>
+
+public class FailingHost4715Attr : IAsyncDiscoveryInitializer
+{
+    public Task InitializeAsync()
+    {
+        throw new TimeoutException("Simulated: AppHost startup timed out.");
+    }
+}
+
+public class Factory4715Attr : IAsyncDiscoveryInitializer
+{
+    [ClassDataSource<FailingHost4715Attr>(Shared = SharedType.PerTestSession)]
+    public required FailingHost4715Attr AppHost { get; init; }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public class TestDiDataSourceAttribute : DependencyInjectionDataSourceAttribute<IDisposable>
+{
+    [ClassDataSource<Factory4715Attr>(Shared = SharedType.PerTestSession)]
+    public Factory4715Attr Factory { get; init; } = default!;
+
+    public override IDisposable CreateScope(DataGeneratorMetadata dataGeneratorMetadata)
+    {
+        // This should never be reached because Factory initialization throws
+        return new MemoryStream();
+    }
+
+    public override object? Create(IDisposable scope, Type type)
+    {
+        return new object();
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+[TestDiDataSource]
+public class AttributePropertyInjectionFailureTests(object _)
+{
+    [Test]
+    public void Test_Should_Fail_Not_Stall()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}

--- a/TUnit.TestProject/Bugs/4715/BackgroundProcessInitTests.cs
+++ b/TUnit.TestProject/Bugs/4715/BackgroundProcessInitTests.cs
@@ -1,0 +1,85 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._4715;
+
+/// <summary>
+/// Reproduction for issue #4715: InitializeAsync starts a background process
+/// (simulating Aspire DistributedApplication.StartAsync), then throws.
+/// The background process keeps running and prevents the process from exiting.
+/// </summary>
+
+public class BackgroundProcessHost4715 : IAsyncDiscoveryInitializer, IAsyncDisposable
+{
+    private CancellationTokenSource? _cts;
+    private Task? _backgroundTask;
+
+    public async Task InitializeAsync()
+    {
+        // Simulate starting a background process (like Aspire's Application.StartAsync())
+        _cts = new CancellationTokenSource();
+        _backgroundTask = Task.Run(async () =>
+        {
+            try
+            {
+                // Simulate a long-running service
+                await Task.Delay(Timeout.Infinite, _cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when disposed
+            }
+        }, _cts.Token);
+
+        // Give the background task time to start
+        await Task.Delay(10);
+
+        // Now throw (simulating WaitForResourceAsync timeout)
+        throw new TimeoutException("The operation has timed out waiting for resource.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+        }
+
+        if (_backgroundTask != null)
+        {
+            try
+            {
+                await _backgroundTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected
+            }
+        }
+    }
+}
+
+public class BackgroundFactory4715 : IAsyncDiscoveryInitializer
+{
+    [ClassDataSource<BackgroundProcessHost4715>(Shared = SharedType.PerTestSession)]
+    public required BackgroundProcessHost4715 AppHost { get; init; }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+public class BackgroundProcessInitFailureTests
+{
+    [ClassDataSource<BackgroundFactory4715>(Shared = SharedType.PerTestSession)]
+    public required BackgroundFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test_Should_Fail_Not_Stall()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}

--- a/TUnit.TestProject/Bugs/4715/PropertyInjectionInitFailureTests.cs
+++ b/TUnit.TestProject/Bugs/4715/PropertyInjectionInitFailureTests.cs
@@ -1,0 +1,106 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._4715;
+
+/// <summary>
+/// Reproduction for issue #4715: Test runner stalls when IAsyncInitializer.InitializeAsync()
+/// throws an exception during property injection in a nested dependency chain.
+/// Pattern: Test class → property (WebApplicationFactory) → nested property (AppHost) → InitializeAsync throws
+/// </summary>
+
+// Scenario 1: Nested property with IAsyncInitializer that throws during execution
+public class FailingAppHost4715 : IAsyncInitializer
+{
+    public Task InitializeAsync()
+    {
+        throw new TimeoutException("Simulated: The operation has timed out (e.g., Docker container failed to start).");
+    }
+}
+
+public class WebApplicationFactory4715 : IAsyncInitializer
+{
+    [ClassDataSource<FailingAppHost4715>(Shared = SharedType.PerTestSession)]
+    public required FailingAppHost4715 AppHost { get; init; }
+
+    public Task InitializeAsync()
+    {
+        // This should never be reached because AppHost.InitializeAsync() throws first
+        return Task.CompletedTask;
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+public class PropertyInjectionInitFailureTests
+{
+    [ClassDataSource<WebApplicationFactory4715>(Shared = SharedType.PerTestSession)]
+    public required WebApplicationFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test_Should_Fail_Not_Stall()
+    {
+        // This test should never execute - it should fail during initialization
+        // because the nested AppHost.InitializeAsync() throws TimeoutException
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}
+
+// Scenario 2: Same as above but with IAsyncDiscoveryInitializer (initialized during discovery phase)
+public class FailingDiscoveryAppHost4715 : IAsyncDiscoveryInitializer
+{
+    public Task InitializeAsync()
+    {
+        throw new TimeoutException("Simulated discovery init failure: The operation has timed out.");
+    }
+}
+
+public class DiscoveryWebApplicationFactory4715 : IAsyncDiscoveryInitializer
+{
+    [ClassDataSource<FailingDiscoveryAppHost4715>(Shared = SharedType.PerTestSession)]
+    public required FailingDiscoveryAppHost4715 AppHost { get; init; }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+public class PropertyInjectionDiscoveryInitFailureTests
+{
+    [ClassDataSource<DiscoveryWebApplicationFactory4715>(Shared = SharedType.PerTestSession)]
+    public required DiscoveryWebApplicationFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test_Should_Fail_Not_Stall_During_Discovery()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}
+
+// Scenario 3: Multiple tests sharing the same failing factory (tests if the shared object error is handled for all)
+[EngineTest(ExpectedResult.Failure)]
+public class PropertyInjectionInitFailureMultiTest1
+{
+    [ClassDataSource<WebApplicationFactory4715>(Shared = SharedType.PerTestSession)]
+    public required WebApplicationFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test1_Should_Fail_Not_Stall()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+public class PropertyInjectionInitFailureMultiTest2
+{
+    [ClassDataSource<WebApplicationFactory4715>(Shared = SharedType.PerTestSession)]
+    public required WebApplicationFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test2_Should_Fail_Not_Stall()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}

--- a/TUnit.TestProject/Bugs/4715/PropertyInjectionSlowInitTests.cs
+++ b/TUnit.TestProject/Bugs/4715/PropertyInjectionSlowInitTests.cs
@@ -1,0 +1,49 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._4715;
+
+/// <summary>
+/// Reproduction for issue #4715: Test runner stalls when IAsyncInitializer.InitializeAsync()
+/// hangs for a long time before eventually timing out.
+/// This simulates a Docker container or web server that takes too long to start.
+/// </summary>
+
+public class SlowFailingAppHost4715 : IAsyncInitializer
+{
+    public async Task InitializeAsync()
+    {
+        // Simulate a slow initialization that eventually times out
+        // In the real scenario, this might be waiting for a Docker container to start
+        await Task.Delay(TimeSpan.FromSeconds(30));
+        throw new TimeoutException("The operation has timed out after waiting for container.");
+    }
+}
+
+public class SlowWebApplicationFactory4715 : IAsyncInitializer
+{
+    [ClassDataSource<SlowFailingAppHost4715>(Shared = SharedType.PerTestSession)]
+    public required SlowFailingAppHost4715 AppHost { get; init; }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// This test should fail within a reasonable time, not stall indefinitely.
+/// The 30-second delay in InitializeAsync simulates a slow Docker container startup.
+/// </summary>
+[EngineTest(ExpectedResult.Failure)]
+public class PropertyInjectionSlowInitFailureTests
+{
+    [ClassDataSource<SlowWebApplicationFactory4715>(Shared = SharedType.PerTestSession)]
+    public required SlowWebApplicationFactory4715 Factory { get; init; }
+
+    [Test]
+    public void Test_Should_Eventually_Fail()
+    {
+        throw new InvalidOperationException("This test should not have executed");
+    }
+}


### PR DESCRIPTION
## Summary

- Threads the 5-minute discovery timeout `CancellationToken` from `TestDiscoveryService.DiscoverTestsStreamAsync` through the entire property injection chain: `TestBuilderPipeline` → `TestBuilder` → `ObjectLifecycleService` → `PropertyInjector` → `EnsureInitializedAsync`
- When `IAsyncInitializer.InitializeAsync()` hangs during property injection in a chained `ClassDataSource` dependency pattern, the timeout now fires and unblocks all waiters via `OperationCanceledException`
- Adds reproduction test cases covering: immediate failures, slow init (30s delay), discovery-phase failures, attribute-based injection, background process scenarios, and shared object multi-test failures