### PR TITLE
chore: fix TUnit.Assertions.FSharp pre-release package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,7 +97,7 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.10.0" />
     <PackageVersion Include="trxparser" Version="0.5.0" />
-    <PackageVersion Include="TUnit.Assertions.FSharp" Version="0.75.38-PullRequest3485.0" />
+    <PackageVersion Include="TUnit.Assertions.FSharp" Version="1.16.4" />
     <PackageVersion Include="Verify" Version="31.13.1" />
     <PackageVersion Include="Verify.NUnit" Version="31.13.1" />
     <PackageVersion Include="TUnit" Version="1.16.4" />


### PR DESCRIPTION
## Summary
- Updates `TUnit.Assertions.FSharp` version in `Directory.Packages.props` from `0.75.38-PullRequest3485.0` (a stale pre-release version from PR #3485) to `1.16.4` to match all other TUnit packages.

## Context
The `TUnit.Assertions.FSharp` entry in `Directory.Packages.props` was set to `0.75.38-PullRequest3485.0`, which is a pre-release version from an old pull request build. All other TUnit packages (`TUnit`, `TUnit.Core`, `TUnit.Engine`, `TUnit.Assertions`, `TUnit.AspNetCore`) are at version `1.16.4`. This inconsistency could cause issues for F# projects that consume TUnit via NuGet, since `TUnit.Assertions.props` automatically adds a PackageReference to `TUnit.Assertions.FSharp` for `.fsproj` files.

Closes #4884

## Test plan
- [x] `dotnet build TUnit.Assertions.FSharp/TUnit.Assertions.FSharp.fsproj` succeeds
- [ ] CI pipeline passes