### PR TITLE
perf: disable GitVersion MSBuild task globally

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -129,7 +129,6 @@ jobs:
         shell: bash
         run: >-
           dotnet build TUnit.CI.slnx -c Release
-          -p:DisableGitVersionTask=true
           "-p:Version=${{ steps.gitversion.outputs.semVer }}"
           "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
           "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"
@@ -143,7 +142,6 @@ jobs:
         run: >-
           dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release
           --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0
-          -p:DisableGitVersionTask=true
           "-p:Version=${{ steps.gitversion.outputs.semVer }}"
           "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
           "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectName) == 'TUnit.Pipeline'">
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TUnit.Pipeline'">
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -14,7 +14,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- We only need GitVersion.MsBuild for version properties, not the generated class -->
+    <!-- Disable GitVersion MSBuild task by default - CI computes version once and passes properties explicitly.
+         This prevents GitVersion from spawning a process per project×TFM (153+ invocations). -->
+    <DisableGitVersionTask>true</DisableGitVersionTask>
     <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/TUnit.Templates/content/Directory.Build.props
+++ b/TUnit.Templates/content/Directory.Build.props
@@ -15,7 +15,7 @@
         <Using Include="TUnit.Assertions.Extensions" />
     </ItemGroup>
 
-    <ItemGroup Condition="$(MSBuildProjectName) == 'ExampleNamespace.TestProject' And $(MSBuildProjectDirectory.Contains('TUnit.Aspire.Starter'))">
+    <ItemGroup Condition="'$(MSBuildProjectName)' == 'ExampleNamespace.TestProject' And $(MSBuildProjectDirectory.Contains('TUnit.Aspire.Starter'))">
         <PackageReference Remove="TUnit.Aspire" />
         <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\TUnit.Aspire\TUnit.Aspire.csproj" />
         <Using Include="TUnit.Assertions" />

--- a/TestProject.props
+++ b/TestProject.props
@@ -25,8 +25,8 @@
 
     </PropertyGroup>
 
-    <Target Name="CleanSourceGeneratedViewer" BeforeTargets="BeforeBuild">
-        <Message Text="Removing SourceGeneratedViewer directory..." Importance="high" />
+    <Target Name="CleanSourceGeneratedViewer" BeforeTargets="BeforeBuild"
+            Condition="'$(ContinuousIntegrationBuild)' != 'true' AND Exists('$(ProjectDir)SourceGeneratedViewer')">
         <ItemGroup>
             <FilesToDelete Include="$(ProjectDir)SourceGeneratedViewer\**\*" />
         </ItemGroup>


### PR DESCRIPTION
## Summary

- **Disable GitVersion MSBuild task by default** in `Directory.Build.props` — eliminates 153+ `dotnet-gitversion` process spawns per build. CI already computes the version once via `gittools/actions/gitversion/execute` and passes properties explicitly, making the per-project MSBuild task redundant.
- **Skip `CleanSourceGeneratedViewer` in CI** — the target was running every build with no `Inputs`/`Outputs`, deleting and recreating source-gen viewer files unnecessarily. Now conditioned on `ContinuousIntegrationBuild != true` and directory existence.
- **Remove redundant `-p:DisableGitVersionTask=true`** from CI workflow — no longer needed since it's the default.
- **Fix unquoted MSBuild condition expressions** (AP-02) in `Directory.Build.props` and `TUnit.Templates/content/Directory.Build.props`.

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| Incremental no-op | ~30s | **~4s** |
| Full build | 5m 27s | **4m 20s** |

## Test plan

- [x] Full solution build succeeds (`dotnet build TUnit.CI.slnx`)
- [x] Incremental build correctly skips all targets (~4s)
- [ ] CI workflow builds and passes (version properties still passed explicitly)