### PR TITLE
fix: skip IResourceWithoutLifetime resources in Aspire fixture wait logic

### DIFF
--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -169,7 +169,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             case ResourceWaitBehavior.AllHealthy:
             {
                 var model = app.Services.GetRequiredService<DistributedApplicationModel>();
-                var names = model.Resources.Select(r => r.Name).ToList();
+                var names = GetWaitableResourceNames(model);
                 await WaitForResourcesWithFailFastAsync(app, notificationService, names, waitForHealthy: true, cancellationToken);
                 break;
             }
@@ -177,7 +177,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             case ResourceWaitBehavior.AllRunning:
             {
                 var model = app.Services.GetRequiredService<DistributedApplicationModel>();
-                var names = model.Resources.Select(r => r.Name).ToList();
+                var names = GetWaitableResourceNames(model);
                 await WaitForResourcesWithFailFastAsync(app, notificationService, names, waitForHealthy: false, cancellationToken);
                 break;
             }
@@ -521,6 +521,32 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         }
 
         return string.Join(Environment.NewLine, lines);
+    }
+
+    private List<string> GetWaitableResourceNames(DistributedApplicationModel model)
+    {
+        var waitable = new List<string>();
+        List<string>? skipped = null;
+
+        foreach (var r in model.Resources)
+        {
+            if (r is IResourceWithoutLifetime)
+            {
+                skipped ??= [];
+                skipped.Add(r.Name);
+            }
+            else
+            {
+                waitable.Add(r.Name);
+            }
+        }
+
+        if (skipped is { Count: > 0 })
+        {
+            LogProgress($"Skipping {skipped.Count} resource(s) without lifecycle: [{string.Join(", ", skipped)}]");
+        }
+
+        return waitable;
     }
 
     private sealed class ResourceLogWatcher(CancellationTokenSource cts) : IAsyncDisposable


### PR DESCRIPTION
## Summary

- Aspire 13.2.0 introduces internal `{name}-rebuilder` resources for .NET Project resources that appear in `DistributedApplicationModel.Resources` but never transition to Running/Healthy
- `AllHealthy`/`AllRunning` wait modes now filter out `IResourceWithoutLifetime` resources (data-holder/reference resources with no lifecycle) before waiting, preventing indefinite hangs
- Skipped resources are logged via `LogProgress` for visibility

Fixes #5260

## Test plan

- [ ] Verify `TUnit.Aspire` builds on all target frameworks (net8.0, net9.0, net10.0)
- [ ] Verify Aspire integration tests pass with Aspire 13.2.0 AppHost that includes project resources (which now have companion rebuilder resources)
- [ ] Verify `AllHealthy` mode no longer hangs on rebuilder resources
- [ ] Verify `AllRunning` mode no longer hangs on rebuilder resources
- [ ] Verify `Named` mode is unaffected (does not use the new filter)
- [ ] Verify skipped resources appear in log output