### PR TITLE
perf: restrict AbstractTestClassWithDataSourcesAnalyzer to source assembly

### DIFF
--- a/TUnit.Analyzers/AbstractTestClassWithDataSourcesAnalyzer.cs
+++ b/TUnit.Analyzers/AbstractTestClassWithDataSourcesAnalyzer.cs
@@ -59,22 +59,7 @@ public class AbstractTestClassWithDataSourcesAnalyzer : ConcurrentDiagnosticAnal
                     return false;
                 }
 
-                // Check for data source attributes
-                var currentType = attributeClass;
-                while (currentType != null)
-                {
-                    var typeName = currentType.Name;
-
-                    // Check for known data source attributes
-                    if (typeName.Contains("DataSource") || typeName == "ArgumentsAttribute")
-                    {
-                        return true;
-                    }
-
-                    currentType = currentType.BaseType;
-                }
-
-                // Also check if it implements IDataSourceAttribute
+                // Check if it implements IDataSourceAttribute
                 return attributeClass.AllInterfaces.Any(i =>
                     i.GloballyQualified() == WellKnown.AttributeFullyQualifiedClasses.IDataSourceAttribute.WithGlobalPrefix);
             });
@@ -103,20 +88,14 @@ public class AbstractTestClassWithDataSourcesAnalyzer : ConcurrentDiagnosticAnal
     {
         hasAnyConcreteSubclasses = false;
 
-        // Get all named types in the compilation (including referenced assemblies)
-        var allTypes = GetAllNamedTypes(context.Compilation.GlobalNamespace);
+        // Get all named types in the source assembly only (not referenced assemblies)
+        var allTypes = GetAllNamedTypes(context.Compilation.Assembly.GlobalNamespace);
 
         // Check if any concrete class inherits from the abstract class and has [InheritsTests]
         foreach (var type in allTypes)
         {
             // Skip abstract classes
             if (type.IsAbstract)
-            {
-                continue;
-            }
-
-            // Only consider types that are defined in source (not from referenced assemblies)
-            if (!type.Locations.Any(l => l.IsInSource))
             {
                 continue;
             }


### PR DESCRIPTION
## Summary
- **Restrict type scanning to source assembly only**: Changed `GetAllNamedTypes(context.Compilation.GlobalNamespace)` to `GetAllNamedTypes(context.Compilation.Assembly.GlobalNamespace)`. Previously the analyzer recursively walked every type in the entire compilation (including all referenced assemblies) for each abstract test class analyzed. Now it only scans types defined in the source assembly, which is all that's needed since subclasses must be in the user's code.
- **Remove redundant `IsInSource` filter**: Since `Assembly.GlobalNamespace` only contains types from the source assembly, the subsequent `type.Locations.Any(l => l.IsInSource)` check was redundant and has been removed.
- **Replace fragile string-based data source detection with interface check**: Removed the `typeName.Contains("DataSource") || typeName == "ArgumentsAttribute"` string check that walked the type hierarchy. The `IDataSourceAttribute` interface check is comprehensive and authoritative -- all data source attributes (`ArgumentsAttribute`, `MethodDataSourceAttribute`, `ClassDataSourceAttribute`, etc.) implement `IDataSourceAttribute` either directly or through `ITypedDataSourceAttribute<T>` / `IAsyncUntypedDataSourceGeneratorAttribute`.

Closes #4864

## Test plan
- [x] All 12 existing `AbstractTestClassWithDataSourcesAnalyzerTests` pass on both .NET 8 and .NET 9
- [x] `dotnet build TUnit.Analyzers/TUnit.Analyzers.csproj` succeeds with no errors