### PR TITLE
chore: centralize hardcoded configuration values into constants

### DIFF
--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -1,0 +1,32 @@
+namespace TUnit.Core;
+
+/// <summary>
+/// Default values shared across TUnit.Core and TUnit.Engine.
+/// Centralizes magic numbers so they can be tuned in a single place.
+/// </summary>
+public static class Defaults
+{
+    /// <summary>
+    /// Default timeout applied to individual tests when no <c>[Timeout]</c> attribute is specified.
+    /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
+    /// </summary>
+    public static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Default timeout applied to hook methods (Before/After at every level)
+    /// when no explicit timeout is configured.
+    /// </summary>
+    public static readonly TimeSpan HookTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
+    /// before the process is forcefully terminated.
+    /// </summary>
+    public static readonly TimeSpan ForcefulExitTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Brief delay during process exit to allow After hooks registered via
+    /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
+    /// </summary>
+    public static readonly TimeSpan ProcessExitHookDelay = TimeSpan.FromMilliseconds(500);
+}

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -62,7 +62,7 @@ public class EngineCancellationToken : IDisposable
             _forcefulExitStarted = true;
 
             // Start a new forceful exit timer
-            _ = Task.Delay(TimeSpan.FromSeconds(30), CancellationToken.None).ContinueWith(t =>
+            _ = Task.Delay(Defaults.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
             {
                 if (!t.IsCanceled)
                 {
@@ -86,7 +86,7 @@ public class EngineCancellationToken : IDisposable
             // ProcessExit has limited time (~3s on Windows), so we can only wait briefly.
             // Thread.Sleep is appropriate here: we're on a synchronous event handler thread
             // and just need a simple delay — no need to involve the task scheduler.
-            Thread.Sleep(500);
+            Thread.Sleep(Defaults.ProcessExitHookDelay);
         }
     }
 

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -349,12 +349,12 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                 var waitTask = Task.Run(async () =>
                 {
                     // For .NET Standard 2.0 compatibility, use Task.Delay for timeout
-                    var timeoutTask = Task.Delay(TimeSpan.FromMinutes(30));
+                    var timeoutTask = Task.Delay(Defaults.TestTimeout);
                     var completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask)
                     {
-                        throw new TimeoutException("Synchronous operation on dedicated thread timed out after 30 minutes");
+                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {Defaults.TestTimeout.TotalMinutes} minutes");
                     }
 
                     // Await the actual task to get its result or exception

--- a/TUnit.Core/Hooks/HookMethod.cs
+++ b/TUnit.Core/Hooks/HookMethod.cs
@@ -28,7 +28,7 @@ public abstract record HookMethod
     /// Gets the timeout for this hook method. This will be set during hook registration
     /// by the event receiver infrastructure, falling back to the default 5-minute timeout.
     /// </summary>
-    public TimeSpan? Timeout { get; internal set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan? Timeout { get; internal set; } = Defaults.HookTimeout;
 
     public required IHookExecutor HookExecutor { get; init; }
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -1040,7 +1040,7 @@ internal sealed class TestBuilder : ITestBuilder
             AttributesByType = attributes.ToAttributeDictionary(),
             MethodGenericArguments = testData.ResolvedMethodGenericArguments,
             ClassGenericArguments = testData.ResolvedClassGenericArguments,
-            Timeout = TimeSpan.FromMinutes(30) // Default 30-minute timeout (can be overridden by TimeoutAttribute)
+            Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
             // Don't set RetryLimit here - let discovery event receivers set it
         };
 
@@ -1133,7 +1133,7 @@ internal sealed class TestBuilder : ITestBuilder
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = TimeSpan.FromMinutes(30)
+            Timeout = Core.Defaults.TestTimeout
         };
     }
 

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -263,7 +263,7 @@ internal sealed class TestBuilderPipeline
                 ReturnType = typeof(Task),
                 MethodMetadata = metadata.MethodMetadata,
                 AttributesByType = attributes.ToAttributeDictionary(),
-                Timeout = TimeSpan.FromMinutes(30) // Default 30-minute timeout (can be overridden by TimeoutAttribute)
+                Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                 // Don't set RetryLimit here - let discovery event receivers set it
             };
 
