### PR TITLE
fix: resolve System.Memory version conflict on .NET Framework (net462)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,6 +90,7 @@
     </PackageVersion>
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />

--- a/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester.FSharp/TUnit.NugetTester.FSharp.fsproj
+++ b/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester.FSharp/TUnit.NugetTester.FSharp.fsproj
@@ -28,6 +28,7 @@
         </PackageReference>
         <PackageReference Include="Polyfill" />
         <PackageReference Include="FSharp.Core" />
+        <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester.VB/TUnit.NugetTester.VB.vbproj
+++ b/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester.VB/TUnit.NugetTester.VB.vbproj
@@ -23,6 +23,7 @@
             <VersionOverride Condition="'$(TUnitVersion)' != ''">$(TUnitVersion)</VersionOverride>
         </PackageReference>
         <PackageReference Include="Polyfill" />
+        <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester/TUnit.NugetTester.csproj
+++ b/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester/TUnit.NugetTester.csproj
@@ -25,6 +25,7 @@
             <VersionOverride Condition="'$(TUnitVersion)' != ''">$(TUnitVersion)</VersionOverride>
         </PackageReference>
         <PackageReference Include="Polyfill" />
+        <PackageReference Include="System.Memory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Add explicit `System.Memory 4.6.3` package reference to NuGet tester projects (C#, F#, VB.NET) for .NET Framework targets
- Add `System.Memory` to `Directory.Packages.props` for central package management

## Root Cause

The NuGet tester projects target both .NET Framework (net462) and .NET Core. They reference `TUnit.NugetTester.Library` (netstandard2.0), which creates two NuGet resolution paths for `System.Memory`:

| Path | Package | Assembly Version |
|------|---------|-----------------|
| Direct transitive (net461 lib) | 4.5.5 | 4.0.1.2 |
| Via Library (netstandard2.0 lib) | 4.6.3 | 4.0.2.0 |

MSBuild picks `4.0.1.2` as "primary" and copies that DLL. At runtime, code compiled against `4.0.2.0` fails with `FileLoadException`.

Adding an explicit `System.Memory 4.6.3` reference makes it the primary, resolving to assembly version `4.0.5.0` (net462 lib) which unifies both.

## Test plan

- [x] Verified all three tester projects (C#, F#, VB.NET) build for net462 with no MSB3277 warnings
- [ ] CI passes for `modularpipeline (windows-latest)` with net462 target

Fixes #5297