### PR TITLE
fix: standardize assertion error message formatting

### DIFF
--- a/TUnit.Assertions.Tests/Assertions/Delegates/Throws.ExactlyTests.cs
+++ b/TUnit.Assertions.Tests/Assertions/Delegates/Throws.ExactlyTests.cs
@@ -10,7 +10,7 @@ public partial class Throws
         {
             var expectedMessage = """
                                   Expected to throw exactly CustomException
-                                  but threw TUnit.Assertions.Tests.Assertions.Delegates.Throws+OtherException
+                                  but threw OtherException
 
                                   at Assert.That(action).ThrowsExactly<CustomException>()
                                   """.NormalizeLineEndings();

--- a/TUnit.Assertions.Tests/Assertions/Delegates/Throws.OfTypeTests.cs
+++ b/TUnit.Assertions.Tests/Assertions/Delegates/Throws.OfTypeTests.cs
@@ -10,7 +10,7 @@ public partial class Throws
         {
             var expectedMessage = """
                                   Expected to throw CustomException
-                                  but threw TUnit.Assertions.Tests.Assertions.Delegates.Throws+OtherException
+                                  but threw OtherException
 
                                   at Assert.That(action).Throws<CustomException>()
                                   """.NormalizeLineEndings();
@@ -29,7 +29,7 @@ public partial class Throws
         {
             var expectedMessage = """
                                   Expected to throw SubCustomException
-                                  but threw TUnit.Assertions.Tests.Assertions.Delegates.Throws+CustomException
+                                  but threw CustomException
 
                                   at Assert.That(action).Throws<SubCustomException>()
                                   """.NormalizeLineEndings();

--- a/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
@@ -54,7 +54,7 @@ public class AsyncEnumerableAssertionTests
         var action = async () => await Assert.That(items).HasCount(5);
 
         var exception = await Assert.That(action).Throws<AssertionException>();
-        await Assert.That(exception.Message).Contains("found 3 items");
+        await Assert.That(exception.Message).Contains("received 3 items");
     }
 
     // Contains tests
@@ -72,7 +72,7 @@ public class AsyncEnumerableAssertionTests
         var action = async () => await Assert.That(items).Contains(99);
 
         var exception = await Assert.That(action).Throws<AssertionException>();
-        await Assert.That(exception.Message).Contains("item 99 was not found");
+        await Assert.That(exception.Message).Contains("99 was not found in the collection");
     }
 
     // DoesNotContain tests
@@ -90,7 +90,7 @@ public class AsyncEnumerableAssertionTests
         var action = async () => await Assert.That(items).DoesNotContain(5);
 
         var exception = await Assert.That(action).Throws<AssertionException>();
-        await Assert.That(exception.Message).Contains("item 5 was found");
+        await Assert.That(exception.Message).Contains("5 was found in the collection");
     }
 
     // All tests
@@ -157,7 +157,7 @@ public class AsyncEnumerableAssertionTests
         var action = async () => await Assert.That(items!).IsEmpty();
 
         var exception = await Assert.That(action).Throws<AssertionException>();
-        await Assert.That(exception.Message).Contains("was null");
+        await Assert.That(exception.Message).Contains("received null");
     }
 
     // String async enumerable

--- a/TUnit.Assertions.Tests/Bugs/Tests2145.cs
+++ b/TUnit.Assertions.Tests/Bugs/Tests2145.cs
@@ -16,12 +16,12 @@ public class Tests2145
 
         var expectedMessage = """
                 Expected to be equal to "world"
-                but found "hello"
+                but received "hello"
 
                 at Assert.That(val).IsEqualTo("world")
 
                 Expected to be equal to "World"
-                but found "hello"
+                but received "hello"
 
                 at Assert.That(val).IsEqualTo("World")
                 """;

