### PR TITLE
Use CallerArgumentExpression for TestDataRow by default.

### DIFF
--- a/TUnit.Core/Helpers/TestDataRowUnwrapper.cs
+++ b/TUnit.Core/Helpers/TestDataRowUnwrapper.cs
@@ -29,7 +29,7 @@ internal static class TestDataRowUnwrapper
         if (value is ITestDataRow testDataRow)
         {
             data = testDataRow.GetData();
-            metadata = new TestDataRowMetadata(testDataRow.DisplayName, testDataRow.Skip, testDataRow.Categories);
+            metadata = new TestDataRowMetadata(testDataRow.DisplayName, testDataRow.DataExpression, testDataRow.Skip, testDataRow.Categories);
             return true;
         }
 

--- a/TUnit.Core/TestContext.Metadata.cs
+++ b/TUnit.Core/TestContext.Metadata.cs
@@ -28,6 +28,13 @@ public partial class TestContext
             return _cachedDisplayName;
         }
 
+        // Use expression-based display format when no explicit DisplayName was provided
+        if (!string.IsNullOrEmpty(DataSourceExpression))
+        {
+            _cachedDisplayName = $"{TestDetails.TestName}({DataSourceExpression})";
+            return _cachedDisplayName;
+        }
+
         if (TestDetails.TestMethodArguments.Length == 0)
         {
             _cachedDisplayName = TestDetails.TestName;

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -211,6 +211,16 @@ public partial class TestContext : Context,
         DataSourceDisplayName = displayName;
     }
 
+    /// <summary>
+    /// Expression text from CallerArgumentExpression on TestDataRow.
+    /// Used as the argument representation in the default TestName(expression) format.
+    /// </summary>
+    internal string? DataSourceExpression { get; private set; }
+
+    internal void SetDataSourceExpression(string expression)
+    {
+        DataSourceExpression = expression;
+    }
 
     internal TestDetails TestDetails { get; set; } = null!;
 

--- a/TUnit.Core/TestDataRow.cs
+++ b/TUnit.Core/TestDataRow.cs
@@ -10,6 +10,7 @@ internal interface ITestDataRow
 {
     object? GetData();
     string? DisplayName { get; }
+    string? DataExpression { get; }
     string? Skip { get; }
     string[]? Categories { get; }
 }
@@ -20,33 +21,67 @@ internal interface ITestDataRow
 /// per-row display names, skip reasons, or categories.
 /// </summary>
 /// <typeparam name="T">The type of the test data.</typeparam>
-/// <param name="Data">The actual test data to be passed to the test method.</param>
-/// <param name="DisplayName">
-/// Optional custom display name for the test case. If not specified, the argument expression from <paramref name="Data"/> is used.
-/// Supports parameter substitution using $paramName or $arg1, $arg2, etc.
-/// </param>
-/// <param name="Skip">
-/// Optional skip reason. When set, the test case will be skipped with this message.
-/// </param>
-/// <param name="Categories">
-/// Optional categories to apply to this specific test case.
-/// </param>
 /// <example>
 /// <code>
 /// public static IEnumerable&lt;TestDataRow&lt;(string Username, string Password)&gt;&gt; GetLoginData()
 /// {
-///     yield return new(("admin", "secret123")); // DisplayName '("admin", "secret123")' is inferred
-///     yield return new(("guest", "guest"), DisplayName: "Guest login");
+///     yield return new(("admin", "secret123")); // DisplayName includes method name + expression
+///     yield return new(("guest", "guest"), DisplayName: "Guest login"); // DisplayName fully overridden
 ///     yield return new(("", ""), DisplayName: "Empty credentials", Skip: "Not implemented yet");
 /// }
 /// </code>
 /// </example>
