### PR TITLE
fix: #4812 incorrect TUnit0001 on custom generic IDataSourceAttribute

### DIFF
--- a/TUnit.Analyzers/TestDataAnalyzer.cs
+++ b/TUnit.Analyzers/TestDataAnalyzer.cs
@@ -910,15 +910,13 @@ public class TestDataAnalyzer : ConcurrentDiagnosticAnalyzer
                 }
             }
             
-            // Final fallback: if no specific data source generator base type found, use the attribute's own type arguments
-            if (typeArguments.IsEmpty && attribute.AttributeClass?.TypeArguments.IsEmpty == false)
-            {
-                typeArguments = attribute.AttributeClass.TypeArguments;
-            }
+            // Don't fall back to the attribute's own type arguments - for custom generic attributes
+            // implementing IDataSourceAttribute, the generic parameters may not correspond to the
+            // test parameter types (they could be used for other purposes in the implementation)
         }
 
-        // If still no type arguments (like ArgumentsAttribute which returns object?[]?),
-        // skip compile-time type checking as it will be validated at runtime
+        // If no type arguments found (like ArgumentsAttribute which returns object?[]?, or custom
+        // generic data source attributes), skip compile-time type checking as it will be validated at runtime
         if (typeArguments.IsEmpty)
         {
             return;


### PR DESCRIPTION
## Description

This PR fixes TUnit0001 being raised against type parameters that the analyzer can't conclusively know are affecting the actual test argument parameters.

## Related Issue

Fixes #4812 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [x] All existing tests pass (`dotnet test`)
- [x] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
