### PR TITLE
fix: add timing tolerances to flaky timing-based test assertions

### DIFF
--- a/TUnit.TestProject/ConstraintKeyStressTests.cs
+++ b/TUnit.TestProject/ConstraintKeyStressTests.cs
@@ -161,11 +161,12 @@ public class ConstraintKeyStressTests
                 if (overlap)
                 {
                     // This indicates a constraint violation - tests with same key should be serial
-                    // Note: Due to timing precision and async nature, allow small overlaps (< 10ms)
+                    // Note: Due to timing precision, async nature, and CI scheduling variability,
+                    // allow small overlaps (< 50ms) as tolerance for framework overhead
                     var overlapDuration = GetOverlapDuration(currentWindow, otherWindow);
 
                     // Use Assert.Fail for constraint violations
-                    if (overlapDuration.TotalMilliseconds >= 10)
+                    if (overlapDuration.TotalMilliseconds >= 50)
                     {
                         Assert.Fail(
                             $"Tests with shared constraint keys should not overlap significantly. " +

--- a/TUnit.TestProject/NotInParallelExecutionTests.cs
+++ b/TUnit.TestProject/NotInParallelExecutionTests.cs
@@ -129,7 +129,19 @@ public class NotInParallelExecutionTests
                 return false;
             }
 
-            return StartTime < other.EndTime.Value && other.StartTime < EndTime.Value;
+            // Allow a small tolerance (50ms) for framework overhead and CI scheduling variability
+            var tolerance = TimeSpan.FromMilliseconds(50);
+
+            // Check if tests ran sequentially (one after the other) with tolerance
+            var thisRanFirst = EndTime.Value <= other.StartTime.Add(tolerance);
+            var otherRanFirst = other.EndTime.Value <= StartTime.Add(tolerance);
+
+            if (thisRanFirst || otherRanFirst)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/TUnit.TestProject/NotInParallelOrderExecutionTests.cs
+++ b/TUnit.TestProject/NotInParallelOrderExecutionTests.cs
@@ -221,7 +221,19 @@ public class NotInParallelOrderExecutionTests
                 return false;
             }
 
-            return StartTime < other.EndTime.Value && other.StartTime < EndTime.Value;
+            // Allow a small tolerance (50ms) for framework overhead and CI scheduling variability
+            var tolerance = TimeSpan.FromMilliseconds(50);
+
+            // Check if tests ran sequentially (one after the other) with tolerance
+            var thisRanFirst = EndTime.Value <= other.StartTime.Add(tolerance);
+            var otherRanFirst = other.EndTime.Value <= StartTime.Add(tolerance);
+
+            if (thisRanFirst || otherRanFirst)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/TUnit.TestProject/ParallelPropertyInjectionTests.cs
+++ b/TUnit.TestProject/ParallelPropertyInjectionTests.cs
@@ -122,9 +122,9 @@ public class ParallelPropertyInjectionTests
         Console.WriteLine($"Actual total time: {actualTotalTime.TotalMilliseconds}ms");
         Console.WriteLine($"Time saved by parallel initialization: {(totalSequentialTime - actualTotalTime).TotalMilliseconds}ms");
         
-        // Verify parallel execution: actual time should be significantly less than sequential time
-        // Allow some margin for thread scheduling overhead
-        await Assert.That(actualTotalTime.TotalMilliseconds).IsLessThan(totalSequentialTime.TotalMilliseconds * 0.8);
+        // Verify parallel execution: actual time should be less than sequential time
+        // Use a generous margin (0.95) for CI systems with variable thread scheduling overhead
+        await Assert.That(actualTotalTime.TotalMilliseconds).IsLessThan(totalSequentialTime.TotalMilliseconds * 0.95);
     }
     
     // Test with nested properties that also benefit from parallel initialization
@@ -222,6 +222,7 @@ public class ParallelPropertyInjectionTests
         Console.WriteLine($"Time saved by parallel initialization: {totalSequentialTime - actualTotalTime}ms");
         
         // Properties at the same level should be initialized in parallel
-        await Assert.That(actualTotalTime).IsLessThan(totalSequentialTime * 0.8);
+        // Use a generous margin (0.95) for CI systems with variable thread scheduling overhead
+        await Assert.That(actualTotalTime).IsLessThan(totalSequentialTime * 0.95);
     }
 }


### PR DESCRIPTION
## Summary
- Timing-based assertions in `TUnit.TestProject` are inherently flaky on CI systems with variable load, causing intermittent test failures
- Added tolerances (typically 50ms) to all overlap detection logic across 7 test files to account for framework overhead and thread scheduling variability on CI
- Widened parallel execution timing ratios from strict 0.8x to 0.95x, and lowered minimum concurrency thresholds where the original values were unrealistic under load

## Changes
- **ParallelPropertyInjectionTests**: Relaxed parallel-vs-sequential ratio from 0.8 to 0.95 (both test methods)
- **ConstraintKeyStressTests**: Increased overlap tolerance from 10ms to 50ms
- **NotInParallelExecutionTests**: Added 50ms tolerance to `OverlapsWith` method
- **NotInParallelOrderExecutionTests**: Added 50ms tolerance to `OverlapsWith` method
- **CombinedConstraintsSelfContainedTest**: Added 50ms tolerance to key overlap and group overlap checks
- **CombinedParallelConstraintsTests**: Added 50ms tolerance to schema/data overlap and API/DB group overlap checks
- **ParallelismValidationTests**: Added 50ms tolerance to `StrictlySerialTests` overlap detection; lowered `HighParallelismTests` concurrency threshold from 4 to 2

## Test plan
- [x] `dotnet build TUnit.TestProject/TUnit.TestProject.csproj` compiles with 0 errors
- [ ] CI pipeline passes without flaky timing failures
- [ ] Tolerances are tight enough to still catch real concurrency violations (50ms is well below the 100-300ms `Task.Delay` durations used in the tests)