### PR TITLE
perf: remove unnecessary lock in ObjectTracker.TrackObjects

### DIFF
--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -85,9 +85,8 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
             return;
         }
 
-        // No lock needed: TrackedObjects is per-TestContext and TrackObjects is called
-        // from a single thread per test. The previous lock(kvp.Value) caused unnecessary
-        // Monitor.Enter_Slowpath contention (~1.25% CPU) during parallel test execution.
+        // No lock needed: TrackedObjects is per-TestContext and TrackObjects
+        // is called from a single thread per test.
         foreach (var kvp in trackableDict)
         {
             foreach (var obj in kvp.Value)
@@ -214,7 +213,6 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
             }
         }
 
-        // Dispose outside the lock to avoid blocking other untrack operations
         if (shouldDispose)
         {
             await disposer.DisposeAsync(obj).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Remove `lock (kvp.Value)` in `ObjectTracker.TrackObjects()` that caused `Monitor.Enter_Slowpath` contention (~1.25% exclusive CPU during parallel execution)
- The lock was unnecessary: `TrackedObjects` is per-`TestContext` and `TrackObjects` is called from a single thread per test
- The shared state (`s_trackedObjects` ConcurrentDictionary) is already thread-safe via `GetOrAdd`
- Also removed a stale comment in `UntrackObject` that referenced a non-existent lock

## Test plan
- [x] Builds successfully (TUnit.Core and TUnit.Engine, Release, net10.0)
- [x] DisposableFieldTests and DisposablePropertyTests pass
- [ ] CI passes