### PR TITLE
refactor(mocks): clean up Mock API surface

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::MyService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::MyService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::MyService> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -81,13 +81,13 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<string> GetValue(this global::TUnit.Mocks.Mock<global::MyService> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValue", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall DoWork(this global::TUnit.Mocks.Mock<global::MyService> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "DoWork", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "DoWork", matchers);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IReadWriter>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IReadWriter>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IReadWriter> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -79,26 +79,26 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.VoidMockMethodCall Flush(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Flush", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Flush", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<string> Read(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Read", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Read", matchers);
         }
 
         public static IReadWriter_Write_M2_MockCall Write(this global::TUnit.Mocks.Mock<global::IReadWriter> mock, global::TUnit.Mocks.Arguments.Arg<string> data)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };
-            return new IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Write", matchers);
+            return new IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Write", matchers);
         }
 
         public static IReadWriter_Write_M2_MockCall Write(this global::TUnit.Mocks.Mock<global::IReadWriter> mock, global::System.Func<string, bool> data)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_data = data;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher };
-            return new IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Write", matchers);
+            return new IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Write", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IAsyncService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IAsyncService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IAsyncService> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -136,46 +136,46 @@ namespace TUnit.Mocks.Generated
         public static IAsyncService_GetValueAsync_M0_MockCall GetValueAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::TUnit.Mocks.Arguments.Arg<string> key)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-            return new IAsyncService_GetValueAsync_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValueAsync", matchers);
+            return new IAsyncService_GetValueAsync_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValueAsync", matchers);
         }
 
         public static IAsyncService_GetValueAsync_M0_MockCall GetValueAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::System.Func<string, bool> key)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-            return new IAsyncService_GetValueAsync_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValueAsync", matchers);
+            return new IAsyncService_GetValueAsync_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValueAsync", matchers);
         }
 
         public static IAsyncService_DoWorkAsync_M1_MockCall DoWorkAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new IAsyncService_DoWorkAsync_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "DoWorkAsync", matchers);
+            return new IAsyncService_DoWorkAsync_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "DoWorkAsync", matchers);
         }
 
         public static IAsyncService_ComputeAsync_M2_MockCall ComputeAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::TUnit.Mocks.Arguments.Arg<int> input)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-            return new IAsyncService_ComputeAsync_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "ComputeAsync", matchers);
+            return new IAsyncService_ComputeAsync_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "ComputeAsync", matchers);
         }
 
         public static IAsyncService_ComputeAsync_M2_MockCall ComputeAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::System.Func<int, bool> input)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_input = input;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-            return new IAsyncService_ComputeAsync_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "ComputeAsync", matchers);
+            return new IAsyncService_ComputeAsync_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "ComputeAsync", matchers);
         }
 
         public static IAsyncService_InitializeAsync_M3_MockCall InitializeAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::TUnit.Mocks.Arguments.Arg<global::System.Threading.CancellationToken> ct)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { ct.Matcher };
-            return new IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "InitializeAsync", matchers);
+            return new IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "InitializeAsync", matchers);
         }
 
         public static IAsyncService_InitializeAsync_M3_MockCall InitializeAsync(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, global::System.Func<global::System.Threading.CancellationToken, bool> ct)
         {
             global::TUnit.Mocks.Arguments.Arg<global::System.Threading.CancellationToken> __fa_ct = ct;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_ct.Matcher };
-            return new IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "InitializeAsync", matchers);
+            return new IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "InitializeAsync", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
@@ -15,7 +15,7 @@ namespace TUnit.Mocks.Generated
     {
         extension(global::TUnit.Mocks.Mock<global::INotifier> mock)
         {
-            public INotifier_MockEvents Events => new(global::TUnit.Mocks.Mock.GetEngine(mock));
+            public INotifier_MockEvents Events => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock));
         }
 
         extension(INotifier_MockEvents events)
@@ -39,7 +39,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::INotifier>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::INotifier>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::INotifier> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -121,19 +121,19 @@ namespace TUnit.Mocks.Generated
         public static INotifier_Notify_M0_MockCall Notify(this global::TUnit.Mocks.Mock<global::INotifier> mock, global::TUnit.Mocks.Arguments.Arg<string> message)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { message.Matcher };
-            return new INotifier_Notify_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Notify", matchers);
+            return new INotifier_Notify_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Notify", matchers);
         }
 
         public static INotifier_Notify_M0_MockCall Notify(this global::TUnit.Mocks.Mock<global::INotifier> mock, global::System.Func<string, bool> message)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_message = message;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_message.Matcher };
-            return new INotifier_Notify_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Notify", matchers);
+            return new INotifier_Notify_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Notify", matchers);
         }
 
         public static void RaiseItemAdded(this global::TUnit.Mocks.Mock<global::INotifier> mock, string e)
         {
-            ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.Mock.GetEngine(mock).Raisable!).RaiseEvent("ItemAdded", (object?)e);
+            ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("ItemAdded", (object?)e);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IRepository>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IRepository>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IRepository> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -79,40 +79,40 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetById", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<int, bool> id) where T : class
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetById", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Save", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<T, bool> entity) where T : class, new()
         {
             global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Save", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Transform", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
         {
             global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Transform", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
@@ -41,7 +41,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::TUnit.Mocks.Generated.IMyService_Mockable>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::TUnit.Mocks.Generated.IMyService_Mockable>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IMyService_Mockable> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -109,13 +109,13 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<string> GetName(this global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IMyService_Mockable> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetName", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetName", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<global::ClientConfig> CreateDefaultConfig(this global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IMyService_Mockable> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<global::ClientConfig>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "CreateDefaultConfig", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<global::ClientConfig>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "CreateDefaultConfig", matchers);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::ITest>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::ITest>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::ITest> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -74,34 +74,34 @@ namespace TUnit.Mocks.Generated
         public static ITest_Test_M0_MockCall Test(this global::TUnit.Mocks.Mock<global::ITest> mock, global::TUnit.Mocks.Arguments.Arg<string> @event)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { @event.Matcher };
-            return new ITest_Test_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Test", matchers);
+            return new ITest_Test_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Test", matchers);
         }
 
         public static ITest_Test_M0_MockCall Test(this global::TUnit.Mocks.Mock<global::ITest> mock, global::System.Func<string, bool> @event)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_event = @event;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_event.Matcher };
-            return new ITest_Test_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Test", matchers);
+            return new ITest_Test_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Test", matchers);
         }
 
         public static ITest_Get_M1_MockCall Get(this global::TUnit.Mocks.Mock<global::ITest> mock, global::TUnit.Mocks.Arguments.Arg<int> @class, global::TUnit.Mocks.Arguments.Arg<string> @return)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { @class.Matcher, @return.Matcher };
-            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Get", matchers);
+            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
         }
 
         public static ITest_Get_M1_MockCall Get(this global::TUnit.Mocks.Mock<global::ITest> mock, global::System.Func<int, bool> @class, global::TUnit.Mocks.Arguments.Arg<string> @return)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_class = @class;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_class.Matcher, @return.Matcher };
-            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Get", matchers);
+            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
         }
 
         public static ITest_Get_M1_MockCall Get(this global::TUnit.Mocks.Mock<global::ITest> mock, global::TUnit.Mocks.Arguments.Arg<int> @class, global::System.Func<string, bool> @return)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_return = @return;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { @class.Matcher, __fa_return.Matcher };
-            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Get", matchers);
+            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
         }
 
         public static ITest_Get_M1_MockCall Get(this global::TUnit.Mocks.Mock<global::ITest> mock, global::System.Func<int, bool> @class, global::System.Func<string, bool> @return)
@@ -109,7 +109,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<int> __fa_class = @class;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_return = @return;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_class.Matcher, __fa_return.Matcher };
-            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Get", matchers);
+            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -15,7 +15,7 @@ namespace TUnit.Mocks.Generated
     {
         extension(global::TUnit.Mocks.Mock<global::IService> mock)
         {
-            public IService_MockEvents Events => new(global::TUnit.Mocks.Mock.GetEngine(mock));
+            public IService_MockEvents Events => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock));
         }
 
         extension(IService_MockEvents events)
@@ -39,7 +39,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IService> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -150,41 +150,41 @@ namespace TUnit.Mocks.Generated
         public static IService_GetAsync_M3_MockCall GetAsync(this global::TUnit.Mocks.Mock<global::IService> mock, global::TUnit.Mocks.Arguments.Arg<int> id)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-            return new IService_GetAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "GetAsync", matchers);
+            return new IService_GetAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAsync", matchers);
         }
 
         public static IService_GetAsync_M3_MockCall GetAsync(this global::TUnit.Mocks.Mock<global::IService> mock, global::System.Func<int, bool> id)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-            return new IService_GetAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "GetAsync", matchers);
+            return new IService_GetAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAsync", matchers);
         }
 
         public static IService_Process_M4_MockCall Process(this global::TUnit.Mocks.Mock<global::IService> mock, global::TUnit.Mocks.Arguments.Arg<string> data)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };
-            return new IService_Process_M4_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 4, "Process", matchers);
+            return new IService_Process_M4_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "Process", matchers);
         }
 
         public static IService_Process_M4_MockCall Process(this global::TUnit.Mocks.Mock<global::IService> mock, global::System.Func<string, bool> data)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_data = data;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher };
-            return new IService_Process_M4_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 4, "Process", matchers);
+            return new IService_Process_M4_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "Process", matchers);
         }
 
         extension(global::TUnit.Mocks.Mock<global::IService> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string> Name
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 0, 1, "Name", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 1, "Name", true, true);
 
             public global::TUnit.Mocks.PropertyMockCall<int> Count
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 2, 0, "Count", true, false);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 0, "Count", true, false);
         }
 
         public static void RaiseStatusChanged(this global::TUnit.Mocks.Mock<global::IService> mock, string e)
         {
-            ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.Mock.GetEngine(mock).Raisable!).RaiseEvent("StatusChanged", (object?)e);
+            ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("StatusChanged", (object?)e);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IFoo>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IFoo>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IFoo> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -103,34 +103,34 @@ namespace TUnit.Mocks.Generated
         public static IFoo_Bar_M0_MockCall Bar(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<object?> baz)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { baz.Matcher };
-            return new IFoo_Bar_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Bar", matchers);
+            return new IFoo_Bar_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Bar", matchers);
         }
 
         public static IFoo_Bar_M0_MockCall Bar(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<object?, bool> baz)
         {
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_baz = baz;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_baz.Matcher };
-            return new IFoo_Bar_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Bar", matchers);
+            return new IFoo_Bar_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Bar", matchers);
         }
 
         public static IFoo_GetValue_M1_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string?> key, global::TUnit.Mocks.Arguments.Arg<int> count)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher, count.Matcher };
