### PR TITLE
Drop net6.0 and net7.0 TFMs, keep net8.0+ and netstandard2.x

### DIFF
--- a/TUnit.Assertions.SourceGenerator.Tests/MethodAssertionGeneratorTests.cs
+++ b/TUnit.Assertions.SourceGenerator.Tests/MethodAssertionGeneratorTests.cs
@@ -219,14 +219,14 @@ internal class MethodAssertionGeneratorTests : TestsBase<MethodAssertionGenerato
             await Assert.That(mainFile).Contains("bool exact = true");
         });
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [Test]
     public Task RefStructParameter() => RunTest(
         Path.Combine(Sourcy.Git.RootDirectory.FullName,
             "TUnit.Assertions.SourceGenerator.Tests",
             "TestData",
             "RefStructParameterAssertion.cs"),
-        new RunTestOptions { PreprocessorSymbols = ["NET6_0_OR_GREATER"] },
+        new RunTestOptions { PreprocessorSymbols = ["NET8_0_OR_GREATER"] },
         async generatedFiles =>
         {
             await Assert.That(generatedFiles).HasCount(1);

--- a/TUnit.Assertions.SourceGenerator.Tests/TestData/RefStructParameterAssertion.cs
+++ b/TUnit.Assertions.SourceGenerator.Tests/TestData/RefStructParameterAssertion.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.Attributes;
 

--- a/TUnit.Assertions.Tests/DateOnlyAssertionTests.cs
+++ b/TUnit.Assertions.Tests/DateOnlyAssertionTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;

--- a/TUnit.Assertions.Tests/EquatableTests.cs
+++ b/TUnit.Assertions.Tests/EquatableTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace TUnit.Assertions.Tests;
 
 /// <summary>

--- a/TUnit.Assertions.Tests/IndexAssertionTests.cs
+++ b/TUnit.Assertions.Tests/IndexAssertionTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;

--- a/TUnit.Assertions.Tests/RangeAssertionTests.cs
+++ b/TUnit.Assertions.Tests/RangeAssertionTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;

--- a/TUnit.Assertions.Tests/TaskAssertionTests.cs
+++ b/TUnit.Assertions.Tests/TaskAssertionTests.cs
@@ -115,7 +115,7 @@ public class TaskAssertionTests
         await Assert.That(task).IsNotFaulted();
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [Test]
     public async Task Test_Task_IsCompletedSuccessfully()
     {

--- a/TUnit.Assertions.Tests/TimeOnlyAssertionTests.cs
+++ b/TUnit.Assertions.Tests/TimeOnlyAssertionTests.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;

--- a/TUnit.Assertions.Tests/TimeZoneInfoAssertionTests.cs
+++ b/TUnit.Assertions.Tests/TimeZoneInfoAssertionTests.cs
@@ -18,7 +18,7 @@ public class TimeZoneInfoAssertionTests
         await Assert.That(utc).DoesNotSupportDaylightSavingTime();
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [Test]
     public async Task Test_TimeZoneInfo_HasIanaId()
     {

--- a/TUnit.Assertions/Conditions/BigIntegerAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/BigIntegerAssertionExtensions.cs
@@ -10,7 +10,7 @@ namespace TUnit.Assertions.Conditions;
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsZero), ExpectationMessage = "be zero")]
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsZero), CustomName = "IsNotZero", NegateLogic = true, ExpectationMessage = "be zero")]
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsOne), ExpectationMessage = "be one")]
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsOne), CustomName = "IsNotOne", NegateLogic = true, ExpectationMessage = "be one")]
 #endif
@@ -18,7 +18,7 @@ namespace TUnit.Assertions.Conditions;
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsEven), ExpectationMessage = "be even")]
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsEven), CustomName = "IsNotEven", NegateLogic = true, ExpectationMessage = "be even")]
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsPowerOfTwo), ExpectationMessage = "be a power of two")]
 [AssertionFrom<BigInteger>(nameof(BigInteger.IsPowerOfTwo), CustomName = "IsNotPowerOfTwo", NegateLogic = true, ExpectationMessage = "be a power of two")]
 #endif

--- a/TUnit.Assertions/Conditions/DateOnlyAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/DateOnlyAssertionExtensions.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Attributes;
 
 namespace TUnit.Assertions.Conditions;

--- a/TUnit.Assertions/Conditions/Helpers/TypeHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/TypeHelper.cs
@@ -81,7 +81,7 @@ internal static class TypeHelper
             || type == typeof(Guid)
             || typeof(Type).IsAssignableFrom(type)
             || typeof(MemberInfo).IsAssignableFrom(type)
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             || type == typeof(DateOnly)
             || type == typeof(TimeOnly)
 #endif

--- a/TUnit.Assertions/Conditions/IndexAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/IndexAssertionExtensions.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Attributes;
 
 namespace TUnit.Assertions.Conditions;

--- a/TUnit.Assertions/Conditions/RangeAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/RangeAssertionExtensions.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Attributes;
 
 namespace TUnit.Assertions.Conditions;

--- a/TUnit.Assertions/Conditions/SpecializedEqualityAssertions.cs
+++ b/TUnit.Assertions/Conditions/SpecializedEqualityAssertions.cs
@@ -3,7 +3,7 @@ using TUnit.Assertions.Core;
 
 namespace TUnit.Assertions.Conditions;
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 /// <summary>
 /// Asserts that a DateOnly value is equal to another, with optional tolerance.
 /// </summary>
@@ -49,7 +49,7 @@ public class DateOnlyEqualsAssertion : ToleranceBasedEqualsAssertion<DateOnly, i
 }
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 /// <summary>
 /// Asserts that a TimeOnly value is equal to another, with optional tolerance.
 /// </summary>