--- a/TUnit.Assertions.Tests/Helpers/StringDifferenceTests.cs
+++ b/TUnit.Assertions.Tests/Helpers/StringDifferenceTests.cs
@@ -7,7 +7,7 @@ public class StringDifferenceTests
     {
         var expectedMessage = """
                               Expected to be equal to "some text"
-                              but found ""
+                              but received ""
 
                               at Assert.That(actual).IsEqualTo(expected)
                               """.NormalizeLineEndings();
@@ -26,7 +26,7 @@ public class StringDifferenceTests
     {
         var expectedMessage = """
                               Expected to be equal to ""
-                              but found "actual text"
+                              but received "actual text"
 
                               at Assert.That(actual).IsEqualTo(expected)
                               """.NormalizeLineEndings();
@@ -45,7 +45,7 @@ public class StringDifferenceTests
     {
         var expectedMessage = """
                               Expected to be equal to "some text"
-                              but found "some"
+                              but received "some"
 
                               at Assert.That(actual).IsEqualTo(expected)
                               """.NormalizeLineEndings();
@@ -64,7 +64,7 @@ public class StringDifferenceTests
     {
         var expectedMessage = """
                               Expected to be equal to "some"
-                              but found "some text"
+                              but received "some text"
 
                               at Assert.That(actual).IsEqualTo(expected)
                               """.NormalizeLineEndings();

--- a/TUnit.Assertions.Tests/MemberCollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/MemberCollectionAssertionTests.cs
@@ -30,7 +30,7 @@ public class MemberCollectionAssertionTests
             await Assert.That(obj).Member(x => x.Tags, tags => tags.HasCount(5)));
 
         await Assert.That(exception.Message).Contains("to have count 5");
-        await Assert.That(exception.Message).Contains("but found 2");
+        await Assert.That(exception.Message).Contains("but received 2");
     }
 
     [Test]

--- a/TUnit.Assertions.Tests/Old/StringEqualsAssertionTests.cs
+++ b/TUnit.Assertions.Tests/Old/StringEqualsAssertionTests.cs
@@ -153,7 +153,7 @@ public class StringEqualsAssertionTests
         var exception = await TUnitAssert.ThrowsAsync<TUnitAssertionException>(async () => await TUnitAssert.That(value1).IsEqualTo(value2));
 
         var expectedMessage = $"Expected to be equal to \"Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se…\"{Environment.NewLine}" +
-                              $"but found \"Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se…\" which differs at index 556:{Environment.NewLine}" +
+                              $"but received \"Lorem ipsum dolor sit amet diam duo amet sea rebum.  Et voluptua ex voluptua no praesent diam eu se…\" which differs at index 556:{Environment.NewLine}" +
                               $"                            ↓{Environment.NewLine}" +
                               $"   \"Consequat odio ea veniam. Amet enim in gubergren s…\"{Environment.NewLine}" +
                               $"   \"Consequat odio ea veniam! Amet enim in gubergren s…\"{Environment.NewLine}" +

--- a/TUnit.Assertions.Tests/Old/StringRegexAssertionTests.cs
+++ b/TUnit.Assertions.Tests/Old/StringRegexAssertionTests.cs
@@ -58,7 +58,7 @@ public partial class StringRegexAssertionTests
 
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text match pattern
+             Expected to match pattern
              but The regex "^\d+$" does not match with "{text}"
 
              at Assert.That(text).Matches(pattern)
@@ -83,7 +83,7 @@ public partial class StringRegexAssertionTests
 
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text match pattern
+             Expected to match pattern
              but The regex "^\d+$" does not match with "{text}"
 
              at Assert.That(text).Matches(pattern)
@@ -112,7 +112,7 @@ public partial class StringRegexAssertionTests
         
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text match regex
+             Expected to match regex
              but The regex "^\d+$" does not match with "Hello123World"
 
              at Assert.That(text).Matches(regex)
@@ -194,8 +194,8 @@ public partial class StringRegexAssertionTests
 
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text to not match with pattern
-             but The regex "^\d+$" matches with "{text}"
+             Expected to not match pattern
+             but received "{text}" which matches the pattern "^\d+$"
 
              at Assert.That(text).DoesNotMatch(pattern)
              """.NormalizeLineEndings()
@@ -219,8 +219,8 @@ public partial class StringRegexAssertionTests
 
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text to not match with pattern
-             but The regex "^\d+$" matches with "{text}"
+             Expected to not match pattern
+             but received "{text}" which matches the pattern "^\d+$"
 
              at Assert.That(text).DoesNotMatch(pattern)
              """.NormalizeLineEndings()
@@ -248,8 +248,8 @@ public partial class StringRegexAssertionTests
         
         await TUnitAssert.That(exception!.Message.NormalizeLineEndings()).IsEqualTo(
             $"""
-             Expected text to not match with regex
-             but The regex "^\d+$" matches with "{text}"
+             Expected to not match regex
+             but received "{text}" which matches the pattern "^\d+$"
 
              at Assert.That(text).DoesNotMatch(regex)
              """.NormalizeLineEndings()

--- a/TUnit.Assertions.Tests/SatisfiesTests.cs
+++ b/TUnit.Assertions.Tests/SatisfiesTests.cs
@@ -92,7 +92,7 @@ public class SatisfiesTests
             ).Throws<AssertionException>()
             .WithMessageMatching("""
                                  *to satisfy*
-                                 *found "Hello"*
+                                 *received "Hello"*
                                  """);
     }
 
@@ -125,7 +125,7 @@ public class SatisfiesTests
             .WithMessageMatching(
                 """
                 *to satisfy*
-                *found "Baz"*
+                *received "Baz"*
                 """
                 );
     }
