### PR TITLE
Speed up Engine.Tests by removing ProcessorCount parallelism cap

### DIFF
--- a/TUnit.Engine.Tests/GlobalSettings.cs
+++ b/TUnit.Engine.Tests/GlobalSettings.cs
@@ -1,5 +1,3 @@
-﻿using TUnit.Core.Helpers;
-using TUnit.Engine.Tests.Attributes;
+﻿using TUnit.Engine.Tests.Attributes;
 
-[assembly: ParallelLimiter<ProcessorCountParallelLimit>]
 [assembly: SetDisplayNameWithClass]

--- a/TUnit.Engine.Tests/TimeoutTests1.cs
+++ b/TUnit.Engine.Tests/TimeoutTests1.cs
@@ -5,6 +5,7 @@ namespace TUnit.Engine.Tests;
 
 public class TimeoutTests1(TestMode testMode) : InvokableTestBase(testMode)
 {
+    [Test]
     public async Task Test()
     {
         await RunTestsWithFilter(


### PR DESCRIPTION
## Summary

- Remove `[assembly: ParallelLimiter<ProcessorCountParallelLimit>]` from `TUnit.Engine.Tests/GlobalSettings.cs`
- Add missing `[Test]` attribute to `TimeoutTests1.Test()` which was silently not running

## Why

`TUnit.Engine.Tests` has ~119 test methods across 58 classes, each of which spawns a subprocess via CliWrap and waits for it to complete. These tests are **I/O-bound** — the outer process does no meaningful CPU work.

`ProcessorCountParallelLimit` is designed for CPU-bound tests. Applied here it forces serial batching: on a 4-core CI machine, 119 tests run in ~30 sequential rounds. Removing the cap lets TUnit schedule all subprocess tests concurrently, so total runtime approaches the duration of the slowest single subprocess rather than `ceil(N / cores) × avg_time`.

The three `[NotInParallel]` tests (`JUnitReporterTests`, `GitHubReporterTests`, `FirstEventReceiversRegressionTest`) are unaffected — they still serialize via their own attribute.