@@ -391,7 +391,7 @@ internal sealed class TestBuilderPipeline
                         ReturnType = typeof(Task),
                         MethodMetadata = resolvedMetadata.MethodMetadata,
                         AttributesByType = attributes.ToAttributeDictionary(),
-                        Timeout = TimeSpan.FromMinutes(30) // Default 30-minute timeout (can be overridden by TimeoutAttribute)
+                        Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                         // Don't set Timeout and RetryLimit here - let discovery event receivers set them
                     };
 
@@ -471,7 +471,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = TimeSpan.FromMinutes(30) // Default 30-minute timeout
+            Timeout = Core.Defaults.TestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(
@@ -523,7 +523,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = TimeSpan.FromMinutes(30) // Default 30-minute timeout
+            Timeout = Core.Defaults.TestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Constants/EngineDefaults.cs
+++ b/TUnit.Engine/Constants/EngineDefaults.cs
@@ -1,0 +1,97 @@
+namespace TUnit.Engine.Constants;
+
+/// <summary>
+/// Default configuration values for the TUnit test engine.
+/// Centralizes magic numbers so they can be tuned in a single place.
+/// </summary>
+internal static class EngineDefaults
+{
+    // ── Discovery ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Maximum time allowed for test discovery before the operation is cancelled.
+    /// </summary>
+    public static readonly TimeSpan DiscoveryTimeout = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Maximum time allowed for test data generation in the discovery circuit breaker
+    /// before it trips.
+    /// </summary>
+    public static readonly TimeSpan MaxGenerationTime = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Maximum proportion of available memory that test data generation may consume
+    /// before the discovery circuit breaker trips.
+    /// </summary>
+    public const double MaxMemoryPercentage = 0.7;
+
+    /// <summary>
+    /// Conservative fallback for total available memory when the runtime cannot determine
+    /// the actual value (e.g., on older .NET runtimes).
+    /// </summary>
+    public const long FallbackAvailableMemoryBytes = 1024L * 1024L * 1024L; // 1 GB
+
+    /// <summary>
+    /// Maximum number of retry passes when resolving test dependencies.
+    /// </summary>
+    public const int DependencyResolutionMaxRetries = 3;
+
+    // ── Event Batching ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Default number of events collected before a batch is flushed.
+    /// </summary>
+    public const int DefaultEventBatchSize = 100;
+
+    /// <summary>
+    /// Minimum batch delay used when the caller specifies <see cref="TimeSpan.Zero"/>.
+    /// Prevents a tight spin loop in the batching consumer.
+    /// </summary>
+    public static readonly TimeSpan MinBatchDelay = TimeSpan.FromMilliseconds(10);
+
+    /// <summary>
+    /// Maximum time to wait for the background processing task to complete
+    /// during dispose / shutdown.
+    /// </summary>
+    public static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
+    // ── Timeout Handling ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Grace period given to a timed-out task to handle cancellation
+    /// before a <see cref="TimeoutException"/> is thrown.
+    /// </summary>
+    public static readonly TimeSpan TimeoutGracePeriod = TimeSpan.FromSeconds(1);
+
+    // ── IDE Streaming ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Interval at which cumulative test output snapshots are streamed to the IDE.
+    /// </summary>
+    public static readonly TimeSpan IdeStreamingThrottleInterval = TimeSpan.FromSeconds(1);
+
+    // ── File-Write Retry (Reporters) ────────────────────────────────────
+
+    /// <summary>
+    /// Maximum number of attempts when writing a report file that may be locked
+    /// by another process.
+    /// </summary>
+    public const int FileWriteMaxAttempts = 5;
+
+    /// <summary>
+    /// Base delay in milliseconds for exponential back-off when retrying a locked file write.
+    /// Actual delay = <c>BaseRetryDelayMs * 2^(attempt-1) + jitter</c>.
+    /// </summary>
+    public const int BaseRetryDelayMs = 50;
+
+    /// <summary>
+    /// Maximum random jitter in milliseconds added to retry delays to prevent thundering-herd effects.
+    /// </summary>
+    public const int MaxRetryJitterMs = 50;
+
+    /// <summary>
+    /// Maximum file size in bytes for the GitHub Step Summary file.
+    /// GitHub imposes a 1 MB limit on step summary files.
+    /// </summary>
+    public const long GitHubSummaryMaxFileSizeBytes = 1L * 1024L * 1024L; // 1 MB
+}

--- a/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -1,3 +1,5 @@
+using TUnit.Engine.Constants;
+
 namespace TUnit.Engine.Helpers;
 
 /// <summary>
@@ -8,7 +10,7 @@ internal static class TimeoutHelper
     /// <summary>
     /// Grace period to allow tasks to handle cancellation before throwing timeout exception.
     /// </summary>
-    private static readonly TimeSpan GracePeriod = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan GracePeriod = EngineDefaults.TimeoutGracePeriod;
 
     /// <summary>
     /// Executes a ValueTask-returning operation with an optional timeout.

--- a/TUnit.Engine/Logging/IdeStreamingSink.cs
+++ b/TUnit.Engine/Logging/IdeStreamingSink.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using TUnit.Core;
 using TUnit.Core.Logging;
+using TUnit.Engine.Constants;
 
 #pragma warning disable TPEXP
 
@@ -33,7 +34,7 @@ internal sealed class IdeStreamingSink : ILogSink, IAsyncDisposable
 {
     private readonly TUnitMessageBus _messageBus;
     private readonly ConcurrentDictionary<string, TestStreamingState> _activeTests = new();
-    private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+    private readonly TimeSpan _throttleInterval = EngineDefaults.IdeStreamingThrottleInterval;
 
     public IdeStreamingSink(TUnitMessageBus messageBus)
     {

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -5,6 +5,7 @@ using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 using TUnit.Engine.Configuration;
+using TUnit.Engine.Constants;
 using TUnit.Engine.Framework;
 using TUnit.Engine.Xml;
 
@@ -123,7 +124,7 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
             Directory.CreateDirectory(directory);
         }
 
-        const int maxAttempts = 5;
+        const int maxAttempts = EngineDefaults.FileWriteMaxAttempts;
 
         for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
@@ -139,8 +140,8 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
             }
             catch (IOException ex) when (attempt < maxAttempts && IsFileLocked(ex))
             {
-                var baseDelay = 50 * Math.Pow(2, attempt - 1);
-                var jitter = Random.Shared.Next(0, 50);
+                var baseDelay = EngineDefaults.BaseRetryDelayMs * Math.Pow(2, attempt - 1);
+                var jitter = Random.Shared.Next(0, EngineDefaults.MaxRetryJitterMs);
                 var delay = (int)(baseDelay + jitter);
 
                 Console.WriteLine($"JUnit XML file is locked, retrying in {delay}ms (attempt {attempt}/{maxAttempts})");

--- a/TUnit.Engine/Services/DiscoveryCircuitBreaker.cs
+++ b/TUnit.Engine/Services/DiscoveryCircuitBreaker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using TUnit.Engine.Constants;
 
 namespace TUnit.Engine.Services;
 
@@ -17,11 +18,11 @@ public sealed class DiscoveryCircuitBreaker
     /// Creates a new discovery circuit breaker with intelligent limits
     /// </summary>
     public DiscoveryCircuitBreaker(
-        double maxMemoryPercentage = 0.7, // Use up to 70% of available memory
-        TimeSpan? maxGenerationTime = null) // Default 2 minutes
+        double maxMemoryPercentage = EngineDefaults.MaxMemoryPercentage,
+        TimeSpan? maxGenerationTime = null)
     {
         _maxMemoryBytes = (long)(GetAvailableMemoryBytes() * maxMemoryPercentage);
-        _maxGenerationTime = maxGenerationTime ?? TimeSpan.FromMinutes(2);
+        _maxGenerationTime = maxGenerationTime ?? EngineDefaults.MaxGenerationTime;
         _stopwatch = Stopwatch.StartNew();
         
         // Track initial memory to calculate growth
@@ -104,7 +105,7 @@ public sealed class DiscoveryCircuitBreaker
         }
 
         // Conservative fallback: assume 1GB available
-        return 1024L * 1024L * 1024L;
+        return EngineDefaults.FallbackAvailableMemoryBytes;
     }
 
     public void Dispose()

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -1,5 +1,6 @@
 using TUnit.Core;
 using TUnit.Core.Helpers;
