### PR TITLE
docs: fix position of `--results-directory` in documentation

### DIFF
--- a/docs/docs/examples/tunit-ci-pipeline.md
+++ b/docs/docs/examples/tunit-ci-pipeline.md
@@ -4,7 +4,7 @@ When using TUnit in a CI/CD pipeline, you'll want to run tests, collect results,
 
 The best practice is to use the .NET SDK CLI (`dotnet test` or `dotnet run`) directly to maintain full control over execution, ensure reproducibility across environments, and allow for local debugging.
 
-> **Note**: The `--` separator is required to pass arguments to the test runner when using `dotnet test`. CLI flags/args from extension packages (such as `--coverage`, `--report-trx`, `--results-directory`) must come after the `--` separator so they are parsed as program arguments to the TUnit test runner, not as `dotnet test` arguments. For example: `dotnet test -- --coverage --report-trx` instead of `dotnet test --coverage --report-trx`.
+> **Note**: The `--` separator is required to pass arguments to the test runner when using `dotnet test`. CLI flags/args from extension packages (such as `--coverage`, `--report-trx`) must come after the `--` separator so they are parsed as program arguments to the TUnit test runner, not as `dotnet test` arguments. For example: `dotnet test -- --coverage --report-trx` instead of `dotnet test --coverage --report-trx`.
 
 ## GitHub Actions
 
@@ -48,7 +48,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Run tests with coverage
-      run: dotnet test --configuration Release --no-build -- --coverage --report-trx --results-directory ./TestResults
+      run: dotnet test --configuration Release --no-build --results-directory ./TestResults -- --coverage --report-trx
 
     - name: Upload test results
       if: always()  # Run even if tests fail
@@ -140,7 +140,7 @@ jobs:
         dotnet-version: '9.0.x'
 
     - name: Run tests
-      run: dotnet test --configuration Release -- --report-trx --results-directory ./TestResults
+      run: dotnet test --configuration Release --results-directory ./TestResults -- --report-trx
 
     - name: Comment PR with results
       if: always()
@@ -219,9 +219,9 @@ stages:
       displayName: 'Build solution'
 
     - script: |
-        dotnet test --configuration $(buildConfiguration) --no-build -- \
+        dotnet test --configuration $(buildConfiguration) --no-build --results-directory $(Agent.TempDirectory) -- \
           --coverage --coverage-output-format cobertura \
-          --report-trx --results-directory $(Agent.TempDirectory)
+          --report-trx
       displayName: 'Run tests with coverage'
       continueOnError: true
 
@@ -311,9 +311,9 @@ test:unit:
   dependencies:
     - build
   script:
-    - dotnet test --configuration $BUILD_CONFIGURATION --no-build --
+    - dotnet test --configuration $BUILD_CONFIGURATION --no-build --results-directory ./TestResults --
       --coverage --coverage-output-format cobertura
-      --report-trx --results-directory ./TestResults
+      --report-trx
   coverage: '/Total\s+\|\s+(\d+\.?\d*)%/'
   artifacts:
     when: always
@@ -330,9 +330,9 @@ test:integration:
   dependencies:
     - build
   script:
-    - dotnet test --configuration $BUILD_CONFIGURATION --no-build --
+    - dotnet test --configuration $BUILD_CONFIGURATION --no-build --results-directory ./TestResults --
       --treenode-filter "/*/*/*/*[Category=Integration]"
-      --report-trx --results-directory ./TestResults
+      --report-trx
   artifacts:
     when: always
     paths:
@@ -420,9 +420,9 @@ jobs:
       - run:
           name: Run tests
           command: |
-            dotnet test --configuration Release --no-build -- \
+            dotnet test --configuration Release --no-build --results-directory ./TestResults -- \
               --coverage --coverage-output-format cobertura \
-              --report-trx --results-directory ./TestResults
+              --report-trx
 
       - run:
           name: Process test results
@@ -489,8 +489,8 @@ RUN dotnet build --configuration Release --no-restore
 # Run tests
 FROM build AS test
 WORKDIR /src
-RUN dotnet test --configuration Release --no-build -- \
-    --coverage --report-trx --results-directory /testresults
+RUN dotnet test --configuration Release --no-build --results-directory /testresults -- \
+    --coverage --report-trx
 
 # Export test results
 FROM scratch AS export


### PR DESCRIPTION
## Description
I finally got the [CI-Build in Mockolate](https://github.com/aweXpect/Mockolate/pull/223) to work with TUnit. The problem was, that the `--results-directory` is no custom CLI argument, but has to be specified before the `--` separator.

This PR updates the documentation accordingly!

## Related Issue

- Fixes #4083

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [ ] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [ ] All existing tests pass (`dotnet test`)
- [ ] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
