### PR TITLE
perf: add CI solution filter to reduce build times

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -117,7 +117,7 @@ jobs:
         shell: pwsh
 
       - name: Build
-        run: dotnet build -c Release
+        run: dotnet build TUnit.CI.slnx -c Release
 
       - name: Publish AOT
         run: dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0

--- a/TUnit.CI.slnx
+++ b/TUnit.CI.slnx
@@ -1,0 +1,100 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Any CPU" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+
+  <!-- Core framework packages -->
+  <Folder Name="/Core/">
+    <Project Path="TUnit/TUnit.csproj" />
+    <Project Path="TUnit.Core/TUnit.Core.csproj" />
+    <Project Path="TUnit.Engine/TUnit.Engine.csproj" />
+    <Project Path="TUnit.Assertions/TUnit.Assertions.csproj" />
+    <Project Path="TUnit.Assertions.FSharp/TUnit.Assertions.FSharp.fsproj" />
+  </Folder>
+
+  <!-- Extension libraries and integrations -->
+  <Folder Name="/Libraries/">
+    <Project Path="TUnit.Aspire/TUnit.Aspire.csproj" />
+    <Project Path="TUnit.AspNetCore/TUnit.AspNetCore.csproj" />
+    <Project Path="TUnit.FsCheck/TUnit.FsCheck.csproj" />
+    <Project Path="TUnit.Logging.Microsoft/TUnit.Logging.Microsoft.csproj" />
+    <Project Path="TUnit.Mocks/TUnit.Mocks.csproj" />
+    <Project Path="TUnit.Mocks.Assertions/TUnit.Mocks.Assertions.csproj" />
+    <Project Path="TUnit.Mocks.Http/TUnit.Mocks.Http.csproj" />
+    <Project Path="TUnit.Mocks.Logging/TUnit.Mocks.Logging.csproj" />
+    <Project Path="TUnit.Playwright/TUnit.Playwright.csproj" />
+  </Folder>
+
+  <!-- Roslyn analyzers and code fixers -->
+  <Folder Name="/Analyzers/">
+    <Project Path="TUnit.Analyzers/TUnit.Analyzers.csproj" />
+    <Project Path="TUnit.Analyzers.CodeFixers/TUnit.Analyzers.CodeFixers.csproj" />
+    <Project Path="TUnit.Analyzers.Roslyn414/TUnit.Analyzers.Roslyn414.csproj" />
+    <Project Path="TUnit.Analyzers.Roslyn44/TUnit.Analyzers.Roslyn44.csproj" />
+    <Project Path="TUnit.Analyzers.Roslyn47/TUnit.Analyzers.Roslyn47.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers/TUnit.AspNetCore.Analyzers.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.Roslyn414/TUnit.AspNetCore.Analyzers.Roslyn414.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.Roslyn44/TUnit.AspNetCore.Analyzers.Roslyn44.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.Roslyn47/TUnit.AspNetCore.Analyzers.Roslyn47.csproj" />
+    <Project Path="TUnit.Assertions.Analyzers/TUnit.Assertions.Analyzers.csproj" />
+    <Project Path="TUnit.Assertions.Analyzers.CodeFixers/TUnit.Assertions.Analyzers.CodeFixers.csproj" />
+    <Project Path="TUnit.Mocks.Analyzers/TUnit.Mocks.Analyzers.csproj" />
+  </Folder>
+
+  <!-- Source generators and Roslyn version variants -->
+  <Folder Name="/SourceGenerators/">
+    <Project Path="TUnit.Assertions.SourceGenerator/TUnit.Assertions.SourceGenerator.csproj" />
+    <Project Path="TUnit.Core.SourceGenerator/TUnit.Core.SourceGenerator.csproj" />
+    <Project Path="TUnit.Core.SourceGenerator.Roslyn414/TUnit.Core.SourceGenerator.Roslyn414.csproj" />
+    <Project Path="TUnit.Core.SourceGenerator.Roslyn44/TUnit.Core.SourceGenerator.Roslyn44.csproj" />
+    <Project Path="TUnit.Core.SourceGenerator.Roslyn47/TUnit.Core.SourceGenerator.Roslyn47.csproj" />
+    <Project Path="TUnit.Mocks.SourceGenerator/TUnit.Mocks.SourceGenerator.csproj" />
+    <Project Path="TUnit.Mocks.SourceGenerator.Roslyn414/TUnit.Mocks.SourceGenerator.Roslyn414.csproj" />
+    <Project Path="TUnit.Mocks.SourceGenerator.Roslyn44/TUnit.Mocks.SourceGenerator.Roslyn44.csproj" />
+    <Project Path="TUnit.Mocks.SourceGenerator.Roslyn47/TUnit.Mocks.SourceGenerator.Roslyn47.csproj" />
+  </Folder>
+
+  <!-- Test projects -->
+  <Folder Name="/Tests/">
+    <Project Path="TUnit.Analyzers.Tests/TUnit.Analyzers.Tests.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.Tests/TUnit.AspNetCore.Analyzers.Tests.csproj" />
+    <Project Path="TUnit.Assertions.Analyzers.CodeFixers.Tests/TUnit.Assertions.Analyzers.CodeFixers.Tests.csproj" />
+    <Project Path="TUnit.Assertions.Analyzers.Tests/TUnit.Assertions.Analyzers.Tests.csproj" />
+    <Project Path="TUnit.Assertions.SourceGenerator.Tests/TUnit.Assertions.SourceGenerator.Tests.csproj" />
+    <Project Path="TUnit.Assertions.Tests/TUnit.Assertions.Tests.csproj" />
+    <Project Path="TUnit.Core.SourceGenerator.Tests/TUnit.Core.SourceGenerator.Tests.csproj" />
+    <Project Path="TUnit.Engine.Tests/TUnit.Engine.Tests.csproj" />
+    <Project Path="TUnit.Mocks.Analyzers.Tests/TUnit.Mocks.Analyzers.Tests.csproj" />
+    <Project Path="TUnit.Mocks.Http.Tests/TUnit.Mocks.Http.Tests.csproj" />
+    <Project Path="TUnit.Mocks.Logging.Tests/TUnit.Mocks.Logging.Tests.csproj" />
+    <Project Path="TUnit.Mocks.SourceGenerator.Tests/TUnit.Mocks.SourceGenerator.Tests.csproj" />
+    <Project Path="TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj" />
+    <Project Path="TUnit.PublicAPI/TUnit.PublicAPI.csproj" />
+    <Project Path="TUnit.RpcTests/TUnit.RpcTests.csproj" />
+    <Project Path="TUnit.Templates.Tests/TUnit.Templates.Tests.csproj" />
+    <Project Path="TUnit.UnitTests/TUnit.UnitTests.csproj" />
+  </Folder>
+
+  <!-- Build infrastructure -->
+  <Folder Name="/Build/">
+    <Project Path="TUnit.Pipeline/TUnit.Pipeline.csproj" />
+  </Folder>
+
+  <!-- Example/test projects needed by pipeline -->
+  <Folder Name="/Examples/">
+    <Project Path="TUnit.Example.Asp.Net/TUnit.Example.Asp.Net.csproj" />
+    <Project Path="TUnit.Example.Asp.Net.TestProject/TUnit.Example.Asp.Net.TestProject.csproj" />
+    <Project Path="TUnit.Example.FsCheck.TestProject/TUnit.Example.FsCheck.TestProject.csproj" />
+    <Project Path="TUnit.TestProject/TUnit.TestProject.csproj" />
+    <Project Path="TUnit.TestProject.FSharp/TUnit.TestProject.FSharp.fsproj" />
+    <Project Path="TUnit.TestProject.Library/TUnit.TestProject.Library.csproj" />
+    <Project Path="TUnit.TestProject.VB.NET/TUnit.TestProject.VB.NET.vbproj" />
+  </Folder>
+
+  <!-- Templates package (content projects excluded - not needed for CI) -->
+  <Folder Name="/Templates/">
+    <Project Path="TUnit.Templates/TUnit.Templates.csproj" />
+  </Folder>
+</Solution>

