### PR TITLE
Demote granular internal logs from Debug to Trace level

### DIFF
--- a/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet10_0.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet10_0.verified.txt
@@ -21,14 +21,14 @@ file static class TUnitInfrastructure
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
-            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
+            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
         }
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_0 = typeof(global::TUnit.TestProject.Library.AsyncBaseTests);
@@ -37,7 +37,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_0.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -45,7 +45,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -53,7 +53,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_1 = typeof(global::VerifyTUnit.DerivePathInfo);
@@ -62,7 +62,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_1.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -70,7 +70,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -78,7 +78,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_2 = typeof(global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests);
@@ -87,7 +87,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_2.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -95,7 +95,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }

--- a/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet8_0.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet8_0.verified.txt
@@ -21,14 +21,14 @@ file static class TUnitInfrastructure
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
-            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
+            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
         }
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_0 = typeof(global::TUnit.TestProject.Library.AsyncBaseTests);
@@ -37,7 +37,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_0.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -45,7 +45,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -53,7 +53,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_1 = typeof(global::VerifyTUnit.DerivePathInfo);
@@ -62,7 +62,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_1.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -70,7 +70,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -78,7 +78,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_2 = typeof(global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests);
@@ -87,7 +87,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_2.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -95,7 +95,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }

--- a/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet9_0.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.DotNet9_0.verified.txt
@@ -21,14 +21,14 @@ file static class TUnitInfrastructure
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
-            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
+            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
         }
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_0 = typeof(global::TUnit.TestProject.Library.AsyncBaseTests);
@@ -37,7 +37,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_0.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -45,7 +45,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -53,7 +53,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_1 = typeof(global::VerifyTUnit.DerivePathInfo);
@@ -62,7 +62,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_1.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -70,7 +70,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -78,7 +78,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_2 = typeof(global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests);
@@ -87,7 +87,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_2.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -95,7 +95,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }

--- a/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.Net4_7.verified.txt
+++ b/TUnit.Core.SourceGenerator.Tests/DuplicateTypeNameAcrossAssembliesTests.InfrastructureGenerator_WithDuplicateTypeNames_CompilesSuccessfully.Net4_7.verified.txt
@@ -21,14 +21,14 @@ file static class TUnitInfrastructure
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
-            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
+            global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading 3 assembly reference(s)...");
         }
         catch { /* TUnit.Core not available - skip logging */ }
         try
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_0 = typeof(global::TUnit.TestProject.Library.AsyncBaseTests);
@@ -37,7 +37,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_0.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.TestProject.Library.AsyncBaseTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -45,7 +45,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.TestProject.Library.AsyncBaseTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -53,7 +53,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_1 = typeof(global::VerifyTUnit.DerivePathInfo);
@@ -62,7 +62,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_1.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::VerifyTUnit.DerivePathInfo");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -70,7 +70,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::VerifyTUnit.DerivePathInfo: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -78,7 +78,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Loading assembly containing: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
             var type_2 = typeof(global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests);
@@ -87,7 +87,7 @@ file static class TUnitInfrastructure
             global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type_2.TypeHandle);
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Assembly initialized: global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests");
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }
@@ -95,7 +95,7 @@ file static class TUnitInfrastructure
         {
             try
             {
-                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
+                global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace("[ModuleInitializer:TestsBase`1] Failed to load global::TUnit.Core.SourceGenerator.Tests.AotConverterGeneratorTests: " + ex.Message);
             }
             catch { /* TUnit.Core not available - skip logging */ }
         }

--- a/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
@@ -400,7 +400,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
                     sourceBuilder.AppendLine("try");
                     sourceBuilder.AppendLine("{");
                     sourceBuilder.Indent();
-                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug(\"[ModuleInitializer:{model.AssemblyName}] Loading {model.TypesToReference.Length} assembly reference(s)...\");");
+                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace(\"[ModuleInitializer:{model.AssemblyName}] Loading {model.TypesToReference.Length} assembly reference(s)...\");");
                     sourceBuilder.Unindent();
                     sourceBuilder.AppendLine("}");
                     sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip logging */ }");