@@ -144,7 +144,7 @@ public class SatisfiesTests
             ).Throws<AssertionException>()
             .WithMessageMatching("""
                                  *to satisfy*
-                                 *found "Hello"*
+                                 *received "Hello"*
                                  """);
     }
 
@@ -176,7 +176,7 @@ public class SatisfiesTests
             ).Throws<AssertionException>()
             .WithMessageMatching(
                 """
-                *found "Blah"*
+                *received "Blah"*
                 """
                 );
     }

--- a/TUnit.Assertions.Tests/ThrowInDelegateValueAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ThrowInDelegateValueAssertionTests.cs
@@ -7,7 +7,7 @@ public class ThrowInDelegateValueAssertionTests
     {
         var expectedContains = """
                          Expected to be equal to True
-                         but threw System.Exception
+                         but threw Exception
                          """.NormalizeLineEndings();
         var assertion = async () => await Assert.That(() =>
         {
@@ -31,7 +31,7 @@ public class ThrowInDelegateValueAssertionTests
 
         await Assert.That(assertion)
             .Throws<AssertionException>()
-            .WithMessageContaining("SYSTEM.EXCEPTION", StringComparison.OrdinalIgnoreCase);
+            .WithMessageContaining("EXCEPTION", StringComparison.OrdinalIgnoreCase);
     }
 
     [Test]

--- a/TUnit.Assertions/Collections/CollectionChecks.cs
+++ b/TUnit.Assertions/Collections/CollectionChecks.cs
@@ -34,7 +34,7 @@ public static class CollectionChecks
             return AssertionResult.Passed;
         }
 
-        return AssertionResult.Failed("it was empty");
+        return AssertionResult.Failed("received empty collection");
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public static class CollectionChecks
         {
             if (predicate(item))
             {
-                return AssertionResult.Failed("found item matching predicate");
+                return AssertionResult.Failed("received item matching predicate");
             }
         }
 
@@ -157,7 +157,7 @@ public static class CollectionChecks
             return AssertionResult.Passed;
         }
 
-        return AssertionResult.Failed($"found {actual}");
+        return AssertionResult.Failed($"received {actual}");
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public static class CollectionChecks
             return AssertionResult.Passed;
         }
 
-        return AssertionResult.Failed($"it had {count} item(s)");
+        return AssertionResult.Failed($"received {count} item(s)");
     }
 
     /// <summary>
@@ -622,6 +622,6 @@ public static class CollectionChecks
             return AssertionResult.Passed;
         }
 
-        return AssertionResult.Failed("the set does not equal the specified collection");
+        return AssertionResult.Failed("received set does not equal the specified collection");
     }
 }

--- a/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
+++ b/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
@@ -22,7 +22,7 @@ public abstract class AsyncEnumerableAssertionConditionBase<TItem> : AsyncEnumer
 
         if (metadata.Value == null)
         {
-            return AssertionResult.Failed("was null");
+            return AssertionResult.Failed("received null");
         }
 
         // Materialize the async enumerable
@@ -105,7 +105,7 @@ public class AsyncEnumerableHasCountAssertion<TItem> : AsyncEnumerableAssertionC
     {
         return items.Count == _expected
             ? AssertionResult.Passed
-            : AssertionResult.Failed($"found {items.Count} items");
+            : AssertionResult.Failed($"received {items.Count} items");
     }
 
     protected override string GetExpectation() => $"to have {_expected} items";
