### PR TITLE
fix: disable IDE streaming sink by default to prevent test runner crashes

### DIFF
--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -153,7 +153,11 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         }
 
         // IdeStreamingSink: For IDE clients - real-time output streaming
-        if (VerbosityService.IsIdeClient)
+        // Disabled by default due to compatibility issues with Microsoft Testing Platform
+        // (duplicate TestNodeUid in TestApplicationResult.ConsumeAsync causes crashes in Rider/VS Code).
+        // Enable via TUNIT_ENABLE_IDE_STREAMING=1 environment variable.
+        if (VerbosityService.IsIdeClient &&
+            Environment.GetEnvironmentVariable("TUNIT_ENABLE_IDE_STREAMING") == "1")
         {
             TUnitLoggerFactory.AddSink(new IdeStreamingSink(MessageBus));
         }

--- a/docs/docs/customization-extensibility/logging.md
+++ b/docs/docs/customization-extensibility/logging.md
@@ -43,7 +43,11 @@ TUnit automatically registers these sinks based on your execution context:
 |------|-----------------|---------|
 | **TestOutputSink** | Always | Captures output for test results shown after execution |
 | **ConsoleOutputSink** | `--output Detailed` | Writes real-time output to the console |
-| **RealTimeOutputSink** | IDE clients (VS, Rider) | Streams output to IDE test explorers |
+| **RealTimeOutputSink** | IDE clients + `TUNIT_ENABLE_IDE_STREAMING=1` | Streams output to IDE test explorers |
+
+:::note
+The RealTimeOutputSink (IDE streaming) is disabled by default due to compatibility issues with the Microsoft Testing Platform that can cause crashes in some IDEs. Set the `TUNIT_ENABLE_IDE_STREAMING=1` environment variable to opt in. See [Environment Variables](/docs/reference/environment-variables) for details.
+:::
 
 ### Creating Custom Log Sinks
 

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -85,6 +85,27 @@ export TUNIT_MAX_PARALLEL_TESTS=0    # Unlimited parallelism
 
 **Note:** Command-line arguments take precedence over environment variables.
 
+### TUNIT_ENABLE_IDE_STREAMING
+
+Enables real-time output streaming to IDE test explorers (Rider, VS Code, Visual Studio).
+
+```bash
+# Bash/Linux/macOS
+export TUNIT_ENABLE_IDE_STREAMING=1
+
+# PowerShell
+$env:TUNIT_ENABLE_IDE_STREAMING = "1"
+
+# Windows Command Prompt
+set TUNIT_ENABLE_IDE_STREAMING=1
+```
+
+**Default:** Disabled
+
+**Use case:** When running tests in an IDE, this enables real-time streaming of test output (e.g. `Console.WriteLine`) to the test explorer while tests are still running. Without this, output is shown after each test completes.
+
+**Note:** This feature is disabled by default due to known compatibility issues with the Microsoft Testing Platform that can cause test runner crashes in some IDEs. Enable it only if you want real-time output streaming and are not experiencing issues.
+
 ## Microsoft Testing Platform Environment Variables
 
 These environment variables are provided by the underlying Microsoft Testing Platform:
@@ -196,3 +217,4 @@ When the same setting is configured in multiple places, TUnit follows this prior
 | `TUNIT_ENABLE_JUNIT_REPORTER` | - | Enables JUnit reporter |
 | `JUNIT_XML_OUTPUT_PATH` | - | JUnit output path |
 | `TUNIT_MAX_PARALLEL_TESTS` | `--maximum-parallel-tests` | Max parallel tests |
+| `TUNIT_ENABLE_IDE_STREAMING` | - | Enable real-time IDE output streaming |


### PR DESCRIPTION
## Summary
- Disables `IdeStreamingSink` by default — it was causing crashes in Rider and VS Code when tests write to `Console.WriteLine` followed by an async delay
- The root cause is the Microsoft Testing Platform's `TestApplicationResult.ConsumeAsync` throwing `ArgumentException` on duplicate `TestNodeUid` keys, triggered by the sink's output update + heartbeat pattern
- The feature can be re-enabled via the `TUNIT_ENABLE_IDE_STREAMING=1` environment variable for users who want real-time output streaming

Closes #4749

## Test plan
- [ ] Verify tests with `Console.WriteLine` + `Task.Delay` no longer crash in Rider/VS Code
- [ ] Verify setting `TUNIT_ENABLE_IDE_STREAMING=1` re-enables the streaming behavior
- [ ] Verify test output is still visible in IDE test explorers after test completion (via `ConsoleOutputSink` / `TestOutputSink`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)