### PR TITLE
ci: add concurrency groups to cancel redundant workflow runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: number
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/cloudshop-example.yml
+++ b/.github/workflows/cloudshop-example.yml
@@ -7,6 +7,10 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '0 0 * * 5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-deploy:
     name: Test Deploy to GitHub Pages

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
-   
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/dotnet-build-different-locale.yml
+++ b/.github/workflows/dotnet-build-different-locale.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   modularpipeline:
     strategy:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   modularpipeline:
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Pull Requests' }}


### PR DESCRIPTION
## Summary

- Adds `concurrency` groups with `cancel-in-progress: true` to 7 GitHub Actions workflows that use `push`/`pull_request` triggers
- When a new commit is pushed to a PR branch, any in-progress run for that branch is automatically cancelled, saving runner time
- Uses `github.head_ref || github.run_id` so PR runs are grouped by branch while push/schedule/dispatch runs remain independent

### Workflows updated
- `.NET` (dotnet.yml)
- `Locale Test` (dotnet-build-different-locale.yml)
- `CloudShop Example Tests` (cloudshop-example.yml)
- `CodeQL Advanced` (codeql.yml)
- `Deploy to GitHub Pages` (deploy-pages.yml)
- `Test Deploy to GitHub Pages` (deploy-pages-test.yml)
- `Claude Code Review` (claude-code-review.yml)

### Skipped (no benefit)
- `mock-benchmarks.yml` — already has concurrency configured
- Schedule/event-only workflows (`speed-comparison`, `claude-autofix`, `review-stale`, `claude-issue-triage`, `claude`)

## Test plan
- [ ] Verify workflow YAML is valid (CI will validate on this PR)
- [ ] Push a follow-up commit to this PR to confirm the first run gets cancelled