### PR TITLE
docs: add XML documentation to core public APIs

### DIFF
--- a/TUnit.Core/Attributes/BaseTestAttribute.cs
+++ b/TUnit.Core/Attributes/BaseTestAttribute.cs
@@ -1,12 +1,24 @@
 ﻿namespace TUnit.Core;
 
-// Any new test type attributes should inherit from this
-// This ensures we have a location of the test provided by the compiler
-// Using [CallerLineNumber] [CallerFilePath]
+/// <summary>
+/// Base class for test method attributes. Automatically captures the source file path and line number
+/// where the test is defined, using compiler services.
+/// </summary>
+/// <remarks>
+/// Inherit from this class to create custom test type attributes. The <see cref="File"/> and <see cref="Line"/>
+/// properties are populated automatically by the compiler via <c>[CallerFilePath]</c> and <c>[CallerLineNumber]</c>.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 public abstract class BaseTestAttribute : TUnitAttribute
 {
+    /// <summary>
+    /// Gets the source file path where the test is defined.
+    /// </summary>
     public readonly string File;
+
+    /// <summary>
+    /// Gets the line number in the source file where the test is defined.
+    /// </summary>
     public readonly int Line;
 
     internal BaseTestAttribute(string file, int line)

--- a/TUnit.Core/Attributes/ClassConstructorSourceAttribute.cs
+++ b/TUnit.Core/Attributes/ClassConstructorSourceAttribute.cs
@@ -3,9 +3,44 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Specifies a custom <see cref="IClassConstructor"/> to use when creating test class instances.
+/// This enables dependency injection and custom object creation for test classes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Can be applied at the class level (affecting only that class) or at the assembly level
+/// (affecting all test classes in the assembly).
+/// </para>
+/// <para>
+/// The specified type must implement <see cref="IClassConstructor"/> and have a parameterless constructor.
+/// For strongly-typed usage, prefer <see cref="ClassConstructorAttribute{T}"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [ClassConstructor&lt;DependencyInjectionClassConstructor&gt;]
+/// public class MyTests
+/// {
+///     private readonly IMyService _service;
+///
+///     public MyTests(IMyService service)
+///     {
+///         _service = service;
+///     }
+///
+///     [Test]
+///     public void TestWithInjectedDependency() { }
+/// }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class)]
 public class ClassConstructorAttribute : TUnitAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassConstructorAttribute"/> class.
+    /// </summary>
+    /// <param name="classConstructorType">The type that implements <see cref="IClassConstructor"/>.</param>
     public ClassConstructorAttribute(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type classConstructorType)
@@ -13,10 +48,18 @@ public class ClassConstructorAttribute : TUnitAttribute
         ClassConstructorType = classConstructorType;
     }
 
+    /// <summary>
+    /// Gets or sets the type that implements <see cref="IClassConstructor"/> and is used to create test class instances.
+    /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
     public Type ClassConstructorType { get; init; }
 }
 
+/// <summary>
+/// Specifies a custom <see cref="IClassConstructor"/> to use when creating test class instances.
+/// Generic version that provides compile-time type safety.
+/// </summary>
+/// <typeparam name="T">The type that implements <see cref="IClassConstructor"/>.</typeparam>
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class)]
 public sealed class ClassConstructorAttribute<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)] T>()