-public record TestDataRow<T>(
-    T Data,
-    [CallerArgumentExpression(nameof(Data))] string? DisplayName = null,
-    string? Skip = null,
-    string[]? Categories = null
-) : ITestDataRow
+public record TestDataRow<T> : ITestDataRow
 {
+    /// <summary>
+    /// The actual test data to be passed to the test method.
+    /// </summary>
+    public T Data { get; init; }
+
+    /// <summary>
+    /// Optional custom display name for the test case. When set, replaces the entire display name.
+    /// Supports parameter substitution using $paramName or $arg1, $arg2, etc.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Auto-captured expression text of the Data argument via CallerArgumentExpression.
+    /// Used as the argument representation in the default TestName(expression) format
+    /// when DisplayName is not explicitly set.
+    /// </summary>
+    public string? DataExpression { get; init; }
+
+    /// <summary>
+    /// Optional skip reason. When set, the test case will be skipped with this message.
+    /// </summary>
+    public string? Skip { get; init; }
+
+    /// <summary>
+    /// Optional categories to apply to this specific test case.
+    /// </summary>
+    public string[]? Categories { get; init; }
+
+    /// <summary>
+    /// Creates a new TestDataRow wrapping the specified data.
+    /// </summary>
+    /// <param name="Data">The test data.</param>
+    /// <param name="DisplayName">Optional custom display name. When set, replaces the entire display name.</param>
+    /// <param name="Skip">Optional skip reason.</param>
+    /// <param name="Categories">Optional categories.</param>
+    /// <param name="DataExpression">Auto-captured expression text. Leave unset to let the compiler fill it in.</param>
+    public TestDataRow(
+        T Data,
+        string? DisplayName = null,
+        string? Skip = null,
+        string[]? Categories = null,
+        [CallerArgumentExpression(nameof(Data))] string? DataExpression = null)
+    {
+        this.Data = Data;
+        this.DisplayName = DisplayName;
+        this.Skip = Skip;
+        this.Categories = Categories;
+        this.DataExpression = DataExpression;
+    }
+
     object? ITestDataRow.GetData() => Data;
 }

--- a/TUnit.Core/TestDataRowMetadata.cs
+++ b/TUnit.Core/TestDataRowMetadata.cs
@@ -4,10 +4,12 @@ namespace TUnit.Core;
 /// Metadata extracted from a <see cref="TestDataRow{T}"/> wrapper or data source attributes.
 /// </summary>
 /// <param name="DisplayName">Custom display name for the test case.</param>
+/// <param name="DataExpression">Auto-captured expression text of the Data argument.</param>
 /// <param name="Skip">Skip reason - test will be skipped if set.</param>
 /// <param name="Categories">Categories to apply to the test case.</param>
 internal record TestDataRowMetadata(
     string? DisplayName,
+    string? DataExpression,
     string? Skip,
     string[]? Categories
 )
@@ -15,7 +17,7 @@ internal record TestDataRowMetadata(
     /// <summary>
     /// Returns true if any metadata property is set.
     /// </summary>
-    public bool HasMetadata => DisplayName is not null || Skip is not null || Categories is { Length: > 0 };
+    public bool HasMetadata => DisplayName is not null || DataExpression is not null || Skip is not null || Categories is { Length: > 0 };
 
     /// <summary>
     /// Merges this metadata with another, preferring non-null values from this instance.
@@ -29,6 +31,7 @@ internal record TestDataRowMetadata(
 
         return new TestDataRowMetadata(
             DisplayName ?? other.DisplayName,
+            DataExpression ?? other.DataExpression,
             Skip ?? other.Skip,
             Categories ?? other.Categories
         );

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -864,6 +864,12 @@ internal sealed class TestBuilder : ITestBuilder
                 context.SetDataSourceDisplayName(dataRowMetadata.DisplayName!);
             }
 
+            // Apply data expression for default display name formatting (only when no explicit DisplayName)
+            if (string.IsNullOrEmpty(dataRowMetadata.DisplayName) && !string.IsNullOrEmpty(dataRowMetadata.DataExpression))
+            {
+                context.SetDataSourceExpression(dataRowMetadata.DataExpression!);
+            }
+
             // Apply skip reason from data source
             if (!string.IsNullOrEmpty(dataRowMetadata.Skip))
             {

--- a/TUnit.Engine/Helpers/DataSourceMetadataExtractor.cs
+++ b/TUnit.Engine/Helpers/DataSourceMetadataExtractor.cs
@@ -49,7 +49,7 @@ internal static class DataSourceMetadataExtractor
             return null;
         }
 
-        return new TestDataRowMetadata(displayName, skip, categories);
+        return new TestDataRowMetadata(displayName, null, skip, categories);
     }
 
     /// <summary>

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1405,9 +1405,10 @@ namespace
     }
     public class TestDataRow<T> : <.TestDataRow<T>>
     {
-        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null) { }
+        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null, [.("Data")] string? DataExpression = null) { }
         public string[]? Categories { get; init; }
         public T Data { get; init; }
