### PR TITLE
fix: propagate CancellationToken to inner loop in AotConverterGenerator

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
@@ -111,6 +111,8 @@ public class AotConverterGenerator : IIncrementalGenerator
 
             foreach(var nodes in root.DescendantNodes())
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if(nodes is MethodDeclarationSyntax method)
                 {
                     var methodSymbol = semanticModel.GetDeclaredSymbol(method);


### PR DESCRIPTION
## Summary

- Adds `cancellationToken.ThrowIfCancellationRequested()` at the start of the `DescendantNodes()` inner loop in `ScanTestParameters`, ensuring the generator responds to cancellation during long-running node traversals
- The outer syntax tree loop and the `typesToScan` loop already had cancellation checks, but the potentially large inner loop over all descendant nodes in each tree did not

## Test plan

- [x] `dotnet build TUnit.Core.SourceGenerator/TUnit.Core.SourceGenerator.csproj` succeeds with zero warnings and zero errors
- [ ] Existing source generator snapshot tests pass (no output change expected since this is a behavioral fix only)

Closes #4900