@@ -141,12 +141,12 @@ public class AsyncEnumerableContainsAssertion<TItem> : AsyncEnumerableAssertionC
         {
             return contains
                 ? AssertionResult.Passed
-                : AssertionResult.Failed($"item {_expected} was not found");
+                : AssertionResult.Failed($"{_expected} was not found in the collection");
         }
         else
         {
             return contains
-                ? AssertionResult.Failed($"item {_expected} was found")
+                ? AssertionResult.Failed($"{_expected} was found in the collection")
                 : AssertionResult.Passed;
         }
     }

--- a/TUnit.Assertions/Conditions/BetweenAssertion.cs
+++ b/TUnit.Assertions/Conditions/BetweenAssertion.cs
@@ -78,7 +78,7 @@ public class BetweenAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         var minComparison = value.CompareTo(_minimum);
@@ -92,7 +92,7 @@ public class BetweenAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation()

--- a/TUnit.Assertions/Conditions/CollectionCountSource.cs
+++ b/TUnit.Assertions/Conditions/CollectionCountSource.cs
@@ -232,7 +232,7 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
             return AssertionResult.Passed;
         }
 
-        return AssertionResult.Failed($"found {_actualCount}");
+        return AssertionResult.Failed($"received {_actualCount}");
     }
 
     protected override string GetExpectation()

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -78,7 +78,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
 
         if (exception != null)
         {
-            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().FullName}"));
+            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().Name}"));
         }
 
         // Deep comparison with ignored types
@@ -92,7 +92,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
                 return AssertionResult._passedTask;
             }
 
-            return Task.FromResult(AssertionResult.Failed(result.Message ?? $"found {value}"));
+            return Task.FromResult(AssertionResult.Failed(result.Message ?? $"received {value}"));
         }
 
         // Standard equality comparison
@@ -103,7 +103,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Deep comparison requires reflection access to all public properties and fields of runtime types")]

--- a/TUnit.Assertions/Conditions/EquatableAssertion.cs
+++ b/TUnit.Assertions/Conditions/EquatableAssertion.cs
@@ -29,7 +29,7 @@ public class EquatableAssertion<TActual, TExpected> : Assertion<TActual>
 
         if (exception != null)
         {
-            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().FullName}"));
+            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().Name}"));
         }
 
         if (value == null)
@@ -43,7 +43,7 @@ public class EquatableAssertion<TActual, TExpected> : Assertion<TActual>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be equal to {_expected}";
@@ -74,7 +74,7 @@ public class NullableEquatableAssertion<TActual, TExpected> : Assertion<TActual?
 
         if (exception != null)
         {
-            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().FullName}"));
+            return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().Name}"));
         }
 
         if (!value.HasValue)
@@ -88,7 +88,7 @@ public class NullableEquatableAssertion<TActual, TExpected> : Assertion<TActual?
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value.Value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value.Value}"));
     }
 
     protected override string GetExpectation() => $"to be equal to {_expected}";

--- a/TUnit.Assertions/Conditions/GreaterThanAssertion.cs
+++ b/TUnit.Assertions/Conditions/GreaterThanAssertion.cs
@@ -29,7 +29,7 @@ public class GreaterThanAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         if (value.CompareTo(_minimum) > 0)
@@ -37,7 +37,7 @@ public class GreaterThanAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be greater than {_minimum}";
@@ -67,7 +67,7 @@ public class GreaterThanOrEqualAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         if (value.CompareTo(_minimum) >= 0)
@@ -75,7 +75,7 @@ public class GreaterThanOrEqualAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be greater than or equal to {_minimum}";

--- a/TUnit.Assertions/Conditions/LessThanAssertion.cs
+++ b/TUnit.Assertions/Conditions/LessThanAssertion.cs
@@ -28,7 +28,7 @@ public class LessThanAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         if (value.CompareTo(_maximum) < 0)
@@ -36,7 +36,7 @@ public class LessThanAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be less than {_maximum}";
@@ -66,7 +66,7 @@ public class LessThanOrEqualAssertion<TValue> : Assertion<TValue>
 
         if (value == null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         if (value.CompareTo(_maximum) <= 0)
@@ -74,7 +74,7 @@ public class LessThanOrEqualAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be less than or equal to {_maximum}";

--- a/TUnit.Assertions/Conditions/NotEqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/NotEqualsAssertion.cs
@@ -67,7 +67,7 @@ public class NotEqualsAssertion<TValue> : Assertion<TValue>
                 return AssertionResult._passedTask;
             }
 
