### PR TITLE
fix: pass assembly version properties to dotnet pack

### DIFF
--- a/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
+++ b/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
@@ -41,10 +41,11 @@ public class PackTUnitFilesModule : Module<List<PackedProject>>
 
             var properties = new List<KeyValue>
             {
-                // Explicitly set PackageVersion to match the version the pipeline uses
-                // for downstream operations (template install, nuget test, etc.).
-                // GitVersion.MsBuild handles AssemblyVersion/FileVersion automatically.
                 new KeyValue("PackageVersion", packageVersion),
+                new KeyValue("AssemblyVersion", version.AssemblySemVer!),
+                new KeyValue("FileVersion", version.AssemblySemFileVer!),
+                new KeyValue("InformationalVersion", version.InformationalVersion!),
+                new KeyValue("Version", version.SemVer!),
             };
 
             await context.DotNet()


### PR DESCRIPTION
## Summary

- `DisableGitVersionTask=true` was added in #5266 to eliminate 153+ GitVersion process spawns per build, but `PackTUnitFilesModule` was not updated to pass version properties explicitly
- `dotnet pack` rebuilds assemblies without `AssemblyVersion`/`FileVersion`/`InformationalVersion`, resulting in default versions (1.0.0.0) in the NuGet packages
- Consumers hit `FileNotFoundException` at runtime due to strong-name version mismatch (e.g. looking for `TUnit.Core, Version=1.19.74.0` but finding `1.0.0.0`)
- Now passes `AssemblyVersion`, `FileVersion`, `InformationalVersion`, and `Version` to `dotnet pack`, matching what the CI build step already does

Reproducer: https://github.com/thomhurst/Dekaf/actions/runs/23673435711/job/68971685700?pr=647

## Test plan

- [ ] CI builds and packs successfully
- [ ] Verify NuGet package assemblies have correct AssemblyVersion (not 1.0.0.0)
- [ ] Consumer projects can load TUnit without `FileNotFoundException`