### PR TITLE
ci: add gate to prevent .received.txt files from being committed (#4880)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,6 +40,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for .received.txt files
+        shell: bash
+        run: |
+          if find . -name "*.received.txt" -not -path "./node_modules/*" | grep -q .; then
+            echo "ERROR: .received.txt files found. These should not be committed."
+            echo "Please replace them with .verified.txt files or remove them."
+            find . -name "*.received.txt" -not -path "./node_modules/*"
+            exit 1
+          fi
+
       - name: Setup .NET Framework
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
## Summary
- Adds a CI step early in the pipeline (right after checkout, before build/test) that checks for any `.received.txt` files in the repository and fails the build if any are found
- The `.gitignore` already contains `*.received.*` which prevents accidental staging, but this CI gate provides a second layer of defense
- Uses `shell: bash` to ensure consistent behavior across all three matrix OS runners (ubuntu, windows, macos)

Closes #4880

## Test plan
- [ ] Verify the CI step passes on a clean checkout (no `.received.txt` files exist in the repo)
- [ ] Verify the step would fail if a `.received.txt` file were committed by temporarily adding one and running the `find` command locally