### PR TITLE
fix: prevent StringBuilder race in console interceptor during parallel tests

### DIFF
--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -82,16 +82,13 @@ public abstract class Context : IContext, IDisposable
 
     public virtual string GetStandardOutput()
     {
-        if (_outputBuilder.Length == 0)
-        {
-            return string.Empty;
-        }
-
         _outputLock.EnterReadLock();
 
         try
         {
-            return _outputBuilder.ToString();
+            return _outputBuilder.Length == 0
+                ? string.Empty
+                : _outputBuilder.ToString();
         }
         finally
         {
@@ -101,16 +98,13 @@ public abstract class Context : IContext, IDisposable
 
     public virtual string GetErrorOutput()
     {
-        if (_errorOutputBuilder.Length == 0)
-        {
-            return string.Empty;
-        }
-
         _errorOutputLock.EnterReadLock();
 
         try
         {
-            return _errorOutputBuilder.ToString();
+            return _errorOutputBuilder.Length == 0
+                ? string.Empty
+                : _errorOutputBuilder.ToString();
         }
         finally
         {

--- a/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
@@ -164,18 +164,15 @@ internal abstract class OptimizedConsoleInterceptor : TextWriter
     }
 
 #if NET
+    // StringBuilder overrides intentionally omitted — base TextWriter iterates chunks
+    // via GetChunks() and calls Write(ReadOnlySpan<char>) per chunk, avoiding ToString()
+    // which races with concurrent StringBuilder mutation (see #5411).
     public override void Write(ReadOnlySpan<char> buffer) => Write(new string(buffer));
-    public override void Write(StringBuilder? value) => Write(value?.ToString() ?? string.Empty);
     public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new())
         => WriteAsync(new string(buffer.Span));
-    public override Task WriteAsync(StringBuilder? value, CancellationToken cancellationToken = new())
-        => WriteAsync(value?.ToString() ?? string.Empty);
     public override void WriteLine(ReadOnlySpan<char> buffer) => WriteLine(new string(buffer));
-    public override void WriteLine(StringBuilder? value) => WriteLine(value?.ToString() ?? string.Empty);
     public override Task WriteLineAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = new())
         => WriteLineAsync(new string(buffer.Span));
-    public override Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = new())
-        => WriteLineAsync(value?.ToString() ?? string.Empty);
 #endif
 
     public override IFormatProvider FormatProvider => GetOriginalOut().FormatProvider;


### PR DESCRIPTION
## Summary

- **Remove StringBuilder overrides** from `OptimizedConsoleInterceptor` — the overrides called `ToString()` which traverses the entire internal chunk linked list atomically. If the caller's `StringBuilder` is mutated concurrently (e.g. pooled `StringBuilder` from ASP.NET Core logging under parallel test execution), `ToString()` throws `ArgumentOutOfRangeException(chunkLength)`. The base `TextWriter` implementation iterates chunks via `GetChunks()` and copies each one independently via `Write(ReadOnlySpan<char>)`, which the interceptor already overrides — this eliminates the race window rather than catching the exception after the fact.
- **Move `StringBuilder.Length` checks inside `ReaderWriterLockSlim`** in `Context.GetStandardOutput()` / `GetErrorOutput()` — `StringBuilder.Length` is not thread-safe and was being read outside synchronization.

## Why this differs from #5412

PR #5412 catches the `ArgumentOutOfRangeException` and swallows it (losing the log entry). This PR prevents the race entirely by not calling `ToString()` — instead letting the base `TextWriter` handle `StringBuilder` arguments chunk-by-chunk, which is the same approach used by `StreamWriter` (the normal `Console.Out`).

## Test plan

- [x] `ContextThreadSafetyTests` pass across all target frameworks
- [x] Builds cleanly with zero warnings
- [ ] The original flaky failure requires high concurrency + code coverage on Linux CI to reproduce — verify in CI

Fixes #5411