-            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "GetValue", matchers);
+            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
         }
 
         public static IFoo_GetValue_M1_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string?, bool> key, global::TUnit.Mocks.Arguments.Arg<int> count)
         {
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher, count.Matcher };
-            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "GetValue", matchers);
+            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
         }
 
         public static IFoo_GetValue_M1_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string?> key, global::System.Func<int, bool> count)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_count = count;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher, __fa_count.Matcher };
-            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "GetValue", matchers);
+            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
         }
 
         public static IFoo_GetValue_M1_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string?, bool> key, global::System.Func<int, bool> count)
@@ -138,27 +138,27 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_key = key;
             global::TUnit.Mocks.Arguments.Arg<int> __fa_count = count;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher, __fa_count.Matcher };
-            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "GetValue", matchers);
+            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string> nonNull, global::TUnit.Mocks.Arguments.Arg<string?> nullable, global::TUnit.Mocks.Arguments.Arg<object?> obj)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { nonNull.Matcher, nullable.Matcher, obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string, bool> nonNull, global::TUnit.Mocks.Arguments.Arg<string?> nullable, global::TUnit.Mocks.Arguments.Arg<object?> obj)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_nonNull = nonNull;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_nonNull.Matcher, nullable.Matcher, obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string> nonNull, global::System.Func<string?, bool> nullable, global::TUnit.Mocks.Arguments.Arg<object?> obj)
         {
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_nullable = nullable;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { nonNull.Matcher, __fa_nullable.Matcher, obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string, bool> nonNull, global::System.Func<string?, bool> nullable, global::TUnit.Mocks.Arguments.Arg<object?> obj)
@@ -166,14 +166,14 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_nonNull = nonNull;
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_nullable = nullable;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_nonNull.Matcher, __fa_nullable.Matcher, obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string> nonNull, global::TUnit.Mocks.Arguments.Arg<string?> nullable, global::System.Func<object?, bool> obj)
         {
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_obj = obj;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { nonNull.Matcher, nullable.Matcher, __fa_obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string, bool> nonNull, global::TUnit.Mocks.Arguments.Arg<string?> nullable, global::System.Func<object?, bool> obj)
@@ -181,7 +181,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_nonNull = nonNull;
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_obj = obj;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_nonNull.Matcher, nullable.Matcher, __fa_obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string> nonNull, global::System.Func<string?, bool> nullable, global::System.Func<object?, bool> obj)
@@ -189,7 +189,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_nullable = nullable;
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_obj = obj;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { nonNull.Matcher, __fa_nullable.Matcher, __fa_obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string, bool> nonNull, global::System.Func<string?, bool> nullable, global::System.Func<object?, bool> obj)
@@ -198,26 +198,26 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_nullable = nullable;
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_obj = obj;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_nonNull.Matcher, __fa_nullable.Matcher, __fa_obj.Matcher };
-            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Process", matchers);
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 
         public static IFoo_GetAsync_M3_MockCall GetAsync(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string?> key)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-            return new IFoo_GetAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "GetAsync", matchers);
+            return new IFoo_GetAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAsync", matchers);
         }
 
         public static IFoo_GetAsync_M3_MockCall GetAsync(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::System.Func<string?, bool> key)
         {
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-            return new IFoo_GetAsync_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "GetAsync", matchers);
+            return new IFoo_GetAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAsync", matchers);
         }
 
         extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string?> NullableProp
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 4, 5, "NullableProp", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, 5, "NullableProp", true, true);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IDictionary>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IDictionary>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IDictionary> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -87,20 +87,20 @@ namespace TUnit.Mocks.Generated
         public static IDictionary_TryGetValue_M0_MockCall TryGetValue(this global::TUnit.Mocks.Mock<global::IDictionary> mock, global::TUnit.Mocks.Arguments.Arg<string> key)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-            return new IDictionary_TryGetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "TryGetValue", matchers);
+            return new IDictionary_TryGetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "TryGetValue", matchers);
         }
 
         public static IDictionary_TryGetValue_M0_MockCall TryGetValue(this global::TUnit.Mocks.Mock<global::IDictionary> mock, global::System.Func<string, bool> key)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-            return new IDictionary_TryGetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "TryGetValue", matchers);
+            return new IDictionary_TryGetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "TryGetValue", matchers);
         }
 
         public static IDictionary_Swap_M1_MockCall Swap(this global::TUnit.Mocks.Mock<global::IDictionary> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, b.Matcher };
-            return new IDictionary_Swap_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Swap", matchers);
+            return new IDictionary_Swap_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Swap", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IFormatter>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IFormatter>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IFormatter> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -84,47 +84,47 @@ namespace TUnit.Mocks.Generated
         public static IFormatter_Format_M0_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> value)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { value.Matcher };
-            return new IFormatter_Format_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Format", matchers);
+            return new IFormatter_Format_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Format", matchers);
         }
 
         public static IFormatter_Format_M0_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> value)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_value = value;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_value.Matcher };
-            return new IFormatter_Format_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Format", matchers);
+            return new IFormatter_Format_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Format", matchers);
         }
 
         public static IFormatter_Format_M1_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<int> value)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { value.Matcher };
-            return new IFormatter_Format_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Format", matchers);
+            return new IFormatter_Format_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Format", matchers);
         }
 
         public static IFormatter_Format_M1_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<int, bool> value)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_value = value;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_value.Matcher };
-            return new IFormatter_Format_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Format", matchers);
+            return new IFormatter_Format_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Format", matchers);
         }
 
         public static IFormatter_Format_M2_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::TUnit.Mocks.Arguments.Arg<string> arg1)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, arg1.Matcher };
-            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Format", matchers);
+            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Format", matchers);
         }
 
         public static IFormatter_Format_M2_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::TUnit.Mocks.Arguments.Arg<string> arg1)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_template = template;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, arg1.Matcher };
-            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Format", matchers);
+            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Format", matchers);
         }
 
         public static IFormatter_Format_M2_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::System.Func<string, bool> arg1)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, __fa_arg1.Matcher };
-            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Format", matchers);
+            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Format", matchers);
         }
 
         public static IFormatter_Format_M2_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::System.Func<string, bool> arg1)
@@ -132,27 +132,27 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_template = template;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, __fa_arg1.Matcher };
-            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Format", matchers);
+            return new IFormatter_Format_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::TUnit.Mocks.Arguments.Arg<string> arg1, global::TUnit.Mocks.Arguments.Arg<string> arg2)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, arg1.Matcher, arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::TUnit.Mocks.Arguments.Arg<string> arg1, global::TUnit.Mocks.Arguments.Arg<string> arg2)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_template = template;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, arg1.Matcher, arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::System.Func<string, bool> arg1, global::TUnit.Mocks.Arguments.Arg<string> arg2)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, __fa_arg1.Matcher, arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::System.Func<string, bool> arg1, global::TUnit.Mocks.Arguments.Arg<string> arg2)
@@ -160,14 +160,14 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_template = template;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, __fa_arg1.Matcher, arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::TUnit.Mocks.Arguments.Arg<string> arg1, global::System.Func<string, bool> arg2)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg2 = arg2;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, arg1.Matcher, __fa_arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::TUnit.Mocks.Arguments.Arg<string> arg1, global::System.Func<string, bool> arg2)
@@ -175,7 +175,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_template = template;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg2 = arg2;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, arg1.Matcher, __fa_arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::TUnit.Mocks.Arguments.Arg<string> template, global::System.Func<string, bool> arg1, global::System.Func<string, bool> arg2)
@@ -183,7 +183,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg2 = arg2;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { template.Matcher, __fa_arg1.Matcher, __fa_arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
 
         public static IFormatter_Format_M3_MockCall Format(this global::TUnit.Mocks.Mock<global::IFormatter> mock, global::System.Func<string, bool> template, global::System.Func<string, bool> arg1, global::System.Func<string, bool> arg2)
@@ -192,7 +192,7 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg1 = arg1;
             global::TUnit.Mocks.Arguments.Arg<string> __fa_arg2 = arg2;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, __fa_arg1.Matcher, __fa_arg2.Matcher };
-            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "Format", matchers);
+            return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IRepository>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IRepository>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IRepository> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -80,13 +80,13 @@ namespace TUnit.Mocks.Generated
         extension(global::TUnit.Mocks.Mock<global::IRepository> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string> Name
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 0, 1, "Name", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 1, "Name", true, true);
 
             public global::TUnit.Mocks.PropertyMockCall<int> Count
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 2, 0, "Count", true, false);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 0, "Count", true, false);
 
             public global::TUnit.Mocks.PropertyMockCall<bool> IsOpen
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 0, 4, "IsOpen", false, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 4, "IsOpen", false, true);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IBufferProcessor>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IBufferProcessor>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IBufferProcessor> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -90,13 +90,13 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.VoidMockMethodCall Process(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock, global::TUnit.Mocks.Arguments.RefStructArg<global::System.ReadOnlySpan<byte>> data)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Process", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Process", matchers);
         }
         #else
         public static global::TUnit.Mocks.VoidMockMethodCall Process(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Process", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Process", matchers);
         }
         #endif
 
@@ -104,20 +104,20 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<int> Parse(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock, global::TUnit.Mocks.Arguments.RefStructArg<global::System.ReadOnlySpan<char>> text)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { text.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<int>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Parse", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<int>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Parse", matchers);
         }
         #else
         public static global::TUnit.Mocks.MockMethodCall<int> Parse(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<int>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Parse", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<int>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Parse", matchers);
         }
         #endif
 
         public static global::TUnit.Mocks.MockMethodCall<string> GetName(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "GetName", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetName", matchers);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
@@ -57,7 +57,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::TUnit.Mocks.Generated.IServiceFactory_Mockable>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::TUnit.Mocks.Generated.IServiceFactory_Mockable>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IServiceFactory_Mockable> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -125,19 +125,19 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<string> GetName(this global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IServiceFactory_Mockable> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetName", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetName", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<global::ClientConfig> CreateDefaultConfig(this global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IServiceFactory_Mockable> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<global::ClientConfig>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "CreateDefaultConfig", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<global::ClientConfig>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "CreateDefaultConfig", matchers);
         }
 
         extension(global::TUnit.Mocks.Mock<global::TUnit.Mocks.Generated.IServiceFactory_Mockable> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string> ServiceId
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 2, 3, "ServiceId", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 3, "ServiceId", true, true);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IMyService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IMyService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IMyService> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -74,14 +74,14 @@ namespace TUnit.Mocks.Generated
         public static IMyService_GetValue_M0_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IMyService> mock, global::TUnit.Mocks.Arguments.Arg<string> key)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-            return new IMyService_GetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValue", matchers);
