### PR TITLE
refactor(mocks): extract MockTypeModel.Visibility helper

### DIFF
--- a/TUnit.Mocks.SourceGenerator/Builders/MockBridgeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockBridgeBuilder.cs
@@ -36,8 +36,7 @@ internal static class MockBridgeBuilder
     private static void BuildBridgeInterface(CodeWriter writer, MockTypeModel model, string safeName)
     {
         writer.AppendLine("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
-        var visibility = model.IsPublic ? "public" : "internal";
-        using (writer.Block($"{visibility} interface {safeName}Mockable : {model.FullyQualifiedName}"))
+        using (writer.Block($"{model.Visibility} interface {safeName}Mockable : {model.FullyQualifiedName}"))
         {
             bool first = true;
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockEventsBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockEventsBuilder.cs
@@ -16,11 +16,9 @@ internal static class MockEventsBuilder
 
         using (writer.Block("namespace TUnit.Mocks.Generated"))
         {
-            var visibility = model.IsPublic ? "public" : "internal";
-
             // Lightweight struct holding engine reference — no allocation
             writer.AppendLine("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
-            using (writer.Block($"{visibility} readonly struct {safeName}_MockEvents"))
+            using (writer.Block($"{model.Visibility} readonly struct {safeName}_MockEvents"))
             {
                 writer.AppendLine($"internal readonly global::TUnit.Mocks.MockEngine<{mockableType}> Engine;");
                 writer.AppendLine();
@@ -29,7 +27,7 @@ internal static class MockEventsBuilder
 
             writer.AppendLine();
 
-            using (writer.Block($"{visibility} static class {safeName}_MockEventsExtensions"))
+            using (writer.Block($"{model.Visibility} static class {safeName}_MockEventsExtensions"))
             {
                 // Extension property on Mock<T> — non-nullable, only present when type has events
                 using (writer.Block($"extension(global::TUnit.Mocks.Mock<{mockableType}> mock)"))

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -37,8 +37,7 @@ internal static class MockMembersBuilder
         using (writer.Block("namespace TUnit.Mocks.Generated"))
         {
             // Extension methods class
-            var visibility = model.IsPublic ? "public" : "internal";
-            using (writer.Block($"{visibility} static class {safeName}_MockMemberExtensions"))
+            using (writer.Block($"{model.Visibility} static class {safeName}_MockMemberExtensions"))
             {
                 bool firstMember = true;
 
@@ -84,7 +83,7 @@ internal static class MockMembersBuilder
             {
                 if (!ShouldGenerateTypedWrapper(method, hasEvents)) continue;
                 writer.AppendLine();
-                GenerateUnifiedSealedClass(writer, method, safeName, instanceEventArray, visibility);
+                GenerateUnifiedSealedClass(writer, method, safeName, instanceEventArray, model.Visibility);
             }
         }
 
@@ -148,7 +147,7 @@ internal static class MockMembersBuilder
         // Ref struct returns use the void wrapper (can't use ref structs as generic type args)
         if (method.IsVoid || method.IsRefStructReturn)
         {
-            GenerateVoidUnifiedClass(writer, wrapperName, matchableParams, events, method.Parameters, hasRefStructParams, allNonOutParams, method.SpanReturnElementType, method.ReturnType, visibility,
+            GenerateVoidUnifiedClass(writer, wrapperName, visibility, matchableParams, events, method.Parameters, hasRefStructParams, allNonOutParams, method.SpanReturnElementType, method.ReturnType,
                 isAsync: method.IsAsync, isValueTask: method.IsValueTask);
         }
         else if (method.IsReturnTypeStaticAbstractInterface)
@@ -276,11 +275,10 @@ internal static class MockMembersBuilder
         }
     }
 
-    private static void GenerateVoidUnifiedClass(CodeWriter writer, string wrapperName,
+    private static void GenerateVoidUnifiedClass(CodeWriter writer, string wrapperName, string visibility,
         List<MockParameterModel> nonOutParams, EquatableArray<MockEventModel> events,
         EquatableArray<MockParameterModel> allParameters, bool hasRefStructParams, List<MockParameterModel> allNonOutParams,
-        string? spanReturnElementType, string? spanReturnType,
-        string visibility,
+        string? spanReturnElementType = null, string? spanReturnType = null,
         bool isAsync = false, bool isValueTask = false)
     {
         var builderType = "global::TUnit.Mocks.Setup.VoidMethodSetupBuilder";

--- a/TUnit.Mocks.SourceGenerator/Builders/MockStaticExtensionBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockStaticExtensionBuilder.cs
@@ -23,12 +23,11 @@ internal static class MockStaticExtensionBuilder
 
         using (writer.Block("namespace TUnit.Mocks"))
         {
-            var visibility = model.IsPublic ? "public" : "internal";
-            using (writer.Block($"{visibility} static class {extensionClassName}_MockStaticExtension"))
+            using (writer.Block($"{model.Visibility} static class {extensionClassName}_MockStaticExtension"))
             {
                 using (writer.Block($"extension({model.FullyQualifiedName})"))
                 {
-                    using (writer.Block($"{visibility} static global::{mockNamespace}.{shortName}Mock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)"))
+                    using (writer.Block($"{model.Visibility} static global::{mockNamespace}.{shortName}Mock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)"))
                     {
                         writer.AppendLine($"return (global::{mockNamespace}.{shortName}Mock)global::TUnit.Mocks.Mock.Of<{mockableType}>(behavior);");
                     }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
@@ -37,8 +37,7 @@ internal static class MockWrapperTypeBuilder
 
         using (writer.Block($"namespace {mockNamespace}"))
         {
-            var visibility = model.IsPublic ? "public" : "internal";
-            using (writer.Block($"{visibility} sealed class {safeName}Mock : global::TUnit.Mocks.Mock<{mockableType}>, {model.FullyQualifiedName}"))
+            using (writer.Block($"{model.Visibility} sealed class {safeName}Mock : global::TUnit.Mocks.Mock<{mockableType}>, {model.FullyQualifiedName}"))
             {
                 writer.AppendLine("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
                 writer.AppendLine($"internal {safeName}Mock({mockableType} mockObject, global::TUnit.Mocks.MockEngine<{mockableType}> engine)");

--- a/TUnit.Mocks.SourceGenerator/Models/MockTypeModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockTypeModel.cs
@@ -31,6 +31,9 @@ internal sealed record MockTypeModel : IEquatable<MockTypeModel>
     /// </summary>
     public bool IsPublic { get; init; } = true;
 
+    /// <summary>The C# visibility keyword to emit on generated wrapper/extension types.</summary>
+    public string Visibility => IsPublic ? "public" : "internal";
+
     public bool Equals(MockTypeModel? other)
     {
         if (other is null) return false;


### PR DESCRIPTION
## Summary
- Follow-up cleanup to #5426 fix (commit 53bd3505d on main).
- Extracts a single `Visibility` property on `MockTypeModel` to replace the duplicated `IsPublic ? "public" : "internal"` ternary across five builders.
- Restores the optional defaults on `spanReturnElementType` / `spanReturnType` in `GenerateVoidUnifiedClass` by moving the `visibility` parameter earlier in the signature (it had been demoted to required to make room for the new param).

## Test plan
- [x] `TUnit.Mocks.Tests` builds clean
- [x] `Issue5426Tests` (3/3) pass