@@ -415,7 +415,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
                     sourceBuilder.AppendLine("try");
                     sourceBuilder.AppendLine("{");
                     sourceBuilder.Indent();
-                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug(\"[ModuleInitializer:{model.AssemblyName}] Loading assembly containing: {typeName.Replace("\"", "\\\"")}\");");
+                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace(\"[ModuleInitializer:{model.AssemblyName}] Loading assembly containing: {typeName.Replace("\"", "\\\"")}\");");
                     sourceBuilder.Unindent();
                     sourceBuilder.AppendLine("}");
                     sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip logging */ }");
@@ -426,7 +426,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
                     sourceBuilder.AppendLine("try");
                     sourceBuilder.AppendLine("{");
                     sourceBuilder.Indent();
-                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug(\"[ModuleInitializer:{model.AssemblyName}] Assembly initialized: {typeName.Replace("\"", "\\\"")}\");");
+                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace(\"[ModuleInitializer:{model.AssemblyName}] Assembly initialized: {typeName.Replace("\"", "\\\"")}\");");
                     sourceBuilder.Unindent();
                     sourceBuilder.AppendLine("}");
                     sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip logging */ }");
@@ -438,7 +438,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
                     sourceBuilder.AppendLine("try");
                     sourceBuilder.AppendLine("{");
                     sourceBuilder.Indent();
-                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogDebug(\"[ModuleInitializer:{model.AssemblyName}] Failed to load {typeName.Replace("\"", "\\\"")}: \" + ex.Message);");
+                    sourceBuilder.AppendLine($"global::TUnit.Core.GlobalContext.Current.GlobalLogger.LogTrace(\"[ModuleInitializer:{model.AssemblyName}] Failed to load {typeName.Replace("\"", "\\\"")}: \" + ex.Message);");
                     sourceBuilder.Unindent();
                     sourceBuilder.AppendLine("}");
                     sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip logging */ }");

