### PR TITLE
fix: Playwright BrowserTest resource leaks and thread safety

### DIFF
--- a/TUnit.Playwright/BrowserService.cs
+++ b/TUnit.Playwright/BrowserService.cs
@@ -51,5 +51,14 @@ internal class BrowserService : IWorkerService
     }
 
     public Task ResetAsync() => Task.CompletedTask;
-    public Task DisposeAsync() => Browser.CloseAsync();
+
+    public async Task DisposeAsync()
+    {
+        var browser = Browser;
+
+        if (browser != null)
+        {
+            await browser.CloseAsync().ConfigureAwait(false);
+        }
+    }
 }

--- a/TUnit.Playwright/BrowserTest.cs
+++ b/TUnit.Playwright/BrowserTest.cs
@@ -17,12 +17,18 @@ public class BrowserTest : PlaywrightTest
     public IBrowser Browser { get; internal set; } = null!;
 
     private readonly List<IBrowserContext> _contexts = [];
+    private readonly object _contextsLock = new();
     private readonly BrowserTypeLaunchOptions _options;
 
     public async Task<IBrowserContext> NewContext(BrowserNewContextOptions options)
     {
         var context = await Browser.NewContextAsync(options).ConfigureAwait(false);
-        _contexts.Add(context);
+
+        lock (_contextsLock)
+        {
+            _contexts.Add(context);
+        }
+
         return context;
     }
 
@@ -33,7 +39,7 @@ public class BrowserTest : PlaywrightTest
         {
             throw new InvalidOperationException($"BrowserType is not initialized. This may indicate that {nameof(PlaywrightTest)}.{nameof(Playwright)} is not initialized or {nameof(PlaywrightTest)}.{nameof(PlaywrightSetup)} did not execute properly.");
         }
-        
+
         var service = await BrowserService.Register(this, BrowserType, _options).ConfigureAwait(false);
         Browser = service.Browser;
     }
@@ -41,14 +47,34 @@ public class BrowserTest : PlaywrightTest
     [After(HookType.Test, "", 0)]
     public async Task BrowserTearDown(TestContext testContext)
     {
-        if (TestOk(testContext))
+        List<IBrowserContext> contextsSnapshot;
+
+        lock (_contextsLock)
         {
-            foreach (var context in _contexts)
+            contextsSnapshot = [.. _contexts];
+            _contexts.Clear();
+        }
+
+        List<Exception>? exceptions = null;
+
+        foreach (var context in contextsSnapshot)
+        {
+            try
             {
                 await context.CloseAsync().ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                exceptions ??= [];
+                exceptions.Add(ex);
+            }
         }
-        _contexts.Clear();
+
         Browser = null!;
+
+        if (exceptions is { Count: > 0 })
+        {
+            throw new AggregateException("One or more browser contexts failed to close.", exceptions);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **Browser contexts now always closed on teardown** -- previously, `BrowserTest.BrowserTearDown` only closed contexts when the test passed; on failure, contexts were cleared from the list but never actually closed, leaking browser resources.
- **Resilient disposal loops** -- if closing one browser context or disposing one worker service throws, the remaining resources are still cleaned up. Exceptions are collected and re-thrown as an `AggregateException` after all resources have been processed.
- **Null-safe `BrowserService.DisposeAsync`** -- added a null check before calling `Browser.CloseAsync()` to guard against cases where the browser was never successfully created.
- **Thread-safe context tracking** -- `BrowserTest._contexts` list is now protected by a lock to prevent concurrent modification if `NewContext` is called from multiple async continuations.
- **Worker teardown safety** -- `WorkerAwareTest.WorkerTeardown` now handles the case where `_currentWorker` is null, and if `ResetAsync` throws during the "test passed" path, it falls back to disposing all services rather than leaking them.
- **Optimized `RegisterService`** -- replaced `ContainsKey` + indexer double-lookup with a single `TryGetValue` call.

Closes #4879

## Test plan
- [ ] `dotnet build TUnit.Playwright/TUnit.Playwright.csproj` passes on all target frameworks (netstandard2.0, net8.0, net9.0, net10.0)
- [ ] Verify existing Playwright template tests still pass
- [ ] Manual review: confirm all `CloseAsync`/`DisposeAsync` calls are now wrapped in try/catch with proper exception aggregation
- [ ] Manual review: confirm contexts are closed regardless of test pass/fail state