### PR TITLE
feat: make [Timeout] CancellationToken parameter optional (warning instead of error)

### DIFF
--- a/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,4 +8,5 @@ TUnit0061 | Usage | Error | ClassDataSource type requires parameterless construc
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+TUnit0015 | Usage | Error | Changed to Warning severity (CancellationToken parameter now optional)
 TUnit0043 | Usage | Error | Changed to Info severity (now a suggestion instead of error)

--- a/TUnit.Analyzers/Rules.cs
+++ b/TUnit.Analyzers/Rules.cs
@@ -40,7 +40,7 @@ public static class Rules
         CreateDescriptor("TUnit0014", UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MissingTimeoutCancellationTokenAttributes =
-        CreateDescriptor("TUnit0015", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor("TUnit0015", UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MethodMustNotBeStatic =
         CreateDescriptor("TUnit0016", UsageCategory, DiagnosticSeverity.Error);


### PR DESCRIPTION
## Summary

- Downgrades TUnit0015 from `DiagnosticSeverity.Error` to `DiagnosticSeverity.Warning`, making the `CancellationToken` parameter on `[Timeout]` methods optional instead of mandatory
- The timeout mechanism still works without the token (TUnit cancels the test externally), but cooperative cancellation is encouraged via the warning

## Changes

- **`TUnit.Analyzers/Rules.cs`**: Changed `MissingTimeoutCancellationTokenAttributes` severity from `Error` to `Warning`
- **`TUnit.Analyzers/AnalyzerReleases.Unshipped.md`**: Tracked the severity change under "Removed Rules" (standard Roslyn release tracking format for severity changes)

## Context

In integration tests, `[Timeout]` is often used as a safety net to prevent tests from hanging indefinitely. The test logic itself doesn't always pass the cancellation token to anything meaningful. Requiring the parameter as a compile error forces users to add unused parameters just to satisfy the compiler.

With this change:
- Users who want cooperative cancellation can still add the parameter (the warning encourages it)
- Users who just want a timeout ceiling can suppress with `#pragma warning disable TUnit0015`
- Tests compile without being forced to accept an unused `CancellationToken`

Closes #4767

🤖 Generated with [Claude Code](https://claude.com/claude-code)