### PR TITLE
Render span tags and events on separate lines

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -802,7 +802,7 @@ body{
   font-size:.76rem;color:var(--text-2);
 }
 .sp-extra.open{display:block;animation:fade-up .2s var(--ease)}
-.sp-tag{padding-left:1em}.sp-evt{padding-left:1em}.sp-evt-tag{padding-left:2em}
+.sp-tag,.sp-evt{padding-left:1em}.sp-evt-tag{padding-left:2em}
 .global-trace,.suite-trace{
   background:var(--surface-1);border:1px solid var(--border);border-radius:var(--r-lg);
   padding:0;margin-bottom:16px;overflow:hidden;


### PR DESCRIPTION
## Summary
- Renders each tag and event in span details on its own line with indentation
- Previously all tags/events were space-separated on a single line, making them hard to read when there are many entries

## Test plan
- [ ] Open an HTML report with spans that have tags and events
- [ ] Verify tags appear one per line, indented under the "Tags:" heading
- [ ] Verify events appear one per line with their tags further indented