### PR TITLE
perf: replace LINQ with loops in test execution hot paths (#4855)

### DIFF
--- a/TUnit.Core/TestContext.Dependencies.cs
+++ b/TUnit.Core/TestContext.Dependencies.cs
@@ -29,9 +29,23 @@ public partial class TestContext
             return [];
         }
 
-        var tests = testFinder.GetTests(classType).Where(predicate).ToList();
+        var allTests = testFinder.GetTests(classType);
+        var tests = new List<TestContext>();
+        var hasUnfinished = false;
 
-        if (tests.Any(x => x.Result == null))
+        foreach (var test in allTests)
+        {
+            if (predicate(test))
+            {
+                tests.Add(test);
+                if (test.Result == null)
+                {
+                    hasUnfinished = true;
+                }
+            }
+        }
+
+        if (hasUnfinished)
         {
             throw new InvalidOperationException(
                 "Cannot get unfinished tests - Did you mean to add a [DependsOn] attribute?"
@@ -47,43 +61,49 @@ public partial class TestContext
 
         var classType = TestDetails.ClassType;
 
-        var tests = testFinder.GetTestsByNameAndParameters(
+        var testsArray = testFinder.GetTestsByNameAndParameters(
             testName,
             [],
             classType,
             [],
             []
-        ).ToList();
+        );
 
-        if (tests.Any(x => x.Result == null))
+        foreach (var test in testsArray)
         {
-            throw new InvalidOperationException(
-                "Cannot get unfinished tests - Did you mean to add a [DependsOn] attribute?"
-            );
+            if (test.Result == null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot get unfinished tests - Did you mean to add a [DependsOn] attribute?"
+                );
+            }
         }
 
-        return tests;
+        return new List<TestContext>(testsArray);
     }
 
     internal List<TestContext> GetTests(string testName, Type classType)
     {
         var testFinder = ServiceProvider.GetService<ITestFinder>()!;
 
-        var tests = testFinder.GetTestsByNameAndParameters(
+        var testsArray = testFinder.GetTestsByNameAndParameters(
             testName,
             [],
             classType,
             [],
             []
-        ).ToList();
+        );
 
-        if (tests.Any(x => x.Result == null))
+        foreach (var test in testsArray)
         {
-            throw new InvalidOperationException(
-                "Cannot get unfinished tests - Did you mean to add a [DependsOn] attribute?"
-            );
+            if (test.Result == null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot get unfinished tests - Did you mean to add a [DependsOn] attribute?"
+                );
+            }
         }
 
-        return tests;
+        return new List<TestContext>(testsArray);
     }
 }

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -440,8 +440,8 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
 
             var objectsAtDepth = graph.GetObjectsAtDepth(depth);
 
-            // Pre-allocate task list without LINQ Select
-            var tasks = new List<Task>();
+            // Pre-allocate task list with known capacity
+            var tasks = new List<Task>(objectsAtDepth.Count);
             foreach (var obj in objectsAtDepth)
             {
                 tasks.Add(initializer(obj, cancellationToken).AsTask());

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -115,7 +115,14 @@ internal sealed class TestDependencyResolver
                     }
                 }
 
-                test.Dependencies = uniqueDependencies.Values.ToArray();
+                var depsArray = new ResolvedDependency[uniqueDependencies.Count];
+                var i = 0;
+                foreach (var dep in uniqueDependencies.Values)
+                {
+                    depsArray[i++] = dep;
+                }
+
+                test.Dependencies = depsArray;
 
                 _testsWithPendingDependencies.Remove(test);
 
@@ -191,7 +198,14 @@ internal sealed class TestDependencyResolver
     /// </summary>
     public void BatchResolveDependencies(List<AbstractExecutableTest> tests)
     {
-        var testsWithDependencies = tests.Where(t => t.Metadata.Dependencies.Length > 0).ToList();
+        var testsWithDependencies = new List<AbstractExecutableTest>();
+        foreach (var t in tests)
+        {
+            if (t.Metadata.Dependencies.Length > 0)
+            {
+                testsWithDependencies.Add(t);
+            }
+        }
 
         if (testsWithDependencies.Count == 0)
         {
@@ -256,7 +270,14 @@ internal sealed class TestDependencyResolver
                 }
             }
 
-            test.Dependencies = uniqueDependencies.Values.ToArray();
+            var depsArray = new ResolvedDependency[uniqueDependencies.Count];
+            var i = 0;
+            foreach (var dep in uniqueDependencies.Values)
+            {
+                depsArray[i++] = dep;
+            }
+
+            test.Dependencies = depsArray;
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace LINQ chains (`Where().ToList()`, `.Values.ToArray()`, `.Any()`) with simple `foreach` loops in test execution hot paths to reduce allocations
- Merge two-pass filter+check patterns into single-pass loops in `TestContext.Dependencies`
- Pre-allocate `List<Task>` with known capacity in `ObjectLifecycleService`

Closes #4855

## Changes

### `TUnit.Engine/Services/TestDependencyResolver.cs`
- `uniqueDependencies.Values.ToArray()` → pre-allocated `ResolvedDependency[]` with manual copy (2 occurrences)
- `tests.Where(t => ...).ToList()` → `foreach` loop with conditional `Add`

### `TUnit.Core/TestContext.Dependencies.cs`
- `GetTests(predicate)`: merged `.Where(predicate).ToList()` + `.Any(x => x.Result == null)` two-pass into single-pass `foreach` loop
- `GetTests(testName)` and `GetTests(testName, classType)`: removed redundant `.ToList()` on `TestContext[]` return; replaced `.Any()` check with `foreach` loop

### `TUnit.Engine/Services/ObjectLifecycleService.cs`
- `new List<Task>()` → `new List<Task>(objectsAtDepth.Count)` to pre-allocate with known capacity

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` — builds successfully (0 warnings, 0 errors)
- [x] `dotnet build TUnit.Core/TUnit.Core.csproj` — builds successfully (0 warnings, 0 errors)
- [ ] CI passes all existing tests (no behavioral changes, only allocation reduction)