### PR TITLE
Remove defunct `UseTestingPlatformProtocol` reference for vscode

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -60,7 +60,7 @@ TUnit requires `Microsoft.Testing.Platform` support to be enabled in your IDE.
 
 **Rider:** Settings > Build, Execution, Deployment > Unit Testing > Testing Platform > enable "Testing Platform support", then restart.
 
-**VS Code:** Install C# Dev Kit, then set `"dotnet.testWindow.useTestingPlatformProtocol": true` in settings, then reload.
+**VS Code:** Install C# Dev Kit, then reload.
 
 If tests still don't appear after enabling, try a clean rebuild. In Visual Studio, deleting the `.vs` folder can help.
 


### PR DESCRIPTION
## Description

`dotnet.testWindow.useTestingPlatformProtocol` seems to be a defunct setting in vscode now. No need to include it anymore. 

There are more references to testing platform protocol, but I'm not sure if that's related: https://github.com/search?q=repo%3Athomhurst%2FTUnit%20useTestingPlatformProtocol&type=code

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [x] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works
