### PR TITLE
fix: improve TimeoutCancellationTokenAnalyzer parameter validation (#4860)

### DIFF
--- a/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -3,6 +3,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TUnit0061 | Usage | Error | ClassDataSource type requires parameterless constructor
+TUnit0062 | Usage | Warning | CancellationToken must be the last parameter
 
 ### Removed Rules
 

--- a/TUnit.Analyzers/Resources.resx
+++ b/TUnit.Analyzers/Resources.resx
@@ -498,6 +498,15 @@
     <data name="TUnit0072Title" xml:space="preserve">
         <value>Conflicting data source attributes</value>
     </data>
+    <data name="TUnit0062Description" xml:space="preserve">
+        <value>CancellationToken parameter must be the last parameter in the method signature. Move it to the end of the parameter list.</value>
+    </data>
+    <data name="TUnit0062MessageFormat" xml:space="preserve">
+        <value>CancellationToken must be the last parameter</value>
+    </data>
+    <data name="TUnit0062Title" xml:space="preserve">
+        <value>CancellationToken must be the last parameter</value>
+    </data>
     <data name="TUnit0300Description" xml:space="preserve">
         <value>Generic types and methods may not be AOT-compatible when using dynamic type creation. Consider using concrete types or ensure all generic combinations are known at compile time.</value>
     </data>

--- a/TUnit.Analyzers/Rules.cs
+++ b/TUnit.Analyzers/Rules.cs
@@ -42,6 +42,9 @@ public static class Rules
     public static readonly DiagnosticDescriptor MissingTimeoutCancellationTokenAttributes =
         CreateDescriptor("TUnit0015", UsageCategory, DiagnosticSeverity.Warning);
 
+    public static readonly DiagnosticDescriptor CancellationTokenMustBeLastParameter =
+        CreateDescriptor("TUnit0062", UsageCategory, DiagnosticSeverity.Warning);
+
     public static readonly DiagnosticDescriptor MethodMustNotBeStatic =
         CreateDescriptor("TUnit0016", UsageCategory, DiagnosticSeverity.Error);
 

--- a/TUnit.Analyzers/TimeoutCancellationTokenAnalyzer.cs
+++ b/TUnit.Analyzers/TimeoutCancellationTokenAnalyzer.cs
@@ -9,7 +9,9 @@ namespace TUnit.Analyzers;
 public class TimeoutCancellationTokenAnalyzer : ConcurrentDiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        ImmutableArray.Create(Rules.MissingTimeoutCancellationTokenAttributes);
+        ImmutableArray.Create(
+            Rules.MissingTimeoutCancellationTokenAttributes,
+            Rules.CancellationTokenMustBeLastParameter);
 
     protected override void InitializeInternal(AnalysisContext context)
     {
@@ -23,7 +25,7 @@ public class TimeoutCancellationTokenAnalyzer : ConcurrentDiagnosticAnalyzer
             return;
         }
 
-        if (!methodSymbol.IsTestMethod(context.Compilation) && 
+        if (!methodSymbol.IsTestMethod(context.Compilation) &&
             !methodSymbol.IsHookMethod(context.Compilation, out _, out _, out _))
         {
             return;
@@ -51,13 +53,31 @@ public class TimeoutCancellationTokenAnalyzer : ConcurrentDiagnosticAnalyzer
             return;
         }
 
-        var lastParameter = parameters.Last();
+        var cancellationTokenType = context.Compilation.GetTypeByMetadataName(typeof(CancellationToken).FullName!);
 
-        if (!SymbolEqualityComparer.Default.Equals(lastParameter.Type,
-                context.Compilation.GetTypeByMetadataName(typeof(CancellationToken).FullName!)))
+        var cancellationTokenIndex = -1;
+        for (var i = 0; i < parameters.Length; i++)
         {
+            if (SymbolEqualityComparer.Default.Equals(parameters[i].Type, cancellationTokenType))
+            {
+                cancellationTokenIndex = i;
+                break;
+            }
+        }
+
+        if (cancellationTokenIndex == -1)
+        {
+            // CancellationToken is not present at all
             context.ReportDiagnostic(
                 Diagnostic.Create(Rules.MissingTimeoutCancellationTokenAttributes,
+                    context.Symbol.Locations.FirstOrDefault())
+            );
+        }
+        else if (cancellationTokenIndex != parameters.Length - 1)
+        {
+            // CancellationToken exists but is not the last parameter
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rules.CancellationTokenMustBeLastParameter,
                     context.Symbol.Locations.FirstOrDefault())
             );
         }


### PR DESCRIPTION
## Summary
- Improved `TimeoutCancellationTokenAnalyzer` to scan all parameters for `CancellationToken` instead of only checking the last parameter
- Added new diagnostic rule `TUnit0062` ("CancellationToken must be the last parameter") for cases where `CancellationToken` exists but is not in the last position
- Existing `TUnit0015` diagnostic now only fires when `CancellationToken` is missing entirely, providing clearer messaging

## Test plan
- [x] Added test: `CancellationToken` as first parameter with data after it reports `TUnit0062`
- [x] Added test: `CancellationToken` in the middle of multiple parameters reports `TUnit0062`
- [x] Added test: `CancellationToken` as first of three parameters reports `TUnit0062`
- [x] Added test: data parameter followed by `CancellationToken` (correct order) reports no error
- [x] Verified all existing tests still pass (no regressions)
- [x] All 609 analyzer tests pass on net9.0

Closes #4860