### PR TITLE
feat: remove intermediary `List<IProperty>`

### DIFF
--- a/TUnit.Engine/Logging/IdeStreamingSink.cs
+++ b/TUnit.Engine/Logging/IdeStreamingSink.cs
@@ -207,10 +207,8 @@ internal sealed class IdeStreamingSink : ILogSink, IAsyncDisposable
 
         // Build properties list with cumulative output
         // Rider replaces the displayed output with each update, so we send full snapshots.
-        var properties = new List<IProperty>(3)
-        {
-            InProgressTestNodeStateProperty.CachedInstance
-        };
+        var properties = new PropertyBag();
+        properties.Add(InProgressTestNodeStateProperty.CachedInstance);
 
         if (!string.IsNullOrEmpty(output))
         {
@@ -226,7 +224,7 @@ internal sealed class IdeStreamingSink : ILogSink, IAsyncDisposable
         {
             Uid = new TestNodeUid(testId),
             DisplayName = testContext.GetDisplayName(),
-            Properties = new PropertyBag(properties)
+            Properties = properties
         };
     }
 

--- a/TUnit.Engine/Services/TestFilterService.cs
+++ b/TUnit.Engine/Services/TestFilterService.cs
@@ -184,15 +184,12 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
             return cachedBag;
         }
 
-        // Pre-calculate capacity: 2 properties per category + custom properties
-        var categoryCount = test.Context.Metadata.TestDetails.Categories.Count;
-        var customPropCount = test.Context.Metadata.TestDetails.CustomProperties.Sum(p => p.Value.Count);
-        var properties = new List<IProperty>(categoryCount * 2 + customPropCount);
+        var propertyBag = new PropertyBag();
 
         foreach (var category in test.Context.Metadata.TestDetails.Categories)
         {
-            properties.Add(new TestMetadataProperty(category));
-            properties.Add(new TestMetadataProperty("Category", category));
+            propertyBag.Add(new TestMetadataProperty(category));
+            propertyBag.Add(new TestMetadataProperty("Category", category));
         }
 
         // Replace LINQ with manual loop for better performance in hot path
@@ -200,11 +197,9 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         {
             foreach (var value in propertyEntry.Value)
             {
-                properties.Add(new TestMetadataProperty(propertyEntry.Key, value));
+                propertyBag.Add(new TestMetadataProperty(propertyEntry.Key, value));
             }
         }
-
-        var propertyBag = new PropertyBag(properties);
 
         // Cache the PropertyBag for future calls
         test.CachedPropertyBag = propertyBag;


### PR DESCRIPTION
Remove unneeded intermediary `List<IProperty>` collections, and add directly to `PropertyBag`. Note that it's not possible to presize `PropertyBag` as it appears to use a linked list internally.

Benchmarks don't show the benefits to test filtering

### Before
<img width="573" height="274" alt="image" src="https://github.com/user-attachments/assets/724bc60b-d934-4458-a675-76989806cdb6" />


### After
<img width="578" height="220" alt="image" src="https://github.com/user-attachments/assets/6c3ae034-e72c-4ecc-aa5f-f2d9433352ea" />
