### PR TITLE
fix: add missing AOT trimming suppressions and null safety for type names

### DIFF
--- a/TUnit.Engine/Extensions/JsonExtensions.cs
+++ b/TUnit.Engine/Extensions/JsonExtensions.cs
@@ -65,7 +65,7 @@ internal static class JsonExtensions
             classParamTypeNames = new string[classParameterTypes.Length];
             for (var i = 0; i < classParameterTypes.Length; i++)
             {
-                classParamTypeNames[i] = classParameterTypes[i].FullName ?? "Unknown";
+                classParamTypeNames[i] = classParameterTypes[i]?.FullName ?? classParameterTypes[i]?.Name ?? "Unknown";
             }
         }
         else
@@ -77,7 +77,7 @@ internal static class JsonExtensions
         var methodParamTypeNames = new string[methodParameters.Length];
         for (var i = 0; i < methodParameters.Length; i++)
         {
-            methodParamTypeNames[i] = methodParameters[i].Type.FullName ?? "Unknown";
+            methodParamTypeNames[i] = methodParameters[i].Type?.FullName ?? methodParameters[i].Type?.Name ?? "Unknown";
         }
 
         return new TestJson

--- a/TUnit.Engine/Services/PropertyInjector.cs
+++ b/TUnit.Engine/Services/PropertyInjector.cs
@@ -230,6 +230,7 @@ internal sealed class PropertyInjector
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Source-gen properties are AOT-safe")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ContainingType is annotated with DynamicallyAccessedMembers in PropertyInjectionMetadata")]
     private async Task InjectSourceGeneratedPropertyAsync(
         object instance,
         PropertyInjectionMetadata metadata,
@@ -376,6 +377,7 @@ internal sealed class PropertyInjector
         return Task.CompletedTask;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ContainingType is annotated with DynamicallyAccessedMembers in PropertyInjectionMetadata")]
     private async Task RecurseIntoNestedPropertiesCoreAsync(object instance, PropertyInjectionPlan plan,
         ConcurrentDictionary<string, object?> objectBag, MethodMetadata? methodMetadata, TestContextEvents events,
         ConcurrentDictionary<object, byte> visitedObjects, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Add `[UnconditionalSuppressMessage("Trimming", "IL2075")]` to `InjectSourceGeneratedPropertyAsync` and `RecurseIntoNestedPropertiesCoreAsync` in `PropertyInjector.cs`, where `GetProperty()` is called on `ContainingType` (already annotated with `[DynamicallyAccessedMembers]` in `PropertyInjectionMetadata`)
- Fix null safety in `JsonExtensions.cs` lines 68 and 80 where `Type.FullName` can return null for generic type parameters, by adding null-conditional access and falling back to `Type.Name` before the `"Unknown"` default

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` succeeds with 0 warnings and 0 errors
- [ ] Verify no regressions in existing tests via CI

Closes #4856