### PR TITLE
fix: reduce hint name limit to 150 chars for Windows net472 PATH_MAX

### DIFF
--- a/TUnit.Core.SourceGenerator/Helpers/FileNameHelper.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/FileNameHelper.cs
@@ -17,7 +17,9 @@ internal static class FileNameHelper
     /// <returns>A deterministic filename like "MyNamespace_MyClass_MyMethod__Int32_String.g.cs"</returns>
     // Conservative limit to avoid PathTooLongException on Windows with net472,
     // which enforces the legacy 260-character MAX_PATH limit in Roslyn's AddSource.
-    private const int MaxHintNameLength = 200;
+    // Roslyn prepends the CWD to the hint name when calling Path.GetFullPathInternal,
+    // so we must leave ~110 chars of headroom for the working directory path.
+    private const int MaxHintNameLength = 150;
 
     public static string GetDeterministicFileNameForMethod(INamedTypeSymbol typeSymbol, IMethodSymbol methodSymbol)
     {


### PR DESCRIPTION
## Summary

- Reduces `MaxHintNameLength` from 200 to 150 in `FileNameHelper.cs` to fix `PathTooLongException` on Windows CI with `net472`
- The previous fix (#4757) was insufficient because .NET Framework 4.7.2's `Path.GetFullPathInternal` prepends the CWD (~69 chars on CI) to the hint name before validating against the hardcoded 260-char `MAX_PATH` limit (200 + 69 = 269 > 260)
- 150 chars leaves ~110 chars of headroom for the working directory, covering CI runners and typical developer environments
- `net8.0`/`net10.0` are unaffected since modern .NET doesn't enforce the legacy path limit

## Test plan

- [ ] Verify `modularpipeline (windows-latest)` CI job passes (specifically `net472` source generator tests)
- [ ] Verify Linux and macOS jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)