--- a/TUnit.Engine/Logging/TUnitFrameworkLogger.cs
+++ b/TUnit.Engine/Logging/TUnitFrameworkLogger.cs
@@ -95,6 +95,8 @@ public class TUnitFrameworkLogger(IExtension extension, IOutputDevice outputDevi
 
     public bool IsDebugEnabled => _minimumLogLevel <= LogLevel.Debug;
 
+    public bool IsTraceEnabled => _minimumLogLevel <= LogLevel.Trace;
+
     public async Task LogErrorAsync(string message)
     {
         await LogAsync(LogLevel.Error, message, null, (s, _) => s);

--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -90,8 +90,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             if (canStart)
             {
                 // Start the test immediately
-                if (_logger.IsDebugEnabled)
-                    await _logger.LogDebugAsync($"Starting test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Starting test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
                 startSignal.SetResult(true);
 
                 var testTask = ExecuteTestAndReleaseKeysAsync(test, constraintKeys, lockedKeys, lockObject, waitingTestIndex, cancellationToken);
@@ -101,8 +101,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             else
             {
                 // Test was already added to the waiting index inside the lock above
-                if (_logger.IsDebugEnabled)
-                    await _logger.LogDebugAsync($"Queueing test {test.TestId} waiting for constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Queueing test {test.TestId} waiting for constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
 
                 var testTask = WaitAndExecuteTestAsync(test, constraintKeys, startSignal, lockedKeys, lockObject, waitingTestIndex, cancellationToken);
                 test.ExecutionTask = testTask;
@@ -129,8 +129,8 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         // Wait for signal to start
         await startSignal.Task.ConfigureAwait(false);
 
-        if (_logger.IsDebugEnabled)
-            await _logger.LogDebugAsync($"Starting previously queued test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+        if (_logger.IsTraceEnabled)
+            await _logger.LogTraceAsync($"Starting previously queued test {test.TestId} with constraint keys: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
 
         await ExecuteTestAndReleaseKeysAsync(test, constraintKeys, lockedKeys, lockObject, waitingTestIndex, cancellationToken).ConfigureAwait(false);
     }
@@ -217,13 +217,13 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             }
 
             // Log and signal tests to start outside the lock
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Released constraint keys for test {test.TestId}: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Released constraint keys for test {test.TestId}: {string.Join(", ", constraintKeys)}").ConfigureAwait(false);
 
             foreach (var testToStart in testsToStart)
             {
-                if (_logger.IsDebugEnabled)
-                    await _logger.LogDebugAsync($"Unblocking waiting test {testToStart.TestId} with constraint keys: {string.Join(", ", testToStart.ConstraintKeys)}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Unblocking waiting test {testToStart.TestId} with constraint keys: {string.Join(", ", testToStart.ConstraintKeys)}").ConfigureAwait(false);
                 testToStart.StartSignal.SetResult(true);
             }
         }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -169,8 +169,8 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (groupedTests.Parallel.Length > 0)
         {
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
             await ExecuteTestsAsync(groupedTests.Parallel, cancellationToken).ConfigureAwait(false);
         }
 
@@ -183,16 +183,16 @@ internal sealed class TestScheduler : ITestScheduler
             }
             var orderedTestsArray = orderedTests.ToArray();
 
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);
             await ExecuteTestsAsync(orderedTestsArray, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var kvp in groupedTests.ConstrainedParallelGroups)
         {
             var constrainedTests = kvp.Value;
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Starting constrained parallel group '{kvp.Key}' with {constrainedTests.UnconstrainedTests.Length} unconstrained and {constrainedTests.KeyedTests.Length} keyed tests").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting constrained parallel group '{kvp.Key}' with {constrainedTests.UnconstrainedTests.Length} unconstrained and {constrainedTests.KeyedTests.Length} keyed tests").ConfigureAwait(false);
 
             var tasks = new List<Task>();
             if (constrainedTests.UnconstrainedTests.Length > 0)
@@ -211,15 +211,15 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (groupedTests.KeyedNotInParallel.Length > 0)
         {
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
             await _constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).ConfigureAwait(false);
         }
 
         if (groupedTests.NotInParallel.Length > 0)
         {
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Starting {groupedTests.NotInParallel.Length} global NotInParallel tests").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting {groupedTests.NotInParallel.Length} global NotInParallel tests").ConfigureAwait(false);
             await ExecuteSequentiallyAsync(groupedTests.NotInParallel, cancellationToken).ConfigureAwait(false);
         }
 
@@ -250,8 +250,8 @@ internal sealed class TestScheduler : ITestScheduler
             // Execute the batch of dynamic tests if any were found
             if (dynamicTests.Count > 0)
             {
-                if (_logger.IsDebugEnabled)
-                    await _logger.LogDebugAsync($"Executing {dynamicTests.Count} dynamic test(s)").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Executing {dynamicTests.Count} dynamic test(s)").ConfigureAwait(false);
 
                 // Group and execute just like regular tests
                 var dynamicTestsArray = dynamicTests.ToArray();
@@ -283,8 +283,8 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (dynamicTests.Count > 0)
         {
-            if (_logger.IsDebugEnabled)
-                await _logger.LogDebugAsync($"Executing {dynamicTests.Count} remaining dynamic test(s)").ConfigureAwait(false);
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Executing {dynamicTests.Count} remaining dynamic test(s)").ConfigureAwait(false);
 
             var dynamicTestsArray = dynamicTests.ToArray();
             var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTestsArray).ConfigureAwait(false);

--- a/TUnit.Engine/Services/HookDelegateBuilder.cs
+++ b/TUnit.Engine/Services/HookDelegateBuilder.cs
@@ -94,14 +94,14 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
 
         foreach (var hook in sourceHooks)
         {
-            await _logger.LogDebugAsync($"Creating delegate for {hookTypeName} hook: {hook.Name}").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"Creating delegate for {hookTypeName} hook: {hook.Name}").ConfigureAwait(false);
             var hookFunc = await createDelegate(hook);
             hooks.Add((hook.Order, hook.RegistrationIndex, hookFunc));
         }
 
         if (hooks.Count > 0)
         {
-            await _logger.LogDebugAsync($"Built {hooks.Count} {hookTypeName} hook delegate(s)").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"Built {hooks.Count} {hookTypeName} hook delegate(s)").ConfigureAwait(false);
         }
 
         return hooks

