### PR TITLE
refactor: apply Interface Segregation to TUnitServiceProvider

### DIFF
--- a/TUnit.Engine/Framework/ILoggingServices.cs
+++ b/TUnit.Engine/Framework/ILoggingServices.cs
@@ -1,0 +1,14 @@
+using TUnit.Engine.Logging;
+using TUnit.Engine.Services;
+
+namespace TUnit.Engine.Framework;
+
+/// <summary>
+/// Provides access to logging, messaging, and output verbosity services.
+/// </summary>
+internal interface ILoggingServices
+{
+    TUnitFrameworkLogger Logger { get; }
+    VerbosityService VerbosityService { get; }
+    TUnitMessageBus MessageBus { get; }
+}

--- a/TUnit.Engine/Framework/IRequestHandler.cs
+++ b/TUnit.Engine/Framework/IRequestHandler.cs
@@ -8,5 +8,5 @@ namespace TUnit.Engine.Framework;
 /// </summary>
 internal interface IRequestHandler
 {
-    Task HandleRequestAsync(TestExecutionRequest request, TUnitServiceProvider serviceProvider, ExecuteRequestContext context, ITestExecutionFilter? testExecutionFilter);
+    Task HandleRequestAsync(TestExecutionRequest request, ITestDiscoveryServices discoveryServices, ITestExecutionServices executionServices, ILoggingServices loggingServices, ExecuteRequestContext context, ITestExecutionFilter? testExecutionFilter);
 }

--- a/TUnit.Engine/Framework/ITestDiscoveryServices.cs
+++ b/TUnit.Engine/Framework/ITestDiscoveryServices.cs
@@ -1,0 +1,16 @@
+using TUnit.Core.Interfaces;
+using TUnit.Engine.Building;
+using TUnit.Engine.Services;
+
+namespace TUnit.Engine.Framework;
+
+/// <summary>
+/// Provides access to services related to test discovery and filtering.
+/// </summary>
+internal interface ITestDiscoveryServices
+{
+    TestDiscoveryService DiscoveryService { get; }
+    TestBuilderPipeline TestBuilderPipeline { get; }
+    TestFilterService TestFilterService { get; }
+    ITestFinder TestFinder { get; }
+}

--- a/TUnit.Engine/Framework/ITestExecutionServices.cs
+++ b/TUnit.Engine/Framework/ITestExecutionServices.cs
@@ -1,0 +1,15 @@
+using TUnit.Core;
+
+namespace TUnit.Engine.Framework;
+
+/// <summary>
+/// Provides access to services related to test execution and lifecycle management.
+/// </summary>
+internal interface ITestExecutionServices
+{
+    TestExecutor TestExecutor { get; }
+    TestSessionCoordinator TestSessionCoordinator { get; }
+    EngineCancellationToken CancellationToken { get; }
+    CancellationTokenSource FailFastCancellationSource { get; }
+    bool AfterSessionHooksFailed { get; set; }
+}

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -31,7 +31,7 @@ using TUnit.Engine.Services.TestExecution;
 
 namespace TUnit.Engine.Framework;
 
-internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
+internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable, ITestDiscoveryServices, ITestExecutionServices, ILoggingServices
 {
     public ITestExecutionFilter? Filter
     {
@@ -279,7 +279,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         TestSessionCoordinator = Register(new TestSessionCoordinator(EventReceiverOrchestrator,
             Logger,
             testScheduler,
-            serviceProvider: this,
+            executionServices: this,
             ContextProvider,
             lifecycleCoordinator,
             MessageBus,

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -65,7 +65,7 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
 
             serviceProvider.CancellationToken.Initialise(context.CancellationToken);
 
-            await _requestHandler.HandleRequestAsync((TestExecutionRequest) context.Request, serviceProvider, context, GetFilter(context));
+            await _requestHandler.HandleRequestAsync((TestExecutionRequest) context.Request, serviceProvider, serviceProvider, serviceProvider, context, GetFilter(context));
         }
         catch (Exception e) when (IsCancellationException(e))
         {

--- a/TUnit.Engine/TestSessionCoordinator.cs
+++ b/TUnit.Engine/TestSessionCoordinator.cs
@@ -17,7 +17,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     private readonly EventReceiverOrchestrator _eventReceiverOrchestrator;
     private readonly TUnitFrameworkLogger _logger;
     private readonly ITestScheduler _testScheduler;
-    private readonly TUnitServiceProvider _serviceProvider;
+    private readonly ITestExecutionServices _executionServices;
     private readonly IContextProvider _contextProvider;
     private readonly TestLifecycleCoordinator _lifecycleCoordinator;
     private readonly ITUnitMessageBus _messageBus;
@@ -26,7 +26,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     public TestSessionCoordinator(EventReceiverOrchestrator eventReceiverOrchestrator,
         TUnitFrameworkLogger logger,
         ITestScheduler testScheduler,
-        TUnitServiceProvider serviceProvider,
+        ITestExecutionServices executionServices,
         IContextProvider contextProvider,
         TestLifecycleCoordinator lifecycleCoordinator,
         ITUnitMessageBus messageBus,
@@ -34,7 +34,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     {
         _eventReceiverOrchestrator = eventReceiverOrchestrator;
         _logger = logger;
-        _serviceProvider = serviceProvider;
+        _executionServices = executionServices;
         _contextProvider = contextProvider;
         _lifecycleCoordinator = lifecycleCoordinator;
         _messageBus = messageBus;
@@ -93,8 +93,8 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
         // - CancellationToken: Engine-level graceful shutdown (e.g., Ctrl+C)
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
-            _serviceProvider.FailFastCancellationSource.Token,
-            _serviceProvider.CancellationToken.Token);
+            _executionServices.FailFastCancellationSource.Token,
+            _executionServices.CancellationToken.Token);
 
         // Schedule and execute tests (batch approach to preserve ExecutionContext)
         var success = await _testScheduler.ScheduleAndExecuteAsync(testList, linkedCts.Token);
@@ -102,7 +102,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
         // Track whether After(TestSession) hooks failed
         if (!success)
         {
-            _serviceProvider.AfterSessionHooksFailed = true;
+            _executionServices.AfterSessionHooksFailed = true;
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses #4898 - `TUnitServiceProvider` exposes 35+ public properties, violating the Interface Segregation Principle.

- Extracts three focused interfaces from `TUnitServiceProvider` so consumers depend only on the services they actually need:
  - **`ITestDiscoveryServices`**: `DiscoveryService`, `TestBuilderPipeline`, `TestFilterService`, `TestFinder`
  - **`ITestExecutionServices`**: `TestExecutor`, `TestSessionCoordinator`, `CancellationToken`, `FailFastCancellationSource`, `AfterSessionHooksFailed`
  - **`ILoggingServices`**: `Logger`, `VerbosityService`, `MessageBus`
- Updates `TestSessionCoordinator` to depend on `ITestExecutionServices` instead of the full `TUnitServiceProvider`
- Updates `IRequestHandler` and `TestRequestHandler` to accept the specific interfaces they need
- `TUnitServiceProvider` implements all three interfaces, so `TUnitTestFramework` can pass it directly

This is an incremental first step -- further consumers and properties can be migrated to narrower interfaces in follow-up work.

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` passes with zero errors and zero warnings
- [ ] Existing tests continue to pass (no behavioral changes, pure refactoring)