### PR TITLE
chore: centralize environment variable constants (#4882)

### DIFF
--- a/TUnit.Engine/Capabilities/BannerCapability.cs
+++ b/TUnit.Engine/Capabilities/BannerCapability.cs
@@ -6,6 +6,7 @@ using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
 using TUnit.Engine.CommandLineProviders;
+using TUnit.Engine.Configuration;
 using TUnit.Engine.Enums;
 #if NET
 using System.Runtime.CompilerServices;
@@ -23,7 +24,7 @@ internal class BannerCapability(IPlatformInformation platformInformation, IComma
     public Task<string?> GetBannerMessageAsync()
     {
         if (commandLineOptions.IsOptionSet(DisableLogoCommandProvider.DisableLogo)
-            || Environment.GetEnvironmentVariable("TUNIT_DISABLE_LOGO") is not null
+            || Environment.GetEnvironmentVariable(EnvironmentConstants.DisableLogo) is not null
             || loggerFactory.CreateLogger(nameof(BannerCapability)).IsEnabled(LogLevel.Information))
         {
             return Task.FromResult<string?>(GetRuntimeDetails());

--- a/TUnit.Engine/Configuration/EnvironmentConstants.cs
+++ b/TUnit.Engine/Configuration/EnvironmentConstants.cs
@@ -1,0 +1,31 @@
+namespace TUnit.Engine.Configuration;
+
+internal static class EnvironmentConstants
+{
+    // TUnit-specific: Reporters
+    public const string DisableGithubReporter = "TUNIT_DISABLE_GITHUB_REPORTER";
+    public const string DisableJUnitReporter = "TUNIT_DISABLE_JUNIT_REPORTER";
+    public const string EnableJUnitReporter = "TUNIT_ENABLE_JUNIT_REPORTER";
+    public const string GitHubReporterStyle = "TUNIT_GITHUB_REPORTER_STYLE";
+
+    // TUnit-specific: Execution
+    public const string ExecutionMode = "TUNIT_EXECUTION_MODE";
+    public const string MaxParallelTests = "TUNIT_MAX_PARALLEL_TESTS";
+
+    // TUnit-specific: Display and diagnostics
+    public const string DisableLogo = "TUNIT_DISABLE_LOGO";
+    public const string EnableIdeStreaming = "TUNIT_ENABLE_IDE_STREAMING";
+    public const string DiscoveryDiagnostics = "TUNIT_DISCOVERY_DIAGNOSTICS";
+
+    // TUnit-specific: JUnit output
+    public const string JUnitXmlOutputPath = "JUNIT_XML_OUTPUT_PATH";
+
+    // Legacy/deprecated (kept for backwards compatibility)
+    public const string DisableGithubReporterLegacy = "DISABLE_GITHUB_REPORTER";
+
+    // External CI environment variables
+    public const string GitHubActions = "GITHUB_ACTIONS";
+    public const string GitHubStepSummary = "GITHUB_STEP_SUMMARY";
+    public const string GitLabCi = "GITLAB_CI";
+    public const string CiServer = "CI_SERVER";
+}

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -15,6 +15,7 @@ using TUnit.Core.Logging;
 using TUnit.Core.Tracking;
 using TUnit.Engine.Building;
 using TUnit.Engine.Building.Collectors;
+using TUnit.Engine.Configuration;
 using TUnit.Engine.Building.Interfaces;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Discovery;
@@ -157,7 +158,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         // (duplicate TestNodeUid in TestApplicationResult.ConsumeAsync causes crashes in Rider/VS Code).
         // Enable via TUNIT_ENABLE_IDE_STREAMING=1 environment variable.
         if (VerbosityService.IsIdeClient &&
-            Environment.GetEnvironmentVariable("TUNIT_ENABLE_IDE_STREAMING") == "1")
+            Environment.GetEnvironmentVariable(EnvironmentConstants.EnableIdeStreaming) == "1")
         {
             TUnitLoggerFactory.AddSink(new IdeStreamingSink(MessageBus));
         }

--- a/TUnit.Engine/Helpers/ExecutionModeHelper.cs
+++ b/TUnit.Engine/Helpers/ExecutionModeHelper.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.Testing.Platform.CommandLine;
 using TUnit.Core;
 using TUnit.Engine.CommandLineProviders;
+using TUnit.Engine.Configuration;
 
 namespace TUnit.Engine.Helpers;
 
@@ -67,7 +68,7 @@ internal static class ExecutionModeHelper
         }
 
         // Check environment variable
-        var envMode = Environment.GetEnvironmentVariable("TUNIT_EXECUTION_MODE");
+        var envMode = Environment.GetEnvironmentVariable(EnvironmentConstants.ExecutionMode);
         if (!string.IsNullOrEmpty(envMode))
         {
             var mode = envMode!.ToLowerInvariant();

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestHost;
+using TUnit.Engine.Configuration;
 using TUnit.Engine.Framework;
 
 namespace TUnit.Engine.Reporters;
@@ -24,18 +25,18 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     public async Task<bool> IsEnabledAsync()
     {
-        if (Environment.GetEnvironmentVariable("TUNIT_DISABLE_GITHUB_REPORTER") is not null ||
-            Environment.GetEnvironmentVariable("DISABLE_GITHUB_REPORTER") is not null)
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.DisableGithubReporter) is not null ||
+            Environment.GetEnvironmentVariable(EnvironmentConstants.DisableGithubReporterLegacy) is not null)
         {
             return false;
         }
 
-        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is null)
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubActions) is null)
         {
             return false;
         }
 
