### PR TITLE
fix: evaluate SkipAttribute before data source initialization

### DIFF
--- a/TUnit.Engine.Tests/DerivedSkipWithClassDataSourceTests.cs
+++ b/TUnit.Engine.Tests/DerivedSkipWithClassDataSourceTests.cs
@@ -1,0 +1,41 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+/// <summary>
+/// Regression tests for https://github.com/thomhurst/TUnit/issues/4737
+/// Verifies that derived SkipAttribute subclasses properly skip tests
+/// when combined with ClassDataSource, even when the data source's
+/// IAsyncInitializer would throw.
+/// </summary>
+public class DerivedSkipWithClassDataSourceTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task DerivedSkipWithFailingDataSource_ShouldBeSkipped()
+    {
+        await RunTestsWithFilter(
+            "/*/*/DerivedSkipWithFailingClassDataSourceTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(1)
+            ]);
+    }
+
+    [Test]
+    public async Task DerivedSkipWithSucceedingDataSource_ShouldBeSkipped()
+    {
+        await RunTestsWithFilter(
+            "/*/*/DerivedSkipWithSucceedingClassDataSourceTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(1)
+            ]);
+    }
+}

--- a/TUnit.TestProject/Bugs/4737/DerivedSkipWithClassDataSourceTests.cs
+++ b/TUnit.TestProject/Bugs/4737/DerivedSkipWithClassDataSourceTests.cs
@@ -1,0 +1,73 @@
+using TUnit.Core.Interfaces;
+
+namespace TUnit.TestProject.Bugs._4737;
+
+/// <summary>
+/// Derived SkipAttribute that always skips - simulates a CI-environment skip attribute
+/// like the user's IntegrationTestAttribute in issue #4737.
+/// </summary>
+public class AlwaysSkipAttribute() : SkipAttribute("Skip in CI environment")
+{
+    public override Task<bool> ShouldSkip(TestRegisteredContext context)
+    {
+        return Task.FromResult(true);
+    }
+}
+
+/// <summary>
+/// A data source that throws during InitializeAsync - simulates a WebApplicationFactory
+/// that fails to connect to a database that doesn't exist in CI.
+/// </summary>
+public class FailingDataSource : IAsyncInitializer
+{
+    public Task InitializeAsync()
+    {
+        throw new InvalidOperationException("Simulated infrastructure failure: cannot connect to database");
+    }
+}
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/issues/4737
+/// A class-level derived SkipAttribute combined with a ClassDataSource whose
+/// IAsyncInitializer would throw. The test must be reported as skipped, not failed.
+/// </summary>
+[ClassDataSource<FailingDataSource>(Shared = SharedType.PerTestSession)]
+[AlwaysSkip]
+public class DerivedSkipWithFailingClassDataSourceTests(FailingDataSource dataSource)
+{
+    [Test]
+    public void Test()
+    {
+        throw new Exception("This test should have been skipped, not executed!");
+    }
+}
+
+/// <summary>
+/// A data source that succeeds initialization.
+/// </summary>
+public class SucceedingDataSource : IAsyncInitializer
+{
+    public bool IsInitialized { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        IsInitialized = true;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Verifies that a derived SkipAttribute at the class level correctly skips tests
+/// even when a ClassDataSource is present and would succeed. The test body would
+/// fail if executed, proving the skip is effective.
+/// </summary>
+[ClassDataSource<SucceedingDataSource>(Shared = SharedType.PerTestSession)]
+[AlwaysSkip]
+public class DerivedSkipWithSucceedingClassDataSourceTests(SucceedingDataSource dataSource)
+{
+    [Test]
+    public void Test()
+    {
+        throw new Exception("This test should have been skipped, not executed!");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4737

- **Reorder registration phase**: Fire `OnTestRegistered` event receivers (including `SkipAttribute`) **before** `RegisterTestArgumentsAsync` in `TestFilterService.RegisterTest`, and skip argument registration entirely when `SkipReason` is set. This prevents `ClassDataSource` initialization for tests that should be skipped.
- **Early skip check in execution**: Check `SkipReason` in `ExecuteTestInternalAsync` before entering retry/timeout logic and instance creation, avoiding unnecessary work for already-skipped tests.
- **Pre-instance skip check**: Check `SkipReason` in `ExecuteTestLifecycleAsync` before `CreateInstanceAsync()` to prevent data source `IAsyncInitializer` calls that would fail or waste resources for skipped tests.

### Root cause

Derived `SkipAttribute` subclasses (e.g., CI-environment skip attributes) evaluate `ShouldSkip()` at runtime during `OnTestRegistered`. Previously, `RegisterTestArgumentsAsync` ran before event receivers, and `CreateInstanceAsync()` (which triggers `IAsyncInitializer.InitializeAsync()` on data sources) ran before the `SkipReason` check. If initialization threw (e.g., database unavailable in CI), the exception escaped before the skip check could run, marking the test as **failed** instead of **skipped**.

## Test plan

- [x] New regression test: derived `SkipAttribute` + `ClassDataSource` with failing `IAsyncInitializer` → test is skipped, not failed
- [x] New regression test: derived `SkipAttribute` + `ClassDataSource` with succeeding initializer → test is skipped
- [x] Both tests run in all 3 modes (SourceGenerated, Reflection, AOT)
- [x] Existing skip tests pass: `SkipTests`, `DynamicSkipReasonTests`, `SkipInHooksTests`, `SkipTestExceptionTests`
- [x] Existing data source tests pass: `DataSourceCountTests`, `DataSourceExceptionPropagationTests`, `GenericMethodWithDataSourceTests`, `PropertyInjectionInitFailureTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)