### PR TITLE
fix: document and test PublicMethodMissingTestAttributeAnalyzer property/event handling

### DIFF
--- a/TUnit.Analyzers.Tests/PublicMethodMissingTestAttributeAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/PublicMethodMissingTestAttributeAnalyzerTests.cs
@@ -143,10 +143,110 @@ public class PublicMethodMissingTestAttributeAnalyzerTests
                     public void MyTest()
                     {
                     }
-                                
+
                     public ValueTask DisposeAsync()
                     {
                         return ValueTask.CompletedTask;
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Property_Getter_Setter_No_Error()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyTest()
+                    {
+                    }
+
+                    public string? Name { get; set; }
+
+                    public int Age
+                    {
+                        get { return 0; }
+                        set { }
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Event_Accessors_No_Error()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyTest()
+                    {
+                    }
+
+                    public event EventHandler MyEvent
+                    {
+                        add { }
+                        remove { }
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Override_Method_No_Error()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyTest()
+                    {
+                    }
+
+                    public override string ToString()
+                    {
+                        return "test";
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Static_Method_No_Error()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyTest()
+                    {
+                    }
+
+                    public static void StaticHelper()
+                    {
                     }
                 }
                 """

--- a/TUnit.Analyzers/PublicMethodMissingTestAttributeAnalyzer.cs
+++ b/TUnit.Analyzers/PublicMethodMissingTestAttributeAnalyzer.cs
@@ -32,6 +32,9 @@ public class PublicMethodMissingTestAttributeAnalyzer : ConcurrentDiagnosticAnal
             return;
         }
 
+        // MethodKind.Ordinary excludes property accessors (PropertyGet/PropertySet),
+        // event accessors (EventAdd/EventRemove), constructors, destructors, operators,
+        // and other compiler-generated method kinds.
         foreach (var method in methods
                      .Where(x => x.MethodKind == MethodKind.Ordinary)
                      .Where(x => !x.IsAbstract)


### PR DESCRIPTION
## Summary

Closes #4863

- Investigated whether `PublicMethodMissingTestAttributeAnalyzer` produces false positives on property getters/setters and event handlers
- **Finding**: The existing `MethodKind.Ordinary` filter already correctly excludes these cases. In Roslyn's `MethodKind` enum, property accessors have `MethodKind.PropertyGet`/`PropertySet` and event accessors have `MethodKind.EventAdd`/`EventRemove` — all distinct from `MethodKind.Ordinary`
- Added a clarifying comment to the analyzer documenting this behavior
- Added 4 new test cases to explicitly verify no false positives for: properties (auto and explicit), events with custom accessors, override methods, and static methods

## Test plan

- [x] All new tests pass on net8.0 and net9.0
- [x] Existing tests continue to pass
- [x] `dotnet build TUnit.Analyzers/TUnit.Analyzers.csproj` succeeds