### PR TITLE
Fix ConfigureTestConfiguration being invoked twice

### DIFF
--- a/TUnit.AspNetCore/TestWebApplicationFactory.cs
+++ b/TUnit.AspNetCore/TestWebApplicationFactory.cs
@@ -21,7 +21,6 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
         TestContext testContext,
         WebApplicationTestOptions options,
         Action<IServiceCollection> configureIsolatedServices,
-        Action<IConfigurationBuilder> configureIsolatedStartupConfiguration,
         Action<WebHostBuilderContext, IConfigurationBuilder> configureIsolatedAppConfiguration,
         Action<IWebHostBuilder>? configureWebHostBuilder = null)
     {
@@ -29,7 +28,6 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
         {
             var configurationBuilder = new ConfigurationManager();
             ConfigureStartupConfiguration(configurationBuilder);
-            configureIsolatedStartupConfiguration(configurationBuilder);
 
             foreach (var keyValuePair in configurationBuilder.AsEnumerable())
             {

--- a/TUnit.AspNetCore/WebApplicationTest.cs
+++ b/TUnit.AspNetCore/WebApplicationTest.cs
@@ -115,7 +115,6 @@ public abstract class WebApplicationTest<TFactory, TEntryPoint> : WebApplication
                 testContext,
                 _options,
                 ConfigureTestServices,
-                ConfigureTestConfiguration,
                 (_, config) => ConfigureTestConfiguration(config),
                 ConfigureWebHostBuilder));
 

--- a/TUnit.Example.Asp.Net.TestProject/FactoryMethodOrderTests.cs
+++ b/TUnit.Example.Asp.Net.TestProject/FactoryMethodOrderTests.cs
@@ -10,7 +10,7 @@ namespace TUnit.Example.Asp.Net.TestProject;
 ///
 /// This allows:
 /// - Factory to provide base configuration shared across tests
-/// - Tests to override factory defaults via ConfigureTestConfiguration (order 5)
+/// - Tests to override factory defaults via ConfigureTestConfiguration (order 6)
 /// </summary>
 public class FactoryMethodOrderTests : TestsBase
 {
@@ -105,7 +105,7 @@ public class FactoryMethodOrderTests : TestsBase
     }
 
     [Test]
-    [DisplayName("Complete relative execution order: Options → Setup → Config → WebHost → Services → Startup")]
+    [DisplayName("Complete relative execution order: Options → Setup → WebHost → Config → Services → Startup")]
     public async Task Full_Relative_Order()
     {
         _ = Factory.CreateClient();
@@ -113,8 +113,8 @@ public class FactoryMethodOrderTests : TestsBase
         // Verify all hooks were called
         await Assert.That(ConfigureTestOptionsCalledOrder).IsGreaterThan(0);
         await Assert.That(SetupCalledOrder).IsGreaterThan(0);
-        await Assert.That(ConfigureTestConfigurationCalledOrder).IsGreaterThan(0);
         await Assert.That(ConfigureWebHostBuilderCalledOrder).IsGreaterThan(0);
+        await Assert.That(ConfigureTestConfigurationCalledOrder).IsGreaterThan(0);
         await Assert.That(ConfigureTestServicesCalledOrder).IsGreaterThan(0);
         await Assert.That(StartupCalledOrder).IsGreaterThan(0);
 
@@ -124,16 +124,16 @@ public class FactoryMethodOrderTests : TestsBase
             .Because("ConfigureTestOptions runs before SetupAsync");
 
         await Assert.That(SetupCalledOrder)
-            .IsLessThan(ConfigureTestConfigurationCalledOrder)
-            .Because("SetupAsync runs before ConfigureTestConfiguration");
-
-        await Assert.That(ConfigureTestConfigurationCalledOrder)
             .IsLessThan(ConfigureWebHostBuilderCalledOrder)
-            .Because("ConfigureTestConfiguration runs before ConfigureWebHostBuilder");
+            .Because("SetupAsync runs before ConfigureWebHostBuilder");
 
         await Assert.That(ConfigureWebHostBuilderCalledOrder)
+            .IsLessThan(ConfigureTestConfigurationCalledOrder)
+            .Because("ConfigureWebHostBuilder runs before ConfigureTestConfiguration");
+
+        await Assert.That(ConfigureTestConfigurationCalledOrder)
             .IsLessThan(ConfigureTestServicesCalledOrder)
-            .Because("ConfigureWebHostBuilder runs before ConfigureTestServices");
+            .Because("ConfigureTestConfiguration runs before ConfigureTestServices");
 
         await Assert.That(ConfigureTestServicesCalledOrder)
             .IsLessThan(StartupCalledOrder)

--- a/TUnit.Example.Asp.Net.TestProject/TestsBase.cs
+++ b/TUnit.Example.Asp.Net.TestProject/TestsBase.cs
@@ -67,13 +67,8 @@ public abstract class TestsBase : WebApplicationTest<WebApplicationFactory, Prog
 
     protected override void ConfigureTestConfiguration(IConfigurationBuilder config)
     {
-        // Track first call only (this method is called twice - once for startup config, once for app config)
-        if (ConfigureTestConfigurationCalledOrder == 0)
-        {
-            ConfigureTestConfigurationCalledOrder = GetNextOrder();
-            ConfigureTestConfigurationCalledAt = DateTime.UtcNow;
-        }
-
+        ConfigureTestConfigurationCalledOrder = GetNextOrder();
+        ConfigureTestConfigurationCalledAt = DateTime.UtcNow;
         base.ConfigureTestConfiguration(config);
     }
 

--- a/docs/docs/examples/aspnet.md
+++ b/docs/docs/examples/aspnet.md
@@ -124,8 +124,8 @@ Understanding the execution order is critical for writing correct tests. Here's 
 │  3. Factory.ConfigureWebHost    Base factory configuration      │
 │  4. Factory.ConfigureStartup... Base factory startup config     │
 │  ───────────────────────────────────────────────────────────    │
-│  5. ConfigureTestConfiguration  Test config (overrides factory) │
-│  6. ConfigureWebHostBuilder     Escape hatch (low-level access) │
+│  5. ConfigureWebHostBuilder     Escape hatch (low-level access) │
+│  6. ConfigureTestConfiguration  Test config (overrides factory) │
 │  7. ConfigureTestServices       Test services (overrides)       │
 │  ───────────────────────────────────────────────────────────    │
 │  8. Application Startup         Server starts                   │
@@ -143,8 +143,8 @@ Understanding the execution order is critical for writing correct tests. Here's 
 | `SetupAsync` | Per-test | Async operations before config (create DB tables) |
 | `Factory.ConfigureWebHost` | Shared | Base configuration for all tests |
 | `Factory.ConfigureStartupConfiguration` | Shared | Base startup configuration |
-| `ConfigureTestConfiguration` | Per-test | Override factory configuration |
 | `ConfigureWebHostBuilder` | Per-test | Low-level escape hatch |
+| `ConfigureTestConfiguration` | Per-test | Override factory configuration |
 | `ConfigureTestServices` | Per-test | Override factory services |
 
 :::tip Tests Can Override Factory
@@ -790,7 +790,7 @@ The key benefits:
 
 **Problem:** You set a value in `ConfigureTestConfiguration` but the factory's value is still used.
 
-**Solution:** Make sure you're using the same configuration key. The test configuration runs **after** the factory configuration (step 5 vs steps 3-4), so it should override. Check that:
+**Solution:** Make sure you're using the same configuration key. The test configuration runs **after** the factory configuration (step 6 vs steps 3-4), so it should override. Check that:
 
 1. You're using `AddInMemoryCollection` which adds to the config sources
 2. The configuration key path is exactly the same
@@ -927,14 +927,14 @@ public class LifecycleDebugTest : WebApplicationTest<WebApplicationFactory, Prog
         await base.SetupAsync();
     }
 
-    protected override void ConfigureTestConfiguration(IConfigurationBuilder config)
-    {
-        Console.WriteLine("5. ConfigureTestConfiguration");
-    }
-
     protected override void ConfigureWebHostBuilder(IWebHostBuilder builder)
     {
-        Console.WriteLine("6. ConfigureWebHostBuilder");
+        Console.WriteLine("5. ConfigureWebHostBuilder");
+    }
+
+    protected override void ConfigureTestConfiguration(IConfigurationBuilder config)
+    {
+        Console.WriteLine("6. ConfigureTestConfiguration");
     }
 
     protected override void ConfigureTestServices(IServiceCollection services)


### PR DESCRIPTION
## Summary

Fixes #5195

- `ConfigureTestConfiguration` was passed to `GetIsolatedFactory` **twice**: once as startup configuration (applied via `UseSetting` before `Program.cs`) and once as app configuration (applied via `ConfigureAppConfiguration` after `Program.cs`). This caused the method to run twice — once before and once after `Factory.ConfigureWebHost` — breaking the documented lifecycle order.
- Removed the redundant `configureIsolatedStartupConfiguration` parameter from `GetIsolatedFactory` so `ConfigureTestConfiguration` only runs once, at the correct point in the lifecycle (after factory configuration, allowing test overrides).
- Updated lifecycle documentation and tests to reflect the corrected execution order.

## Test plan

- [ ] Verify `TUnit.Example.Asp.Net.TestProject` lifecycle order tests pass (especially `FactoryMethodOrderTests.Full_Relative_Order`)
- [ ] Verify `ConfigureTestConfiguration` is only invoked once per test
- [ ] Verify test configuration values properly override factory configuration values