-        if (Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") is not { } fileName
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubStepSummary) is not { } fileName
             || !File.Exists(fileName))
         {
             return false;
@@ -44,7 +45,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         _outputSummaryFilePath = fileName;
 
         // Determine reporter style from environment variable or default to collapsible
-        var styleEnv = Environment.GetEnvironmentVariable("TUNIT_GITHUB_REPORTER_STYLE");
+        var styleEnv = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubReporterStyle);
         if (!string.IsNullOrEmpty(styleEnv))
         {
             _reporterStyle = styleEnv!.ToLowerInvariant() switch

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestHost;
+using TUnit.Engine.Configuration;
 using TUnit.Engine.Framework;
 using TUnit.Engine.Xml;
 
@@ -17,15 +18,15 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
     public async Task<bool> IsEnabledAsync()
     {
         // Check if explicitly disabled
-        if (Environment.GetEnvironmentVariable("TUNIT_DISABLE_JUNIT_REPORTER") is not null)
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.DisableJUnitReporter) is not null)
         {
             return false;
         }
 
         // Check if explicitly enabled OR running in GitLab CI
-        var explicitlyEnabled = Environment.GetEnvironmentVariable("TUNIT_ENABLE_JUNIT_REPORTER") is not null;
-        var runningInGitLab = Environment.GetEnvironmentVariable("GITLAB_CI") is not null ||
-                              Environment.GetEnvironmentVariable("CI_SERVER") is not null;
+        var explicitlyEnabled = Environment.GetEnvironmentVariable(EnvironmentConstants.EnableJUnitReporter) is not null;
+        var runningInGitLab = Environment.GetEnvironmentVariable(EnvironmentConstants.GitLabCi) is not null ||
+                              Environment.GetEnvironmentVariable(EnvironmentConstants.CiServer) is not null;
 
         if (!explicitlyEnabled && !runningInGitLab)
         {
@@ -35,7 +36,7 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
         // Determine output path (only if not already set via command-line argument)
         if (string.IsNullOrEmpty(_outputPath))
         {
-            _outputPath = Environment.GetEnvironmentVariable("JUNIT_XML_OUTPUT_PATH")
+            _outputPath = Environment.GetEnvironmentVariable(EnvironmentConstants.JUnitXmlOutputPath)
                 ?? GetDefaultOutputPath();
         }
 

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -4,6 +4,7 @@ using TUnit.Core;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Logging;
 using TUnit.Engine.CommandLineProviders;
+using TUnit.Engine.Configuration;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Logging;
 using TUnit.Engine.Models;
@@ -545,7 +546,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
 
         // Check environment variable (second priority)
-        if (Environment.GetEnvironmentVariable("TUNIT_MAX_PARALLEL_TESTS") is string envVar
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.MaxParallelTests) is string envVar
             && int.TryParse(envVar, out var envLimit))
         {
             if (envLimit == 0)

--- a/TUnit.Engine/Services/VerbosityService.cs
+++ b/TUnit.Engine/Services/VerbosityService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Services;
 using TUnit.Engine.CommandLineProviders;
+using TUnit.Engine.Configuration;
 using LogLevel = TUnit.Core.Logging.LogLevel;
 
 #pragma warning disable TPEXP
@@ -78,7 +79,7 @@ public sealed class VerbosityService
         }
 
         // Check legacy environment variable for backwards compatibility
-        if (Environment.GetEnvironmentVariable("TUNIT_DISCOVERY_DIAGNOSTICS") == "1")
+        if (Environment.GetEnvironmentVariable(EnvironmentConstants.DiscoveryDiagnostics) == "1")
         {
             return LogLevel.Debug;
         }


### PR DESCRIPTION
## Summary

- Introduces `TUnit.Engine/Configuration/EnvironmentConstants.cs` containing all environment variable names used across the engine as `const string` fields
- Replaces 15 scattered magic string literals in 7 files with references to the new constants class
- Groups constants by purpose: reporters, execution, display/diagnostics, JUnit output, legacy/deprecated, and external CI variables

Closes #4882

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` passes across all target frameworks (net8.0, net9.0, net10.0, netstandard2.0) with zero warnings and zero errors
- [ ] Verify no behavioral changes — all constants map to the exact same string values as before
- [ ] Confirm CI passes end-to-end