--- a/TUnit.Assertions/Conditions/TaskAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/TaskAssertionExtensions.cs
@@ -15,7 +15,7 @@ namespace TUnit.Assertions.Conditions;
 [AssertionFrom<Task>(nameof(Task.IsFaulted), ExpectationMessage = "be faulted")]
 [AssertionFrom<Task>(nameof(Task.IsFaulted), CustomName = "IsNotFaulted", NegateLogic = true, ExpectationMessage = "be faulted")]
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [AssertionFrom<Task>(nameof(Task.IsCompletedSuccessfully), ExpectationMessage = "be completed successfully")]
 [AssertionFrom<Task>(nameof(Task.IsCompletedSuccessfully), CustomName = "IsNotCompletedSuccessfully", NegateLogic = true, ExpectationMessage = "be completed successfully")]
 #endif

--- a/TUnit.Assertions/Conditions/TimeOnlyAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/TimeOnlyAssertionExtensions.cs
@@ -1,4 +1,4 @@
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using TUnit.Assertions.Attributes;
 
 namespace TUnit.Assertions.Conditions;

--- a/TUnit.Assertions/Conditions/TimeZoneInfoAssertionExtensions.cs
+++ b/TUnit.Assertions/Conditions/TimeZoneInfoAssertionExtensions.cs
@@ -9,7 +9,7 @@ namespace TUnit.Assertions.Conditions;
 [AssertionFrom<TimeZoneInfo>(nameof(TimeZoneInfo.SupportsDaylightSavingTime), ExpectationMessage = "support daylight saving time")]
 [AssertionFrom<TimeZoneInfo>(nameof(TimeZoneInfo.SupportsDaylightSavingTime), CustomName = "DoesNotSupportDaylightSavingTime", NegateLogic = true, ExpectationMessage = "support daylight saving time")]
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [AssertionFrom<TimeZoneInfo>(nameof(TimeZoneInfo.HasIanaId), ExpectationMessage = "have an IANA ID")]
 [AssertionFrom<TimeZoneInfo>(nameof(TimeZoneInfo.HasIanaId), CustomName = "DoesNotHaveIanaId", NegateLogic = true, ExpectationMessage = "have an IANA ID")]
 #endif

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1347,7 +1347,7 @@ public static class AssertionExtensions
         return new TValue_IsLessThanOrEqualTo_TValue_Assertion<DateTimeOffset>(source.Context, expected);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asserts that the DateOnly is after the expected DateOnly.
     /// Alias for IsGreaterThan for better readability with dates.

--- a/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
@@ -103,7 +103,7 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
         return ((IAssertionSource<Task>)this).IsNotFaulted();
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asserts that the task completed successfully.
     /// </summary>

--- a/TUnit.Assertions/Sources/TaskAssertion.cs
+++ b/TUnit.Assertions/Sources/TaskAssertion.cs
@@ -232,7 +232,7 @@ public class TaskAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
         return ((IAssertionSource<Task<TValue>>)this).IsNotFaulted();
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     /// <summary>
     /// Asserts that the task completed successfully.
     /// </summary>

--- a/TUnit.Core/Attributes/TestData/MatrixSourceRangeAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MatrixSourceRangeAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace TUnit.Core;
 
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [AttributeUsage(AttributeTargets.Parameter)]
 public class MatrixRangeAttribute<T>(T min, T max, T step)
     : MatrixAttribute<T>(CreateRange(min, max, step))

--- a/TUnit.Core/DataGeneratorMetadataCreator.cs
+++ b/TUnit.Core/DataGeneratorMetadataCreator.cs
@@ -212,7 +212,7 @@ internal static class DataGeneratorMetadataCreator
     /// Creates DataGeneratorMetadata for property injection using PropertyInfo (reflection mode).
     /// This method is only called in reflection mode, not in source-generated/AOT scenarios.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access",
         Justification = "This method is only used in reflection mode. In AOT/source-gen mode, property injection uses compile-time generated PropertyMetadata.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling",
