### PR TITLE
fix: xUnit code fixer bugs for Assert.Single, Assert.Collection, and Assert.All

### DIFF
--- a/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
@@ -973,7 +973,7 @@ public class XUnitMigrationAnalyzerTests
                     public async Task MyTest()
                     {
                         var items = new[] { 1, 2, 3 };
-                        // TODO: TUnit migration - Assert.Collection had element inspectors. Manually add assertions for each element.
+                        // TODO: TUnit migration - Assert.Collection element inspectors were dropped and need manual conversion: [0]: x => Assert.Equal(1, x); [1]: x => Assert.Equal(2, x); [2]: x => Assert.Equal(3, x)
                         await Assert.That(items).HasCount(3);
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes three xUnit code fixer bugs reported in #4805, #4806, and #4811:

- **#4805 - Assert.Single drops predicate lambda**: `Assert.Single(collection, predicate)` now correctly converts to `Assert.That(collection.Where(predicate)).HasSingleItem()` instead of silently dropping the predicate
- **#4806 - Assert.Collection drops element inspectors**: The TODO comment now preserves the full text of each element inspector (e.g. `[0]: x => Assert.Equal(1, x)`) so assertions aren't silently lost during migration
- **#4811 - Assert.All produces invalid code**: When `Assert.All` has a multi-statement lambda body that can't be converted to a simple predicate, the two-phase analyzer now skips conversion instead of producing invalid `Assert.That(items).All(item => { Assert.True(...); })` code

Both the assertion code fixer (`XUnitAssertionCodeFixProvider`) and the two-phase migration analyzer (`XUnitTwoPhaseAnalyzer`) are updated where applicable.

## Test plan

- [x] New tests added for `Assert.Single` with and without predicate in assertion code fixer
- [x] Existing `Assert_Collection_Adds_Todo_Comment` test updated to match improved TODO message
- [x] All 52 assertion code fixer tests pass
- [x] All 268 two-phase migration analyzer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)