### PR TITLE
fix: remove empty Dispose and fix nullability annotation

### DIFF
--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -12,7 +12,7 @@ using TUnit.Engine.Utilities;
 
 namespace TUnit.Engine.Services;
 
-internal sealed class EventReceiverOrchestrator : IDisposable
+internal sealed class EventReceiverOrchestrator
 {
     private readonly EventReceiverRegistry _registry = new();
     private readonly TUnitFrameworkLogger _logger;
@@ -547,8 +547,4 @@ internal sealed class EventReceiverOrchestrator : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        // No longer need to dispose _registry - it no longer uses ReaderWriterLockSlim
-    }
 }

--- a/TUnit.Engine/Services/PropertyInjector.cs
+++ b/TUnit.Engine/Services/PropertyInjector.cs
@@ -169,7 +169,7 @@ internal sealed class PropertyInjector
     }
 
     private async Task InjectPropertiesRecursiveAsync(
-        object instance,
+        object? instance,
         ConcurrentDictionary<string, object?> objectBag,
         MethodMetadata? methodMetadata,
         TestContextEvents events,


### PR DESCRIPTION
## Summary

Closes #4858

- **Remove unnecessary `IDisposable` implementation from `EventReceiverOrchestrator`**: The `Dispose()` method was empty (the underlying `EventReceiverRegistry` no longer uses `ReaderWriterLockSlim`). No callers explicitly call `Dispose()` on this type -- it was only invoked by `TUnitServiceProvider.DisposeAsync()` which iterates registered services and disposes any that implement `IDisposable`. Removing the interface means the service provider simply skips it during cleanup.
- **Add nullable annotation to `PropertyInjector.InjectPropertiesRecursiveAsync`**: The `instance` parameter was typed as non-nullable `object` but had a null guard that returned early. This is correct behavior for a recursive method (nested property values can be null), so the parameter is now annotated as `object?` to match the actual contract.

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` succeeds with 0 warnings and 0 errors across all target frameworks (netstandard2.0, net8.0, net9.0, net10.0)
- [ ] CI passes