-            return Task.FromResult(AssertionResult.Failed($"both values are equivalent"));
+            return Task.FromResult(AssertionResult.Failed("received equivalent values"));
         }
 
         var comparer = _comparer ?? EqualityComparer<TValue>.Default;
@@ -77,7 +77,7 @@ public class NotEqualsAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"both values are {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Deep comparison requires reflection access to all public properties and fields of runtime types")]

--- a/TUnit.Assertions/Conditions/NullAssertion.cs
+++ b/TUnit.Assertions/Conditions/NullAssertion.cs
@@ -27,7 +27,7 @@ public class NullAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => "to be null";
@@ -48,7 +48,7 @@ public class NotNullAssertion<TValue> : Assertion<TValue>
     {
         if (metadata.Exception != null)
         {
-            return Task.FromResult(AssertionResult.Failed("value is null"));
+            return Task.FromResult(AssertionResult.Failed("received null"));
         }
 
         var value = metadata.Value;
@@ -58,7 +58,7 @@ public class NotNullAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed("value is null"));
+        return Task.FromResult(AssertionResult.Failed("received null"));
     }
 
     protected override string GetExpectation() => "to not be null";
@@ -103,7 +103,7 @@ public class IsDefaultAssertion<TValue> : Assertion<TValue> where TValue : struc
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be default({typeof(TValue).Name})";
@@ -136,7 +136,7 @@ public class IsNotDefaultAssertion<TValue> : Assertion<TValue> where TValue : st
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name})"));
+        return Task.FromResult(AssertionResult.Failed($"received default({typeof(TValue).Name})"));
     }
 
     protected override string GetExpectation() => $"to not be default({typeof(TValue).Name})";
@@ -170,7 +170,7 @@ public class IsDefaultNullableAssertion<TValue> : Assertion<TValue?> where TValu
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be default({typeof(TValue).Name}?)";
@@ -204,7 +204,7 @@ public class IsNotDefaultNullableAssertion<TValue> : Assertion<TValue?> where TV
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name}?)"));
+        return Task.FromResult(AssertionResult.Failed($"received default({typeof(TValue).Name}?)"));
     }
 
     protected override string GetExpectation() => $"to not be default({typeof(TValue).Name}?)";
@@ -238,7 +238,7 @@ public class IsDefaultReferenceAssertion<TValue> : Assertion<TValue> where TValu
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be default({typeof(TValue).Name})";
@@ -272,7 +272,7 @@ public class IsNotDefaultReferenceAssertion<TValue> : Assertion<TValue> where TV
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value is default({typeof(TValue).Name})"));
+        return Task.FromResult(AssertionResult.Failed($"received default({typeof(TValue).Name})"));
     }
 
     protected override string GetExpectation() => $"to not be default({typeof(TValue).Name})";

--- a/TUnit.Assertions/Conditions/PredicateAssertions.cs
+++ b/TUnit.Assertions/Conditions/PredicateAssertions.cs
@@ -38,7 +38,7 @@ public class SatisfiesAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"value {value} does not satisfy predicate"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to satisfy {_predicateDescription}";
@@ -90,7 +90,7 @@ public class IsEquatableOrEqualToAssertion<TValue> : ComparerBasedAssertion<TVal
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found {value}"));
+        return Task.FromResult(AssertionResult.Failed($"received {value}"));
     }
 
     protected override string GetExpectation() => $"to be equal to {_expected}";

--- a/TUnit.Assertions/Conditions/ReferenceEqualityAssertions.cs
+++ b/TUnit.Assertions/Conditions/ReferenceEqualityAssertions.cs
@@ -35,7 +35,7 @@ public class SameReferenceAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed("references are different"));
+        return Task.FromResult(AssertionResult.Failed("received different references"));
     }
 
     protected override string GetExpectation() => "to be the same reference";