+using TUnit.Engine.Constants;
 
 namespace TUnit.Engine.Services;
 
@@ -272,7 +273,7 @@ internal sealed class TestDependencyResolver
                 }
             }
 
-            var maxRetries = 3;
+            var maxRetries = EngineDefaults.DependencyResolutionMaxRetries;
             for (var retry = 0; retry < maxRetries && _testsWithPendingDependencies.Count > 0; retry++)
             {
                 ResolvePendingDependencies();

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -6,6 +6,7 @@ using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
 using TUnit.Engine.Building;
 using TUnit.Engine.Building.Interfaces;
+using TUnit.Engine.Constants;
 using TUnit.Engine.Services;
 
 namespace TUnit.Engine;
@@ -83,7 +84,7 @@ internal sealed class TestDiscoveryService : IDataProducer
             // Build tests directly from the pre-collected metadata (avoid re-collecting)
             // Apply 5-minute discovery timeout matching the streaming path (#4715)
             using var filterCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            filterCts.CancelAfter(TimeSpan.FromMinutes(5));
+            filterCts.CancelAfter(EngineDefaults.DiscoveryTimeout);
 
             var buildingContext = new Building.TestBuildingContext(isForExecution, Filter: null);
             var tests = await _testBuilderPipeline.BuildTestsFromMetadataAsync(
@@ -160,7 +161,7 @@ internal sealed class TestDiscoveryService : IDataProducer
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cts.CancelAfter(TimeSpan.FromMinutes(5));
+        cts.CancelAfter(EngineDefaults.DiscoveryTimeout);
 
         var tests = await _testBuilderPipeline.BuildTestsStreamingAsync(testSessionId, buildingContext, metadataFilter: null, cts.Token).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary

Closes #4902

- Introduces `TUnit.Core.Defaults` with shared constants (default test timeout, hook timeout, forceful-exit timeout, process-exit hook delay) used by both TUnit.Core and TUnit.Engine.
- Introduces `TUnit.Engine.Constants.EngineDefaults` with engine-specific constants (discovery timeout, circuit-breaker limits, event batch parameters, shutdown timeout, timeout grace period, IDE streaming interval, file-write retry configuration, GitHub summary max file size, dependency resolution retry count).
- Replaces **all** hardcoded magic numbers across 13 files in TUnit.Engine and TUnit.Core with references to these named constants.

### Constants introduced

| Constant | Value | Used in |
|---|---|---|
| `Defaults.TestTimeout` | 30 min | TestBuilder, TestBuilderPipeline (x4), DedicatedThreadExecutor |
| `Defaults.HookTimeout` | 5 min | HookMethod |
| `Defaults.ForcefulExitTimeout` | 30 s | EngineCancellationToken |
| `Defaults.ProcessExitHookDelay` | 500 ms | EngineCancellationToken |
| `EngineDefaults.DiscoveryTimeout` | 5 min | TestDiscoveryService (x2) |
| `EngineDefaults.MaxGenerationTime` | 2 min | DiscoveryCircuitBreaker |
| `EngineDefaults.MaxMemoryPercentage` | 0.7 | DiscoveryCircuitBreaker |
| `EngineDefaults.FallbackAvailableMemoryBytes` | 1 GB | DiscoveryCircuitBreaker |
| `EngineDefaults.DependencyResolutionMaxRetries` | 3 | TestDependencyResolver |
| `EngineDefaults.DefaultEventBatchSize` | 100 | EventBatcher |
| `EngineDefaults.MinBatchDelay` | 10 ms | EventBatcher |
| `EngineDefaults.ShutdownTimeout` | 5 s | EventBatcher |
| `EngineDefaults.TimeoutGracePeriod` | 1 s | TimeoutHelper |
| `EngineDefaults.IdeStreamingThrottleInterval` | 1 s | IdeStreamingSink |
| `EngineDefaults.FileWriteMaxAttempts` | 5 | JUnitReporter, GitHubReporter |
| `EngineDefaults.BaseRetryDelayMs` | 50 | JUnitReporter, GitHubReporter |
| `EngineDefaults.MaxRetryJitterMs` | 50 | JUnitReporter, GitHubReporter |
| `EngineDefaults.GitHubSummaryMaxFileSizeBytes` | 1 MB | GitHubReporter |

## Test plan

- [x] `dotnet build TUnit.Core/TUnit.Core.csproj` passes with 0 warnings and 0 errors
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` passes with 0 warnings and 0 errors
- [ ] CI passes all existing tests (pure refactor, no behavioral change)