+            return new IMyService_GetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
 
         public static IMyService_GetValue_M0_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IMyService> mock, global::System.Func<string, bool> key)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-            return new IMyService_GetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValue", matchers);
+            return new IMyService_GetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
 
         /// <summary>Configure the mock setup for <c>GetConfigProvider</c>.</summary>
@@ -93,7 +93,7 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<object?> GetConfigProvider(this global::TUnit.Mocks.Mock<global::IMyService> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "GetConfigProvider", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetConfigProvider", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::ICalculator>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::ICalculator>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::ICalculator> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -79,21 +79,21 @@ namespace TUnit.Mocks.Generated
         public static ICalculator_Add_M0_MockCall Add(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, b.Matcher };
-            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Add", matchers);
+            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
         }
 
         public static ICalculator_Add_M0_MockCall Add(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::System.Func<int, bool> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_a = a;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_a.Matcher, b.Matcher };
-            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Add", matchers);
+            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
         }
 
         public static ICalculator_Add_M0_MockCall Add(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::System.Func<int, bool> b)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_b = b;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, __fa_b.Matcher };
-            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Add", matchers);
+            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
         }
 
         public static ICalculator_Add_M0_MockCall Add(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::System.Func<int, bool> a, global::System.Func<int, bool> b)
@@ -101,27 +101,27 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<int> __fa_a = a;
             global::TUnit.Mocks.Arguments.Arg<int> __fa_b = b;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_a.Matcher, __fa_b.Matcher };
-            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Add", matchers);
+            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
         }
 
         public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, b.Matcher };
-            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Subtract", matchers);
+            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
         }
 
         public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::System.Func<int, bool> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_a = a;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_a.Matcher, b.Matcher };
-            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Subtract", matchers);
+            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
         }
 
         public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::System.Func<int, bool> b)
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_b = b;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, __fa_b.Matcher };
-            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Subtract", matchers);
+            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
         }
 
         public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::System.Func<int, bool> a, global::System.Func<int, bool> b)
@@ -129,13 +129,13 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<int> __fa_a = a;
             global::TUnit.Mocks.Arguments.Arg<int> __fa_b = b;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_a.Matcher, __fa_b.Matcher };
-            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Subtract", matchers);
+            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Reset(this global::TUnit.Mocks.Mock<global::ICalculator> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Reset", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Reset", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::ExternalLib.ExternalClient>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::ExternalLib.ExternalClient>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -100,26 +100,26 @@ namespace TUnit.Mocks.Generated
         public static ExternalLib_ExternalClient_PublicMethod_M0_MockCall PublicMethod(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock, global::TUnit.Mocks.Arguments.Arg<string> input)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-            return new ExternalLib_ExternalClient_PublicMethod_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "PublicMethod", matchers);
+            return new ExternalLib_ExternalClient_PublicMethod_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "PublicMethod", matchers);
         }
 
         public static ExternalLib_ExternalClient_PublicMethod_M0_MockCall PublicMethod(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock, global::System.Func<string, bool> input)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_input = input;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-            return new ExternalLib_ExternalClient_PublicMethod_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "PublicMethod", matchers);
+            return new ExternalLib_ExternalClient_PublicMethod_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "PublicMethod", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<string> ProtectedInternalMethod(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "ProtectedInternalMethod", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ProtectedInternalMethod", matchers);
         }
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string> PublicProperty
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 2, 3, "PublicProperty", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 3, "PublicProperty", true, true);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::ExternalLib.ServiceClient>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::ExternalLib.ServiceClient>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -72,14 +72,14 @@ namespace TUnit.Mocks.Generated
         public static ExternalLib_ServiceClient_GetValue_M0_MockCall GetValue(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock, global::TUnit.Mocks.Arguments.Arg<string> key)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-            return new ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValue", matchers);
+            return new ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
 
         public static ExternalLib_ServiceClient_GetValue_M0_MockCall GetValue(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock, global::System.Func<string, bool> key)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-            return new ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetValue", matchers);
+            return new ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::BaseService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::BaseService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::BaseService> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -95,46 +95,46 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetById", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<int, bool> id) where T : class
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "GetById", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Save", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<T, bool> entity) where T : class, new()
         {
             global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Save", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Transform", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
         {
             global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.Mock.GetEngine(mock), 2, "Transform", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>> GetAll<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock) where T : class
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.Mock.GetEngine(mock), 3, "GetAll", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers);
         }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
@@ -8,7 +8,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterFactory<global::IGreeter>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterFactory<global::IGreeter>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::IGreeter> Create(global::TUnit.Mocks.MockBehavior behavior, object[] constructorArgs)
@@ -69,14 +69,14 @@ namespace TUnit.Mocks.Generated
         public static IGreeter_Greet_M0_MockCall Greet(this global::TUnit.Mocks.Mock<global::IGreeter> mock, global::TUnit.Mocks.Arguments.Arg<string> name)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { name.Matcher };
-            return new IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Greet", matchers);
+            return new IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Greet", matchers);
         }
 
         public static IGreeter_Greet_M0_MockCall Greet(this global::TUnit.Mocks.Mock<global::IGreeter> mock, global::System.Func<string, bool> name)
         {
             global::TUnit.Mocks.Arguments.Arg<string> __fa_name = name;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_name.Matcher };
-            return new IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Greet", matchers);
+            return new IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Greet", matchers);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -8,13 +8,13 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<string> PublicMethod(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
         {
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "PublicMethod", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "PublicMethod", matchers);
         }
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<string> PublicProperty
-                => new(global::TUnit.Mocks.Mock.GetEngine(mock), 1, 2, "PublicProperty", true, true);
+                => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, 2, "PublicProperty", true, true);
         }
     }
 }
@@ -32,7 +32,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterWrapFactory<global::ExternalLib.ExternalService>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterWrapFactory<global::ExternalLib.ExternalService>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> Create(global::TUnit.Mocks.MockBehavior behavior, global::ExternalLib.ExternalService instance)

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -8,27 +8,27 @@ namespace TUnit.Mocks.Generated
         public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Get", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers);
         }
 
         public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<int, bool> id) where T : class
         {
             global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.Mock.GetEngine(mock), 0, "Get", matchers);
+            return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<T> item) where T : class, new()
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { item.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Store", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers);
         }
 
         public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<T, bool> item) where T : class, new()
         {
             global::TUnit.Mocks.Arguments.Arg<T> __fa_item = item;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_item.Matcher };
-            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), 1, "Store", matchers);
+            return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers);
         }
     }
 }
@@ -46,7 +46,7 @@ namespace TUnit.Mocks.Generated
         [global::System.Runtime.CompilerServices.ModuleInitializer]
         internal static void Register()
         {
-            global::TUnit.Mocks.Mock.RegisterWrapFactory<global::Repository>(Create);
+            global::TUnit.Mocks.MockRegistry.RegisterWrapFactory<global::Repository>(Create);
         }
 
         private static global::TUnit.Mocks.Mock<global::Repository> Create(global::TUnit.Mocks.MockBehavior behavior, global::Repository instance)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockDelegateFactoryBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockDelegateFactoryBuilder.cs
@@ -23,7 +23,7 @@ internal static class MockDelegateFactoryBuilder
                 writer.AppendLine("[global::System.Runtime.CompilerServices.ModuleInitializer]");
                 using (writer.Block("internal static void Register()"))
                 {
-                    writer.AppendLine($"global::TUnit.Mocks.Mock.RegisterDelegateFactory<{model.FullyQualifiedName}>(Create);");
+                    writer.AppendLine($"global::TUnit.Mocks.MockRegistry.RegisterDelegateFactory<{model.FullyQualifiedName}>(Create);");
                 }
                 writer.AppendLine();
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockEventsBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockEventsBuilder.cs
@@ -32,7 +32,7 @@ internal static class MockEventsBuilder
                 // Extension property on Mock<T> — non-nullable, only present when type has events
                 using (writer.Block($"extension(global::TUnit.Mocks.Mock<{mockableType}> mock)"))
                 {
-                    writer.AppendLine($"public {safeName}_MockEvents Events => new(global::TUnit.Mocks.Mock.GetEngine(mock));");
+                    writer.AppendLine($"public {safeName}_MockEvents Events => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock));");
                 }
 
                 writer.AppendLine();

--- a/TUnit.Mocks.SourceGenerator/Builders/MockFactoryBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockFactoryBuilder.cs
@@ -51,11 +51,11 @@ internal static class MockFactoryBuilder
                         .Concat(model.AdditionalInterfaceNames)
                         .Select(t => $"typeof({t}).FullName");
                     var keyExpr = "string.Join(\"|\", new[] { " + string.Join(", ", allTypes) + " })";
-                    writer.AppendLine($"global::TUnit.Mocks.Mock.RegisterMultiFactory({keyExpr}, Create);");
+                    writer.AppendLine($"global::TUnit.Mocks.MockRegistry.RegisterMultiFactory({keyExpr}, Create);");
                 }
                 else
                 {
-                    writer.AppendLine($"global::TUnit.Mocks.Mock.RegisterFactory<{mockableType}>(Create);");
+                    writer.AppendLine($"global::TUnit.Mocks.MockRegistry.RegisterFactory<{mockableType}>(Create);");
                 }
             }
             writer.AppendLine();
@@ -79,7 +79,7 @@ internal static class MockFactoryBuilder
             writer.AppendLine("[global::System.Runtime.CompilerServices.ModuleInitializer]");
             using (writer.Block("internal static void Register()"))
             {
-                writer.AppendLine($"global::TUnit.Mocks.Mock.RegisterWrapFactory<{model.FullyQualifiedName}>(Create);");
+                writer.AppendLine($"global::TUnit.Mocks.MockRegistry.RegisterWrapFactory<{model.FullyQualifiedName}>(Create);");
             }
             writer.AppendLine();
 
@@ -102,7 +102,7 @@ internal static class MockFactoryBuilder
             writer.AppendLine("[global::System.Runtime.CompilerServices.ModuleInitializer]");
             using (writer.Block("internal static void Register()"))
             {
-                writer.AppendLine($"global::TUnit.Mocks.Mock.RegisterFactory<{model.FullyQualifiedName}>(Create);");
+                writer.AppendLine($"global::TUnit.Mocks.MockRegistry.RegisterFactory<{model.FullyQualifiedName}>(Create);");
             }
             writer.AppendLine();
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -640,19 +640,19 @@ internal static class MockMembersBuilder
             if (useTypedWrapper)
             {
                 var wrapperName = GetWrapperName(safeName, method);
-                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else if (method.IsVoid || method.IsRefStructReturn)
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else if (method.IsReturnTypeStaticAbstractInterface)
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
         }
     }