@@ -72,7 +72,7 @@ public class NotSameReferenceAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed("references are the same"));
+        return Task.FromResult(AssertionResult.Failed("received the same reference"));
     }
 
     protected override string GetExpectation() => "to not be the same reference";

--- a/TUnit.Assertions/Conditions/SetAssertions.cs
+++ b/TUnit.Assertions/Conditions/SetAssertions.cs
@@ -282,5 +282,5 @@ public class SetEqualsAssertion<TSet, TItem> : SetAssertionBase<TSet, TItem>
         return Task.FromResult(CollectionChecks.CheckSetEquals(adapter, _other));
     }
 
-    protected override string GetExpectation() => "to equal the specified collection";
+    protected override string GetExpectation() => "to be equal to the specified collection";
 }

--- a/TUnit.Assertions/Conditions/StringAssertions.cs
+++ b/TUnit.Assertions/Conditions/StringAssertions.cs
@@ -98,7 +98,7 @@ public class StringContainsAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     private static string RemoveWhitespace(string input)
@@ -202,7 +202,7 @@ public class StringDoesNotContainAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{_expected}\" in \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\" which contains \"{_expected}\""));
     }
 
     protected override string GetExpectation() => $"to not contain \"{_expected}\"";
@@ -269,7 +269,7 @@ public class StringStartsWithAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => $"to start with \"{_expected}\"";
@@ -336,7 +336,7 @@ public class StringEndsWithAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => $"to end with \"{_expected}\"";
@@ -403,7 +403,7 @@ public class StringDoesNotStartWithAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => $"to not start with \"{_expected}\"";
@@ -470,7 +470,7 @@ public class StringDoesNotEndWithAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => $"to not end with \"{_expected}\"";
@@ -508,7 +508,7 @@ public class StringIsNotEmptyAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => "to not be null or empty";
@@ -546,7 +546,7 @@ public class StringIsEmptyAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\""));
     }
 
     protected override string GetExpectation() => "to be empty";
@@ -587,7 +587,7 @@ public class StringLengthAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"found length {value.Length}"));
+        return Task.FromResult(AssertionResult.Failed($"received string with length {value.Length}"));
     }
 
     protected override string GetExpectation() => $"to have length {_expectedLength}";
@@ -703,9 +703,9 @@ public class StringMatchesAssertion : Assertion<RegexMatchCollection>
         var expression = Context.ExpressionBuilder.ToString();
         if (expression.Contains(".Matches(regex)") || expression.Contains(".Matches(Matches_"))
         {
-            return "text match regex";
+            return "to match regex";
         }
-        return "text match pattern";
+        return "to match pattern";
     }
 }
 
@@ -779,7 +779,7 @@ public class StringDoesNotMatchAssertion : Assertion<string>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"The regex \"{_pattern}\" matches with \"{value}\""));
+        return Task.FromResult(AssertionResult.Failed($"received \"{value}\" which matches the pattern \"{_pattern}\""));
     }
 
     protected override string GetExpectation()
@@ -788,8 +788,8 @@ public class StringDoesNotMatchAssertion : Assertion<string>
         var expression = Context.ExpressionBuilder.ToString();
         if (expression.Contains(".DoesNotMatch(regex)") || expression.Contains(".DoesNotMatch(DoesNotMatch_") || expression.Contains(".DoesNotMatch(FindNumber"))
         {
-            return "text to not match with regex";
+            return "to not match regex";
         }
-        return "text to not match with pattern";
+        return "to not match pattern";
     }
 }

--- a/TUnit.Assertions/Conditions/StringEqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/StringEqualsAssertion.cs
@@ -135,7 +135,7 @@ public class StringEqualsAssertion<TActual> : Assertion<TActual>
         if (actualValue == null || expectedValue == null ||
             (actualValue.Length <= 100 && expectedValue.Length <= 100))
         {
-            return $"found \"{originalValue}\"";
+            return $"received \"{originalValue}\"";
         }
 
         // Find the first index where the strings differ
@@ -160,12 +160,12 @@ public class StringEqualsAssertion<TActual> : Assertion<TActual>
         // If still no difference found, just show the value (shouldn't happen)
         if (diffIndex == -1)
         {
-            return $"found \"{originalValue}\"";
+            return $"received \"{originalValue}\"";
         }
 
         // Build the message with truncation and diff display
         var message = new StringBuilder();
