### PR TITLE
perf(aspnetcore): prevent thread pool starvation during parallel WebApplicationTest server init

### DIFF
--- a/TUnit.AspNetCore/WebApplicationTest.cs
+++ b/TUnit.AspNetCore/WebApplicationTest.cs
@@ -15,7 +15,7 @@ public abstract class WebApplicationTest
     // Capped at 8: startup is reflection/I/O-bound, not CPU-bound, so ProcessorCount alone
     // would allow too many concurrent builds on high-core-count machines.
     private static readonly int _maxConcurrentServerInits = Math.Min(Environment.ProcessorCount * 2, 8);
-    protected static readonly SemaphoreSlim ServerInitSemaphore =
+    private protected static readonly SemaphoreSlim ServerInitSemaphore =
         new(_maxConcurrentServerInits, _maxConcurrentServerInits);
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `WebApplicationFactory.Server` is a synchronous property that blocks the calling thread while building the DI container and starting the host
- When many tests start in parallel, each holds an async continuation thread for the full duration of app startup, exhausting the thread pool and causing cascading slowdowns
- Fix offloads the synchronous `Server` access to `Task.Run` (freeing the async thread immediately) and caps concurrent builds with a `SemaphoreSlim` (`ProcessorCount * 2`) to prevent flooding the thread pool

## Details

The degradation with more concurrent tests is classic thread pool starvation: N tests × synchronous server startup time = N threads held, hitting the min-thread threshold and triggering the 250ms-per-thread spin-up delay for any new work.

There is no public async initialization path in `WebApplicationFactory<T>` (no `InitializeAsync` equivalent), so `Task.Run` with a concurrency cap is the correct workaround.

## Test Plan

- [x] All 39 existing `TUnit.AspNetCore.NugetTester` tests pass
- [ ] Verify with a large parallel test suite that startup time no longer degrades with concurrency