### PR TITLE
fix: TypeExtensions.GetMetadataName handles null Namespace (#4866)

### DIFF
--- a/TUnit.Analyzers/Extensions/TypeExtensions.cs
+++ b/TUnit.Analyzers/Extensions/TypeExtensions.cs
@@ -8,7 +8,7 @@ public static class TypeExtensions
 {
     public static string GetMetadataName(this Type type)
     {
-        return $"{type.Namespace}.{type.Name}";
+        return string.IsNullOrEmpty(type.Namespace) ? type.Name : $"{type.Namespace}.{type.Name}";
     }
 
     public static string GetFullNameWithoutGenericArity(this Type type)


### PR DESCRIPTION
## Summary

- Fix `TypeExtensions.GetMetadataName` producing `"null.TypeName"` when a type is in the root (global) namespace
- When `Type.Namespace` is null or empty, the method now returns just `type.Name` instead of `$"{type.Namespace}.{type.Name}"`

Closes #4866

## Test plan

- [x] Verified the project builds successfully with `dotnet build TUnit.Analyzers/TUnit.Analyzers.csproj`
- [ ] Confirm analyzer correctly resolves metadata names for types in the root namespace
- [ ] Confirm analyzer still correctly resolves metadata names for types in named namespaces