### PR TITLE
Remove redundant prefixes from tracing timeline spans

### DIFF
--- a/TUnit.Engine/Reporters/Html/ActivityCollector.cs
+++ b/TUnit.Engine/Reporters/Html/ActivityCollector.cs
@@ -284,6 +284,7 @@ internal sealed class ActivityCollector : IDisposable
             SpanId = activity.SpanId.ToString(),
             ParentSpanId = parentSpanId,
             Name = EnrichSpanName(activity),
+            SpanType = activity.DisplayName,
             Source = activity.Source.Name,
             Kind = activity.Kind.ToString(),
             StartTimeMs = activity.StartTimeUtc.Subtract(DateTime.UnixEpoch).TotalMilliseconds,

--- a/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
@@ -187,6 +187,9 @@ internal sealed class SpanData
     [JsonPropertyName("name")]
     public required string Name { get; init; }
 
+    [JsonPropertyName("spanType")]
+    public string? SpanType { get; init; }
+
     [JsonPropertyName("source")]
     public required string Source { get; init; }
 

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1159,7 +1159,7 @@ spans.forEach(s => {
 // Build suite span lookup: className -> span
 const suiteSpanByClass = {};
 spans.forEach(s => {
-    if (!s.name.startsWith('test suite')) return;
+    if (s.spanType !== 'test suite') return;
     const tag = (s.tags||[]).find(t => t.key === 'test.suite.name');
     if (tag) suiteSpanByClass[tag.value] = s;
 });
@@ -1460,7 +1460,7 @@ function renderSuiteTrace(className) {
     if (!allSpans) return '';
     const all = getDescendants(allSpans, suite.spanId);
     const testCaseIds = new Set();
-    all.forEach(s => { if (s.name.startsWith('test case')) testCaseIds.add(s.spanId); });
+    all.forEach(s => { if (s.spanType === 'test case') testCaseIds.add(s.spanId); });
     const tcDescendants = new Set();
     testCaseIds.forEach(id => { getDescendants(all, id).forEach(s => { if (s.spanId !== id) tcDescendants.add(s.spanId); }); });
     const filtered = all.filter(s => !tcDescendants.has(s.spanId) && !testCaseIds.has(s.spanId));
@@ -1476,7 +1476,7 @@ function renderSuiteTrace(className) {
 
 // Global timeline: session + assembly + suite spans
 function renderGlobalTimeline() {
-    const topSpans = spans.filter(s => s.name.startsWith('test session') || s.name.startsWith('test assembly') || s.name.startsWith('test suite'));
+    const topSpans = spans.filter(s => s.spanType === 'test session' || s.spanType === 'test assembly' || s.spanType === 'test suite');
     if (!topSpans.length) return '';
     return '<div class="global-trace"><div class="tl-toggle">' + tlArrow + 'Execution Timeline</div><div class="tl-content"><div class="tl-content-inner"><div class="tl-content-pad">' + renderSpanRows(topSpans, 'global') + '</div></div></div></div>';
 }


### PR DESCRIPTION
## Summary
- Removes "test assembly:", "test suite:", and "test case:" prefixes from span names in the HTML report tracing timeline
- The span type is already clear from indentation level and naming, so the prefixes just consume space and cause text overflow that hides the full name
- Updates `GetTestSpanLookup` to identify test case spans by tag (`tunit.test.node_uid`) rather than name prefix, which is more robust

## Test plan
- [ ] Generate an HTML report and verify tracing timeline shows span names without prefixes
- [ ] Verify span indentation still clearly communicates hierarchy
- [ ] Confirm test trace linking still works (tests link to their spans correctly)