### PR TITLE
fix: remove global Retry(3) from InvokableTestBase

### DIFF
--- a/TUnit.Engine.Tests/CancellationAfterHooksTests.cs
+++ b/TUnit.Engine.Tests/CancellationAfterHooksTests.cs
@@ -8,6 +8,7 @@ namespace TUnit.Engine.Tests;
 /// Validates that After hooks execute even when tests are cancelled (Issue #3882).
 /// These tests run the cancellation test scenarios and verify that After hooks created marker files.
 /// </summary>
+[Retry(3)]
 public class CancellationAfterHooksTests(TestMode testMode) : InvokableTestBase(testMode)
 {
     private static readonly string TempPath = Path.GetTempPath();

--- a/TUnit.Engine.Tests/ExternalCancellationTests.cs
+++ b/TUnit.Engine.Tests/ExternalCancellationTests.cs
@@ -17,6 +17,7 @@ namespace TUnit.Engine.Tests;
 /// See: https://github.com/Tyrrrz/CliWrap/issues/47
 /// </remarks>
 [ExcludeOn(OS.Windows)]
+[Retry(3)]
 public class ExternalCancellationTests(TestMode testMode) : InvokableTestBase(testMode)
 {
     private static readonly string TempPath = Path.GetTempPath();

--- a/TUnit.Engine.Tests/InvokableTestBase.cs
+++ b/TUnit.Engine.Tests/InvokableTestBase.cs
@@ -8,7 +8,6 @@ using TUnit.Engine.Tests.Enums;
 namespace TUnit.Engine.Tests;
 
 [MethodDataSource(nameof(GetTestModes))]
-[Retry(3)]
 public abstract class InvokableTestBase(TestMode testMode)
 {
     public static IEnumerable<TestMode> GetTestModes()

--- a/TUnit.Engine.Tests/ParallelismValidationEngineTests.cs
+++ b/TUnit.Engine.Tests/ParallelismValidationEngineTests.cs
@@ -10,6 +10,7 @@ namespace TUnit.Engine.Tests;
 /// 2. ParallelLimiter correctly limits concurrency
 /// 3. Different parallel limiters work independently
 /// </summary>
+[Retry(3)]
 public class ParallelismValidationEngineTests(TestMode testMode) : InvokableTestBase(testMode)
 {
     [Test]

--- a/TUnit.Engine.Tests/Scheduling/ConstraintKeySchedulerConcurrencyTests.cs
+++ b/TUnit.Engine.Tests/Scheduling/ConstraintKeySchedulerConcurrencyTests.cs
@@ -10,6 +10,7 @@ namespace TUnit.Engine.Tests.Scheduling;
 /// 2. No deadlocks occur under high contention
 /// 3. Tests complete within reasonable timeout
 /// </summary>
+[Retry(3)]
 public class ConstraintKeySchedulerConcurrencyTests(TestMode testMode) : InvokableTestBase(testMode)
 {
     [Test]


### PR DESCRIPTION
## Summary
- Removed the global `[Retry(3)]` attribute from `InvokableTestBase`, which was silently retrying all ~50 engine test classes and masking intermittent failures
- Added targeted `[Retry(3)]` to only the four test classes that are genuinely timing-sensitive:
  - `CancellationAfterHooksTests` -- validates After hooks run on cancellation, sensitive to process timing
  - `ExternalCancellationTests` -- sends SIGINT to subprocesses, inherently racy
  - `ParallelismValidationEngineTests` -- validates concurrency behavior, timing-dependent
  - `ConstraintKeySchedulerConcurrencyTests` -- high-contention deadlock detection with timeouts

Closes #4878

## Test plan
- [x] `dotnet build TUnit.Engine.Tests/TUnit.Engine.Tests.csproj` passes with 0 errors
- [ ] CI passes -- the four annotated classes retain retry protection while all other tests now fail fast on first failure