### PR TITLE
fix: prevent StringBuilder race in console interceptor during parallel tests

### DIFF
--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -82,16 +82,13 @@ public abstract class Context : IContext, IDisposable
 
     public virtual string GetStandardOutput()
     {
-        if (_outputBuilder.Length == 0)
-        {
-            return string.Empty;
-        }
-
         _outputLock.EnterReadLock();
 
         try
         {
-            return _outputBuilder.ToString();
+            return _outputBuilder.Length == 0
+                ? string.Empty
+                : _outputBuilder.ToString();
         }
         finally
         {
@@ -101,16 +98,13 @@ public abstract class Context : IContext, IDisposable
 
     public virtual string GetErrorOutput()
     {
-        if (_errorOutputBuilder.Length == 0)
-        {
-            return string.Empty;
-        }
-
         _errorOutputLock.EnterReadLock();
 
         try
         {
-            return _errorOutputBuilder.ToString();
+            return _errorOutputBuilder.Length == 0
+                ? string.Empty
+                : _errorOutputBuilder.ToString();
         }
         finally
         {

--- a/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
@@ -165,17 +165,50 @@ internal abstract class OptimizedConsoleInterceptor : TextWriter
 
 #if NET
     public override void Write(ReadOnlySpan<char> buffer) => Write(new string(buffer));
-    public override void Write(StringBuilder? value) => Write(value?.ToString() ?? string.Empty);
+    public override void Write(StringBuilder? value) => Write(CopyStringBuilderSafely(value));
     public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new())
         => WriteAsync(new string(buffer.Span));
     public override Task WriteAsync(StringBuilder? value, CancellationToken cancellationToken = new())
-        => WriteAsync(value?.ToString() ?? string.Empty);
+        => WriteAsync(CopyStringBuilderSafely(value));
     public override void WriteLine(ReadOnlySpan<char> buffer) => WriteLine(new string(buffer));
-    public override void WriteLine(StringBuilder? value) => WriteLine(value?.ToString() ?? string.Empty);
+    public override void WriteLine(StringBuilder? value) => WriteLine(CopyStringBuilderSafely(value));
     public override Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new())
         => WriteLineAsync(new string(buffer.Span));
     public override Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = new())
-        => WriteLineAsync(value?.ToString() ?? string.Empty);
+        => WriteLineAsync(CopyStringBuilderSafely(value));
+
+    /// <summary>
+    /// Safely copies the content of a caller-owned StringBuilder into a string.
+    /// Callers (e.g., ASP.NET Core's ConsoleLogger) may pool and reuse their
+    /// StringBuilder after Write returns. If the StringBuilder is mutated
+    /// concurrently during the copy, the ArgumentOutOfRangeException is caught
+    /// and the output for that single log entry is lost rather than crashing
+    /// the test.
+    /// </summary>
+    private static string CopyStringBuilderSafely(StringBuilder? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            int length = value.Length;
+            if (length == 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Create(length, value, static (span, sb) => sb.CopyTo(0, span, span.Length));
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // The caller's StringBuilder was mutated concurrently (e.g., returned
+            // to a pool and reused by another thread). Swallow rather than crash.
+            return string.Empty;
+        }
+    }
 #endif
 
     public override IFormatProvider FormatProvider => GetOriginalOut().FormatProvider;


### PR DESCRIPTION
Fixes #5411

## Problem

`OptimizedConsoleInterceptor.Write(StringBuilder)` calls `.ToString()` on the caller's `StringBuilder`. ASP.NET Core's `ConsoleLogger` pools its `StringBuilder` and may return it to the pool immediately after `Write` returns. Under parallel test execution with code coverage, another thread can pick up the pooled `StringBuilder` and mutate it while `.ToString()` is still traversing the internal chunk list, causing:

```
ArgumentOutOfRangeException: Index was out of range. (Parameter 'chunkLength')
    at System.Text.StringBuilder.ToString()
```

## Fix

**`OptimizedConsoleInterceptor.cs`**: Replace `value?.ToString()` with `CopyStringBuilderSafely(value)` for all `StringBuilder`-accepting overloads (`Write`, `WriteAsync`, `WriteLine`, `WriteLineAsync`). The helper copies via `string.Create` + `StringBuilder.CopyTo` and catches `ArgumentOutOfRangeException` if the race hits — losing one log entry rather than crashing the test.

**`Context.cs`**: Move the `_outputBuilder.Length` early-return check inside the `ReaderWriterLockSlim` in `GetStandardOutput()` and `GetErrorOutput()`. `StringBuilder.Length` is not thread-safe and was being read outside the lock.

## Test plan

- Existing `ContextThreadSafetyTests` covers concurrent read/write on the output builder
- The flaky failure is inherently difficult to reproduce locally — it requires high concurrency + code coverage instrumentation on Linux CI