### PR TITLE
fix: update Net4_7 Core API snapshot for merged PRs

### DIFF
--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -511,6 +511,13 @@ namespace
         public static readonly .DefaultExecutor Instance;
         protected override . ExecuteAsync(<.> action) { }
     }
+    public static class Defaults
+    {
+        public static readonly  ForcefulExitTimeout;
+        public static readonly  HookTimeout;
+        public static readonly  ProcessExitHookDelay;
+        public static readonly  TestTimeout;
+    }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
     {
         protected DependencyInjectionDataSourceAttribute() { }
@@ -562,6 +569,7 @@ namespace
         public void SetDisplayName(string displayName) { }
         public void SetDisplayNameFormatter( formatterType) { }
         public void SetPriority(. priority) { }
+        public void SetRetryBackoff(int backoffMs, double backoffMultiplier) { }
         public void SetRetryLimit(int retryLimit) { }
         public void SetRetryLimit(int retryCount, <.TestContext, , int, .<bool>> shouldRetry) { }
     }
@@ -1138,7 +1146,10 @@ namespace
     public class RetryAttribute : .TUnitAttribute, .IScopedAttribute, ., .
     {
         public RetryAttribute(int times) { }
+        public int BackoffMs { get; set; }
+        public double BackoffMultiplier { get; set; }
         public int Order { get; }
+        public []? RetryOnExceptionTypes { get; set; }
         public  ScopeType { get; }
         public int Times { get; }
         public . OnTestDiscovered(.DiscoveredTestContext context) { }
@@ -1407,6 +1418,8 @@ namespace
         public [] MethodGenericArguments { get; set; }
         public required .MethodMetadata MethodMetadata { get; set; }
         public required string MethodName { get; init; }
+        public int RetryBackoffMs { get; set; }
+        public double RetryBackoffMultiplier { get; set; }
         public int RetryLimit { get; set; }
         public required  ReturnType { get; set; }
         public required object?[] TestClassArguments { get; set; }
@@ -2359,6 +2372,8 @@ namespace .Interfaces
     }
     public interface ITestConfiguration
     {
+        int RetryBackoffMs { get; }
+        double RetryBackoffMultiplier { get; }
         int RetryLimit { get; }
         ? Timeout { get; }
     }


### PR DESCRIPTION
## Summary
- Updates `Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt` with APIs added by merged PRs #4929 (Defaults class) and #4949 (retry backoff)
- Adds: `Defaults` static class with `ForcefulExitTimeout`, `HookTimeout`, `ProcessExitHookDelay`, `TestTimeout`
- Adds: `SetRetryBackoff` method on `DiscoveredTest`
- Adds: `BackoffMs`, `BackoffMultiplier`, `RetryOnExceptionTypes` properties on `RetryAttribute`
- Adds: `RetryBackoffMs`, `RetryBackoffMultiplier` on `TestDetails` and `ITestConfiguration`

## Test plan
- [ ] CI passes `Core_Library_Has_No_API_Changes` on net472 (windows)
- [ ] No regressions on other frameworks