@@ -779,19 +779,19 @@ internal static class MockMembersBuilder
             if (useTypedWrapper)
             {
                 var wrapperName = GetWrapperName(safeName, method);
-                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else if (method.IsVoid || method.IsRefStructReturn)
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else if (method.IsReturnTypeStaticAbstractInterface)
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
             else
             {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.Mock.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
             }
         }
     }
@@ -815,7 +815,7 @@ internal static class MockMembersBuilder
                 var safePropName = GetSafeMemberName(prop.Name);
 
                 writer.AppendLine($"public global::TUnit.Mocks.PropertyMockCall<{prop.ReturnType}> {safePropName}");
-                writer.AppendLine($"    => new(global::TUnit.Mocks.Mock.GetEngine(mock), {getterMemberId}, {setterMemberId}, \"{prop.Name}\", {hasGetter}, {hasSetter});");
+                writer.AppendLine($"    => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {getterMemberId}, {setterMemberId}, \"{prop.Name}\", {hasGetter}, {hasSetter});");
             }
         }
     }
@@ -855,7 +855,7 @@ internal static class MockMembersBuilder
 
             using (writer.Block($"public static void Raise{evt.Name}({raiseParams})"))
             {
-                writer.AppendLine($"((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.Mock.GetEngine(mock).Raisable!).RaiseEvent(\"{evt.Name}\", {argsExpr});");
+                writer.AppendLine($"((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent(\"{evt.Name}\", {argsExpr});");
             }
         }
     }

--- a/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
+++ b/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
@@ -211,7 +211,7 @@ public class VerifyAllMessageTests
         // Act — don't call the method
 
         // Assert
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
         await Assert.That(ex.Message).Contains("Add(");
         await Assert.That(ex.Message).Contains("never invoked");
     }
@@ -228,7 +228,7 @@ public class VerifyAllMessageTests
         // Act — don't call any methods
 
         // Assert
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
         await Assert.That(ex.Message).Contains("Add(");
         await Assert.That(ex.Message).Contains("GetName()");
         await Assert.That(ex.Message).Contains("Log(");
@@ -247,7 +247,7 @@ public class VerifyAllMessageTests
         mock.Object.GetName();
 
         // Assert — no exception
-        Mock.VerifyAll(mock);
+        mock.VerifyAll();
         await Assert.That(true).IsTrue();
     }
 }
@@ -266,7 +266,7 @@ public class InvocationOrderingTests
         mock.Object.GetName();
         mock.Object.Add(3, 4);
 
-        var invocations = Mock.GetInvocations(mock);
+        var invocations = mock.Invocations;
         await Assert.That(invocations).HasCount().EqualTo(4);
         await Assert.That(invocations[0].MemberName).IsEqualTo("Add");
         await Assert.That(invocations[1].MemberName).IsEqualTo("Log");
@@ -283,7 +283,7 @@ public class InvocationOrderingTests
         mock.Object.GetName();
         mock.Object.Log("msg");
 
-        var invocations = Mock.GetInvocations(mock);
+        var invocations = mock.Invocations;
         for (int i = 1; i < invocations.Count; i++)
         {
             await Assert.That(invocations[i].SequenceNumber)
@@ -306,7 +306,7 @@ public class AutoTrackPropertyResetTests
     public async Task Reset_Clears_Auto_Tracked_Property_Values()
     {
         var mock = Mock.Of<ISettingsService>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
 
         var svc = mock.Object;
         svc.Theme = "dark";
@@ -316,8 +316,8 @@ public class AutoTrackPropertyResetTests
         await Assert.That(svc.FontSize).IsEqualTo(14);
 
         // Reset should clear tracked values
-        Mock.Reset(mock);
-        Mock.SetupAllProperties(mock);
+        mock.Reset();
+        mock.SetupAllProperties();
 
         // After reset + re-enable auto-track, values are back to defaults
         await Assert.That(svc.Theme).IsNotEqualTo("dark");
@@ -374,9 +374,9 @@ public class MockDefaultValueProviderPropertyTests
         var mock = Mock.Of<IGreeter>();
         var provider = new FixedStringProvider();
 
-        Mock.SetDefaultValueProvider(mock, provider);
+        mock.DefaultValueProvider = provider;
 
-        await Assert.That(Mock.GetDefaultValueProvider(mock)).IsEqualTo(provider);
+        await Assert.That(mock.DefaultValueProvider).IsEqualTo(provider);
     }
 
     [Test]
@@ -399,13 +399,13 @@ public class MockBehaviorPropertyTests
     public async Task Loose_Mock_Has_Loose_Behavior()
     {
         var mock = Mock.Of<ICalculator>();
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
     }
 
     [Test]
     public async Task Strict_Mock_Has_Strict_Behavior()
     {
         var mock = Mock.Of<ICalculator>(MockBehavior.Strict);
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
     }
 }

--- a/TUnit.Mocks.Tests/AutoTrackPropertyTests.cs
+++ b/TUnit.Mocks.Tests/AutoTrackPropertyTests.cs
@@ -23,7 +23,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — opt in to auto-tracking
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
 
         // Act
         mock.Object.Name = "Alice";
@@ -38,7 +38,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
 
         // Act
         mock.Object.Name = "Bob";
@@ -68,7 +68,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
         mock.Name.Returns("Configured");
 
         // Act — set a tracked value, but explicit setup should win
@@ -83,7 +83,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
 
         // Act — set then overwrite
         mock.Object.Name = "First";
@@ -111,7 +111,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — explicit opt-in enables auto-tracking
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
 
         // Act
         mock.Object.Name = "Alice";
@@ -140,7 +140,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — strict mode with explicit opt-in
         var mock = Mock.Of<IAutoTrackEntity>(MockBehavior.Strict);
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
         mock.Name.Set(Any());
         mock.Name.Returns("");
 
@@ -156,11 +156,11 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = Mock.Of<IAutoTrackEntity>();
-        Mock.SetupAllProperties(mock);
+        mock.SetupAllProperties();
         mock.Object.Name = "Alice";
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — tracked values cleared, but auto-track still active
         await Assert.That(mock.Object.Name).IsEmpty();

--- a/TUnit.Mocks.Tests/BasicMockTests.cs
+++ b/TUnit.Mocks.Tests/BasicMockTests.cs
@@ -160,7 +160,7 @@ public class BasicMockTests
         await Assert.That(calc.Add(1, 1)).IsEqualTo(42);
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — after reset, returns default
         await Assert.That(calc.Add(1, 1)).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
+++ b/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
@@ -28,7 +28,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = Mock.Of<IGreeter>();
-        Mock.SetDefaultValueProvider(mock, new CustomProvider());
+        mock.DefaultValueProvider = new CustomProvider();
 
         IGreeter greeter = mock.Object;
 
@@ -44,7 +44,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = Mock.Of<ICalculator>();
-        Mock.SetDefaultValueProvider(mock, new CustomProvider());
+        mock.DefaultValueProvider = new CustomProvider();
 
         ICalculator calc = mock.Object;
 
@@ -60,7 +60,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = Mock.Of<ICalculator>();
-        Mock.SetDefaultValueProvider(mock, new CustomProvider());
+        mock.DefaultValueProvider = new CustomProvider();
         mock.Add(1, 2).Returns(100);
 
         ICalculator calc = mock.Object;
@@ -92,7 +92,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = Mock.Of<IGreeter>();
-        Mock.SetDefaultValueProvider(mock, DefaultValueProvider.Instance);
+        mock.DefaultValueProvider = DefaultValueProvider.Instance;
 
         IGreeter greeter = mock.Object;
 

--- a/TUnit.Mocks.Tests/DiagnosticsTests.cs
+++ b/TUnit.Mocks.Tests/DiagnosticsTests.cs
@@ -16,7 +16,7 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(1, 2); // only exercise the first setup
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.TotalSetups).IsEqualTo(2);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(1);
@@ -36,7 +36,7 @@ public class DiagnosticsTests
         _ = calc.Add(1, 2); // matches setup
         _ = calc.Add(5, 5); // no setup match — unmatched
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.UnmatchedCalls).HasCount().EqualTo(1);
         await Assert.That(diag.UnmatchedCalls[0].MemberName).IsEqualTo("Add");
@@ -52,7 +52,7 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(1, 2);
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.TotalSetups).IsEqualTo(1);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(1);
@@ -67,7 +67,7 @@ public class DiagnosticsTests
         mock.Add(1, 2).Returns(3);
         mock.Add(3, 4).Returns(7);
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.TotalSetups).IsEqualTo(2);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);
@@ -80,7 +80,7 @@ public class DiagnosticsTests
         var mock = Mock.Of<ICalculator>();
         mock.Add(Any(), Is<int>(x => x > 0)).Returns(1);
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.UnusedSetups).HasCount().EqualTo(1);
         var setup = diag.UnusedSetups[0];
@@ -98,9 +98,9 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(5, 5); // unmatched
 
-        Mock.Reset(mock);
+        mock.Reset();
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.TotalSetups).IsEqualTo(0);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);
@@ -113,7 +113,7 @@ public class DiagnosticsTests
     {
         var mock = Mock.Of<ICalculator>();
 
-        var diag = Mock.GetDiagnostics(mock);
+        var diag = mock.GetDiagnostics();
 
         await Assert.That(diag.TotalSetups).IsEqualTo(0);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/EdgeCaseTests.cs
+++ b/TUnit.Mocks.Tests/EdgeCaseTests.cs
@@ -582,7 +582,7 @@ public class ResetReconfigurationTests
         await Assert.That(firstResult).IsEqualTo("A");
 
         // Reset and reconfigure
-        Mock.Reset(mock);
+        mock.Reset();
         mock.GetConfig("key").Returns("B");
 
         // Second phase
@@ -609,7 +609,7 @@ public class ResetReconfigurationTests
         mock.GetConfig("key2").WasCalled(Times.Once);
 
         // Reset — clears call history
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Post-reset: previous calls should not count
         mock.GetConfig("key1").WasNeverCalled();

--- a/TUnit.Mocks.Tests/EventSubscriptionSetupTests.cs
+++ b/TUnit.Mocks.Tests/EventSubscriptionSetupTests.cs
@@ -87,7 +87,7 @@ public class EventSubscriptionSetupTests
         var callbackFired = false;
 
         mock.Events.DataReady.OnSubscribe(() => callbackFired = true);
-        Mock.Reset(mock);
+        mock.Reset();
 
         mock.Object.DataReady += (sender, args) => { };
 

--- a/TUnit.Mocks.Tests/EventSubscriptionVerifyTests.cs
+++ b/TUnit.Mocks.Tests/EventSubscriptionVerifyTests.cs
@@ -83,7 +83,7 @@ public class EventSubscriptionVerifyTests
         mock.Object.OnStringAction += _ => { };
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert
         await Assert.That(mock.Events.OnStringAction.WasSubscribed).IsFalse();

--- a/TUnit.Mocks.Tests/InvocationsTests.cs
+++ b/TUnit.Mocks.Tests/InvocationsTests.cs
@@ -19,7 +19,7 @@ public class InvocationsTests
         svc.GetValue("key2");
         svc.Process(42);
 
-        await Assert.That(Mock.GetInvocations(mock).Count).IsEqualTo(3);
+        await Assert.That(mock.Invocations.Count).IsEqualTo(3);
     }
 
     [Test]
