### PR TITLE
feat: add Args property to AspireFixture for AppHost arguments

### DIFF
--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -115,8 +115,8 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     /// Use this to pass configuration values that are consumed during AppHost builder creation:
     /// <code>
     /// protected override string[] Args => [
-    ///     "UseVolumes=false",
-    ///     "UsePostgresWithSessionLifetime=true"
+    ///     "--UseVolumes=false",
+    ///     "--UsePostgresWithSessionLifetime=true"
     /// ];
     /// </code>
     /// For configuration that can be set after builder creation, use <see cref="ConfigureBuilder"/> instead.
@@ -201,10 +201,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         var sw = Stopwatch.StartNew();
 
         LogProgress($"Creating distributed application builder for {typeof(TAppHost).Name}...");
-        var args = Args;
-        var builder = args.Length > 0
-            ? await DistributedApplicationTestingBuilder.CreateAsync<TAppHost>(args)
-            : await DistributedApplicationTestingBuilder.CreateAsync<TAppHost>();
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<TAppHost>(Args);
         ConfigureBuilder(builder);
         LogProgress($"Builder created in {sw.Elapsed.TotalSeconds:0.0}s");
 

--- a/docs/docs/examples/aspire.md
+++ b/docs/docs/examples/aspire.md
@@ -239,9 +239,9 @@ public class AppFixture : AspireFixture<Projects.MyAppHost>
 {
     protected override string[] Args =>
     [
-        "UseVolumes=false",
-        "UsePostgresWithPersistentLifetime=false",
-        "UsePostgresWithSessionLifetime=true"
+        "--UseVolumes=false",
+        "--UsePostgresWithPersistentLifetime=false",
+        "--UsePostgresWithSessionLifetime=true"
     ];
 }
 ```


### PR DESCRIPTION
## Summary
- Adds a `protected virtual string[] Args` property to `AspireFixture<TAppHost>` that forwards command-line arguments to `DistributedApplicationTestingBuilder.CreateAsync<TAppHost>(args)`
- Fixes the gap where `ConfigureBuilder` is called *after* `CreateAsync`, making it impossible to set configuration values consumed during AppHost builder creation
- Updates docs with the new property, usage example, and guidance on `Args` vs `ConfigureBuilder`

Closes #4973

## Test plan
- [ ] Verify `TUnit.Aspire` builds successfully
- [ ] Verify that overriding `Args` in a subclass passes values through to `CreateAsync`
- [ ] Verify that the default (empty args) preserves existing behavior (no-args `CreateAsync` call)