### PR TITLE
fix: InstanceValuesInTestClassAnalyzer uses return instead of continue (#4859)

### DIFF
--- a/TUnit.Analyzers/InstanceValuesInTestClassAnalyzer.cs
+++ b/TUnit.Analyzers/InstanceValuesInTestClassAnalyzer.cs
@@ -56,7 +56,7 @@ public class InstanceValuesInTestClassAnalyzer : ConcurrentDiagnosticAnalyzer
 
             if (!SymbolEqualityComparer.Default.Equals(targetSymbol?.ContainingType, testClass))
             {
-                return;
+                continue;
             }
 
             if (SymbolEqualityComparer.Default.Equals(targetSymbol, fieldOrProperty))


### PR DESCRIPTION
## Summary

- Fix a bug in `InstanceValuesInTestClassAnalyzer.AnalyzeOperation` where a `return` statement inside a `foreach` loop exits the entire method instead of using `continue` to skip to the next field/property
- When iterating over `fieldsAndProperties`, if the assignment target's containing type doesn't match the test class, only the current iteration should be skipped -- not the entire analysis

## Details

In `TUnit.Analyzers/InstanceValuesInTestClassAnalyzer.cs` around line 59, the `foreach` loop over `fieldsAndProperties` had a `return;` that would exit the `AnalyzeOperation` method entirely when the target symbol's containing type didn't match the test class. This has been changed to `continue;` so the loop properly continues checking the remaining fields and properties.

Closes #4859

## Test plan

- [x] Existing analyzer tests pass (the `Do_Not_Flag_When_Not_Assigning_To_New_Class` test covers this scenario)
- [x] Project builds successfully with zero errors