### PR TITLE
perf: run GitVersion once in CI instead of per-project

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -116,11 +116,41 @@ jobs:
           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
         shell: pwsh
 
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3
+        with:
+          versionSpec: '6.7.x'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3
+
       - name: Build
-        run: dotnet build TUnit.CI.slnx -c Release
+        shell: bash
+        run: >-
+          dotnet build TUnit.CI.slnx -c Release
+          -p:DisableGitVersionTask=true
+          "-p:Version=${{ steps.gitversion.outputs.semVer }}"
+          "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
+          "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"
+          "-p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}"
+          "-p:PackageVersion=${{ steps.gitversion.outputs.fullSemVer }}"
+          "-p:RepositoryBranch=${{ steps.gitversion.outputs.branchName }}"
+          "-p:RepositoryCommit=${{ steps.gitversion.outputs.sha }}"
 
       - name: Publish AOT
-        run: dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0
+        shell: bash
+        run: >-
+          dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release
+          --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0
+          -p:DisableGitVersionTask=true
+          "-p:Version=${{ steps.gitversion.outputs.semVer }}"
+          "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
+          "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"
+          "-p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}"
+          "-p:PackageVersion=${{ steps.gitversion.outputs.fullSemVer }}"
+          "-p:RepositoryBranch=${{ steps.gitversion.outputs.branchName }}"
+          "-p:RepositoryCommit=${{ steps.gitversion.outputs.sha }}"
 
       - name: Expose GitHub Actions Runtime
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

Run GitVersion a single time via `gittools/actions` before the build and pass version properties via `/p:` flags, disabling the per-project `RunGitVersion` MSBuild target.

## Problem

The `GitVersion.MsBuild` global package reference causes `RunGitVersion` to execute for **every project × TFM combination** — 153 invocations at ~1.5s each, accumulating **231s of cumulative time** spawning `dotnet gitversion.dll` to compute identical version info from git history.

## Solution

- Install GitVersion once via `gittools/actions/gitversion/setup@v3`
- Execute it once via `gittools/actions/gitversion/execute@v3`
- Pass all version properties (`Version`, `AssemblyVersion`, `FileVersion`, `InformationalVersion`, `PackageVersion`, `RepositoryBranch`, `RepositoryCommit`) to `dotnet build` and `dotnet publish` via `/p:` flags
- Set `DisableGitVersionTask=true` to skip the per-project MSBuild target

## How it was found

Binary log analysis (`/bl:`) of `dotnet build TUnit.CI.slnx -c Release` revealed the `Exec` task (GitVersion) as the second largest time consumer after `Csc` (compilation).