### PR TITLE
Truncate exceptions in GitHub summary tables

### DIFF
--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -321,15 +321,34 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         return stateProperty switch
         {
             FailedTestNodeStateProperty failedTestNodeStateProperty =>
-                failedTestNodeStateProperty.Exception?.ToString() ?? "Test failed",
+                GetTruncatedExceptionMessage(failedTestNodeStateProperty.Exception) ?? "Test failed",
             ErrorTestNodeStateProperty errorTestNodeStateProperty =>
-                errorTestNodeStateProperty.Exception?.ToString() ?? "Test failed",
+                GetTruncatedExceptionMessage(errorTestNodeStateProperty.Exception) ?? "Test failed",
             TimeoutTestNodeStateProperty timeoutTestNodeStateProperty => timeoutTestNodeStateProperty.Explanation,
 #pragma warning disable CS0618 // CancelledTestNodeStateProperty is obsolete
             CancelledTestNodeStateProperty => "Test was cancelled",
 #pragma warning restore CS0618
             _ => null
         };
+    }
+
+    private static string? GetTruncatedExceptionMessage(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return null;
+        }
+
+        var message = exception.Message;
+
+        var firstStackTraceLine = exception.StackTrace?.Split('\n').FirstOrDefault()?.Trim();
+
+        if (string.IsNullOrWhiteSpace(firstStackTraceLine))
+        {
+            return message;
+        }
+
+        return $"{message}\n{firstStackTraceLine}";
     }
 
     private static string GetStatus(IProperty? stateProperty)


### PR DESCRIPTION
## Summary
- GitHub summary tables have limited data capacity, but previously full `Exception.ToString()` (type, message, and entire stack trace) was written to the details column
- Now only the exception message and first line of the stack trace are included, keeping summaries concise while still providing useful diagnostic info

## Test plan
- [ ] Verify build passes
- [ ] Run tests with intentional failures and check GitHub summary output contains truncated exceptions