-        message.Append($"found \"{TruncateString(originalValue, 99)}\" which differs at index {diffIndex}:");
+        message.Append($"received \"{TruncateString(originalValue, 99)}\" which differs at index {diffIndex}:");
         message.AppendLine();
 
         // Show context around the difference (about 24 chars before and 26 after)

--- a/TUnit.Assertions/Conditions/ThrowsAssertion.cs
+++ b/TUnit.Assertions/Conditions/ThrowsAssertion.cs
@@ -38,7 +38,7 @@ public abstract class BaseThrowsAssertion<TException, TSelf> : Assertion<TExcept
         // If there was an evaluation exception, something went wrong during evaluation
         if (evaluationException != null)
         {
-            return Task.FromResult(AssertionResult.Failed($"threw {evaluationException.GetType().FullName}"));
+            return Task.FromResult(AssertionResult.Failed($"threw {evaluationException.GetType().Name}"));
         }
 
         // The exception should be in the value field after MapException

--- a/TUnit.Assertions/Conditions/TypeOfAssertion.cs
+++ b/TUnit.Assertions/Conditions/TypeOfAssertion.cs
@@ -84,7 +84,7 @@ public class IsNotTypeOfAssertion<TValue, TExpected> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"type was {actualType.Name}"));
+        return Task.FromResult(AssertionResult.Failed($"received type {actualType.Name}"));
     }
 
     protected override string GetExpectation() => $"to not be of type {_expectedType.Name}";
@@ -227,7 +227,7 @@ public class IsTypeOfRuntimeAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed($"type was {actualType.Name}"));
+        return Task.FromResult(AssertionResult.Failed($"received type {actualType.Name}"));
     }
 
     protected override string GetExpectation() => $"to be of type {_expectedType.Name}";


### PR DESCRIPTION
## Summary

Fixes #4867

- **GetExpectation()** now consistently uses the `"to [verb] [value]"` pattern across all assertion conditions (e.g., `"to match regex"` instead of `"text match regex"`, `"to not match pattern"` instead of `"text to not match with pattern"`)
- **Failure messages** now consistently use `"received [actual]"` instead of a mix of `"found"`, `"value is"`, `"was"`, `"both values are"`, etc.
- **Exception type names** in throw assertions now consistently use `.Name` (short name like `OtherException`) instead of `.FullName` (fully qualified like `TUnit.Assertions.Tests.Assertions.Delegates.Throws+OtherException`)

### Files changed

**17 source files** in `TUnit.Assertions/Conditions/` and `TUnit.Assertions/Collections/`:
- `StringAssertions.cs` - regex/pattern match expectation wording, failure message standardization
- `StringEqualsAssertion.cs` - "found" to "received" in diff messages
- `EqualsAssertion.cs`, `EquatableAssertion.cs` - `.FullName` to `.Name`, "found" to "received"
- `NotEqualsAssertion.cs` - "both values are" to "received"
- `NullAssertion.cs` - "value is null/default" to "received null/default"
- `GreaterThanAssertion.cs`, `LessThanAssertion.cs`, `BetweenAssertion.cs` - "value is null" / "found" to "received"
- `PredicateAssertions.cs` - "value does not satisfy" to "received"
- `ReferenceEqualityAssertions.cs` - "references are different/same" to "received different/same references"
- `TypeOfAssertion.cs` - "type was" to "received type"
- `AsyncEnumerableAssertions.cs` - "was null" / "item X was not found" to "received null" / "X was not found in the collection"
- `CollectionCountSource.cs`, `CollectionChecks.cs` - "found" to "received", "it was empty" to "received empty collection"
- `SetAssertions.cs` - "to equal" to "to be equal to" in GetExpectation
- `ThrowsAssertion.cs` - `.FullName` to `.Name`

**10 test files** updated to match the new message format.

## Test plan

- [x] `dotnet build TUnit.Assertions/TUnit.Assertions.csproj` passes with 0 errors
- [x] `dotnet test TUnit.Assertions.Tests/TUnit.Assertions.Tests.csproj` - all 6935 tests pass across net8.0, net9.0, net10.0, and net48
- [ ] CI pipeline passes