--- a/TUnit.Engine/Services/TestGroupingService.cs
+++ b/TUnit.Engine/Services/TestGroupingService.cs
@@ -199,13 +199,13 @@ internal sealed class TestGroupingService : ITestGroupingService
         };
 
         // Log summary of test categorization
-        await _logger.LogDebugAsync("═══ Test Grouping Summary ═══").ConfigureAwait(false);
-        await _logger.LogDebugAsync($"  Parallel (no constraints): {parallelTests.Count} tests").ConfigureAwait(false);
-        await _logger.LogDebugAsync($"  ParallelGroups: {parallelGroups.Count} groups").ConfigureAwait(false);
-        await _logger.LogDebugAsync($"  ConstrainedParallelGroups: {finalConstrainedGroups.Count} groups").ConfigureAwait(false);
-        await _logger.LogDebugAsync($"  NotInParallel (global): {sortedNotInParallel.Length} tests").ConfigureAwait(false);
-        await _logger.LogDebugAsync($"  KeyedNotInParallel: {keyedArrays.Length} tests").ConfigureAwait(false);
-        await _logger.LogDebugAsync("════════════════════════════").ConfigureAwait(false);
+        await _logger.LogTraceAsync("═══ Test Grouping Summary ═══").ConfigureAwait(false);
+        await _logger.LogTraceAsync($"  Parallel (no constraints): {parallelTests.Count} tests").ConfigureAwait(false);
+        await _logger.LogTraceAsync($"  ParallelGroups: {parallelGroups.Count} groups").ConfigureAwait(false);
+        await _logger.LogTraceAsync($"  ConstrainedParallelGroups: {finalConstrainedGroups.Count} groups").ConfigureAwait(false);
+        await _logger.LogTraceAsync($"  NotInParallel (global): {sortedNotInParallel.Length} tests").ConfigureAwait(false);
+        await _logger.LogTraceAsync($"  KeyedNotInParallel: {keyedArrays.Length} tests").ConfigureAwait(false);
+        await _logger.LogTraceAsync("════════════════════════════").ConfigureAwait(false);
 
         return result;
     }


### PR DESCRIPTION
## Summary
- Moves per-item scheduling, hook building, test grouping, and assembly loading logs from Debug to Trace level, reducing noise at Debug verbosity
- Keeps high-level flow logs (test count, max parallelism config, hook init start/complete, infrastructure bookends) at Debug
- Adds `IsTraceEnabled` property to `TUnitFrameworkLogger` for guard checks

## Files changed
- **ConstraintKeyScheduler** — all 5 per-test constraint key logs → Trace
- **TestScheduler** — 7 per-group/per-batch start logs → Trace; kept 2 flow + 5 config logs as Debug
- **HookDelegateBuilder** — 2 per-hook detail logs → Trace; kept 2 top-level summary logs as Debug
- **TestGroupingService** — 7 summary detail lines → Trace
- **InfrastructureGenerator** — 4 per-assembly generated log patterns → Trace; kept init start/complete as Debug
- **TUnitFrameworkLogger** — added `IsTraceEnabled` property
- 4 snapshot `.verified.txt` files updated to match

## Test plan
- [x] `TUnit.Engine` builds with 0 warnings
- [x] `TUnit.Core.SourceGenerator` builds with 0 warnings
- [x] Snapshot verified files updated to match generator output
- [ ] CI passes