### PR TITLE
fix: relax TUnit0046 to only warn for mutable reference types

### DIFF
--- a/TUnit.Analyzers/Resources.Designer.cs
+++ b/TUnit.Analyzers/Resources.Designer.cs
@@ -1272,25 +1272,25 @@ namespace TUnit.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Return a `Func&lt;T&gt;` rather than a `&lt;T&gt;`..
+        ///   Looks up a localized string similar to When a data source method provides mutable reference types as test parameters, it should return Func&lt;T&gt;....
         /// </summary>
         internal static string TUnit0046Description {
             get {
                 return ResourceManager.GetString("TUnit0046Description", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Return a `Func&lt;T&gt;` rather than a `&lt;T&gt;`..
+        ///   Looks up a localized string similar to Data source method should return Func&lt;T&gt; for mutable reference type parameters to ensure proper test isolation.
         /// </summary>
         internal static string TUnit0046MessageFormat {
             get {
                 return ResourceManager.GetString("TUnit0046MessageFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Return a `Func&lt;T&gt;` rather than a `&lt;T&gt;`.
+        ///   Looks up a localized string similar to Data source should return Func&lt;T&gt; for mutable reference types.
         /// </summary>
         internal static string TUnit0046Title {
             get {

--- a/TUnit.Analyzers/Resources.resx
+++ b/TUnit.Analyzers/Resources.resx
@@ -328,13 +328,13 @@
         <value>Too many data attributes</value>
     </data>
     <data name="TUnit0046Description" xml:space="preserve">
-        <value>When a data source method provides reference types (other than string) as test parameters, it should return Func&lt;T&gt; to defer object creation until the test runs. This prevents shared state between tests and ensures proper test isolation.</value>
+        <value>When a data source method provides mutable reference types as test parameters, it should return Func&lt;T&gt; to defer object creation until the test runs. This prevents shared state between tests and ensures proper test isolation. Immutable types (records with no mutable properties, classes with only get/init properties) are exempt.</value>
     </data>
     <data name="TUnit0046MessageFormat" xml:space="preserve">
-        <value>Data source method should return Func&lt;T&gt; for reference type parameters (other than string) to ensure proper test isolation</value>
+        <value>Data source method should return Func&lt;T&gt; for mutable reference type parameters to ensure proper test isolation</value>
     </data>
     <data name="TUnit0046Title" xml:space="preserve">
-        <value>Data source should return Func&lt;T&gt; for reference types</value>
+        <value>Data source should return Func&lt;T&gt; for mutable reference types</value>
     </data>
     <data name="TUnit0047Description" xml:space="preserve">
         <value>For AsyncLocal values set in before hooks, you must call `context.AddAsyncLocalValues` to access them within tests.</value>

--- a/TUnit.Analyzers/TestDataAnalyzer.cs
+++ b/TUnit.Analyzers/TestDataAnalyzer.cs
@@ -558,7 +558,7 @@ public class TestDataAnalyzer : ConcurrentDiagnosticAnalyzer
                 out var isTuples);
             
 
-            if (!isFunc && unwrappedTypes.Any(x => x.SpecialType != SpecialType.System_String && x.IsReferenceType))
+            if (!isFunc && unwrappedTypes.Any(x => x.HasVisibleMutability()))
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rules.ReturnFunc,
                     dataSourceMethod.Locations.FirstOrDefault()));


### PR DESCRIPTION
## Summary

- **Narrows TUnit0046** to only fire on types that show evidence of mutability, instead of all reference types (except `string`)
- Adds `HasVisibleMutability()` extension method that checks for non-init setters, public mutable fields, `Lazy<T>` members, arrays, interfaces, and type parameters
- Updates diagnostic messages to say "mutable reference types" and note immutable types are exempt
- Adds 12 test cases covering both mutable (warning) and immutable (no warning) scenarios

Fixes #4847

## Test plan

- [x] All 600 analyzer tests pass (599 succeeded, 1 pre-existing skip)
- [x] Both `TUnit.Analyzers` and `TUnit.Analyzers.Roslyn44` build successfully
- [ ] CI passes on all target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)