### PR TITLE
fix: correct StringIsNotEmptyAssertion expectation message (#4871)

### DIFF
--- a/TUnit.Assertions/Conditions/StringAssertions.cs
+++ b/TUnit.Assertions/Conditions/StringAssertions.cs
@@ -477,7 +477,7 @@ public class StringDoesNotEndWithAssertion : Assertion<string>
 }
 
 /// <summary>
-/// Asserts that a string is not empty or whitespace.
+/// Asserts that a string is not null or empty.
 /// </summary>
 [AssertionExtension("IsNotEmpty")]
 public class StringIsNotEmptyAssertion : Assertion<string>
@@ -511,11 +511,11 @@ public class StringIsNotEmptyAssertion : Assertion<string>
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
     }
 
-    protected override string GetExpectation() => "to not be empty or whitespace";
+    protected override string GetExpectation() => "to not be null or empty";
 }
 
 /// <summary>
-/// Asserts that a string is empty or whitespace.
+/// Asserts that a string is empty.
 /// </summary>
 [AssertionExtension("IsEmpty")]
 public class StringIsEmptyAssertion : Assertion<string>
@@ -549,7 +549,7 @@ public class StringIsEmptyAssertion : Assertion<string>
         return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
     }
 
-    protected override string GetExpectation() => "to be empty or whitespace";
+    protected override string GetExpectation() => "to be empty";
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- **Fixed `StringIsNotEmptyAssertion`**: The expectation message said "to not be empty or whitespace" but the code only checks `string.IsNullOrEmpty(value)`. Changed the message to "to not be null or empty" to accurately reflect the behavior.
- **Fixed `StringIsEmptyAssertion`**: Similarly, its message said "to be empty or whitespace" but only checks `value == string.Empty`. Changed to "to be empty".
- Also corrected the XML doc comments on both classes.

No behavioral changes -- only the user-facing expectation messages and doc comments were updated to match the actual logic.

Closes #4871