### PR TITLE
fix: add missing lastParameter variable in TimeoutCancellationTokenAnalyzer

### DIFF
--- a/TUnit.Analyzers/TimeoutCancellationTokenAnalyzer.cs
+++ b/TUnit.Analyzers/TimeoutCancellationTokenAnalyzer.cs
@@ -65,6 +65,8 @@ public class TimeoutCancellationTokenAnalyzer : ConcurrentDiagnosticAnalyzer
             }
         }
 
+        var lastParameter = parameters[parameters.Length - 1];
+
         if (cancellationTokenIndex == -1)
         {
             // CancellationToken is not present at all
@@ -78,7 +80,7 @@ public class TimeoutCancellationTokenAnalyzer : ConcurrentDiagnosticAnalyzer
             // CancellationToken exists but is not the last parameter
             context.ReportDiagnostic(
                 Diagnostic.Create(Rules.CancellationTokenMustBeLastParameter,
-                    context.Symbol.Locations.FirstOrDefault())
+                    parameters[cancellationTokenIndex].Locations.FirstOrDefault() ?? context.Symbol.Locations.FirstOrDefault())
             );
         }
     }


### PR DESCRIPTION
## Summary
- PR #4924 introduced a reference to `lastParameter` on line 73 of `TimeoutCancellationTokenAnalyzer.cs` without declaring the variable, causing `CS0103` build errors on `main`
- This breaks all PR CI checks (locale tests de-DE, fr-FR, pl-PL fail because the build fails)
- Adds `var lastParameter = parameters[parameters.Length - 1]` declaration before the usage
- Also points the `CancellationTokenMustBeLastParameter` diagnostic at the actual CancellationToken parameter location instead of the method

## Test plan
- [x] `dotnet build TUnit.Analyzers/TUnit.Analyzers.csproj` passes with 0 errors
- [ ] CI locale tests (de-DE, fr-FR, pl-PL) should pass after merge