### PR TITLE
docs: clarify CancellationToken in hooks does not need default value

### DIFF
--- a/TUnit.Analyzers/GlobalTestHooksAnalyzer.cs
+++ b/TUnit.Analyzers/GlobalTestHooksAnalyzer.cs
@@ -164,15 +164,20 @@ public class GlobalTestHooksAnalyzer : ConcurrentDiagnosticAnalyzer
             return HookParameterStatus.Valid;
         }
         
-        // Single CancellationToken parameter is valid (though context is recommended)
-        if (parameters.Length == 1 && 
+        // Single CancellationToken parameter is valid (though context is recommended).
+        // Note: A default value is NOT required on the CancellationToken parameter because the
+        // framework always provides one. In source-gen mode, the generated hook body delegate always
+        // passes cancellationToken. In reflection mode, CreateHookDelegate/CreateInstanceHookDelegate
+        // always passes the CancellationToken via method.Invoke args.
+        if (parameters.Length == 1 &&
             parameters[0].Type.GloballyQualifiedNonGeneric() == "global::System.Threading.CancellationToken")
         {
             return HookParameterStatus.Valid;
         }
-        
-        // Context + CancellationToken is valid
-        if (parameters.Length == 2 && 
+
+        // Context + CancellationToken is valid (default value not required on CancellationToken;
+        // the framework always provides one at invocation time).
+        if (parameters.Length == 2 &&
             parameters[0].Type.GloballyQualifiedNonGeneric() == contextType &&
             parameters[1].Type.GloballyQualifiedNonGeneric() == "global::System.Threading.CancellationToken")
         {


### PR DESCRIPTION
## Summary

Closes #4861

After thorough investigation, the `GlobalTestHooksAnalyzer` behavior is **already correct** -- the `CancellationToken` parameter in hook methods does **not** require a default value because the TUnit framework always provides one. This PR adds clarifying comments to prevent future confusion.

### Why no code change is needed

The issue claims that a bare `CancellationToken cancellationToken` parameter (without `= default`) in a hook method will cause runtime issues. This is not the case:

**Source Generator Mode** (`TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs`):
- Every hook body delegate is generated with `CancellationToken cancellationToken` in its signature
- `GenerateStaticMethodInvocation` and `GenerateDirectInvocation` always pass `cancellationToken` to the user's hook method
- Example generated code: `await AsyncConvert.Convert(() => MyClass.SetUp(cancellationToken));`

**Reflection Mode** (`TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs`):
- `CreateHookDelegate<T>()` and `CreateInstanceHookDelegate()` both inspect parameters at runtime
- When a parameter is `CancellationToken`, the framework passes `[cancellationToken]` via `method.Invoke()`

**Hook Execution Pipeline**:
1. `StaticHookMethod<T>.Body` is typed as `Func<T, CancellationToken, ValueTask>` -- always receives a token
2. `HookDelegateBuilder` wraps everything in `Func<TContext, CancellationToken, Task>` -- always passes a token
3. `HookTimeoutHelper` always passes `CancellationToken` to delegates
4. All `HookExecutor` methods receive and forward the `CancellationToken`

The other hook analyzers (`ClassHooksAnalyzer`, `AssemblyTestHooksAnalyzer`, `InstanceTestHooksAnalyzer`) all follow the same pattern -- accepting `CancellationToken` without requiring a default value.

## Test plan

- [x] Verified source generator always passes `CancellationToken` to hook body delegates
- [x] Verified reflection discovery always passes `CancellationToken` via `method.Invoke()`
- [x] Verified `HookDelegateBuilder` and `HookTimeoutHelper` always provide `CancellationToken`
- [x] Confirmed all other hook analyzers follow the same pattern (no default required)
- [x] All 42 existing `GlobalTestHooksAnalyzerTests` pass
- [x] `dotnet build TUnit.Analyzers/TUnit.Analyzers.csproj` succeeds