### PR TITLE
fix: add tooltip to truncated span names in HTML report

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1372,7 +1372,7 @@ function renderSpanRows(sp, uid) {
         const cls = s.status === 'Error' ? 'err' : s.status === 'Ok' ? 'ok' : 'unk';
         h += '<div class="sp-row" data-si="' + i + '">';
         h += '<div class="sp-lbl" style="padding-left:' + (d * 14) + 'px">';
-        h += '<span class="sp-name">' + esc(s.name) + '</span>';
+        h += '<span class="sp-name" title="' + esc(s.name) + '">' + esc(s.name) + '</span>';
         h += '<span class="sp-dur">' + fmt(s.durationMs) + '</span>';
         h += '</div>';
         h += '<div class="sp-track"><div class="sp-bar ' + cls + '" style="left:' + l + '%;width:' + w + '%" title="' + esc(s.name) + ' (' + fmt(s.durationMs) + ')"></div></div>';


### PR DESCRIPTION
## Summary

- Adds a `title` attribute to the `.sp-name` span element in the trace timeline so that truncated span names show the full name on hover
- The CSS already applies `text-overflow: ellipsis` to long span names, but there was no way to see the full text

## Test plan
- [ ] Open an HTML report with long span names (e.g. `hook: TestHooks.LogTestResult...`)
- [ ] Hover over the truncated name and verify the full name appears as a tooltip