@@ -32,7 +32,7 @@ public class InvocationsTests
         svc.GetValue("key1");
         svc.Process(99);
 
-        var invocations = Mock.GetInvocations(mock);
+        var invocations = mock.Invocations;
         await Assert.That(invocations[0].MemberName).IsEqualTo("GetValue");
         await Assert.That(invocations[1].MemberName).IsEqualTo("Process");
     }
@@ -46,14 +46,14 @@ public class InvocationsTests
         var svc = mock.Object;
         svc.GetValue("hello");
 
-        await Assert.That(Mock.GetInvocations(mock)[0].Arguments[0]).IsEqualTo("hello");
+        await Assert.That(mock.Invocations[0].Arguments[0]).IsEqualTo("hello");
     }
 
     [Test]
     public async Task Invocations_Is_Empty_When_No_Calls_Made()
     {
         var mock = Mock.Of<IService>();
-        await Assert.That(Mock.GetInvocations(mock).Count).IsEqualTo(0);
+        await Assert.That(mock.Invocations.Count).IsEqualTo(0);
     }
 
     [Test]
@@ -65,8 +65,8 @@ public class InvocationsTests
         var svc = mock.Object;
         svc.GetValue("key1");
 
-        Mock.Reset(mock);
+        mock.Reset();
 
-        await Assert.That(Mock.GetInvocations(mock).Count).IsEqualTo(0);
+        await Assert.That(mock.Invocations.Count).IsEqualTo(0);
     }
 }

--- a/TUnit.Mocks.Tests/MockRepositoryTests.cs
+++ b/TUnit.Mocks.Tests/MockRepositoryTests.cs
@@ -137,8 +137,8 @@ public class MockRepositoryTests
 
         // Assert — setups and history are cleared
         await Assert.That(serviceMock.Object.GetData(1)).IsEmpty(); // no setup, returns smart default
-        await Assert.That(Mock.GetInvocations(serviceMock)).Count().IsEqualTo(1); // only the new call
-        await Assert.That(Mock.GetInvocations(loggerMock)).Count().IsEqualTo(0); // history cleared
+        await Assert.That(serviceMock.Invocations).Count().IsEqualTo(1); // only the new call
+        await Assert.That(loggerMock.Invocations).Count().IsEqualTo(0); // history cleared
     }
 
     [Test]
@@ -149,7 +149,7 @@ public class MockRepositoryTests
         var mock = repo.Of<IRepoService>();
 
         // Assert — mock inherits strict behavior
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class MockRepositoryTests
         var looseMock = repo.Of<IRepoService>(MockBehavior.Loose);
 
         // Assert — specific behavior overrides repository default
-        await Assert.That(Mock.GetBehavior(looseMock)).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(looseMock.Behavior).IsEqualTo(MockBehavior.Loose);
     }
 
     [Test]
@@ -274,7 +274,7 @@ public class MockRepositoryTests
         var mock = repo.Of<ConcreteService>();
 
         // Assert — partial mock inherits strict behavior from repository
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -285,6 +285,6 @@ public class MockRepositoryTests
         var mock = repo.Of<ConcreteService>(MockBehavior.Loose);
 
         // Assert — behavior overridden
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
     }
 }

--- a/TUnit.Mocks.Tests/MultipleInterfaceTests.cs
+++ b/TUnit.Mocks.Tests/MultipleInterfaceTests.cs
@@ -114,7 +114,7 @@ public class MultipleInterfaceTests
         ((IMultiDisposable)mock.Object).Dispose();
 
         // Assert — all calls recorded in invocations
-        await Assert.That(Mock.GetInvocations(mock)).Count().IsEqualTo(2);
+        await Assert.That(mock.Invocations).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -180,7 +180,7 @@ public class MultipleInterfaceTests
         ((IMultiCloneable)mock.Object).Clone();
 
         // Assert — all 4 calls tracked
-        await Assert.That(Mock.GetInvocations(mock)).Count().IsEqualTo(4);
+        await Assert.That(mock.Invocations).Count().IsEqualTo(4);
     }
 
     [Test]
@@ -190,6 +190,6 @@ public class MultipleInterfaceTests
         var mock = Mock.Of<IMultiLogger, IMultiDisposable>(MockBehavior.Strict);
 
         // Assert — strict behavior inherited
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
     }
 }

--- a/TUnit.Mocks.Tests/OrderedVerificationTests.cs
+++ b/TUnit.Mocks.Tests/OrderedVerificationTests.cs
@@ -340,7 +340,7 @@ public class OrderedVerificationTests
         });
 
         // This should pass because the calls above were verified in VerifyInOrder
-        Mock.VerifyNoOtherCalls(mock);
+        mock.VerifyNoOtherCalls();
     }
 
     [Test]
@@ -365,7 +365,7 @@ public class OrderedVerificationTests
         // Log("hello") was not verified, so this should fail
         var exception = Assert.Throws<MockVerificationException>(() =>
         {
-            Mock.VerifyNoOtherCalls(mock);
+            mock.VerifyNoOtherCalls();
         });
 
         await Assert.That(exception.Message).Contains("Log(hello)");

--- a/TUnit.Mocks.Tests/ProtectedMemberTests.cs
+++ b/TUnit.Mocks.Tests/ProtectedMemberTests.cs
@@ -88,7 +88,7 @@ public class ProtectedMemberTests
         mock.Object.ProcessAndFormat(7);
 
         // Assert — both ComputeValue (base call) and FormatResult are recorded
-        await Assert.That(Mock.GetInvocations(mock)).Count().IsGreaterThanOrEqualTo(2);
+        await Assert.That(mock.Invocations).Count().IsGreaterThanOrEqualTo(2);
     }
 
     [Test]

--- a/TUnit.Mocks.Tests/ResetTests.cs
+++ b/TUnit.Mocks.Tests/ResetTests.cs
@@ -23,7 +23,7 @@ public class ResetTests
         await Assert.That(calc.Add(3, 4)).IsEqualTo(99);
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — after reset, all setups are gone, returns default
         await Assert.That(calc.Add(1, 2)).IsEqualTo(0);
@@ -44,7 +44,7 @@ public class ResetTests
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(3));
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — after reset, call history is cleared
         mock.Add(Any(), Any()).WasNeverCalled();
@@ -62,7 +62,7 @@ public class ResetTests
         await Assert.That(calc.Add(1, 2)).IsEqualTo(42);
 
         // Act — reset and reconfigure with different return value
-        Mock.Reset(mock);
+        mock.Reset();
         mock.Add(1, 2).Returns(100);
 
         // Assert — new setup is in effect
@@ -81,7 +81,7 @@ public class ResetTests
         mock.Add(1, 2).WasCalled(Times.Exactly(2));
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Make one new call
         calc.Add(1, 2);
