### PR TITLE
fix: improve source generator diagnostic locations

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
@@ -79,13 +79,13 @@ public class HookMetadataGenerator : IIncrementalGenerator
             var descriptor = new DiagnosticDescriptor(
                 "THG001",
                 "Hook metadata generation failed",
-                "Failed to generate hook metadata for {0}: {1}",
+                "Failed to generate hook metadata for {0} (at {1}:{2}): {3}",
                 "TUnit",
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true);
 
             var hookName = $"{hook.MinimalTypeName}.{hook.MethodName}";
-            context.ReportDiagnostic(Diagnostic.Create(descriptor, Location.None, hookName, ex.Message));
+            context.ReportDiagnostic(Diagnostic.Create(descriptor, Location.None, hookName, hook.FilePath, hook.LineNumber, ex.Message));
         }
     }
 

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -285,6 +285,8 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
             var methodName = testMethod?.MethodSymbol?.Name ?? "Unknown";
             var className = testMethod?.TypeSymbol?.Name ?? "Unknown";
 
+            var location = testMethod?.MethodSymbol?.Locations.FirstOrDefault() ?? Location.None;
+
             context.ReportDiagnostic(Diagnostic.Create(
                 new DiagnosticDescriptor(
                     "TUNIT0999",
@@ -293,7 +295,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
                     "TUnit",
                     DiagnosticSeverity.Error,
                     true),
-                Location.None,
+                location,
                 className,
                 methodName,
                 ex.ToString())); // Use ToString() to get full stack trace for debugging


### PR DESCRIPTION
## Summary
- **TestMetadataGenerator**: Replace `Location.None` with the actual method symbol location so users can click the error and navigate directly to the failing test method declaration.
- **HookMetadataGenerator**: Include `FilePath` and `LineNumber` in the diagnostic message so users can find the hook method manually (the `HookModel` is a primitive model without Roslyn symbols, so a `Location` object cannot be constructed, but the file/line info is available).
- **AotConverterGenerator**: Improve error messages to include exception type names, messages, and conversion type context (SourceType/TargetType) so users can identify the problematic types.
- **AotConverterGenerator**: Add a broader `catch (Exception)` handler (excluding `OperationCanceledException`) in `ScanTestParameters` to wrap unexpected errors with context, preserving the original exception as `InnerException`.

## Test plan
- [x] `dotnet build TUnit.Core.SourceGenerator/TUnit.Core.SourceGenerator.csproj` passes with 0 warnings and 0 errors
- [ ] Verify that when a source generation error occurs in `TestMetadataGenerator`, the IDE error list shows the correct file/line location
- [ ] Verify that `HookMetadataGenerator` errors now include file path and line number in the message text
- [ ] Verify that `AotConverterGenerator` errors include actionable type information

Closes #4865