+        public string? DataExpression { get; init; }
         public string? DisplayName { get; init; }
         public string? Skip { get; init; }
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1405,9 +1405,10 @@ namespace
     }
     public class TestDataRow<T> : <.TestDataRow<T>>
     {
-        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null) { }
+        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null, [.("Data")] string? DataExpression = null) { }
         public string[]? Categories { get; init; }
         public T Data { get; init; }
+        public string? DataExpression { get; init; }
         public string? DisplayName { get; init; }
         public string? Skip { get; init; }
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1405,9 +1405,10 @@ namespace
     }
     public class TestDataRow<T> : <.TestDataRow<T>>
     {
-        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null) { }
+        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null, [.("Data")] string? DataExpression = null) { }
         public string[]? Categories { get; init; }
         public T Data { get; init; }
+        public string? DataExpression { get; init; }
         public string? DisplayName { get; init; }
         public string? Skip { get; init; }
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1355,9 +1355,10 @@ namespace
     }
     public class TestDataRow<T> : <.TestDataRow<T>>
     {
-        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null) { }
+        public TestDataRow(T Data, string? DisplayName = null, string? Skip = null, string[]? Categories = null, [.("Data")] string? DataExpression = null) { }
         public string[]? Categories { get; init; }
         public T Data { get; init; }
+        public string? DataExpression { get; init; }
         public string? DisplayName { get; init; }
         public string? Skip { get; init; }
     }

--- a/TUnit.TestProject/TestDataRowCallerArgumentExpressionTests.cs
+++ b/TUnit.TestProject/TestDataRowCallerArgumentExpressionTests.cs
@@ -1,0 +1,33 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Pass)]
+public class TestDataRowCallerArgumentExpressionTests
+{
+    [Test]
+    [MethodDataSource(nameof(InferredDisplayNameData))]
+    public async Task Inferred_DisplayName_Uses_CallerArgumentExpression(string username, string password)
+    {
+        await Assert.That(TestContext.Current!.Metadata.DisplayName)
+            .IsEqualTo("""Inferred_DisplayName_Uses_CallerArgumentExpression(("admin", "secret123"))""");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(ExplicitDisplayNameData))]
+    public async Task Explicit_DisplayName_Overrides_CallerArgumentExpression(string username, string password)
+    {
+        await Assert.That(TestContext.Current!.Metadata.DisplayName)
+            .IsEqualTo("Admin login");
+    }
+
+    public static IEnumerable<TestDataRow<(string, string)>> InferredDisplayNameData()
+    {
+        yield return new(("admin", "secret123"));
+    }
+
+    public static IEnumerable<TestDataRow<(string, string)>> ExplicitDisplayNameData()
+    {
+        yield return new(("admin", "secret123"), DisplayName: "Admin login");
+    }
+}


### PR DESCRIPTION
## Description

I just wrote a Test with a lambda as the `Data` argument of the `TestDataRow<>`. If `DisplayName` is not provided, `.ToString() ` seems to get called. For delegates this is the type name, which is not useful.
For my test I created a Create factory method, so that `[CallerArgumentExpression]` is used and I do not have to provide the `DisplayName`.
This PR adds the Attribute directly to `TestDataRow<>`. I am not sure, if that causes a worse `DisplayName` in some cases.

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [ ] All existing tests pass (`dotnet test`)
- [ ] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