@@ -102,7 +102,7 @@ public class ResetTests
         await Assert.That(calc.Add(1, 2)).IsEqualTo(3);
 
         // Act — reset clears all setups
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — strict mock throws again for unconfigured calls
         var exception = Assert.Throws<MockStrictBehaviorException>(() =>
@@ -125,7 +125,7 @@ public class ResetTests
         await Assert.That(greeter.Greet("Alice")).IsEqualTo("Hello, Alice!");
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — after reset, returns default (empty string for non-nullable string)
         var result = greeter.Greet("Alice");
@@ -144,7 +144,7 @@ public class ResetTests
         mock.Log(Any()).WasCalled(Times.Exactly(2));
 
         // Act
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Assert — void method call history is cleared
         mock.Log(Any()).WasNeverCalled();
@@ -163,7 +163,7 @@ public class ResetTests
         mock.Add(1, 1).WasCalled(Times.Once);
 
         // Act — reset
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Re-setup with new values
         mock.Add(1, 1).Returns(20);
@@ -188,17 +188,17 @@ public class ResetTests
         // First cycle
         mock.Add(1, 1).Returns(10);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(10);
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Second cycle
         mock.Add(1, 1).Returns(20);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(20);
-        Mock.Reset(mock);
+        mock.Reset();
 
         // Third cycle
         mock.Add(1, 1).Returns(30);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(30);
-        Mock.Reset(mock);
+        mock.Reset();
 
         // After final reset — returns default
         await Assert.That(calc.Add(1, 1)).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/StateMachineTests.cs
+++ b/TUnit.Mocks.Tests/StateMachineTests.cs
@@ -15,14 +15,14 @@ public class StateMachineTests
     public async Task State_Machine_Returns_Different_Values_Per_State()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
 
-        Mock.InState(mock, "disconnected", m =>
+        mock.InState("disconnected", m =>
         {
             m.GetStatus().Returns("OFFLINE");
         });
 
-        Mock.InState(mock, "connected", m =>
+        mock.InState("connected", m =>
         {
             m.GetStatus().Returns("ONLINE");
         });
@@ -31,10 +31,10 @@ public class StateMachineTests
 
         await Assert.That(conn.GetStatus()).IsEqualTo("OFFLINE");
 
-        Mock.SetState(mock, "connected");
+        mock.SetState("connected");
         await Assert.That(conn.GetStatus()).IsEqualTo("ONLINE");
 
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
         await Assert.That(conn.GetStatus()).IsEqualTo("OFFLINE");
     }
 
@@ -42,15 +42,15 @@ public class StateMachineTests
     public async Task TransitionsTo_Changes_State_After_Call()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
 
-        Mock.InState(mock, "disconnected", m =>
+        mock.InState("disconnected", m =>
         {
             m.Connect().TransitionsTo("connected");
             m.GetStatus().Returns("OFFLINE");
         });
 
-        Mock.InState(mock, "connected", m =>
+        mock.InState("connected", m =>
         {
             m.Disconnect().TransitionsTo("disconnected");
             m.GetStatus().Returns("ONLINE");
@@ -71,14 +71,14 @@ public class StateMachineTests
     public async Task State_Scoped_Throws()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "connected");
+        mock.SetState("connected");
 
-        Mock.InState(mock, "connected", m =>
+        mock.InState("connected", m =>
         {
             m.Connect().Throws<InvalidOperationException>();
         });
 
-        Mock.InState(mock, "disconnected", m =>
+        mock.InState("disconnected", m =>
         {
             m.Disconnect().Throws<InvalidOperationException>();
         });
@@ -97,7 +97,7 @@ public class StateMachineTests
     public async Task No_State_Setups_Match_In_Any_State()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
 
         // Setup without state guard — matches in any state
         mock.GetStatus().Returns("ALWAYS");
@@ -105,10 +105,10 @@ public class StateMachineTests
         IConnection conn = mock.Object;
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
 
-        Mock.SetState(mock, "connected");
+        mock.SetState("connected");
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
 
-        Mock.SetState(mock, null);
+        mock.SetState(null);
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
     }
 
@@ -121,7 +121,7 @@ public class StateMachineTests
         mock.GetStatus().Returns("DEFAULT");
 
         // State-scoped setup
-        Mock.InState(mock, "special", m =>
+        mock.InState("special", m =>
         {
             m.GetStatus().Returns("SPECIAL");
         });
@@ -132,11 +132,11 @@ public class StateMachineTests
         await Assert.That(conn.GetStatus()).IsEqualTo("DEFAULT");
 
         // State set — scoped setup wins (last-wins semantics, state-scoped was added later)
-        Mock.SetState(mock, "special");
+        mock.SetState("special");
         await Assert.That(conn.GetStatus()).IsEqualTo("SPECIAL");
 
         // Different state — scoped doesn't match, global wins
-        Mock.SetState(mock, "other");
+        mock.SetState("other");
         await Assert.That(conn.GetStatus()).IsEqualTo("DEFAULT");
     }
 
@@ -144,9 +144,9 @@ public class StateMachineTests
     public async Task Strict_Mode_Throws_For_Unconfigured_Call_In_State()
     {
         var mock = Mock.Of<IConnection>(MockBehavior.Strict);
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
 
-        Mock.InState(mock, "disconnected", m =>
+        mock.InState("disconnected", m =>
         {
             m.GetStatus().Returns("OFFLINE");
         });
@@ -163,14 +163,14 @@ public class StateMachineTests
     {
         // Regression test: nested InState calls must save/restore PendingRequiredState
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "outer");
+        mock.SetState("outer");
 
-        Mock.InState(mock, "outer", m =>
+        mock.InState("outer", m =>
         {
             m.GetStatus().Returns("OUTER");
 
             // Nested InState should temporarily switch to "inner" scope
-            Mock.InState(mock, "inner", m =>
+            mock.InState("inner", m =>
             {
                 m.Connect();
             });
@@ -186,7 +186,7 @@ public class StateMachineTests
         conn.Disconnect(); // should not throw (setup registered in outer scope)
 
         // In "inner" state, Connect should work (it was set up in inner scope)
-        Mock.SetState(mock, "inner");
+        mock.SetState("inner");
         conn.Connect(); // should not throw
     }
 
@@ -199,18 +199,18 @@ public class StateMachineTests
         mock.GetStatus().Returns("NO_STATE");
 
         // State-scoped setup — added second, wins when in "connected" state
-        Mock.InState(mock, "connected", m =>
+        mock.InState("connected", m =>
         {
             m.GetStatus().Returns("ONLINE");
         });
 
-        Mock.SetState(mock, "connected");
+        mock.SetState("connected");
 
         IConnection conn = mock.Object;
         await Assert.That(conn.GetStatus()).IsEqualTo("ONLINE");
 
         // Clear state — scoped setup no longer matches, global setup wins
-        Mock.SetState(mock, null);
+        mock.SetState(null);
         await Assert.That(conn.GetStatus()).IsEqualTo("NO_STATE");
     }
 
@@ -218,21 +218,21 @@ public class StateMachineTests
     public async Task Reset_Clears_State()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "connected");
+        mock.SetState("connected");
 
-        Mock.Reset(mock);
+        mock.Reset();
 
         // After reset, current state should be null
-        await Assert.That(Mock.GetEngine(mock).CurrentState).IsNull();
+        await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsNull();
     }
 
     [Test]
     public async Task Verify_Works_With_State_Scoped_Setups()
     {
         var mock = Mock.Of<IConnection>();
-        Mock.SetState(mock, "disconnected");
+        mock.SetState("disconnected");
 
-        Mock.InState(mock, "disconnected", m =>
+        mock.InState("disconnected", m =>
         {
             m.Connect().TransitionsTo("connected");
         });

--- a/TUnit.Mocks.Tests/StrictModeTests.cs
+++ b/TUnit.Mocks.Tests/StrictModeTests.cs
@@ -65,7 +65,7 @@ public class StrictModeTests
         // Act & Assert — configured void method should not throw
         ICalculator calc = mock.Object;
         calc.Log("expected message");
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -197,6 +197,6 @@ public class StrictModeTests
 
         // Assert
         await Assert.That(result).IsEqualTo(0);
-        await Assert.That(Mock.GetBehavior(mock)).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
     }
 }

--- a/TUnit.Mocks.Tests/VerifyAllTests.cs
+++ b/TUnit.Mocks.Tests/VerifyAllTests.cs
@@ -21,7 +21,7 @@ public class VerifyAllTests
         svc.GetValue("key");
         svc.Process(1);
 
-        Mock.VerifyAll(mock);
+        mock.VerifyAll();
         await Assert.That(true).IsTrue();
     }
 
@@ -35,7 +35,7 @@ public class VerifyAllTests
         var svc = mock.Object;
         svc.GetValue("key"); // Only call GetValue, not Process
 
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
         await Assert.That(ex.Message).Contains("Process");
     }
 
@@ -45,7 +45,7 @@ public class VerifyAllTests
         var mock = Mock.Of<IService>();
         mock.GetValue(Any()).Returns("value");
 
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
         await Assert.That(ex.Message).Contains("GetValue");
     }
 
@@ -53,7 +53,7 @@ public class VerifyAllTests
     public async Task VerifyAll_Passes_When_No_Setups_Registered()
     {
         var mock = Mock.Of<IService>();
-        Mock.VerifyAll(mock); // No setups = nothing to verify
+        mock.VerifyAll(); // No setups = nothing to verify
         await Assert.That(true).IsTrue();
     }
 
@@ -65,7 +65,7 @@ public class VerifyAllTests
         mock.Process(42);
 
         // Don't call anything
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
         await Assert.That(ex.Message).Contains("GetValue");
         await Assert.That(ex.Message).Contains("Process");
     }

--- a/TUnit.Mocks.Tests/VerifyNoOtherCallsTests.cs
+++ b/TUnit.Mocks.Tests/VerifyNoOtherCallsTests.cs
@@ -21,7 +21,7 @@ public class VerifyNoOtherCallsTests
         svc.GetValue("key1");
 
         mock.GetValue("key1").WasCalled(Times.Once);
-        Mock.VerifyNoOtherCalls(mock);
+        mock.VerifyNoOtherCalls();
 
         await Assert.That(true).IsTrue();
     }
@@ -39,7 +39,7 @@ public class VerifyNoOtherCallsTests
         // Only verify GetValue, not Process
         mock.GetValue("key1").WasCalled(Times.Once);
 
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyNoOtherCalls(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyNoOtherCalls());
         await Assert.That(ex.Message).Contains("Process(42)");
     }
 
@@ -47,7 +47,7 @@ public class VerifyNoOtherCallsTests
     public async Task VerifyNoOtherCalls_Passes_When_No_Calls_Made()
     {
         var mock = Mock.Of<IService>();
-        Mock.VerifyNoOtherCalls(mock);
+        mock.VerifyNoOtherCalls();
         await Assert.That(true).IsTrue();
     }
 
@@ -60,8 +60,8 @@ public class VerifyNoOtherCallsTests
         var svc = mock.Object;
         svc.GetValue("key1");
 
-        Mock.Reset(mock);
-        Mock.VerifyNoOtherCalls(mock); // should pass — history cleared
+        mock.Reset();
+        mock.VerifyNoOtherCalls(); // should pass — history cleared
 
         await Assert.That(true).IsTrue();
     }
@@ -78,7 +78,7 @@ public class VerifyNoOtherCallsTests
         svc.Reset();
 
         // Verify none
-        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyNoOtherCalls(mock));
+        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyNoOtherCalls());
         await Assert.That(ex.Message).Contains("GetValue(a)");
         await Assert.That(ex.Message).Contains("Process(1)");
     }

--- a/TUnit.Mocks/Mock.cs
+++ b/TUnit.Mocks/Mock.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using TUnit.Mocks.Diagnostics;
 using TUnit.Mocks.Verification;
 
 namespace TUnit.Mocks;
@@ -9,21 +7,6 @@ namespace TUnit.Mocks;
 /// </summary>
 public static class Mock
 {
-    // The source generator registers factories via this method at module initialization time.
-    // ConcurrentDictionary is used because module initializers from multiple assemblies
-    // can run concurrently when test assemblies are loaded in parallel.
-    // All factories (interface, class, abstract) use a unified signature with constructor args.
-    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object[], object>> _factories = new();
-
-    // Registry for multi-interface mock factories, keyed by compound type string.
-    private static readonly ConcurrentDictionary<string, Func<MockBehavior, object[], object>> _multiFactories = new();
-
-    // Separate registry for delegate mock factories.
-    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object[], object>> _delegateFactories = new();
-
-    // Separate registry for wrap mock factories that accept a real instance.
-    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object, object>> _wrapFactories = new();
-
     /// <summary>
     /// Retrieves the <see cref="Mock{T}"/> wrapper for a mock implementation object.
     /// Use this to access the mock wrapper from auto-mocked return values or any mocked object.
@@ -54,46 +37,6 @@ public static class Mock
             $"Mock.Get can only be used with objects created by Mock.Of, auto-mocking, or other Mock factory methods.");
     }
 
-    /// <summary>
-    /// Registers a factory for creating mocks of type T. Called by generated code.
-    /// Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void RegisterFactory<T>(Func<MockBehavior, object[], Mock<T>> factory) where T : class
-    {
-        _factories[typeof(T)] = factory;
-    }
-
-    /// <summary>
-    /// Registers a factory for creating multi-interface mocks. Called by generated code.
-    /// Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void RegisterMultiFactory(string key, Func<MockBehavior, object[], object> factory)
-    {
-        _multiFactories[key] = factory;
-    }
-
-    /// <summary>
-    /// Registers a factory for creating delegate mocks of type T. Called by generated code.
-    /// Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void RegisterDelegateFactory<T>(Func<MockBehavior, object[], Mock<T>> factory) where T : class
-    {
-        _delegateFactories[typeof(T)] = factory;
-    }
-
-    /// <summary>
-    /// Registers a factory for creating wrap mocks of type T. Called by generated code.
-    /// Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static void RegisterWrapFactory<T>(Func<MockBehavior, T, Mock<T>> factory) where T : class
-    {
-        _wrapFactories[typeof(T)] = (behavior, instance) => factory(behavior, (T)instance);
-    }
-
     /// <summary>Creates a mock of T in loose mode.</summary>
     public static Mock<T> Of<T>() where T : class => Of<T>(MockBehavior.Loose);
 