@@ -267,7 +267,7 @@ internal static class DataGeneratorMetadataCreator
         return parameters;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access",
         Justification = "This helper is only used in reflection mode. In AOT/source-gen mode, class metadata is generated at compile time.")]
     [UnconditionalSuppressMessage("Trimming", "IL2070:Target method return value does not satisfy 'DynamicallyAccessedMembersAttribute'",

--- a/TUnit.Core/DynamicTestBuilderContext.cs
+++ b/TUnit.Core/DynamicTestBuilderContext.cs
@@ -24,7 +24,7 @@ public class DynamicTestBuilderContext
 
     public IReadOnlyList<AbstractDynamicTest> Tests => _tests.AsReadOnly();
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Adding dynamic tests requires reflection which is not supported in native AOT scenarios.")]
     #endif
     public void AddTest(AbstractDynamicTest test)

--- a/TUnit.Core/Extensions/ReflectionExtensions.cs
+++ b/TUnit.Core/Extensions/ReflectionExtensions.cs
@@ -109,7 +109,7 @@ public static class ReflectionExtensions
 #endif
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Attribute instantiation uses reflection for .NET Framework compatibility")]
     #endif
     private static Attribute[] GetAttributesViaCustomAttributeData(ICustomAttributeProvider provider, Type attributeType, bool inherit)
@@ -173,7 +173,7 @@ public static class ReflectionExtensions
         return attributes.ToArray();
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Attribute instantiation uses reflection for .NET Framework compatibility")]
     #endif
     private static Attribute? CreateAttributeInstance(CustomAttributeData attributeData)
@@ -240,7 +240,7 @@ public static class ReflectionExtensions
         return attribute;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Runtime type property access for attribute argument extraction")]
     #endif
     private static object? ExtractArgumentValue(CustomAttributeTypedArgument arg)
@@ -278,7 +278,7 @@ public static class ReflectionExtensions
     /// <summary>
     /// Gets the "Value" property from a type in an AOT-safer manner.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Property access used for unwrapping test data")]
     #endif
     private static PropertyInfo? GetValuePropertySafe([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
@@ -289,7 +289,7 @@ public static class ReflectionExtensions
     /// <summary>
     /// Gets the "Value" property from a runtime type.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Runtime type property access for attribute argument extraction")]
     #endif
     private static PropertyInfo? GetValuePropertyForType(Type type)

--- a/TUnit.Core/Extensions/TestContextExtensions.cs
+++ b/TUnit.Core/Extensions/TestContextExtensions.cs
@@ -91,7 +91,7 @@ public static class TestContextExtensions
     /// </summary>
     public static bool IsVariant(this Interfaces.ITestDependencies dependencies) => dependencies.ParentTestId != null;
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Dynamic test metadata creation uses reflection")]
     #endif
     public static async Task AddDynamicTest<[DynamicallyAccessedMembers(
@@ -118,7 +118,7 @@ public static class TestContextExtensions
     /// <param name="relationship">The relationship category of this variant to its parent test (defaults to Derived)</param>
     /// <param name="displayName">Optional user-facing display name for the variant (e.g., "Shrink Attempt", "Mutant")</param>
     /// <returns>Information about the created test variant, including its TestId and DisplayName</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Creating test variants requires runtime compilation and reflection")]
     #endif
     public static async Task<TestVariantInfo> CreateTestVariant(

--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -511,7 +511,7 @@ public static class DataSourceHelpers
     /// This method handles all IDataSourceAttribute implementations generically.
     /// Only used in reflection mode - in AOT/source-gen mode, property injection is handled by generated code.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access",
         Justification = "This method is only used in reflection mode. In AOT/source-gen mode, property injection uses compile-time generated code.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling",

--- a/TUnit.Core/Helpers/GenericTypeHelper.cs
+++ b/TUnit.Core/Helpers/GenericTypeHelper.cs
@@ -16,7 +16,7 @@ public static class GenericTypeHelper
     /// <returns>The constructed generic type</returns>
     /// <exception cref="ArgumentNullException">Thrown when genericTypeDefinition is null</exception>
     /// <exception cref="ArgumentException">Thrown when type arguments don't match the generic type definition</exception>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("MakeGenericType requires runtime code generation")]
     [RequiresDynamicCode("MakeGenericType requires runtime code generation")]
 #endif

--- a/TUnit.Core/Helpers/TupleHelper.cs
+++ b/TUnit.Core/Helpers/TupleHelper.cs
@@ -163,7 +163,7 @@ public static class TupleHelper
     /// Expands an array of tuples into individual tuple elements for data source generation
     /// For example: [(1, "a"), (2, "b")] becomes individual items that each unwrap to [1, "a"] and [2, "b"]
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Tuple expansion uses reflection as fallback")]
     #endif
     public static IEnumerable<object?[]> ExpandTupleArray(object? value)

--- a/TUnit.Core/Hooks/LastTestInClassAdapter.cs
+++ b/TUnit.Core/Hooks/LastTestInClassAdapter.cs
@@ -3,7 +3,7 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.Core.Hooks;
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Method with DynamicallyAccessedMembersAttribute accessed via reflection")]
 #endif
 public class LastTestInClassAdapter(ILastTestInClassEventReceiver lastTestInClassEventReceiver, TestContext testContext) : IExecutableHook<ClassHookContext>

--- a/TUnit.Core/Interfaces/ITestRegistry.cs
+++ b/TUnit.Core/Interfaces/ITestRegistry.cs
@@ -14,7 +14,7 @@ public interface ITestRegistry
     /// <param name="context">The current test context</param>
     /// <param name="dynamicTest">The dynamic test instance to add</param>
     /// <returns>A task that completes when the test has been queued for execution</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Adding dynamic tests requires runtime compilation and reflection which are not supported in native AOT scenarios.")]
     #endif
     Task AddDynamicTest<[DynamicallyAccessedMembers(
@@ -39,7 +39,7 @@ public interface ITestRegistry
     /// <param name="relationship">The relationship category of this variant to its parent test</param>
     /// <param name="displayName">Optional user-facing display name for the variant (e.g., "Shrink Attempt", "Mutant")</param>
     /// <returns>A task containing information about the created test variant</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Creating test variants requires runtime compilation and reflection which are not supported in native AOT scenarios.")]
     #endif
     Task<TestVariantInfo> CreateTestVariant(

--- a/TUnit.Core/PropertyInjection/ClassMetadataHelper.cs
+++ b/TUnit.Core/PropertyInjection/ClassMetadataHelper.cs
@@ -12,7 +12,7 @@ internal static class ClassMetadataHelper
     /// <summary>
     /// Gets or creates ClassMetadata for the specified type.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Metadata creation requires reflection")]
     #endif
     public static ClassMetadata GetOrCreateClassMetadata(

--- a/TUnit.Core/PropertyInjection/PropertyInjectionPlanBuilder.cs
+++ b/TUnit.Core/PropertyInjection/PropertyInjectionPlanBuilder.cs
@@ -67,7 +67,7 @@ internal static class PropertyInjectionPlanBuilder
     /// <summary>
     /// Creates an injection plan for reflection mode.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Reflection mode requires runtime property discovery")]
     #endif
     public static PropertyInjectionPlan BuildReflectionPlan(Type type)

--- a/TUnit.Core/PropertyInjection/PropertySetterFactory.cs
+++ b/TUnit.Core/PropertyInjection/PropertySetterFactory.cs
@@ -22,7 +22,7 @@ internal static class PropertySetterFactory
     /// Gets or creates a setter delegate for the given property.
     /// Uses caching to avoid repeated reflection calls.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     public static Action<object, object?> GetOrCreateSetter(PropertyInfo property)
@@ -34,7 +34,7 @@ internal static class PropertySetterFactory
     /// Creates a setter delegate for the given property.
     /// Consider using <see cref="GetOrCreateSetter"/> for better performance through caching.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     public static Action<object, object?> CreateSetter(PropertyInfo property)
@@ -47,7 +47,7 @@ internal static class PropertySetterFactory
     /// Core implementation for creating a setter delegate.
     /// Called by GetOrCreateSetter for caching.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     private static Action<object, object?> CreateSetterCore(PropertyInfo property)
@@ -105,7 +105,7 @@ internal static class PropertySetterFactory
     /// <summary>
     /// Gets the backing field for a property.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     private static FieldInfo? GetBackingField(PropertyInfo property, Type? instanceType = null)
@@ -184,7 +184,7 @@ internal static class PropertySetterFactory
     /// <summary>
     /// Helper method to get field with proper trimming suppression.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Field access for property backing fields requires reflection")]
     #endif
     private static FieldInfo? GetFieldSafe(
@@ -199,7 +199,7 @@ internal static class PropertySetterFactory
     /// <summary>
     /// Checks if a method is init-only.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Checking for init-only setters requires reflection")]
     #endif
     private static bool IsInitOnlyMethod(MethodInfo setMethod)

--- a/TUnit.Core/PropertyInjection/TupleValueResolver.cs
+++ b/TUnit.Core/PropertyInjection/TupleValueResolver.cs
@@ -15,7 +15,7 @@ internal static class TupleValueResolver
     /// <param name="propertyType">The expected property type</param>
     /// <param name="args">The arguments from the data source</param>
     /// <returns>The resolved value, potentially a tuple</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Tuple types are created dynamically")]
     #endif
     public static object? ResolveTupleValue(

--- a/TUnit.Core/PropertySourceRegistry.cs
+++ b/TUnit.Core/PropertySourceRegistry.cs
@@ -78,7 +78,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Discovers injectable properties using reflection (legacy compatibility)
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Reflection discovery is used when source-generated metadata is not available")]
     #endif
     public static PropertyInjectionData[] DiscoverInjectableProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] Type type)
@@ -147,7 +147,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Creates PropertyInjectionData from PropertyInfo (legacy compatibility)
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     private static PropertyInjectionData CreatePropertyInjection(System.Reflection.PropertyInfo property, Type? testClassType = null)
@@ -167,7 +167,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Creates property setter (legacy compatibility)
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field access for init-only properties requires reflection")]
     #endif
     private static Action<object, object?> CreatePropertySetter(System.Reflection.PropertyInfo property, Type? testClassType = null)
@@ -201,7 +201,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Gets backing field for property (legacy compatibility)
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Backing field discovery needed for init-only properties in reflection mode")]
     #endif
     private static System.Reflection.FieldInfo? GetBackingField(System.Reflection.PropertyInfo property, Type? testClassType = null)
@@ -280,7 +280,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Helper method to get field with proper trimming suppression
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Field access for property backing fields requires reflection")]
     #endif
     private static System.Reflection.FieldInfo? GetFieldSafe([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] Type type, string name, System.Reflection.BindingFlags bindingFlags)
@@ -291,7 +291,7 @@ public static class PropertySourceRegistry
     /// <summary>
     /// Checks if method is init-only (legacy compatibility)
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Checking for init-only setters requires reflection")]
     #endif
     private static bool IsInitOnlyMethod(System.Reflection.MethodInfo setMethod)

--- a/TUnit.Core/Services/GenericTypeResolver.cs
+++ b/TUnit.Core/Services/GenericTypeResolver.cs
@@ -8,7 +8,7 @@ namespace TUnit.Core.Services;
 /// <summary>
 /// Implementation of generic type resolution for test methods and classes
 /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Generic type resolution requires runtime type generation")]
 #endif
 public class GenericTypeResolver : IGenericTypeResolver

--- a/TUnit.Core/StaticPropertyReflectionInitializer.cs
+++ b/TUnit.Core/StaticPropertyReflectionInitializer.cs
@@ -8,7 +8,7 @@ namespace TUnit.Core;
 /// <summary>
 /// Handles initialization of static properties with data sources in reflection mode
 /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Reflection mode requires dynamic access for static property initialization")]
 #endif
 public static class StaticPropertyReflectionInitializer
@@ -18,7 +18,7 @@ public static class StaticPropertyReflectionInitializer
     /// <summary>
     /// Initializes static properties with data sources for all loaded types
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Data source initialization may require dynamic code generation")]
 #endif
     public static async Task InitializeAllStaticPropertiesAsync()
@@ -49,7 +49,7 @@ public static class StaticPropertyReflectionInitializer
     /// <summary>
     /// Initializes static properties with data sources for a specific type
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Data source initialization may require dynamic code generation")]
 #endif
     public static async Task InitializeStaticPropertiesForType(Type type)
@@ -84,7 +84,7 @@ public static class StaticPropertyReflectionInitializer
             .Any(attr => attr is IDataSourceAttribute);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Data source initialization may require dynamic code generation")]
 #endif
     private static async Task InitializeStaticProperty(Type type, PropertyInfo property)

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -245,7 +245,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="action"/> is null.</exception>
     public static void OnDisposed(object? o, Action action)
     {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(action);
 #else
         if (action == null)
@@ -267,7 +267,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="asyncAction"/> is null.</exception>
     public static void OnDisposedAsync(object? o, Func<Task> asyncAction)
     {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(asyncAction);
 #else
         if (asyncAction == null)

--- a/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
+++ b/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
@@ -17,7 +17,7 @@ namespace TUnit.Engine.Building.Collectors;
 /// </summary>
 internal sealed class AotTestDataCollector : ITestDataCollector
 {
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "AOT implementation uses source-generated metadata, not reflection")]
     [UnconditionalSuppressMessage("AOT", "IL3051", Justification = "AOT implementation uses source-generated metadata, not dynamic code")]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Dynamic tests are optional and not used in AOT scenarios")]
@@ -28,7 +28,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         return CollectTestsAsync(testSessionId, filter: null);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "AOT implementation uses source-generated metadata, not reflection")]
     [UnconditionalSuppressMessage("AOT", "IL3051", Justification = "AOT implementation uses source-generated metadata, not dynamic code")]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Dynamic tests are optional and not used in AOT scenarios")]
@@ -56,7 +56,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
     /// Collects tests from TestEntry sources (the new fast path).
     /// Uses TestEntryFilterData for pure-data filtering, then materializes only matching entries.
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Materialization uses source-generated metadata")]
     #endif
     private IEnumerable<TestMetadata> CollectTestsFromTestEntries(
@@ -213,7 +213,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Dynamic test conversion requires expression compilation")]
     #endif
     private async IAsyncEnumerable<TestMetadata> ConvertDynamicTestToMetadataStreaming(
@@ -232,7 +232,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Dynamic test metadata creation requires expression extraction and reflection")]
     #endif
     private Task<TestMetadata> CreateMetadataFromDynamicDiscoveryResult(DynamicDiscoveryResult result)
@@ -317,7 +317,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         };
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Dynamic test invocation requires LambdaExpression.Compile")]
     #endif
     private static Func<object, object?[], Task> CreateAotDynamicTestInvoker(DynamicDiscoveryResult result)
@@ -350,7 +350,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         };
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Failed metadata creation accesses Type.Name and assembly info")]
     #endif
     private static TestMetadata CreateFailedTestMetadataForDynamicSource(IDynamicTestSource source, Exception ex)
@@ -372,7 +372,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
         };
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Dummy metadata creation accesses type and assembly information")]
     #endif
     private static MethodMetadata CreateDummyMethodMetadata(Type type, string methodName)

--- a/TUnit.Engine/Building/Interfaces/ITestBuilder.cs
+++ b/TUnit.Engine/Building/Interfaces/ITestBuilder.cs
@@ -25,7 +25,7 @@ internal interface ITestBuilder
     /// <param name="metadata">The test metadata with DataCombinationGenerator</param>
     /// <param name="buildingContext">Context for optimizing test building (e.g., pre-filtering during execution)</param>
     /// <returns>Collection of executable tests for all data combinations</returns>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
     Task<IEnumerable<AbstractExecutableTest>> BuildTestsFromMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext, CancellationToken cancellationToken = default);
@@ -36,7 +36,7 @@ internal interface ITestBuilder
     /// <param name="metadata">The test metadata with DataCombinationGenerator</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Stream of executable tests for all data combinations</returns>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
     IAsyncEnumerable<AbstractExecutableTest> BuildTestsStreamingAsync(
@@ -49,7 +49,7 @@ internal interface ITestBuilder
     /// and ITestDiscoveryEventReceiver events.
     /// </summary>
     /// <param name="test">The test with resolved dependencies</param>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type comes from runtime objects that cannot be annotated")]
 #endif
     ValueTask InvokePostResolutionEventsAsync(AbstractExecutableTest test);

--- a/TUnit.Engine/Building/ReflectionMetadataBuilder.cs
+++ b/TUnit.Engine/Building/ReflectionMetadataBuilder.cs
@@ -9,7 +9,7 @@ internal static class ReflectionMetadataBuilder
     /// <summary>
     /// Creates method metadata from reflection info with proper ReflectionInfo populated
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Method metadata creation uses reflection on parameters and types")]
 #endif
     public static MethodMetadata CreateMethodMetadata(
@@ -40,7 +40,7 @@ internal static class ReflectionMetadataBuilder
         return new ConcreteType(type);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Parameter metadata creation uses reflection")]
 #endif
     private static ParameterMetadata CreateParameterMetadata(
@@ -59,7 +59,7 @@ internal static class ReflectionMetadataBuilder
         };
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Class metadata creation uses reflection on constructors")]
 #endif
     private static ClassMetadata CreateClassMetadata([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -114,7 +114,7 @@ internal sealed class TestBuilder : ITestBuilder
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
     public async Task<IEnumerable<AbstractExecutableTest>> BuildTestsFromMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext, CancellationToken cancellationToken = default)
@@ -659,7 +659,7 @@ internal sealed class TestBuilder : ITestBuilder
         return resolvedTypes;
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Generic type inference uses reflection on data sources and parameters")]
 #endif
     private static Type[] TryInferClassGenericsFromDataSources(TestMetadata metadata)
@@ -953,7 +953,7 @@ internal sealed class TestBuilder : ITestBuilder
     /// Invokes event receivers after dependencies have been resolved.
     /// This is called from TestDiscoveryService after all tests are built and dependencies resolved.
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Type comes from runtime objects that cannot be annotated")]
 #endif
     public async ValueTask InvokePostResolutionEventsAsync(AbstractExecutableTest test)
@@ -1110,7 +1110,7 @@ internal sealed class TestBuilder : ITestBuilder
         await _testArgumentRegistrationService.RegisterTestArgumentsAsync(context, cancellationToken);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scoped attribute filtering uses Type.GetInterfaces and reflection")]
 #endif
     private Task InvokeDiscoveryEventReceiversAsync(TestContext context)
@@ -1410,7 +1410,7 @@ internal sealed class TestBuilder : ITestBuilder
         return null;
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type compatibility checking uses reflection")]
 #endif
     private static bool IsTypeCompatible(Type actualType, Type expectedType)
@@ -1516,7 +1516,7 @@ internal sealed class TestBuilder : ITestBuilder
         public static InstanceCreationResult CreateFailure(Exception exception) => new(null, exception);
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
     public async IAsyncEnumerable<AbstractExecutableTest> BuildTestsStreamingAsync(
@@ -1683,7 +1683,7 @@ internal sealed class TestBuilder : ITestBuilder
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Generic type resolution for instance creation uses reflection")]
 #endif
     private async Task<InstanceCreationResult> CreateInstanceForMethodDataSources(
@@ -1742,7 +1742,7 @@ internal sealed class TestBuilder : ITestBuilder
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Generic type resolution for test building uses reflection")]
 #endif
     private async Task<AbstractExecutableTest?> BuildSingleTestAsync(

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -296,7 +296,7 @@ internal sealed class TestBuilderPipeline
     /// <summary>
     /// Build tests from a single metadata item, yielding them as they're created
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test building in reflection mode uses generic type resolution which requires unreferenced code")]
 #endif
     private async IAsyncEnumerable<AbstractExecutableTest> BuildTestsFromSingleMetadataAsync(TestMetadata metadata, TestBuildingContext buildingContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/TUnit.Engine/Discovery/AsyncDataSourceHelper.cs
+++ b/TUnit.Engine/Discovery/AsyncDataSourceHelper.cs
@@ -7,7 +7,7 @@ namespace TUnit.Engine.Discovery;
 internal static class AsyncDataSourceHelper
 {
     /// Processes async generator items without evaluating them during discovery
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Typed placeholder creation uses reflection on generic types")]
 #endif
     public static List<object?[]> ProcessAsyncGeneratorItemsForDiscovery(object? item)
@@ -112,7 +112,7 @@ internal static class AsyncDataSourceHelper
         return returnType;
     }
     
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Typed placeholder creation uses reflection on generic types")]
 #endif
     private static AsyncDataSourcePlaceholder CreateTypedPlaceholder(object item, Type? resultType)

--- a/TUnit.Engine/Discovery/ConstructorHelper.cs
+++ b/TUnit.Engine/Discovery/ConstructorHelper.cs
@@ -12,7 +12,7 @@ internal static class ConstructorHelper
     /// <summary>
     /// Finds a suitable constructor for a test class, preferring ones marked with [TestConstructor]
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Constructor discovery requires reflection on constructors and attributes")]
 #endif
     public static ConstructorInfo? FindSuitableConstructor(
@@ -36,7 +36,7 @@ internal static class ConstructorHelper
     /// <summary>
     /// Creates an instance of a test class with proper constructor parameter handling
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test instance creation uses ConstructorInfo.Invoke and Activator.CreateInstance")]
 #endif
     public static object? CreateTestClassInstanceWithConstructor(
@@ -113,7 +113,7 @@ internal static class ConstructorHelper
     /// <summary>
     /// Checks if a type has required properties that need initialization
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Required property detection uses reflection on properties and attributes")]
 #endif
     public static bool HasRequiredProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
@@ -132,7 +132,7 @@ internal static class ConstructorHelper
     /// <summary>
     /// Tries to initialize required properties on an instance
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Property initialization uses reflection on properties and their types")]
 #endif
     public static void InitializeRequiredProperties(
@@ -229,7 +229,7 @@ internal static class ConstructorHelper
     /// <summary>
     /// AOT-safe wrapper for Activator.CreateInstance with proper attribution
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Activator.CreateInstance requires reflection")]
 #endif
     private static object? CreateInstanceSafely([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)

--- a/TUnit.Engine/Discovery/GenericTestHelper.cs
+++ b/TUnit.Engine/Discovery/GenericTestHelper.cs
@@ -11,7 +11,7 @@ internal static class GenericTestHelper
     /// <summary>
     /// Safely creates an instance of a test class, handling generic types
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test instance creation uses reflection on constructors")]
 #endif
     public static object? CreateTestClassInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicProperties)] Type testClass)
@@ -54,7 +54,7 @@ internal static class GenericTestHelper
     /// <summary>
     /// Gets the method on the actual implementation class, handling inherited generic methods
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Method lookup traverses type hierarchy using reflection")]
 #endif
     public static MethodInfo? GetMethodOnImplementationType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type implementationType, string methodName, Type[] parameterTypes)
@@ -164,7 +164,7 @@ internal static class GenericTestHelper
     /// <summary>
     /// Helper method to get method from type with proper AOT attribution
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Method lookup uses Type.GetMethod")]
 #endif
     private static MethodInfo? GetMethodFromType(

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -13,7 +13,7 @@ namespace TUnit.Engine.Discovery;
 /// <summary>
 /// Discovers hooks at runtime using reflection for VB.NET and other languages that don't support source generation.
 /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Uses reflection to access nested members")]
 #endif
 internal sealed class ReflectionHookDiscoveryService
@@ -162,7 +162,7 @@ internal sealed class ReflectionHookDiscoveryService
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Hook discovery scans assemblies and types using reflection")]
     #endif
     public static void DiscoverHooks()
@@ -197,7 +197,7 @@ internal sealed class ReflectionHookDiscoveryService
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetReferencedAssemblies is reflection-based but safe for checking references")]
     #endif
     private static bool ShouldScanAssembly(Assembly assembly)
@@ -251,7 +251,7 @@ internal sealed class ReflectionHookDiscoveryService
         return referencesTUnit;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types from Assembly.GetTypes() are used with appropriate annotations")]
     #endif
     private static void DiscoverHooksInAssembly(Assembly assembly)
@@ -263,7 +263,7 @@ internal sealed class ReflectionHookDiscoveryService
 
         try
         {
-            #if NET6_0_OR_GREATER
+            #if NET8_0_OR_GREATER
             [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetTypes is reflection-based but required for hook discovery")]
             [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types from Assembly.GetTypes() are passed to annotated parameters")]
             #endif
@@ -282,7 +282,7 @@ internal sealed class ReflectionHookDiscoveryService
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Types in inheritance chain preserve annotations from the annotated parameter")]
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types in inheritance chain preserve annotations from the annotated parameter")]
     #endif
@@ -825,7 +825,7 @@ internal sealed class ReflectionHookDiscoveryService
         bag.Add(hook);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Parameter types in hooks are determined at runtime and cannot be statically analyzed")]
     #endif
     private static MethodMetadata CreateMethodMetadata(
@@ -962,7 +962,7 @@ internal sealed class ReflectionHookDiscoveryService
     /// <summary>
     /// Extracts the HookExecutor from method attributes, or returns DefaultHookExecutor if not found
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Attribute type reflection is required for hook executor discovery")]
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Hook executor types are determined at runtime from attributes")]
     #endif

--- a/TUnit.Engine/Discovery/ReflectionHookRegistrar.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookRegistrar.cs
@@ -7,7 +7,7 @@ namespace TUnit.Engine.Discovery;
 /// Uses reflection to scan assemblies and register hooks into Sources at runtime.
 /// This implementation requires reflection and is NOT AOT-compatible.
 /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Hook registration uses reflection to scan assemblies and types")]
 #endif
 internal sealed class ReflectionHookRegistrar : IHookRegistrar

--- a/TUnit.Engine/Discovery/TestInstanceHelper.cs
+++ b/TUnit.Engine/Discovery/TestInstanceHelper.cs
@@ -12,7 +12,7 @@ internal static class TestInstanceHelper
     /// <summary>
     /// Creates a test instance with data from class data sources
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test instance creation uses reflection on constructors and properties")]
     #endif
     public static object? CreateTestInstanceWithData(
@@ -134,7 +134,7 @@ internal static class TestInstanceHelper
     /// <summary>
     /// Creates test instance for inherited test classes
     /// </summary>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Inherited test instance creation uses reflection on type hierarchy")]
     #endif
     public static object? CreateInheritedTestInstance(
@@ -185,7 +185,7 @@ internal static class TestInstanceHelper
         public override string ToString() => "<discovery-placeholder>";
     }
     
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Property initialization traverses type hierarchy using reflection")]
     #endif
     private static void InitializeInheritedRequiredProperties(object instance, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)

--- a/TUnit.Engine/Events/EventBatcher.cs
+++ b/TUnit.Engine/Events/EventBatcher.cs
@@ -164,7 +164,7 @@ internal sealed class EventBatcher<TEvent> : IAsyncDisposable, IDisposable where
         try
         {
             // Properly await the task with timeout
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             await _processingTask.WaitAsync(EngineDefaults.ShutdownTimeout, CancellationToken.None);
 #else
             // For .NET Framework, use Task.WhenAny to implement timeout

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -43,7 +43,7 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
         return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2046", Justification = "Reflection mode is not used in AOT/trimmed scenarios")]
     [UnconditionalSuppressMessage("AOT", "IL3051", Justification = "Reflection mode is not used in AOT scenarios")]
     #endif

--- a/TUnit.Engine/Helpers/AssemblyReferenceCache.cs
+++ b/TUnit.Engine/Helpers/AssemblyReferenceCache.cs
@@ -9,7 +9,7 @@ internal static class AssemblyReferenceCache
     private static readonly ConcurrentDictionary<Assembly, AssemblyName[]> _assemblyCache = new();
     private static readonly ConcurrentDictionary<Type, Type[]> _interfaceCache = new();
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Assembly.GetReferencedAssemblies is reflection-based but safe for checking references")]
 #endif
     public static AssemblyName[] GetReferencedAssemblies(Assembly assembly)
@@ -17,7 +17,7 @@ internal static class AssemblyReferenceCache
         return _assemblyCache.GetOrAdd(assembly, static a => a.GetReferencedAssemblies());
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Type.GetInterfaces is reflection-based but safe for type checking")]
 #endif
     public static Type[] GetInterfaces(Type type)

--- a/TUnit.Engine/Helpers/DisplayNameBuilder.cs
+++ b/TUnit.Engine/Helpers/DisplayNameBuilder.cs
@@ -140,7 +140,7 @@ internal static class DisplayNameBuilder
     /// <summary>
     /// Resolves the actual value from a data source factory result
     /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Data source value resolution may use reflection")]
 #endif
     public static async Task<object?> ResolveDataSourceValue(object? value)

--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -21,7 +21,7 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         _parallelLimitLockProvider = parallelLimitLockProvider;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     public async ValueTask ExecuteTestsWithConstraintsAsync(
@@ -114,7 +114,7 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         await Task.WhenAll(activeTasks).ConfigureAwait(false);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task WaitAndExecuteTestAsync(
@@ -135,7 +135,7 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         await ExecuteTestAndReleaseKeysAsync(test, constraintKeys, lockedKeys, lockObject, waitingTestIndex, cancellationToken).ConfigureAwait(false);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteTestAndReleaseKeysAsync(

--- a/TUnit.Engine/Scheduling/IConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/IConstraintKeyScheduler.cs
@@ -5,7 +5,7 @@ namespace TUnit.Engine.Scheduling;
 
 internal interface IConstraintKeyScheduler
 {
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     ValueTask ExecuteTestsWithConstraintsAsync(

--- a/TUnit.Engine/Scheduling/ITestScheduler.cs
+++ b/TUnit.Engine/Scheduling/ITestScheduler.cs
@@ -12,7 +12,7 @@ internal interface ITestScheduler
     /// Schedules and executes tests with optimal parallelization
     /// </summary>
     /// <returns>True if successful, false if After(TestSession) hooks failed</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     Task<bool> ScheduleAndExecuteAsync(

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -65,7 +65,7 @@ internal sealed class TestScheduler : ITestScheduler
             : new SemaphoreSlim(_maxParallelism, _maxParallelism);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     public async Task<bool> ScheduleAndExecuteAsync(
@@ -157,7 +157,7 @@ internal sealed class TestScheduler : ITestScheduler
         return true;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteGroupedTestsAsync(
@@ -228,7 +228,7 @@ internal sealed class TestScheduler : ITestScheduler
         await dynamicTestProcessingTask.ConfigureAwait(false);
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ProcessDynamicTestQueueAsync(CancellationToken cancellationToken)
@@ -301,7 +301,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteTestsAsync(
@@ -314,7 +314,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
         else
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             // Use Parallel.ForEachAsync for bounded concurrency (eliminates unbounded Task.Run queue depth)
             // This dramatically reduces ThreadPool contention and GetQueuedCompletionStatus waits
             await Parallel.ForEachAsync(
@@ -339,7 +339,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteSingleTestAsync(
@@ -365,7 +365,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteSequentiallyAsync(
@@ -383,7 +383,7 @@ internal sealed class TestScheduler : ITestScheduler
         AbstractExecutableTest[] tests,
         CancellationToken cancellationToken)
     {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         // PERFORMANCE OPTIMIZATION: Partition tests by whether they have parallel limiters
         // Tests without limiters can run with unlimited parallelism (avoiding global semaphore overhead)
         var testsWithLimiters = new List<AbstractExecutableTest>();
@@ -450,7 +450,7 @@ internal sealed class TestScheduler : ITestScheduler
 #endif
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private async Task ExecuteWithLimitAsync(
         List<AbstractExecutableTest> tests,
         CancellationToken cancellationToken)

--- a/TUnit.Engine/Services/DiscoveryCircuitBreaker.cs
+++ b/TUnit.Engine/Services/DiscoveryCircuitBreaker.cs
@@ -108,7 +108,7 @@ public sealed class DiscoveryCircuitBreaker
     {
         try
         {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
             // Try to get actual available memory on newer .NET versions
             var gcMemoryInfo = GC.GetGCMemoryInfo();
             if (gcMemoryInfo.TotalAvailableMemoryBytes > 0)

--- a/TUnit.Engine/Services/ReflectionStaticPropertyInitializer.cs
+++ b/TUnit.Engine/Services/ReflectionStaticPropertyInitializer.cs
@@ -9,7 +9,7 @@ namespace TUnit.Engine.Services;
 /// Initializes static properties using both source-generated initializers and reflection-based discovery.
 /// This implementation requires reflection and is NOT AOT-compatible.
 /// </summary>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 [RequiresUnreferencedCode("Uses reflection to discover and initialize static properties")]
 #endif
 internal sealed class ReflectionStaticPropertyInitializer : IStaticPropertyInitializer

--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -19,7 +19,7 @@ internal sealed class TestGenericTypeResolver
     /// <param name="metadata">The test metadata containing generic type information</param>
     /// <param name="testData">The runtime test data containing actual arguments</param>
     /// <returns>A result containing resolved generic types for both class and method</returns>
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
     #endif
     public static TestGenericTypeResolution Resolve(TestMetadata metadata, TestBuilder.TestData testData)
@@ -54,7 +54,7 @@ internal sealed class TestGenericTypeResolver
         return result;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
     #endif
     private static Type[] ResolveClassGenericArguments(
@@ -122,7 +122,7 @@ internal sealed class TestGenericTypeResolver
         return resolvedTypes;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
     #endif
     private static Type[] ResolveMethodGenericArguments(
@@ -417,7 +417,7 @@ internal sealed class TestGenericTypeResolver
         return resolvedTypesFromMapping;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
     #endif
     private static bool TryInferTypesFromArguments(
@@ -443,7 +443,7 @@ internal sealed class TestGenericTypeResolver
         return true;
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
     #endif
     private static void InferTypeMapping(
@@ -459,7 +459,7 @@ internal sealed class TestGenericTypeResolver
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Type mapping inference uses Type.GetInterfaces and reflection")]
 #endif
     private static bool TryInferTypeMapping(

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -207,7 +207,7 @@ internal sealed class TestDiscoveryService : IDataProducer
         }
     }
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Generic test instantiation requires MakeGenericType")]
     #endif
     public async IAsyncEnumerable<AbstractExecutableTest> DiscoverTestsFullyStreamingAsync(
@@ -309,7 +309,7 @@ internal sealed class TestDiscoveryService : IDataProducer
             return;
         }
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         await Parallel.ForEachAsync(
             allTests,
             new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },

--- a/TUnit.Engine/TestSessionCoordinator.cs
+++ b/TUnit.Engine/TestSessionCoordinator.cs
@@ -81,7 +81,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     }
 
 
-    #if NET6_0_OR_GREATER
+    #if NET8_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Test scheduler uses mode-specific services that handle reflection properly")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Test scheduler uses mode-specific services that handle dynamic code properly")]
     #endif

--- a/TUnit.Mocks.Tests/StaticAbstractMemberTests.cs
+++ b/TUnit.Mocks.Tests/StaticAbstractMemberTests.cs
@@ -1,4 +1,4 @@
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 using TUnit.Mocks;
 using TUnit.Mocks.Generated;

--- a/TUnit.TestProject.Library/TUnit.TestProject.Library.csproj
+++ b/TUnit.TestProject.Library/TUnit.TestProject.Library.csproj
@@ -7,7 +7,7 @@
     <Import Project="..\TestLibrary.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net9.0;net10.0;net472;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0;net472;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <Import Project="..\TestLibrary.targets" />

--- a/TUnit.TestProject/MatrixTests.cs
+++ b/TUnit.TestProject/MatrixTests.cs
@@ -75,7 +75,7 @@ public class MatrixTests
             .IsNotEqualTo(CountToTenEnum.Seven);
     }
 
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
         [Test]
         [MatrixDataSource]
         public async Task Range(

--- a/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester/TUnit.NugetTester.csproj
+++ b/tools/tunit-nuget-tester/TUnit.NugetTester/TUnit.NugetTester/TUnit.NugetTester.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net9.0;net10.0;net462;net472;net48;net481</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0;net462;net472;net48;net481</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <IsLibraryTestProject>true</IsLibraryTestProject>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

- Remove `net6.0` from `TargetFrameworks` in `TUnit.TestProject.Library` and `TUnit.NugetTester` csproj files
- Update all 139 `#if NET6_0_OR_GREATER` and `#if NET7_0_OR_GREATER` preprocessor directives to `#if NET8_0_OR_GREATER` across 67 files
- .NET Framework users are unaffected (covered by `netstandard2.0` targets)

Both `net6.0` (Nov 2024) and `net7.0` (May 2024) are out of support. The library projects already target `netstandard2.0;net8.0;net9.0;net10.0` — this change aligns the preprocessor directives and test projects with that reality.

Closes #4786

## Test plan

- [ ] Solution builds with 0 errors
- [ ] CI passes across all target frameworks (net8.0, net9.0, net10.0, netstandard2.0, net472)