### PR TITLE
feat: add TUnit0080 analyzer for missing polyfill types

### DIFF
--- a/TUnit.Analyzers.Tests/MissingPolyfillAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MissingPolyfillAnalyzerTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.CodeAnalysis.Testing;
+using Verifier = TUnit.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<TUnit.Analyzers.MissingPolyfillAnalyzer>;
+
+namespace TUnit.Analyzers.Tests;
+
+public class MissingPolyfillAnalyzerTests
+{
+    [Test]
+    public async Task No_Error_On_Modern_Tfm()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                public class MyClass
+                {
+                }
+                """,
+                test =>
+                {
+                    test.TestState.AdditionalReferences.Clear();
+                }
+            );
+    }
+
+    [Test]
+    public async Task Error_When_ModuleInitializerAttribute_Missing()
+    {
+        var net48References = new ReferenceAssemblies(
+            "net48",
+            new PackageIdentity("Microsoft.NETFramework.ReferenceAssemblies.net48", "1.0.3"),
+            System.IO.Path.Combine("ref", "net48"));
+
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                public class MyClass
+                {
+                }
+                """,
+                test =>
+                {
+                    test.ReferenceAssemblies = net48References;
+                    test.TestState.AdditionalReferences.Clear();
+                    test.CompilerDiagnostics = CompilerDiagnostics.None;
+                },
+                Verifier
+                    .Diagnostic(Rules.MissingPolyfillPackage)
+                    .WithArguments("System.Runtime.CompilerServices.ModuleInitializerAttribute")
+            );
+    }
+}

--- a/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/TUnit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,7 +4,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TUnit0061 | Usage | Error | ClassDataSource type requires parameterless constructor
 TUnit0062 | Usage | Warning | CancellationToken must be the last parameter
-TUnit0080 | Usage | Error | Missing polyfill types required by TUnit
+TUnit0073 | Usage | Error | Missing polyfill types required by TUnit
 
 ### Removed Rules
 

--- a/TUnit.Analyzers/MissingPolyfillAnalyzer.cs
+++ b/TUnit.Analyzers/MissingPolyfillAnalyzer.cs
@@ -7,10 +7,8 @@ namespace TUnit.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class MissingPolyfillAnalyzer : ConcurrentDiagnosticAnalyzer
 {
-    private static readonly string[] RequiredTypes =
-    [
-        "System.Runtime.CompilerServices.ModuleInitializerAttribute",
-    ];
+    private static readonly ImmutableArray<string> RequiredTypes =
+        ImmutableArray.Create("System.Runtime.CompilerServices.ModuleInitializerAttribute");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rules.MissingPolyfillPackage);

--- a/TUnit.Analyzers/Resources.resx
+++ b/TUnit.Analyzers/Resources.resx
@@ -525,13 +525,13 @@
     <data name="TUnit0052Title" xml:space="preserve">
         <value>Multiple constructors found without [TestConstructor] attribute</value>
     </data>
-    <data name="TUnit0080Description" xml:space="preserve">
+    <data name="TUnit0073Description" xml:space="preserve">
         <value>TUnit requires certain types (such as ModuleInitializerAttribute) that are not available on older target frameworks. Install the 'Polyfill' NuGet package to provide these types.</value>
     </data>
-    <data name="TUnit0080MessageFormat" xml:space="preserve">
+    <data name="TUnit0073MessageFormat" xml:space="preserve">
         <value>Type '{0}' is required by TUnit but is not available. Install the 'Polyfill' NuGet package: dotnet add package Polyfill</value>
     </data>
-    <data name="TUnit0080Title" xml:space="preserve">
+    <data name="TUnit0073Title" xml:space="preserve">
         <value>Missing polyfill types required by TUnit</value>
     </data>
     <data name="TUnit0301Description" xml:space="preserve">

--- a/TUnit.Analyzers/Rules.cs
+++ b/TUnit.Analyzers/Rules.cs
@@ -169,7 +169,9 @@ public static class Rules
         CreateDescriptor("TUnit0061", UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MissingPolyfillPackage =
-        CreateDescriptor("TUnit0080", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor("TUnit0073", UsageCategory, DiagnosticSeverity.Error,
+            customTags: [WellKnownDiagnosticTags.CompilationEnd],
+            helpLinkUri: "https://www.nuget.org/packages/Polyfill");
 
     public static readonly DiagnosticDescriptor GenericTypeNotAotCompatible =
         CreateDescriptor("TUnit0300", UsageCategory, DiagnosticSeverity.Warning);
@@ -178,7 +180,8 @@ public static class Rules
         CreateDescriptor("TUnit0301", UsageCategory, DiagnosticSeverity.Warning);
 
 
-    private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity)
+    private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity,
+        string[]? customTags = null, string? helpLinkUri = null)
     {
         return new DiagnosticDescriptor(
             id: diagnosticId,
@@ -190,7 +193,9 @@ public static class Rules
             defaultSeverity: severity,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(diagnosticId + "Description", Resources.ResourceManager,
-                typeof(Resources))
+                typeof(Resources)),
+            helpLinkUri: helpLinkUri,
+            customTags: customTags ?? []
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new `MissingPolyfillAnalyzer` (TUnit0080) that checks if required types like `ModuleInitializerAttribute` are present in the compilation
- On older target frameworks (.NET Framework, netstandard), these types are missing and users need the `Polyfill` NuGet package
- The diagnostic only fires when the type is genuinely absent, so no false positives on modern TFMs

## Test plan
- [ ] Verify analyzer builds across all Roslyn variants (4.4, 4.7, 4.14)
- [ ] Confirm TUnit0080 fires when targeting .NET Framework without Polyfill package
- [ ] Confirm TUnit0080 does not fire on net8.0/net9.0/net10.0