--- a/TUnit.Pipeline/Modules/RunMockHttpTestsModule.cs
+++ b/TUnit.Pipeline/Modules/RunMockHttpTestsModule.cs
@@ -1,0 +1,42 @@
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Extensions;
+using ModularPipelines.Git.Extensions;
+using ModularPipelines.Options;
+using TUnit.Pipeline.Modules.Abstract;
+
+namespace TUnit.Pipeline.Modules;
+
+public class RunMockHttpTestsModule : TestBaseModule
+{
+    protected override IEnumerable<string> TestableFrameworks
+    {
+        get
+        {
+            yield return "net10.0";
+            yield return "net8.0";
+        }
+    }
+
+    protected override Task<(DotNetRunOptions Options, CommandExecutionOptions? ExecutionOptions)> GetTestOptions(IModuleContext context, string framework, CancellationToken cancellationToken)
+    {
+        var project = context.Git().RootDirectory.FindFile(x => x.Name == "TUnit.Mocks.Http.Tests.csproj").AssertExists();
+
+        return Task.FromResult<(DotNetRunOptions, CommandExecutionOptions?)>((
+            new DotNetRunOptions
+            {
+                NoBuild = true,
+                Configuration = "Release",
+                Framework = framework,
+            },
+            new CommandExecutionOptions
+            {
+                WorkingDirectory = project.Folder!.Path,
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["DISABLE_GITHUB_REPORTER"] = "true",
+                }
+            }
+        ));
+    }
+}

