### PR TITLE
fix: DependsOnConflictAnalyzer reports all dependency cycles (#4862)

### DIFF
--- a/TUnit.Analyzers.Tests/DependsOnConflictAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/DependsOnConflictAnalyzerTests.cs
@@ -82,8 +82,18 @@ public class DependsOnConflictAnalyzerTests
 
             Verifier
                 .Diagnostic(Rules.DependsOnConflicts)
+                .WithMessage("DependsOn Conflicts: MyClass1.Test2 > MyClass2.Test > MyClass1.Test > MyClass2.Test2 > MyClass1.Test2")
+                .WithLocation(1),
+
+            Verifier
+                .Diagnostic(Rules.DependsOnConflicts)
                 .WithMessage("DependsOn Conflicts: MyClass2.Test > MyClass1.Test > MyClass2.Test")
-                .WithLocation(2)
+                .WithLocation(2),
+
+            Verifier
+                .Diagnostic(Rules.DependsOnConflicts)
+                .WithMessage("DependsOn Conflicts: MyClass2.Test2 > MyClass1.Test > MyClass2.Test > MyClass1.Test2 > MyClass2.Test2")
+                .WithLocation(3)
         );
     }
 
@@ -131,8 +141,18 @@ public class DependsOnConflictAnalyzerTests
 
             Verifier
                 .Diagnostic(Rules.DependsOnConflicts)
+                .WithMessage("DependsOn Conflicts: MyClass1.Test2 > MyClass2.Test > MyClass1.Test > MyClass2.Test2 > MyClass1.Test2")
+                .WithLocation(1),
+
+            Verifier
+                .Diagnostic(Rules.DependsOnConflicts)
                 .WithMessage("DependsOn Conflicts: MyClass2.Test > MyClass1.Test > MyClass2.Test")
-                .WithLocation(2)
+                .WithLocation(2),
+
+            Verifier
+                .Diagnostic(Rules.DependsOnConflicts)
+                .WithMessage("DependsOn Conflicts: MyClass2.Test2 > MyClass1.Test > MyClass2.Test > MyClass1.Test2 > MyClass2.Test2")
+                .WithLocation(3)
         );
     }
 


### PR DESCRIPTION
## Summary
- Replace the `Chain`-based dependency traversal in `DependsOnConflictAnalyzer` with a proper DFS using a `visited` set and backtracking `path` list
- The old `GetDependencies` method returned immediately upon finding any already-traversed method, which prevented exploring other branches of the dependency graph and caused methods involved in cycles to go unreported
- Now all test methods that participate in dependency cycles correctly receive a `TUnit0033` diagnostic, including those previously missed in class-level `[DependsOn]` scenarios with multiple test methods

Closes #4862

## Test plan
- [x] All 11 existing `DependsOnConflictAnalyzerTests` pass (verified on net9.0)
- [x] Updated `Direct_Conflict_Other_Class_Raises_Error` and `Direct_Conflict_Other_Class_Raises_Error_GenericAttribute` tests to expect diagnostics on all 4 test method locations (previously only 2 of 4 were reported)
- [x] Existing tests for no-conflict scenarios, base class scenarios, nested cycles, deep nested direct/indirect conflicts all continue to pass unchanged