### PR TITLE
fix: remove unnecessary async blocking in ProcessExit handler (#4854)

### DIFF
--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -82,9 +82,11 @@ public class EngineCancellationToken : IDisposable
         {
             CancellationTokenSource.Cancel();
 
-            // Give After hooks a brief moment to execute via registered callbacks
-            // ProcessExit has limited time, so we can only wait briefly
-            Task.Delay(TimeSpan.FromMilliseconds(500)).GetAwaiter().GetResult();
+            // Give After hooks a brief moment to execute via registered callbacks.
+            // ProcessExit has limited time (~3s on Windows), so we can only wait briefly.
+            // Thread.Sleep is appropriate here: we're on a synchronous event handler thread
+            // and just need a simple delay — no need to involve the task scheduler.
+            Thread.Sleep(500);
         }
     }
 

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -361,7 +361,11 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                     await tcs.Task.ConfigureAwait(false);
                 });
 
-                // This wait is safe because it's on a Task.Run thread without SynchronizationContext
+                // This blocking wait is intentional and safe from deadlocks because:
+                // 1. We verified above that the current thread is NOT the dedicated thread
+                // 2. The work is posted to the dedicated thread's queue via Post()
+                // 3. waitTask runs via Task.Run without a SynchronizationContext, so no context capture
+                // 4. SynchronizationContext.Send is synchronous by API contract — blocking is required
                 waitTask.GetAwaiter().GetResult();
             }
         }


### PR DESCRIPTION
## Summary

- **`EngineCancellationToken.cs`**: Replaced `Task.Delay(500).GetAwaiter().GetResult()` with `Thread.Sleep(500)` in the `OnProcessExit` handler. The handler runs on a synchronous event handler thread and only needs a simple delay — there is no reason to involve the task scheduler. This follows the project rule of never blocking on async (no `.Result` or `.GetAwaiter().GetResult()`).
- **`DedicatedThreadExecutor.cs`**: The `.GetAwaiter().GetResult()` in `SynchronizationContext.Send` is intentional and safe — `Send` is synchronous by API contract, the calling thread is verified to not be the dedicated thread, and the `Task.Run` wrapper ensures no `SynchronizationContext` is captured. Added detailed comments explaining why this blocking wait is safe from deadlocks.

Closes #4854

## Test plan

- [x] `dotnet build TUnit.Core/TUnit.Core.csproj` passes with zero warnings/errors across all target frameworks (net8.0, net9.0, net10.0, netstandard2.0)
- [ ] CI pipeline passes