@@ -101,7 +44,7 @@ public static class Mock
     public static Mock<T> Of<T>(MockBehavior behavior, IDefaultValueProvider defaultValueProvider) where T : class
     {
         var mock = Of<T>(behavior);
-        GetEngine(mock).DefaultValueProvider = defaultValueProvider;
+        mock.DefaultValueProvider = defaultValueProvider;
         return mock;
     }
 
@@ -116,7 +59,7 @@ public static class Mock
     /// <summary>Creates a mock of T with specified behavior, optionally passing constructor arguments for concrete classes.</summary>
     public static Mock<T> Of<T>(MockBehavior behavior, params object[] constructorArgs) where T : class
     {
-        if (_factories.TryGetValue(typeof(T), out var factory))
+        if (MockRegistry.TryGetFactory(typeof(T), out var factory))
         {
             return (Mock<T>)factory(behavior, constructorArgs);
         }
@@ -140,7 +83,7 @@ public static class Mock
     /// </remarks>
     public static Mock<T> OfDelegate<T>(MockBehavior behavior) where T : class
     {
-        if (_delegateFactories.TryGetValue(typeof(T), out var factory))
+        if (MockRegistry.TryGetDelegateFactory(typeof(T), out var factory))
         {
             return (Mock<T>)factory(behavior, Array.Empty<object>());
         }
@@ -156,7 +99,7 @@ public static class Mock
     /// <summary>Creates a wrap mock around an existing instance of T with specified behavior.</summary>
     public static Mock<T> Wrap<T>(MockBehavior behavior, T instance) where T : class
     {
-        if (_wrapFactories.TryGetValue(typeof(T), out var factory))
+        if (MockRegistry.TryGetWrapFactory(typeof(T), out var factory))
         {
             return (Mock<T>)factory(behavior, instance);
         }
@@ -176,7 +119,7 @@ public static class Mock
         where T1 : class where T2 : class
     {
         var key = GetMultiKey(typeof(T1), typeof(T2));
-        if (_multiFactories.TryGetValue(key, out var factory))
+        if (MockRegistry.TryGetMultiFactory(key, out var factory))
         {
             return (Mock<T1>)factory(behavior, Array.Empty<object>());
         }
@@ -196,7 +139,7 @@ public static class Mock
         where T1 : class where T2 : class where T3 : class
     {
         var key = GetMultiKey(typeof(T1), typeof(T2), typeof(T3));
-        if (_multiFactories.TryGetValue(key, out var factory))
+        if (MockRegistry.TryGetMultiFactory(key, out var factory))
         {
             return (Mock<T1>)factory(behavior, Array.Empty<object>());
         }
@@ -216,7 +159,7 @@ public static class Mock
         where T1 : class where T2 : class where T3 : class where T4 : class
     {
         var key = GetMultiKey(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
-        if (_multiFactories.TryGetValue(key, out var factory))
+        if (MockRegistry.TryGetMultiFactory(key, out var factory))
         {
             return (Mock<T1>)factory(behavior, Array.Empty<object>());
         }
@@ -224,25 +167,6 @@ public static class Mock
         throw new InvalidOperationException(
             $"No multi-interface mock factory registered for types '{typeof(T1).FullName}', '{typeof(T2).FullName}', '{typeof(T3).FullName}', and '{typeof(T4).FullName}'. " +
             $"Ensure the TUnit.Mocks source generator is referenced in your project.");
-    }
-
-    /// <summary>
-    /// Tries to create an auto-mock for the given type. Returns the mock wrapper (IMock) and
-    /// the implementation object. Only works for types with registered factories.
-    /// Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static bool TryCreateAutoMock(Type type, MockBehavior behavior, out IMock mockWrapper)
-    {
-        if (_factories.TryGetValue(type, out var factory))
-        {
-            var mock = (IMock)factory(behavior, Array.Empty<object>());
-            mockWrapper = mock;
-            return true;
-        }
-
-        mockWrapper = null!;
-        return false;
     }
 
     private static string GetMultiKey(params Type[] types)
@@ -260,94 +184,5 @@ public static class Mock
     public static void VerifyInOrder(Action verificationActions)
     {
         OrderedVerification.Verify(verificationActions);
-    }
-
-    // ──────────────────────────────────────────────────────────
-    //  Static helpers – expose control surface without cluttering Mock<T>
-    // ──────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Gets the mock engine for generated code. Not intended for direct use.
-    /// </summary>
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public static MockEngine<T> GetEngine<T>(Mock<T> mock) where T : class
-        => ((IMockEngineAccess<T>)mock).Engine;
-
-    /// <summary>All calls made to this mock, in order.</summary>
-    public static IReadOnlyList<CallRecord> GetInvocations<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).GetAllCalls();
-
-    /// <summary>Returns the mock behavior (Loose or Strict).</summary>
-    public static MockBehavior GetBehavior<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).Behavior;
-
-    /// <summary>
-    /// Gets the custom default value provider for unconfigured methods in loose mode.
-    /// When set, this provider is consulted before auto-mocking and built-in defaults.
-    /// </summary>
-    public static IDefaultValueProvider? GetDefaultValueProvider<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).DefaultValueProvider;
-
-    /// <summary>
-    /// Sets the custom default value provider for unconfigured methods in loose mode.
-    /// When set, this provider is consulted before auto-mocking and built-in defaults.
-    /// </summary>
-    public static void SetDefaultValueProvider<T>(Mock<T> mock, IDefaultValueProvider? provider) where T : class
-        => GetEngine(mock).DefaultValueProvider = provider;
-
-    /// <summary>
-    /// Enables auto-tracking for all properties. Property setters store values and getters return them,
-    /// acting like real auto-properties. Explicit setups take precedence over auto-tracked values.
-    /// </summary>
-    public static void SetupAllProperties<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).AutoTrackProperties = true;
-
-    /// <summary>Clears all setups and call history.</summary>
-    public static void Reset<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).Reset();
-
-    /// <summary>
-    /// Verifies all registered setups were invoked at least once.
-    /// Throws <see cref="Exceptions.MockVerificationException"/> listing uninvoked setups.
-    /// </summary>
-    public static void VerifyAll<T>(Mock<T> mock) where T : class
-        => ((IMock)mock).VerifyAll();
-
-    /// <summary>
-    /// Fails if any recorded call was not matched by a prior verification statement.
-    /// Throws <see cref="Exceptions.MockVerificationException"/> listing unverified calls.
-    /// </summary>
-    public static void VerifyNoOtherCalls<T>(Mock<T> mock) where T : class
-        => ((IMock)mock).VerifyNoOtherCalls();
-
-    /// <summary>
-    /// Returns a diagnostic report of this mock's setup coverage and call matching.
-    /// </summary>
-    public static MockDiagnostics GetDiagnostics<T>(Mock<T> mock) where T : class
-        => GetEngine(mock).GetDiagnostics();
-
-    /// <summary>
-    /// Sets the current state for state machine mocking. Null clears the state.
-    /// </summary>
-    public static void SetState<T>(Mock<T> mock, string? stateName) where T : class
-        => GetEngine(mock).TransitionTo(stateName);
-
-    /// <summary>
-    /// Configures setups scoped to a specific state. All setups registered inside
-    /// the <paramref name="configure"/> action will only match when the engine is in the specified state.
-    /// </summary>
-    public static void InState<T>(Mock<T> mock, string stateName, Action<Mock<T>> configure) where T : class
-    {
-        var engine = GetEngine(mock);
-        var previous = engine.PendingRequiredState;
-        engine.PendingRequiredState = stateName;
-        try
-        {
-            configure(mock);
-        }
-        finally
-        {
-            engine.PendingRequiredState = previous;
-        }
     }
 }

--- a/TUnit.Mocks/MockEngine.cs
+++ b/TUnit.Mocks/MockEngine.cs
@@ -299,7 +299,7 @@ public sealed class MockEngine<T> : IMockEngineAccess where T : class
             var cacheKey = memberName + "|" + typeof(TReturn).FullName;
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
-                Mock.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
+                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
                 return m;
             });
             if (autoMock is not null)

--- a/TUnit.Mocks/MockOfT.cs
+++ b/TUnit.Mocks/MockOfT.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using TUnit.Mocks.Diagnostics;
 using TUnit.Mocks.Exceptions;
 using TUnit.Mocks.Verification;
 