--- a/TUnit.Core/Attributes/DynamicTestBuilderAttribute.cs
+++ b/TUnit.Core/Attributes/DynamicTestBuilderAttribute.cs
@@ -3,4 +3,8 @@ using System.Runtime.CompilerServices;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a method as a dynamic test builder that programmatically generates test cases at runtime.
+/// Methods decorated with this attribute can yield test definitions dynamically.
+/// </summary>
 public class DynamicTestBuilderAttribute([CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : BaseTestAttribute(file, line);

--- a/TUnit.Core/Attributes/TUnitAttribute.cs
+++ b/TUnit.Core/Attributes/TUnitAttribute.cs
@@ -1,5 +1,9 @@
 ﻿namespace TUnit.Core;
 
+/// <summary>
+/// Base class for all TUnit framework attributes.
+/// This class cannot be instantiated directly; use one of the derived attribute types.
+/// </summary>
 public class TUnitAttribute : Attribute
 {
     internal TUnitAttribute()

--- a/TUnit.Core/Attributes/TestData/ArgumentsAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/ArgumentsAttribute.cs
@@ -32,8 +32,15 @@ namespace TUnit.Core;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class ArgumentsAttribute : Attribute, IDataSourceAttribute, ITestRegisteredEventReceiver
 {
+    /// <summary>
+    /// Gets the array of argument values to pass to the test method.
+    /// </summary>
     public object?[] Values { get; }
 
+    /// <summary>
+    /// Gets or sets a reason to skip this specific test case.
+    /// When set, the test case will be skipped with the given reason.
+    /// </summary>
     public string? Skip { get; set; }
 
     /// <summary>
@@ -60,6 +67,10 @@ public sealed class ArgumentsAttribute : Attribute, IDataSourceAttribute, ITestR
     /// <inheritdoc />
     public bool SkipIfEmpty { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArgumentsAttribute"/> class with the specified test argument values.
+    /// </summary>
+    /// <param name="values">The argument values to pass to the test method. Pass <c>null</c> for a single null argument.</param>
     public ArgumentsAttribute(params object?[]? values)
     {
         if (values == null)
@@ -112,9 +123,26 @@ public ValueTask OnTestRegistered(TestRegisteredContext context)
     public int Order => 0;
 }
 
+/// <summary>
+/// Provides a strongly-typed inline value for a parameterized test with a single parameter.
+/// </summary>
+/// <typeparam name="T">The type of the test parameter.</typeparam>
+/// <param name="value">The value to pass to the test method.</param>
+/// <example>
+/// <code>
+/// [Test]
+/// [Arguments&lt;string&gt;("hello")]
+/// [Arguments&lt;string&gt;("world")]
+/// public void TestWithString(string input) { }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class ArgumentsAttribute<T>(T value) : TypedDataSourceAttribute<T>, ITestRegisteredEventReceiver
 {
+    /// <summary>
+    /// Gets or sets a reason to skip this specific test case.
+    /// When set, the test case will be skipped with the given reason.
+    /// </summary>
     public string? Skip { get; set; }
 
     /// <summary>

--- a/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/ClassDataSourceAttribute.cs
@@ -3,6 +3,33 @@ using TUnit.Core.Helpers;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Provides test data by creating instances of one or more specified types.
+/// The instances are created using their constructors and can optionally be shared across tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this attribute to inject class instances as test method parameters or constructor arguments.
+/// The attribute supports sharing instances across tests via the <see cref="Shared"/> property and
+/// keyed sharing via the <see cref="Keys"/> property.
+/// </para>
+/// <para>
+/// For strongly-typed single-parameter usage, prefer the generic version <see cref="ClassDataSourceAttribute{T}"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Create a new instance for each test
+/// [Test]
+/// [ClassDataSource(typeof(MyService))]
+/// public void TestWithService(MyService service) { }
+///
+/// // Share the instance across all tests in the class
+/// [Test]
+/// [ClassDataSource(typeof(MyService), Shared = [SharedType.PerClass])]
+/// public void TestWithSharedService(MyService service) { }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class ClassDataSourceAttribute : UntypedDataSourceGeneratorAttribute
 {
@@ -74,7 +101,16 @@ public sealed class ClassDataSourceAttribute : UntypedDataSourceGeneratorAttribu
         _types = types;
     }
 
+    /// <summary>
+    /// Gets or sets how instances are shared across tests, one per type parameter.
+    /// Defaults to <see cref="SharedType.None"/> (a new instance per test).
+    /// </summary>
     public SharedType[] Shared { get; set; } = [SharedType.None];
+
+    /// <summary>
+    /// Gets or sets the sharing keys, one per type parameter.
+    /// Used when <see cref="Shared"/> is set to <see cref="SharedType.Keyed"/> to identify shared instances.
+    /// </summary>
     public string[] Keys { get; set; } = [];
 
     [UnconditionalSuppressMessage("Trimming", "IL2062:The parameter of method has a DynamicallyAccessedMembersAttribute, but the value passed to it can not be statically analyzed.",
@@ -121,6 +157,27 @@ public sealed class ClassDataSourceAttribute : UntypedDataSourceGeneratorAttribu
 
 }
 
+/// <summary>
+/// Provides test data by creating an instance of <typeparamref name="T"/>.
+/// The instance is created using its constructor and can optionally be shared across tests.
+/// </summary>
+/// <typeparam name="T">The type to instantiate as test data.</typeparam>
+/// <remarks>
+/// <para>
+/// Use the <see cref="Shared"/> property to control instance sharing:
+/// <see cref="SharedType.None"/> (default) creates a new instance per test,
+/// <see cref="SharedType.PerClass"/> shares within the test class,
+/// <see cref="SharedType.PerAssembly"/> shares across the assembly,
+/// <see cref="SharedType.Keyed"/> shares by a specified <see cref="Key"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Test]
+/// [ClassDataSource&lt;MyService&gt;(Shared = SharedType.PerClass)]
+/// public void TestWithService(MyService service) { }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class ClassDataSourceAttribute<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
     : DataSourceGeneratorAttribute<T>

--- a/TUnit.Core/Attributes/TestData/IDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/IDataSourceAttribute.cs
@@ -1,7 +1,17 @@
 ﻿namespace TUnit.Core;
 
+/// <summary>
+/// Defines a data source that provides test data for parameterized tests.
+/// Implement this interface to create custom data source attributes.
+/// </summary>
 public interface IDataSourceAttribute
 {
+    /// <summary>
+    /// Asynchronously generates data rows for parameterized tests.
+    /// Each yielded function, when invoked, produces one set of arguments for a test invocation.
+    /// </summary>
+    /// <param name="dataGeneratorMetadata">Metadata about the test and parameters being generated.</param>
+    /// <returns>An async enumerable of factory functions that produce test data rows.</returns>
     public IAsyncEnumerable<Func<Task<object?[]?>>> GetDataRowsAsync(DataGeneratorMetadata dataGeneratorMetadata);
 
     /// <summary>

--- a/TUnit.Core/Attributes/TestData/MatrixDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MatrixDataSourceAttribute.cs
@@ -4,6 +4,36 @@ using TUnit.Core.Extensions;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Generates test cases from all combinations (Cartesian product) of parameter values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For boolean parameters, all values (<c>true</c>, <c>false</c>) are generated automatically.
+/// For enum parameters, all defined enum values are generated automatically.
+/// For other types, use <c>[Matrix(...)]</c> on individual parameters to specify the values.
+/// </para>
+/// <para>
+/// Use <see cref="MatrixExclusionAttribute"/> on the test method to exclude specific combinations.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [Test, MatrixDataSource]
+/// public void TestAllCombinations(
+///     [Matrix(1, 2, 3)] int x,
+///     [Matrix("a", "b")] string y)
+/// {
+///     // Generates 6 test cases: (1,"a"), (1,"b"), (2,"a"), (2,"b"), (3,"a"), (3,"b")
+/// }
+///
+/// [Test, MatrixDataSource]
+/// public void TestWithEnum(bool enabled, MyEnum mode)
+/// {
+///     // Automatically generates all bool x enum combinations
+/// }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public sealed class MatrixDataSourceAttribute : UntypedDataSourceGeneratorAttribute, IAccessesInstanceData
 {

--- a/TUnit.Core/Attributes/TestData/SharedType.cs
+++ b/TUnit.Core/Attributes/TestData/SharedType.cs
@@ -1,10 +1,34 @@
 namespace TUnit.Core;
 
+/// <summary>
+/// Specifies how class data source instances are shared across tests.
+/// Used with <see cref="ClassDataSourceAttribute"/> and <see cref="ClassDataSourceAttribute{T}"/>.
+/// </summary>
 public enum SharedType
 {
+    /// <summary>
+    /// A new instance is created for each test (no sharing). This is the default.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// The instance is shared across all tests within the same test class.
+    /// </summary>
     PerClass,
+
+    /// <summary>
+    /// The instance is shared across all tests within the same assembly.
+    /// </summary>
     PerAssembly,
+
+    /// <summary>
+    /// The instance is shared across all tests in the entire test session.
+    /// </summary>
     PerTestSession,
+
+    /// <summary>
+    /// The instance is shared across tests that specify the same key.
+    /// Use the <c>Key</c> or <c>Keys</c> property on the data source attribute to specify the key.
+    /// </summary>
     Keyed,
 }

--- a/TUnit.Core/Attributes/TestHooks/AfterAttribute.cs
+++ b/TUnit.Core/Attributes/TestHooks/AfterAttribute.cs
@@ -4,5 +4,39 @@
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a method as a teardown hook that runs after a specific scope (test, class, assembly, or test session).
+/// The hook is scoped to the class that declares it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use <c>[After(HookType.Test)]</c> to run the method after each test in the declaring class.
+/// Use <c>[After(HookType.Class)]</c> to run the method once after all tests in the class complete.
+/// Use <c>[After(HookType.Assembly)]</c> to run the method once after all tests in the assembly complete.
+/// Use <c>[After(HookType.TestSession)]</c> to run the method once per test session teardown.
+/// </para>
+/// <para>
+/// For hooks that apply globally to every test regardless of class, use <see cref="AfterEveryAttribute"/> instead.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyTests
+/// {
+///     [After(HookType.Test)]
+///     public void CleanUp()
+///     {
+///         // Runs after each test in this class
+///     }
+///
+///     [After(HookType.Class)]
+///     public static void ClassCleanUp()
+///     {
+///         // Runs once after all tests in this class complete
+///     }
+/// }
+/// </code>
+/// </example>
+/// <param name="hookType">The scope at which this hook runs.</param>
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class AfterAttribute(HookType hookType, [CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : HookAttribute(hookType, file, line);

--- a/TUnit.Core/Attributes/TestHooks/AfterEveryAttribute.cs
+++ b/TUnit.Core/Attributes/TestHooks/AfterEveryAttribute.cs
@@ -2,6 +2,39 @@ using System.Runtime.CompilerServices;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a method as a global teardown hook that runs after every test, class, assembly, or test session,
+/// regardless of which class declares it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="AfterAttribute"/> which is scoped to the declaring class,
+/// <c>[AfterEvery]</c> applies globally. For example, <c>[AfterEvery(HookType.Test)]</c> runs after
+/// every test in the entire test suite, not just tests in the declaring class.
+/// </para>
+/// <para>
+/// The method must be <c>static</c> and declared in a class. It will be invoked for all tests matching the specified scope.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class GlobalHooks
+/// {
+///     [AfterEvery(HookType.Test)]
+///     public static void AfterEachTest(TestContext context)
+///     {
+///         // Runs after every test in the entire suite
+///     }
+///
+///     [AfterEvery(HookType.Class)]
+///     public static void AfterEachClass(ClassHookContext context)
+///     {
+///         // Runs after every test class
+///     }
+/// }
+/// </code>
+/// </example>
+/// <param name="hookType">The scope at which this hook runs.</param>
 #pragma warning disable CS9113
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class AfterEveryAttribute(HookType hookType, [CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : HookAttribute(hookType, file, line);

--- a/TUnit.Core/Attributes/TestHooks/BeforeAttribute.cs
+++ b/TUnit.Core/Attributes/TestHooks/BeforeAttribute.cs
@@ -4,5 +4,39 @@
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a method as a setup hook that runs before a specific scope (test, class, assembly, or test session).
+/// The hook is scoped to the class that declares it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use <c>[Before(HookType.Test)]</c> to run the method before each test in the declaring class.
+/// Use <c>[Before(HookType.Class)]</c> to run the method once before all tests in the class.
+/// Use <c>[Before(HookType.Assembly)]</c> to run the method once before all tests in the assembly.
+/// Use <c>[Before(HookType.TestSession)]</c> to run the method once per test session.
+/// </para>
+/// <para>
+/// For hooks that apply globally to every test regardless of class, use <see cref="BeforeEveryAttribute"/> instead.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyTests
+/// {
+///     [Before(HookType.Test)]
+///     public void SetUp()
+///     {
+///         // Runs before each test in this class
+///     }
+///
+///     [Before(HookType.Class)]
+///     public static void ClassSetUp()
+///     {
+///         // Runs once before all tests in this class
+///     }
+/// }
+/// </code>
+/// </example>
+/// <param name="hookType">The scope at which this hook runs.</param>
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class BeforeAttribute(HookType hookType, [CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : HookAttribute(hookType, file, line);

--- a/TUnit.Core/Attributes/TestHooks/BeforeEveryAttribute.cs
+++ b/TUnit.Core/Attributes/TestHooks/BeforeEveryAttribute.cs
@@ -2,6 +2,39 @@ using System.Runtime.CompilerServices;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a method as a global setup hook that runs before every test, class, assembly, or test session,
+/// regardless of which class declares it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="BeforeAttribute"/> which is scoped to the declaring class,
+/// <c>[BeforeEvery]</c> applies globally. For example, <c>[BeforeEvery(HookType.Test)]</c> runs before
+/// every test in the entire test suite, not just tests in the declaring class.
+/// </para>
+/// <para>
+/// The method must be <c>static</c> and declared in a class. It will be invoked for all tests matching the specified scope.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class GlobalHooks
+/// {
+///     [BeforeEvery(HookType.Test)]
+///     public static void BeforeEachTest(TestContext context)
+///     {
+///         // Runs before every test in the entire suite
+///     }
+///
+///     [BeforeEvery(HookType.Class)]
+///     public static void BeforeEachClass(ClassHookContext context)
+///     {
+///         // Runs before every test class
+///     }
+/// }
+/// </code>
+/// </example>
+/// <param name="hookType">The scope at which this hook runs.</param>
 #pragma warning disable CS9113
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class BeforeEveryAttribute(HookType hookType, [CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : HookAttribute(hookType, file, line);

--- a/TUnit.Core/Attributes/TestHooks/HookAttribute.cs
+++ b/TUnit.Core/Attributes/TestHooks/HookAttribute.cs
@@ -1,9 +1,27 @@
 ﻿namespace TUnit.Core;
 
+/// <summary>
+/// Base class for hook attributes (<see cref="BeforeAttribute"/>, <see cref="AfterAttribute"/>,
+/// <see cref="BeforeEveryAttribute"/>, <see cref="AfterEveryAttribute"/>).
+/// </summary>
+/// <remarks>
+/// This class is not intended to be used directly. Use the derived attributes instead.
+/// </remarks>
 public class HookAttribute : TUnitAttribute
 {
+    /// <summary>
+    /// Gets the scope at which this hook runs (Test, Class, Assembly, TestSession, or TestDiscovery).
+    /// </summary>
     public HookType HookType { get; }
+
+    /// <summary>
+    /// Gets the source file path where this hook is defined.
+    /// </summary>
     public string File { get; }
+
+    /// <summary>
+    /// Gets the line number in the source file where this hook is defined.
+    /// </summary>
     public int Line { get; }
 
     internal HookAttribute(HookType hookType, string file, int line)
@@ -18,5 +36,9 @@ public class HookAttribute : TUnitAttribute
         Line = line;
     }
 
+    /// <summary>
+    /// Gets or sets the execution order of this hook relative to other hooks at the same scope.
+    /// Lower values execute first. Default is 0.
+    /// </summary>
     public int Order { get; init; }
 }

--- a/TUnit.Core/Attributes/TestMetadata/ExecutionPriorityAttribute.cs
+++ b/TUnit.Core/Attributes/TestMetadata/ExecutionPriorityAttribute.cs
@@ -3,12 +3,41 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Sets the execution priority for a test, class, or assembly.
+/// Higher priority tests are scheduled to execute before lower priority tests.
+/// </summary>
+/// <remarks>
+/// Priority values range from <see cref="Enums.Priority.Low"/> (runs last) to
+/// <see cref="Enums.Priority.Critical"/> (runs first). The default is <see cref="Enums.Priority.Normal"/>.
+/// </remarks>
+/// <example>
+/// <code>
+/// [Test]
+/// [ExecutionPriority(Priority.High)]
+/// public void ImportantTest() { }
+///
+/// [Test]
+/// [ExecutionPriority(Priority.Low)]
+/// public void LessImportantTest() { }
+/// </code>
+/// </example>
+/// <param name="priority">The execution priority level.</param>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
 public class ExecutionPriorityAttribute : SingleTUnitAttribute, ITestDiscoveryEventReceiver, IScopedAttribute
 {
+    /// <summary>
+    /// Gets the execution priority level for the test.
+    /// </summary>
     public Priority Priority { get; }
+
+    /// <inheritdoc />
     public int Order => 0;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutionPriorityAttribute"/> class.
+    /// </summary>
+    /// <param name="priority">The execution priority level. Defaults to <see cref="Enums.Priority.Normal"/>.</param>
     public ExecutionPriorityAttribute(Priority priority = Priority.Normal)
     {
         Priority = priority;

--- a/TUnit.Core/Attributes/TestMetadata/ExplicitAttribute.cs
+++ b/TUnit.Core/Attributes/TestMetadata/ExplicitAttribute.cs
@@ -2,11 +2,33 @@
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Marks a test method or class to only run when explicitly selected.
+/// Tests marked with this attribute will not run as part of normal test execution
+/// and must be targeted directly by name or filter.
+/// </summary>
+/// <remarks>
+/// This is useful for long-running tests, tests that require specific environments,
+/// or tests that should only be run manually by a developer.
+/// </remarks>
+/// <example>
+/// <code>
+/// [Test]
+/// [Explicit]
+/// public void LongRunningPerformanceTest()
+/// {
+///     // Only runs when explicitly selected
+/// }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class ExplicitAttribute(
     [CallerFilePath] string callerFile = "",
     [CallerMemberName] string callerMemberName = "")
     : TUnitAttribute
 {
+    /// <summary>
+    /// Gets a string identifying where this attribute was applied (file path and member name).
+    /// </summary>
     public string For { get; } = $"{callerFile} {callerMemberName}".Trim();
 }

--- a/TUnit.Core/HookType.cs
+++ b/TUnit.Core/HookType.cs
@@ -1,5 +1,9 @@
 ﻿namespace TUnit.Core;
 
+/// <summary>
+/// Specifies the scope at which a hook (<see cref="BeforeAttribute"/>, <see cref="AfterAttribute"/>,
+/// <see cref="BeforeEveryAttribute"/>, <see cref="AfterEveryAttribute"/>) runs.
+/// </summary>
 public enum HookType
 {
     /// <summary>

--- a/TUnit.Core/TestDetails.cs
+++ b/TUnit.Core/TestDetails.cs
@@ -5,7 +5,9 @@ using TUnit.Core.Interfaces;
 namespace TUnit.Core;
 
 /// <summary>
-/// Simplified test details for the new architecture
+/// Contains detailed metadata about a test, including its identity, class type, method information,
+/// arguments, timeout, retry settings, categories, and custom properties.
+/// Access via <see cref="TestContext.Metadata"/> and its <see cref="Interfaces.ITestMetadata.TestDetails"/> property.
 /// </summary>
 public partial class TestDetails : ITestIdentity, ITestClass, ITestMethod, ITestConfiguration, ITestLocation, ITestDetailsMetadata
 {

--- a/TUnit.Core/TestResult.cs
+++ b/TUnit.Core/TestResult.cs
@@ -2,23 +2,45 @@
 
 namespace TUnit.Core;
 
+/// <summary>
+/// Represents the outcome of a test execution, including the state, timing, exception information, and output.
+/// Access via <see cref="Interfaces.ITestExecution.Result"/> on <see cref="TestContext.Execution"/>.
+/// </summary>
 public record TestResult
 {
     /// <summary>
-    /// Only final states should be used.
+    /// Gets the final state of the test (Passed, Failed, Skipped, Timeout, or Cancelled).
     /// </summary>
     public required TestState State { get; init; }
 
+    /// <summary>
+    /// Gets the timestamp when test execution started, or <c>null</c> if the test did not start.
+    /// </summary>
     public required DateTimeOffset? Start { get; init; }
 
+    /// <summary>
+    /// Gets the timestamp when test execution ended, or <c>null</c> if the test did not complete.
+    /// </summary>
     public required DateTimeOffset? End { get; init; }
 
+    /// <summary>
+    /// Gets the duration of test execution, or <c>null</c> if the test did not complete.
+    /// </summary>
     public required TimeSpan? Duration { get; init; }
 
+    /// <summary>
+    /// Gets the exception that caused the test to fail, or <c>null</c> if the test passed or was skipped.
+    /// </summary>
     public required Exception? Exception { get; init; }
 
+    /// <summary>
+    /// Gets the name of the computer where the test was executed.
+    /// </summary>
     public required string ComputerName { get; init; }
 
+    /// <summary>
+    /// Gets the captured standard output from the test execution.
+    /// </summary>
     public string? Output { get; internal set; }
 
     [JsonIgnore]

--- a/TUnit.Core/TestState.cs
+++ b/TUnit.Core/TestState.cs
@@ -1,14 +1,52 @@
 ﻿namespace TUnit.Core;
 
+/// <summary>
+/// Represents the possible states of a test during its lifecycle.
+/// </summary>
 public enum TestState
 {
+    /// <summary>
+    /// The test has not yet started execution.
+    /// </summary>
     NotStarted,
+
+    /// <summary>
+    /// The test is waiting for its dependencies to complete before it can execute.
+    /// </summary>
     WaitingForDependencies,
+
+    /// <summary>
+    /// The test is queued and waiting for an available execution slot.
+    /// </summary>
     Queued,
+
+    /// <summary>
+    /// The test is currently executing.
+    /// </summary>
     Running,
+
+    /// <summary>
+    /// The test completed successfully.
+    /// </summary>
     Passed,
+
+    /// <summary>
+    /// The test failed due to an assertion failure or unhandled exception.
+    /// </summary>
     Failed,
+
+    /// <summary>
+    /// The test was skipped and did not execute.
+    /// </summary>
     Skipped,
+
+    /// <summary>
+    /// The test exceeded its configured timeout duration.
+    /// </summary>
     Timeout,
+
+    /// <summary>
+    /// The test was cancelled before completion.
+    /// </summary>
     Cancelled
 }


### PR DESCRIPTION
## Summary
- Adds comprehensive XML doc comments (`/// <summary>`, `<param>`, `<returns>`, `<remarks>`, `<example>`) to the most important public APIs in `TUnit.Core` that users interact with directly through IntelliSense
- Targets 22 files across hook attributes, data source attributes, test metadata attributes, core types, and key interfaces
- All existing types that already had good docs were left unchanged; only types missing docs or with placeholder summaries were updated

## What was documented

**Hook attributes:** `[Before]`, `[After]`, `[BeforeEvery]`, `[AfterEvery]`, `HookAttribute` base class

**Data source attributes:** `[MethodDataSource]` (both generic and non-generic), `[ClassDataSource]` (both generic and non-generic), `[MatrixDataSource]`, `[Arguments]` (both generic and non-generic), `IDataSourceAttribute` interface

**Test metadata:** `[Explicit]`, `[ExecutionPriority]`, `SharedType` enum

**Infrastructure:** `TUnitAttribute`, `BaseTestAttribute`, `[ClassConstructor]` (both generic and non-generic), `[DynamicTestBuilder]`

**Core types:** `TestContext` (class-level docs + all key public properties: `Current`, `Id`, `Execution`, `Output`, `Metadata`, `Parallelism`, `Dependencies`, `StateBag`, `Events`, `Isolation`, `Configuration`, `OutputDirectory`, `WorkingDirectory`, `ClassContext`, `Lock`, `GetById`), `TestDetails`, `TestResult` (all properties), `TestState` (all enum values), `HookType`

## Test plan
- [x] `dotnet build TUnit.Core/TUnit.Core.csproj` passes with 0 warnings and 0 errors
- [ ] Verify IntelliSense shows docs correctly in IDE
- [ ] No behavioral changes -- documentation only

Closes #4885