### PR TITLE
use strong typed Enum.Parse

### DIFF
--- a/TUnit.Analyzers/ClassParametersAnalyzer.cs
+++ b/TUnit.Analyzers/ClassParametersAnalyzer.cs
@@ -44,7 +44,7 @@ public class ClassParametersAnalyzer : ConcurrentDiagnosticAnalyzer
                 .SelectMany(x => x.GetAttributes())
                 .Concat(namedTypeSymbol.ContainingAssembly.GetAttributes())
                 .Any(x => x.IsDataSourceAttribute(context.Compilation) || 
-                          x.IsClassConstructorAttribute(context.Compilation));
+                          x.IsClassConstructorAttribute());
                           
         if (!hasDataSourceOrClassConstructor)
         {

--- a/TUnit.Analyzers/Extensions/AttributeExtensions.cs
+++ b/TUnit.Analyzers/Extensions/AttributeExtensions.cs
@@ -119,7 +119,7 @@ public static class AttributeExtensions
         return attributeData.AttributeClass.AllInterfaces.Contains(dataAttributeInterface, SymbolEqualityComparer.Default);
     }
 
-    public static bool IsClassConstructorAttribute(this AttributeData? attributeData, Compilation compilation)
+    public static bool IsClassConstructorAttribute(this AttributeData? attributeData)
     {
         if (attributeData?.AttributeClass is null)
         {
@@ -138,11 +138,6 @@ public static class AttributeExtensions
         }
 
         return false;
-    }
-
-    public static string GetHookType(this AttributeData attributeData)
-    {
-        return attributeData.ConstructorArguments[0].ToCSharpString();
     }
 
     private static HookLevel ParseHookLevel(AttributeData attributeData)


### PR DESCRIPTION
and avoid redundant string +array alloc from the split