--- a/TUnit.Pipeline/Modules/RunMockLoggingTestsModule.cs
+++ b/TUnit.Pipeline/Modules/RunMockLoggingTestsModule.cs
@@ -1,0 +1,42 @@
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Extensions;
+using ModularPipelines.Git.Extensions;
+using ModularPipelines.Options;
+using TUnit.Pipeline.Modules.Abstract;
+
+namespace TUnit.Pipeline.Modules;
+
+public class RunMockLoggingTestsModule : TestBaseModule
+{
+    protected override IEnumerable<string> TestableFrameworks
+    {
+        get
+        {
+            yield return "net10.0";
+            yield return "net8.0";
+        }
+    }
+
+    protected override Task<(DotNetRunOptions Options, CommandExecutionOptions? ExecutionOptions)> GetTestOptions(IModuleContext context, string framework, CancellationToken cancellationToken)
+    {
+        var project = context.Git().RootDirectory.FindFile(x => x.Name == "TUnit.Mocks.Logging.Tests.csproj").AssertExists();
+
+        return Task.FromResult<(DotNetRunOptions, CommandExecutionOptions?)>((
+            new DotNetRunOptions
+            {
+                NoBuild = true,
+                Configuration = "Release",
+                Framework = framework,
+            },
+            new CommandExecutionOptions
+            {
+                WorkingDirectory = project.Folder!.Path,
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["DISABLE_GITHUB_REPORTER"] = "true",
+                }
+            }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- **Add `TUnit.CI.slnx`** — a CI-specific solution that excludes 24 projects not needed for pipeline builds (Playground, CloudShop examples, template content projects, benchmarks, TUnit.Profile, TUnit.SourceGenerator.IncrementalTests)
- **Update `dotnet.yml`** to build `TUnit.CI.slnx` instead of the full solution (86 → 62 projects)
- **Add `RunMockHttpTestsModule` and `RunMockLoggingTestsModule`** — pipeline modules to run the Mocks.Http and Mocks.Logging test projects (these were previously not executed in CI)

## Motivation

The `dotnet build -c Release` step takes ~23 minutes on Ubuntu. Building 24 fewer projects (many multi-targeted) should meaningfully reduce this. The full `TUnit.slnx` remains for local development.

## Test plan

- [ ] Verify CI build completes successfully with `TUnit.CI.slnx`
- [ ] Verify pipeline still runs all expected test modules
- [ ] Verify new mock test modules execute correctly
- [ ] Confirm `TUnit.slnx` is unchanged for local dev