@@ -33,8 +34,36 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <inheritdoc />
-    void IMock.VerifyAll()
+    /// <summary>All calls made to this mock, in order.</summary>
+    public IReadOnlyList<CallRecord> Invocations => _engine.GetAllCalls();
+
+    /// <summary>Returns the mock behavior (Loose or Strict).</summary>
+    public MockBehavior Behavior => _engine.Behavior;
+
+    /// <summary>
+    /// Gets or sets the custom default value provider for unconfigured methods in loose mode.
+    /// When set, this provider is consulted before auto-mocking and built-in defaults.
+    /// </summary>
+    public IDefaultValueProvider? DefaultValueProvider
+    {
+        get => _engine.DefaultValueProvider;
+        set => _engine.DefaultValueProvider = value;
+    }
+
+    /// <summary>
+    /// Enables auto-tracking for all properties. Property setters store values and getters return them,
+    /// acting like real auto-properties. Explicit setups take precedence over auto-tracked values.
+    /// </summary>
+    public void SetupAllProperties() => _engine.AutoTrackProperties = true;
+
+    /// <summary>Clears all setups and call history.</summary>
+    public void Reset() => _engine.Reset();
+
+    /// <summary>
+    /// Verifies all registered setups were invoked at least once.
+    /// Throws <see cref="MockVerificationException"/> listing uninvoked setups.
+    /// </summary>
+    public void VerifyAll()
     {
         var setups = _engine.GetSetups();
         var uninvoked = new List<string>();
@@ -58,8 +87,11 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <inheritdoc />
-    void IMock.VerifyNoOtherCalls()
+    /// <summary>
+    /// Fails if any recorded call was not matched by a prior verification statement.
+    /// Throws <see cref="MockVerificationException"/> listing unverified calls.
+    /// </summary>
+    public void VerifyNoOtherCalls()
     {
         var unverified = _engine.GetUnverifiedCalls();
         if (unverified.Count > 0)
@@ -70,8 +102,42 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
+    /// <summary>
+    /// Returns a diagnostic report of this mock's setup coverage and call matching.
+    /// </summary>
+    public MockDiagnostics GetDiagnostics() => _engine.GetDiagnostics();
+
+    /// <summary>
+    /// Sets the current state for state machine mocking. Null clears the state.
+    /// </summary>
+    public void SetState(string? stateName) => _engine.TransitionTo(stateName);
+
+    /// <summary>
+    /// Configures setups scoped to a specific state. All setups registered inside
+    /// the <paramref name="configure"/> action will only match when the engine is in the specified state.
+    /// </summary>
+    public void InState(string stateName, Action<Mock<T>> configure)
+    {
+        var previous = _engine.PendingRequiredState;
+        _engine.PendingRequiredState = stateName;
+        try
+        {
+            configure(this);
+        }
+        finally
+        {
+            _engine.PendingRequiredState = previous;
+        }
+    }
+
     /// <inheritdoc />
-    void IMock.Reset() => _engine.Reset();
+    void IMock.VerifyAll() => VerifyAll();
+
+    /// <inheritdoc />
+    void IMock.VerifyNoOtherCalls() => VerifyNoOtherCalls();
+
+    /// <inheritdoc />
+    void IMock.Reset() => Reset();
 
     /// <summary>Implicit conversion to T -- no .Object needed.</summary>
     public static implicit operator T(Mock<T> mock) => mock.Object;

--- a/TUnit.Mocks/MockRegistry.cs
+++ b/TUnit.Mocks/MockRegistry.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace TUnit.Mocks;
+
+/// <summary>
+/// Internal registry for mock factories. Called by generated code at module initialization time.
+/// Not intended for direct use.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class MockRegistry
+{
+    // ConcurrentDictionary is used because module initializers from multiple assemblies
+    // can run concurrently when test assemblies are loaded in parallel.
+    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object[], object>> _factories = new();
+
+    private static readonly ConcurrentDictionary<string, Func<MockBehavior, object[], object>> _multiFactories = new();
+
+    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object[], object>> _delegateFactories = new();
+
+    private static readonly ConcurrentDictionary<Type, Func<MockBehavior, object, object>> _wrapFactories = new();
+
+    /// <summary>
+    /// Registers a factory for creating mocks of type T. Called by generated code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterFactory<T>(Func<MockBehavior, object[], Mock<T>> factory) where T : class
+    {
+        _factories[typeof(T)] = factory;
+    }
+
+    /// <summary>
+    /// Registers a factory for creating multi-interface mocks. Called by generated code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterMultiFactory(string key, Func<MockBehavior, object[], object> factory)
+    {
+        _multiFactories[key] = factory;
+    }
+
+    /// <summary>
+    /// Registers a factory for creating delegate mocks of type T. Called by generated code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterDelegateFactory<T>(Func<MockBehavior, object[], Mock<T>> factory) where T : class
+    {
+        _delegateFactories[typeof(T)] = factory;
+    }
+
+    /// <summary>
+    /// Registers a factory for creating wrap mocks of type T. Called by generated code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterWrapFactory<T>(Func<MockBehavior, T, Mock<T>> factory) where T : class
+    {
+        _wrapFactories[typeof(T)] = (behavior, instance) => factory(behavior, (T)instance);
+    }
+
+    /// <summary>
+    /// Tries to create an auto-mock for the given type. Returns the mock wrapper (IMock) and
+    /// the implementation object. Only works for types with registered factories.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static bool TryCreateAutoMock(Type type, MockBehavior behavior, out IMock mockWrapper)
+    {
+        if (_factories.TryGetValue(type, out var factory))
+        {
+            var mock = (IMock)factory(behavior, Array.Empty<object>());
+            mockWrapper = mock;
+            return true;
+        }
+
+        mockWrapper = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the mock engine for generated code. Not intended for direct use.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static MockEngine<T> GetEngine<T>(Mock<T> mock) where T : class
+        => ((IMockEngineAccess<T>)mock).Engine;
+
+    internal static bool TryGetFactory(Type type, out Func<MockBehavior, object[], object> factory)
+        => _factories.TryGetValue(type, out factory!);
+
+    internal static bool TryGetMultiFactory(string key, out Func<MockBehavior, object[], object> factory)
+        => _multiFactories.TryGetValue(key, out factory!);
+
+    internal static bool TryGetDelegateFactory(Type type, out Func<MockBehavior, object[], object> factory)
+        => _delegateFactories.TryGetValue(type, out factory!);
+
+    internal static bool TryGetWrapFactory(Type type, out Func<MockBehavior, object, object> factory)
+        => _wrapFactories.TryGetValue(type, out factory!);
+}

--- a/docs/docs/writing-tests/mocking/advanced.md
+++ b/docs/docs/writing-tests/mocking/advanced.md
@@ -74,15 +74,15 @@ public interface IConnection
 }
 
 var mock = Mock.Of<IConnection>();
-Mock.SetState(mock, "disconnected");
+mock.SetState("disconnected");
 
-Mock.InState(mock, "disconnected", m =>
+mock.InState("disconnected", m =>
 {
     m.GetStatus().Returns("OFFLINE");
     m.Connect().TransitionsTo("connected");
 });
 
-Mock.InState(mock, "connected", m =>
+mock.InState("connected", m =>
 {
     m.GetStatus().Returns("ONLINE");
     m.Disconnect().TransitionsTo("disconnected");
@@ -102,9 +102,9 @@ status = mock.Object.GetStatus();     // "OFFLINE"
 
 | Method | Description |
 |---|---|
-| `Mock.SetState(mock, "name")` | Set the current state |
-| `Mock.SetState(mock, null)` | Clear state (all setups match) |
-| `Mock.InState(mock, "name", configure)` | Register setups scoped to a state |
+| `mock.SetState("name")` | Set the current state |
+| `mock.SetState(null)` | Clear state (all setups match) |
+| `mock.InState("name", configure)` | Register setups scoped to a state |
 | `.TransitionsTo("name")` | Transition state after method call (on setup chain) |
 
 ## Recursive / Auto-Mocking
@@ -187,7 +187,7 @@ mock.Delete(Any());
 svc.GetUser(1);
 // Delete was never called
 
-var diag = Mock.GetDiagnostics(mock);
+var diag = mock.GetDiagnostics();
 diag.TotalSetups;       // 2
 diag.ExercisedSetups;   // 1
 diag.UnusedSetups;      // [Delete(Any())]
@@ -215,7 +215,7 @@ public class TestDefaults : IDefaultValueProvider
 }
 
 var mock = Mock.Of<IService>();
-Mock.SetDefaultValueProvider(mock, new TestDefaults());
+mock.DefaultValueProvider = new TestDefaults();
 
 var name = mock.Object.GetName();  // "test-default" (no setup needed)
 var count = mock.Object.GetCount(); // -1
@@ -231,10 +231,10 @@ Clear all setups, call history, state, and auto-tracked property values:
 mock.GetUser(Any()).Returns(new User("Alice"));
 svc.GetUser(1);
 
-Mock.Reset(mock);
+mock.Reset();
 
 svc.GetUser(1); // returns default (setup cleared)
-Mock.GetInvocations(mock).Count; // 0 (history cleared)
+mock.Invocations.Count; // 0 (history cleared)
 ```
 
 The `SetupAllProperties()` flag is preserved across resets.

--- a/docs/docs/writing-tests/mocking/setup.md
+++ b/docs/docs/writing-tests/mocking/setup.md
@@ -116,7 +116,7 @@ Call `SetupAllProperties()` to make properties behave like real auto-properties 
 
 ```csharp
 var mock = Mock.Of<IEntity>();
-Mock.SetupAllProperties(mock);
+mock.SetupAllProperties();
 
 mock.Object.Name = "Alice";
 var name = mock.Object.Name; // "Alice"

--- a/docs/docs/writing-tests/mocking/verification.md
+++ b/docs/docs/writing-tests/mocking/verification.md
@@ -104,7 +104,7 @@ mock.Delete(Any());
 svc.GetUser(1);
 svc.Delete(2);
 
-Mock.VerifyAll(mock); // passes — both setups were invoked
+mock.VerifyAll(); // passes — both setups were invoked
 ```
 
 If any setup was never called, `VerifyAll` throws listing the uninvoked setups.
@@ -120,7 +120,7 @@ svc.Delete(2);
 mock.GetUser(1).WasCalled(Times.Once);
 mock.Delete(2).WasCalled(Times.Once);
 
-Mock.VerifyNoOtherCalls(mock); // passes — all calls accounted for
+mock.VerifyNoOtherCalls(); // passes — all calls accounted for
 ```
 
 If there are unverified calls, `VerifyNoOtherCalls` throws listing them.
@@ -146,7 +146,7 @@ This integrates with TUnit's assertion engine — failures appear as assertion e
 Access the raw call history for custom inspection:
 
 ```csharp
-var calls = Mock.GetInvocations(mock);
+var calls = mock.Invocations;
 
 await Assert.That(calls).HasCount().EqualTo(3);
 await Assert.That(calls[0].MemberName).IsEqualTo("GetUser");


### PR DESCRIPTION
## Summary

- Move 6 framework-internal methods (`RegisterFactory`, `RegisterMultiFactory`, `RegisterDelegateFactory`, `RegisterWrapFactory`, `TryCreateAutoMock`, `GetEngine`) from `Mock` to a new `[EditorBrowsable(Never)]` `MockRegistry` class — completely removes them from `Mock.` autocomplete even in project-reference scenarios
- Move 11 static helper methods that take `Mock<T>` as first parameter to instance members on `Mock<T>` (e.g. `Mock.GetInvocations(mock)` → `mock.Invocations`, `Mock.Reset(mock)` → `mock.Reset()`)
- `Mock.` autocomplete now shows only 5 entries: `Of`, `OfDelegate`, `Wrap`, `Get`, `VerifyInOrder`

### Before → After

| Before (static) | After (instance) |
|---|---|
| `Mock.GetInvocations(mock)` | `mock.Invocations` |
| `Mock.GetBehavior(mock)` | `mock.Behavior` |
| `Mock.Get/SetDefaultValueProvider(mock, ...)` | `mock.DefaultValueProvider` |
| `Mock.SetupAllProperties(mock)` | `mock.SetupAllProperties()` |
| `Mock.Reset(mock)` | `mock.Reset()` |
| `Mock.VerifyAll(mock)` | `mock.VerifyAll()` |
| `Mock.VerifyNoOtherCalls(mock)` | `mock.VerifyNoOtherCalls()` |
| `Mock.GetDiagnostics(mock)` | `mock.GetDiagnostics()` |
| `Mock.SetState(mock, s)` | `mock.SetState(s)` |
| `Mock.InState(mock, s, a)` | `mock.InState(s, a)` |

## Test plan

- [x] All 679 TUnit.Mocks.Tests pass
- [x] All 22 source generator snapshot tests pass (snapshots updated)
- [x] All Roslyn variant generators build successfully
- [x] Documentation updated (advanced.md, verification.md, setup.md)