### PR TITLE
fix: use unique artifact names to avoid collisions in matrix builds

### DIFF
--- a/TUnit.Engine/Reporters/Html/GitHubArtifactUploader.cs
+++ b/TUnit.Engine/Reporters/Html/GitHubArtifactUploader.cs
@@ -143,7 +143,7 @@ internal static class GitHubArtifactUploader
     private static string GetShortJobId(string jobRunBackendId)
     {
         return jobRunBackendId.Length > 8
-            ? jobRunBackendId.Substring(0, 8)
+            ? jobRunBackendId[..8]
             : jobRunBackendId;
     }
 


### PR DESCRIPTION
## Summary

- Appends a short job backend ID suffix (first 8 chars of `workflowJobRunBackendId`) to the HTML report artifact name, ensuring each matrix job uploads a distinct artifact
- Tracks the accepted artifact name from CreateArtifact and uses it in FinalizeArtifact, fixing a bug where a conflict-deduped name (e.g. `-2`) was not carried forward to finalization

## Test plan

- [ ] Verify artifact uploads succeed in a matrix pipeline without "CreateArtifact failed" warnings
- [ ] Confirm artifacts appear with unique names (e.g. `MyProject-linux-net10.0-report-a1b2c3d4.html`)
- [ ] Confirm FinalizeArtifact uses the correct name when a 409 conflict triggers a name change