### PR TITLE
fix: handle multi-type TheoryData<T1, T2> in xUnit migration

### DIFF
--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
@@ -483,16 +483,15 @@ public class InvocationReplacement : ConversionTarget
 public class TheoryDataConversion : ConversionTarget
 {
     /// <summary>
-    /// The element type(s) from TheoryData&lt;T&gt; (e.g., "TimeSpan" from TheoryData&lt;TimeSpan&gt;
-    /// or "(string, int)" from TheoryData&lt;string, int&gt;)
+    /// The individual type arguments from TheoryData (e.g., ["TimeSpan"] or ["string", "int"]).
     /// </summary>
-    public required string ElementType { get; init; }
+    public required IReadOnlyList<string> ElementTypes { get; init; }
 
     /// <summary>
     /// Whether the TheoryData has multiple type arguments (e.g., TheoryData&lt;string, int&gt;).
     /// When true, initializer expressions { val1, val2 } must be converted to tuple expressions (val1, val2).
     /// </summary>
-    public bool IsMultiType { get; init; }
+    public bool IsMultiType => ElementTypes.Count > 1;
 
     /// <summary>
     /// Annotation for the GenericName (TheoryData&lt;T&gt;) type syntax to convert to IEnumerable&lt;T&gt;

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -229,9 +229,12 @@ public class MigrationTransformer
 
                     if (objectCreation?.Initializer != null)
                     {
+                        // Build the element type: T for single, (T1, T2) for multi
+                        var elementTypeSyntax = BuildElementType(conversion.ElementTypes);
+
                         // Build array type: T[] or (T1, T2)[]
                         var arrayType = SyntaxFactory.ArrayType(
-                            SyntaxFactory.ParseTypeName(conversion.ElementType),
+                            elementTypeSyntax,
                             SyntaxFactory.SingletonList(
                                 SyntaxFactory.ArrayRankSpecifier(
                                     SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(
@@ -241,14 +244,23 @@ public class MigrationTransformer
                             )
                         ).WithoutTrailingTrivia();
 
-                        // Get the open brace token and ensure it has proper newline trivia
+                        // Get the open brace token and ensure it has proper newline trivia.
+                        // When the brace is on a separate line (e.g., new Type\n{), the newline
+                        // may be trailing trivia of the preceding token, not leading trivia of {.
+                        // Preserve existing whitespace indentation when adding the newline.
                         var openBrace = objectCreation.Initializer.OpenBraceToken;
                         if (!openBrace.LeadingTrivia.Any(t => t.IsKind(SyntaxKind.EndOfLineTrivia)))
                         {
-                            // Add newline and proper indentation before the brace
+                            var existingWhitespace = openBrace.LeadingTrivia
+                                .LastOrDefault(t => t.IsKind(SyntaxKind.WhitespaceTrivia));
+
+                            var whitespace = existingWhitespace.IsKind(SyntaxKind.WhitespaceTrivia)
+                                ? existingWhitespace
+                                : SyntaxFactory.Whitespace("    ");
+
                             openBrace = openBrace.WithLeadingTrivia(
                                 SyntaxFactory.EndOfLine("\n"),
-                                SyntaxFactory.Whitespace("    "));
+                                whitespace);
                         }
 
                         // For multi-type TheoryData, convert complex initializer expressions
@@ -292,23 +304,9 @@ public class MigrationTransformer
 
                     if (genericName != null)
                     {
-                        TypeArgumentListSyntax typeArgList;
-                        if (conversion.IsMultiType)
-                        {
-                            // TheoryData<T1, T2, ...> → IEnumerable<(T1, T2, ...)>
-                            var tupleType = SyntaxFactory.TupleType(
-                                SyntaxFactory.SeparatedList(
-                                    genericName.TypeArgumentList.Arguments.Select(
-                                        arg => SyntaxFactory.TupleElement(arg))));
-                            typeArgList = SyntaxFactory.TypeArgumentList(
-                                SyntaxFactory.SingletonSeparatedList<TypeSyntax>(tupleType));
-                        }
-                        else
-                        {
-                            // TheoryData<T> → IEnumerable<T>
-                            typeArgList = SyntaxFactory.TypeArgumentList(
-                                SyntaxFactory.SeparatedList(genericName.TypeArgumentList.Arguments));
-                        }
+                        var elementTypeSyntax = BuildElementType(conversion.ElementTypes);
+                        var typeArgList = SyntaxFactory.TypeArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(elementTypeSyntax));
 
                         var enumerableType = SyntaxFactory.GenericName(
                             SyntaxFactory.Identifier("IEnumerable"),
@@ -333,6 +331,24 @@ public class MigrationTransformer
         }
 
         return currentRoot;
+    }
+
+    /// <summary>
+    /// Builds the element TypeSyntax from the stored type argument strings.
+    /// Single type: returns the type directly (e.g., "TimeSpan" → TimeSpan).
+    /// Multi type: returns a tuple type (e.g., ["string", "int"] → (string, int)).
+    /// </summary>
+    private static TypeSyntax BuildElementType(IReadOnlyList<string> elementTypes)
+    {
+        if (elementTypes.Count == 1)
+        {
+            return SyntaxFactory.ParseTypeName(elementTypes[0]);
+        }
+
+        return SyntaxFactory.TupleType(
+            SyntaxFactory.SeparatedList(
+                elementTypes.Select(t =>
+                    SyntaxFactory.TupleElement(SyntaxFactory.ParseTypeName(t)))));
     }
 
     /// <summary>

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/XUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/XUnitTwoPhaseAnalyzer.cs
@@ -1837,12 +1837,7 @@ public class XUnitTwoPhaseAnalyzer : MigrationAnalyzer
                 var typeArgs = originalGeneric.TypeArgumentList.Arguments;
                 if (typeArgs.Count == 0) continue;
 
-                // For single type: TheoryData<T> → IEnumerable<T>, element type is T
-                // For multi type: TheoryData<T1, T2> → IEnumerable<(T1, T2)>, element type is (T1, T2)
-                var isMultiType = typeArgs.Count > 1;
-                var elementType = isMultiType
-                    ? $"({string.Join(", ", typeArgs.Select(t => t.ToString()))})"
-                    : typeArgs[0].ToString();
+                var elementTypes = typeArgs.Select(t => t.ToString()).ToList();
 
                 // Create annotations for both the type and the object creation
                 var typeAnnotation = new SyntaxAnnotation("TUnitMigration", Guid.NewGuid().ToString());
@@ -1850,8 +1845,7 @@ public class XUnitTwoPhaseAnalyzer : MigrationAnalyzer
 
                 var conversion = new TheoryDataConversion
                 {
-                    ElementType = elementType,
-                    IsMultiType = isMultiType,
+                    ElementTypes = elementTypes,
                     TypeAnnotation = typeAnnotation,
                     CreationAnnotation = creationAnnotation,
                     OriginalText = originalGeneric.ToString()

--- a/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
@@ -626,6 +626,53 @@ public class XUnitMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task TheoryData_MultiType_PropertyGetter_Can_Be_Converted()
+    {
+        await CodeFixer
+            .VerifyCodeFixAsync(
+                """
+                {|#0:using Xunit;
+
+                public class MyClass
+                {
+                    public static TheoryData<string, int> MyData
+                    {
+                        get
+                        {
+                            var data = new TheoryData<string, int>
+                            {
+                                { "a", 1 },
+                                { "b", 2 }
+                            };
+                            return data;
+                        }
+                    }
+                }|}
+                """,
+                Verifier.Diagnostic(Rules.XunitMigration).WithLocation(0),
+                """
+
+                public class MyClass
+                {
+                    public static IEnumerable<(string, int)> MyData
+                    {
+                        get
+                        {
+                            var data = new (string, int)[]
+                            {
+                                ("a", 1),
+                                ("b", 2)
+                            };
+                            return data;
+                        }
+                    }
+                }
+                """,
+                ConfigureXUnitTest
+            );
+    }
+
+    [Test]
     public async Task TheoryData_ThreeTypes_Can_Be_Converted()
     {
         await CodeFixer


### PR DESCRIPTION
## Summary

Fixes #5000

- `TheoryData<T1, T2, ...>` with multiple type arguments was incorrectly converted to `IEnumerable<T1, T2>` (invalid — `IEnumerable<T>` only takes one type parameter) and `T1[]` (losing subsequent types)
- Now correctly converts to `IEnumerable<(T1, T2, ...)>` using tuples, with proper `(T1, T2)[]` array creation and `{ val1, val2 }` initializer expressions converted to `(val1, val2)` tuple expressions
- Single-type `TheoryData<T>` continues to work as before (`IEnumerable<T>` + `T[]`)

### Example

```csharp
// Before (xUnit):
public static readonly TheoryData<string, int> Items = new()
{
    { "a", 1 },
    { "b", 2 }
};

// After (TUnit) — now correct:
public static readonly IEnumerable<(string, int)> Items = new (string, int)[]
{
    ("a", 1),
    ("b", 2)
};
```

## Test plan

- [x] Added `TheoryData_MultiType_Is_Flagged` test — verifies analyzer detects multi-type TheoryData
- [x] Added `TheoryData_MultiType_Can_Be_Converted` test — verifies code fix produces correct tuple-based output
- [x] All 73 existing xUnit migration tests continue to pass