### PR TITLE
fix: prevent test hangs when shared IAsyncDiscoveryInitializer partially initializes then throws

### DIFF
--- a/TUnit.Engine.Tests/AttributePropertyInjectionFailureTests.cs
+++ b/TUnit.Engine.Tests/AttributePropertyInjectionFailureTests.cs
@@ -1,0 +1,21 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class AttributePropertyInjectionFailureTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/AttributePropertyInjectionFailureTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4715. When `InitializeAsync()` starts resources (e.g. ports, background processes via `Application.StartAsync()`) then throws, TUnit was removing the failed entry from its initialization caches to allow retry. The retry calls `InitializeAsync()` again on the same partially-initialized shared object, which hangs because the first resources still hold ports/processes.

- **Stop removing failed/cancelled entries from `ObjectInitializer` and `ObjectLifecycleService` caches** — the faulted `Lazy<Task>` / `TaskCompletionSource` stays in cache so subsequent callers get the same error immediately instead of retrying
- **Fix fast-path in `ObjectLifecycleService.EnsureInitializedAsync`** to also check `IsCanceled` so cancelled initializations don't silently return an uninitialized object
- **Add 5-minute discovery timeout to the filter execution path** (used by VS Test Explorer / `dotnet test --filter`), matching the existing timeout in the streaming path
- **Add engine test** for the attribute-based property injection failure scenario (the exact pattern from #4715)

## Test plan

- [x] `AttributePropertyInjectionFailureTests` in TestProject fails fast (~1s), not hanging
- [x] `BackgroundProcessInitFailureTests` in TestProject fails fast (~1s), not hanging
- [x] `PropertyInjectionInitFailureTests` engine test passes (3/3 — SourceGenerated, Reflection, AOT)
- [x] `AttributePropertyInjectionFailureTests` engine test passes (3/3 — SourceGenerated, Reflection, AOT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)