### PR TITLE
perf: reduce allocations and lock contention in ObjectTracker

### DIFF
--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -58,28 +58,29 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     }
 
     /// <summary>
-    /// Checks if an object exists in any of the depth-keyed HashSets without allocating a flattened set.
+    /// Takes a snapshot of currently tracked objects before new discovery mutates the dictionary.
+    /// Uses ReferenceEqualityComparer to match object identity semantics.
     /// </summary>
-    private static bool IsAlreadyTracked(Dictionary<int, HashSet<object>> trackedObjects, object obj)
+    private static HashSet<object> SnapshotTrackedObjects(Dictionary<int, HashSet<object>> trackedObjects)
     {
+        var snapshot = new HashSet<object>(Helpers.ReferenceEqualityComparer.Instance);
         foreach (var kvp in trackedObjects)
         {
-            if (kvp.Value.Contains(obj))
+            foreach (var obj in kvp.Value)
             {
-                return true;
+                snapshot.Add(obj);
             }
         }
 
-        return false;
+        return snapshot;
     }
 
     public void TrackObjects(TestContext testContext)
     {
-        var alreadyTracked = testContext.TrackedObjects;
+        var alreadyTrackedSnapshot = SnapshotTrackedObjects(testContext.TrackedObjects);
 
-        // Get new trackable objects
         var trackableDict = trackableObjectGraphProvider.GetTrackableObjects(testContext);
-        if (trackableDict.Count == 0 && alreadyTracked.Count == 0)
+        if (trackableDict.Count == 0 && alreadyTrackedSnapshot.Count == 0)
         {
             return;
         }
@@ -90,7 +91,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
             {
                 foreach (var obj in kvp.Value)
                 {
-                    if (!IsAlreadyTracked(alreadyTracked, obj))
+                    if (!alreadyTrackedSnapshot.Contains(obj))
                     {
                         TrackObject(obj);
                     }


### PR DESCRIPTION
## Summary

- **Eliminate HashSet allocations in `FlattenTrackedObjects()`**: Replaced with `IsAlreadyTracked()` (O(n) containment check across depth buckets, no allocation) and `CountTrackedObjects()` (sum counts without materializing a set). These were called twice per test, each allocating a new `HashSet<object>`.
- **Remove intermediate `newTrackableObjects` HashSet** in `TrackObjects()`: Objects are now tracked directly during iteration instead of being collected first and iterated again.
- **Remove global `s_disposalLock`**: `Counter.Decrement()` uses `Interlocked.Decrement` which atomically returns the new value, so only one thread can ever observe `count == 0` for a given counter. The global lock was unnecessary contention across unrelated objects.
- **Parallelize disposal** in `UntrackObjectsAsync()`: Uses `Task.WhenAll` instead of sequential `await` for objects that require async disposal, with a fast-path that skips `Task` allocation for synchronously completed `ValueTask`s.
- **Remove unused `using` directives** (`System.Collections.Immutable`, `System.Diagnostics.CodeAnalysis`).

## Test plan

- [ ] Verify TUnit.Core builds successfully across all target frameworks
- [ ] Run existing object tracking tests to confirm no behavioral changes
- [ ] Verify disposal ordering is still correct (objects with ref count reaching 0 are disposed exactly once)