### PR TITLE
Disable HTML report in speed comparison benchmarks

### DIFF
--- a/tools/speed-comparison/Tests.Benchmark/RuntimeBenchmarks.cs
+++ b/tools/speed-comparison/Tests.Benchmark/RuntimeBenchmarks.cs
@@ -21,7 +21,8 @@ public class RuntimeBenchmarks : BenchmarkBase
             .WithArguments(["--treenode-filter",  $"/*/*/{ClassName}/*"])
             .WithEnvironmentVariables(new Dictionary<string, string?>
             {
-                ["TUNIT_DISABLE_GITHUB_REPORTER"] = "true"
+                ["TUNIT_DISABLE_GITHUB_REPORTER"] = "true",
+                ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
             })
             .WithStandardOutputPipe(PipeTarget.ToStream(OutputStream))
             .ExecuteBufferedAsync();
@@ -37,7 +38,8 @@ public class RuntimeBenchmarks : BenchmarkBase
             .WithArguments(["--treenode-filter",  $"/*/*/{ClassName}/*"])
             .WithEnvironmentVariables(new Dictionary<string, string?>
             {
-                ["TUNIT_DISABLE_GITHUB_REPORTER"] = "true"
+                ["TUNIT_DISABLE_GITHUB_REPORTER"] = "true",
+                ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
             })
             .WithStandardOutputPipe(PipeTarget.ToStream(OutputStream))
             .ExecuteBufferedAsync();


### PR DESCRIPTION
## Summary
- Adds `TUNIT_DISABLE_HTML_REPORTER=true` to both `TUnit()` and `TUnit_AOT()` benchmark methods in `RuntimeBenchmarks.cs`
- The GitHub reporter was already disabled; this also disables the HTML report to reduce unnecessary overhead during benchmark runs

## Test plan
- [ ] Verify speed comparison workflow runs successfully without generating HTML reports