### PR TITLE
fix: use Skip.When for AOT tests outside CI

### DIFF
--- a/TUnit.Engine.Tests/InvokableTestBase.cs
+++ b/TUnit.Engine.Tests/InvokableTestBase.cs
@@ -3,6 +3,7 @@ using System.Text;
 using CliWrap;
 using CliWrap.Buffered;
 using TrxTools.TrxParser;
+using TUnit.Core;
 using TUnit.Engine.Tests.Enums;
 
 namespace TUnit.Engine.Tests;
@@ -79,10 +80,8 @@ public abstract class InvokableTestBase(TestMode testMode)
     private async Task RunWithAot(string filter, List<Action<TestRun>> assertions,
         RunOptions runOptions, string assertionExpression)
     {
-        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != "true")
-        {
-            return;
-        }
+        Skip.When(Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != "true",
+            "AOT tests are only run in GitHub Actions CI. Set GITHUB_ACTIONS=true to run locally.");
 
         var files = FindFolder(x => x.Name == "TESTPROJECT_AOT")!
             .EnumerateFiles("*", SearchOption.AllDirectories)


### PR DESCRIPTION
## Summary
- Replace silent `return` with `Skip.When()` in `InvokableTestBase.RunWithAot()` so AOT tests that only run in GitHub Actions CI are visibly marked as skipped with a reason, instead of silently passing
- Uses TUnit's native skip mechanism (`TUnit.Core.Skip.When`) which properly marks the test as "Skipped" in test results with the message: "AOT tests are only run in GitHub Actions CI. Set GITHUB_ACTIONS=true to run locally."

Closes #4877

## Test plan
- [ ] Verify the project builds successfully (`dotnet build TUnit.Engine.Tests/TUnit.Engine.Tests.csproj`)
- [ ] Run engine tests locally and confirm AOT-mode tests show as "Skipped" with the reason message rather than silently passing
- [ ] Verify AOT tests still execute normally when `GITHUB_ACTIONS=true` is set (CI environment)