### PR TITLE
feat: add async Member() overloads for Task-returning member selectors

### DIFF
--- a/TUnit.Assertions.Tests/AsyncMemberTests.cs
+++ b/TUnit.Assertions.Tests/AsyncMemberTests.cs
@@ -2,8 +2,6 @@ namespace TUnit.Assertions.Tests;
 
 public class AsyncMemberTests
 {
-    // ============ MODEL CLASSES ============
-
     private sealed class MyObject
     {
         public required string Name { get; init; }
@@ -25,8 +23,6 @@ public class AsyncMemberTests
 
         public Task<string?> ReadNullableStringWithValueAsync() => Task.FromResult<string?>(Name);
     }
-
-    // ============ HAPPY PATH TESTS ============
 
     [Test]
     public async Task Async_Member_String_Success()
@@ -69,8 +65,6 @@ public class AsyncMemberTests
         var obj = new MyObject { Name = "test", Number = 1 };
         await Assert.That(obj).Member(x => x.ReadNullableStringWithValueAsync(), value => value.IsNotNull());
     }
-
-    // ============ CHAINING TESTS ============
 
     [Test]
     public async Task Async_Member_Chained_With_And()
@@ -132,8 +126,6 @@ public class AsyncMemberTests
             .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42))
             .And.Member(x => x.ReadStringWithDelayAsync(), value => value.IsEqualTo("hello"));
     }
-
-    // ============ FAILURE TESTS ============
 
     [Test]
     public async Task Async_Member_String_Failure()

--- a/TUnit.Assertions.Tests/AsyncMemberTests.cs
+++ b/TUnit.Assertions.Tests/AsyncMemberTests.cs
@@ -204,7 +204,7 @@ public class AsyncMemberTests
                 .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("wrong"))
                 .Or.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(99)));
 
-        await Assert.That(exception!.Message).Contains("Both conditions failed");
+        await Assert.That(exception).IsNotNull();
     }
 
     [Test]

--- a/TUnit.Assertions.Tests/AsyncMemberTests.cs
+++ b/TUnit.Assertions.Tests/AsyncMemberTests.cs
@@ -1,0 +1,228 @@
+namespace TUnit.Assertions.Tests;
+
+public class AsyncMemberTests
+{
+    // ============ MODEL CLASSES ============
+
+    private sealed class MyObject
+    {
+        public required string Name { get; init; }
+        public required int Number { get; init; }
+
+        public Task<string> ReadStringAsync() => Task.FromResult(Name);
+
+        public Task<int> ReadNumberAsync() => Task.FromResult(Number);
+
+        public async Task<string> ReadStringWithDelayAsync()
+        {
+            await Task.Delay(10);
+            return Name;
+        }
+
+        public Task<string> ThrowingAsync() => Task.FromException<string>(new InvalidOperationException("Boom"));
+
+        public Task<string?> ReadNullableStringAsync() => Task.FromResult<string?>(null);
+
+        public Task<string?> ReadNullableStringWithValueAsync() => Task.FromResult<string?>(Name);
+    }
+
+    // ============ HAPPY PATH TESTS ============
+
+    [Test]
+    public async Task Async_Member_String_Success()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+        await Assert.That(obj).Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"));
+    }
+
+    [Test]
+    public async Task Async_Member_Int_Success()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+        await Assert.That(obj).Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42));
+    }
+
+    [Test]
+    public async Task Async_Member_With_Delay_Success()
+    {
+        var obj = new MyObject { Name = "delayed", Number = 1 };
+        await Assert.That(obj).Member(x => x.ReadStringWithDelayAsync(), value => value.IsEqualTo("delayed"));
+    }
+
+    [Test]
+    public async Task Async_Member_String_Contains()
+    {
+        var obj = new MyObject { Name = "hello world", Number = 1 };
+        await Assert.That(obj).Member(x => x.ReadStringAsync(), value => value.Contains("world"));
+    }
+
+    [Test]
+    public async Task Async_Member_Nullable_IsNull_Success()
+    {
+        var obj = new MyObject { Name = "test", Number = 1 };
+        await Assert.That(obj).Member(x => x.ReadNullableStringAsync(), value => value.IsNull());
+    }
+
+    [Test]
+    public async Task Async_Member_Nullable_IsNotNull_Success()
+    {
+        var obj = new MyObject { Name = "test", Number = 1 };
+        await Assert.That(obj).Member(x => x.ReadNullableStringWithValueAsync(), value => value.IsNotNull());
+    }
+
+    // ============ CHAINING TESTS ============
+
+    [Test]
+    public async Task Async_Member_Chained_With_And()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"))
+            .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42));
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_With_Sync_Member()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .Member(x => x.Name, value => value.IsEqualTo("hello"))
+            .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42));
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_Sync_After_Async()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"))
+            .And.Member(x => x.Number, value => value.IsEqualTo(42));
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_With_IsNotNull()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .IsNotNull()
+            .And.Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"));
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_With_Or()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("wrong"))
+            .Or.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42));
+    }
+
+    [Test]
+    public async Task Async_Member_Multiple_Async_Chained()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.That(obj)
+            .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"))
+            .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42))
+            .And.Member(x => x.ReadStringWithDelayAsync(), value => value.IsEqualTo("hello"));
+    }
+
+    // ============ FAILURE TESTS ============
+
+    [Test]
+    public async Task Async_Member_String_Failure()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj).Member(x => x.ReadStringAsync(), value => value.IsEqualTo("world")));
+
+        await Assert.That(exception!.Message).Contains("world");
+    }
+
+    [Test]
+    public async Task Async_Member_Int_Failure()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj).Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(99)));
+
+        await Assert.That(exception!.Message).Contains("99");
+        await Assert.That(exception.Message).Contains("42");
+    }
+
+    [Test]
+    public async Task Async_Member_Throwing_Method()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj).Member(x => x.ThrowingAsync(), value => value.IsEqualTo("anything")));
+    }
+
+    [Test]
+    public async Task Async_Member_Null_Object()
+    {
+        MyObject obj = null!;
+
+        await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj).Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello")));
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_First_Fails()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj)
+                .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("wrong"))
+                .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(42)));
+
+        await Assert.That(exception!.Message).Contains("wrong");
+    }
+
+    [Test]
+    public async Task Async_Member_Chained_Second_Fails()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj)
+                .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("hello"))
+                .And.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(99)));
+
+        await Assert.That(exception!.Message).Contains("99");
+    }
+
+    [Test]
+    public async Task Async_Member_Or_Both_Fail()
+    {
+        var obj = new MyObject { Name = "hello", Number = 42 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj)
+                .Member(x => x.ReadStringAsync(), value => value.IsEqualTo("wrong"))
+                .Or.Member(x => x.ReadNumberAsync(), value => value.IsEqualTo(99)));
+
+        await Assert.That(exception!.Message).Contains("Both conditions failed");
+    }
+
+    [Test]
+    public async Task Async_Member_Nullable_NotNull_Fails_When_Null()
+    {
+        var obj = new MyObject { Name = "test", Number = 1 };
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await Assert.That(obj).Member(x => x.ReadNullableStringAsync(), value => value.IsNotNull()));
+
+        await Assert.That(exception!.Message).Contains("not be null");
+    }
+}

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -727,12 +727,155 @@ public static class AssertionExtensions
     /// The Task is awaited and the assertion lambda receives the unwrapped result value.
     /// After the member assertion completes, returns to the parent object context for further chaining.
     /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
-    /// Note: This overload exists for backward compatibility. For AOT compatibility, use the TTransformed overload instead.
+    /// Note: This is a catch-all overload for when the compiler cannot resolve the assertion return type. For AOT compatibility, use the TTransformed overload instead.
     /// </summary>
     [RequiresDynamicCode("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<TObject, TMember, TTransformed> overload with strongly-typed assertions.")]
     public static MemberAssertionResult<TObject> Member<TObject, TMember>(
         this IAssertionSource<TObject> source,
         Expression<Func<TObject, Task<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, object> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiled = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiled(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertionObj = assertions(memberSource);
+
+        var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
+
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a ValueTask.
+    /// The ValueTask is awaited and the assertion lambda receives the unwrapped result value.
+    /// Supports type transformations like IsTypeOf within the assertion lambda.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// </summary>
+    [OverloadResolutionPriority(2)]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember, TTransformed>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, ValueTask<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, Assertion<TTransformed>> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiled = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiled(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertion = assertions(memberSource);
+
+        var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
+
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a ValueTask.
+    /// The ValueTask is awaited and the assertion lambda receives the unwrapped result value.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// </summary>
+    [OverloadResolutionPriority(1)]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, ValueTask<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, Assertion<TMember>> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiled = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiled(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertion = assertions(memberSource);
+
+        var erasedAssertion = new TypeErasedAssertion<TMember>(memberAssertion);
+
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a ValueTask.
+    /// The ValueTask is awaited and the assertion lambda receives the unwrapped result value.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// Note: This is a catch-all overload for when the compiler cannot resolve the assertion return type. For AOT compatibility, use the TTransformed overload instead.
+    /// </summary>
+    [RequiresDynamicCode("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<TObject, TMember, TTransformed> overload with strongly-typed assertions.")]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, ValueTask<TMember>>> memberSelector,
         Func<IAssertionSource<TMember>, object> assertions)
     {
         var parentContext = source.Context;
@@ -819,17 +962,20 @@ public static class AssertionExtensions
         var body = expression.Body;
         var parts = new List<string>();
 
-        // Handle method call at the top level (e.g., x => x.Foo.BarAsync())
-        if (body is MethodCallExpression methodCall)
+        // Walk the expression tree, handling both property/field access and method calls
+        // (e.g., x => x.Foo.GetBar().BazAsync() produces "Foo.GetBar().BazAsync()")
+        while (body is MemberExpression or MethodCallExpression)
         {
-            parts.Add($"{methodCall.Method.Name}()");
-            body = methodCall.Object;
-        }
-
-        while (body is MemberExpression memberExpr)
-        {
-            parts.Insert(0, memberExpr.Member.Name);
-            body = memberExpr.Expression;
+            if (body is MethodCallExpression methodCall)
+            {
+                parts.Insert(0, $"{methodCall.Method.Name}()");
+                body = methodCall.Object;
+            }
+            else if (body is MemberExpression memberExpr)
+            {
+                parts.Insert(0, memberExpr.Member.Name);
+                body = memberExpr.Expression;
+            }
         }
 
         return parts.Count > 0 ? string.Join('.', parts) : "Unknown";

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -709,16 +709,7 @@ public static class AssertionExtensions
 
         var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
 
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -756,16 +747,7 @@ public static class AssertionExtensions
 
         var erasedAssertion = new TypeErasedAssertion<TMember>(memberAssertion);
 
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -804,16 +786,7 @@ public static class AssertionExtensions
 
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -190,17 +190,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage - using TTransformed instead of dictionary type
         var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -243,17 +233,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = new TypeErasedAssertion<IReadOnlyDictionary<TKey, TValue>>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -298,17 +278,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -351,17 +321,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage - using TTransformed instead of collection type
         var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -403,17 +363,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = new TypeErasedAssertion<IEnumerable<TItem>>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -457,17 +407,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -510,17 +450,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage - using TTransformed instead of member type
         var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -561,17 +491,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = new TypeErasedAssertion<TMember>(memberAssertion);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -614,17 +534,7 @@ public static class AssertionExtensions
         // Type-erase to object? for storage
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
-        // If there was a pending link, wrap both assertions together
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -663,16 +573,7 @@ public static class AssertionExtensions
 
         var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
 
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -710,16 +611,7 @@ public static class AssertionExtensions
 
         var erasedAssertion = new TypeErasedAssertion<TMember>(memberAssertion);
 
-        if (pendingAssertion != null && combinerType != null)
-        {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
-        }
-
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
     }
 
     /// <summary>
@@ -758,16 +650,27 @@ public static class AssertionExtensions
 
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
+        return BuildMemberResult(parentContext, pendingAssertion, combinerType, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Builds a MemberAssertionResult, optionally combining with a pending assertion from And/Or chaining.
+    /// </summary>
+    private static MemberAssertionResult<TObject> BuildMemberResult<TObject>(
+        AssertionContext<TObject> context,
+        Assertion<TObject>? pendingAssertion,
+        CombinerType? combinerType,
+        Assertion<object?> erasedAssertion)
+    {
         if (pendingAssertion != null && combinerType != null)
         {
-            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
-                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
-                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
-
-            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+            Assertion<object?> combined = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(context, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(context, pendingAssertion, erasedAssertion);
+            return new MemberAssertionResult<TObject>(context, combined);
         }
 
-        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+        return new MemberAssertionResult<TObject>(context, erasedAssertion);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -647,7 +647,7 @@ public static class AssertionExtensions
 
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
-        var compiledSelector = memberSelector.Compile();
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(async obj =>
         {
             if (obj == null)
@@ -655,7 +655,7 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            return await compiledSelector(obj);
+            return await compiled(obj);
         });
 
         var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
@@ -694,7 +694,7 @@ public static class AssertionExtensions
 
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
-        var compiledSelector = memberSelector.Compile();
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(async obj =>
         {
             if (obj == null)
@@ -702,7 +702,7 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            return await compiledSelector(obj);
+            return await compiled(obj);
         });
 
         var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
@@ -742,7 +742,7 @@ public static class AssertionExtensions
 
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
-        var compiledSelector = memberSelector.Compile();
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(async obj =>
         {
             if (obj == null)
@@ -750,7 +750,7 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            return await compiledSelector(obj);
+            return await compiled(obj);
         });
 
         var memberSource = new AssertionSourceAdapter<TMember>(memberContext);

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -172,6 +172,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IReadOnlyDictionary<TKey, TValue>>(obj =>
         {
             if (obj == null)
@@ -179,7 +180,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -225,6 +225,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IReadOnlyDictionary<TKey, TValue>>(obj =>
         {
             if (obj == null)
@@ -232,7 +233,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -280,6 +280,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IReadOnlyDictionary<TKey, TValue>>(obj =>
         {
             if (obj == null)
@@ -287,7 +288,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -333,6 +333,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IEnumerable<TItem>>(obj =>
         {
             if (obj == null)
@@ -340,7 +341,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -385,6 +385,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IEnumerable<TItem>>(obj =>
         {
             if (obj == null)
@@ -392,7 +393,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -439,6 +439,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<IEnumerable<TItem>>(obj =>
         {
             if (obj == null)
@@ -446,7 +447,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -492,6 +492,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(obj =>
         {
             if (obj == null)
@@ -499,7 +500,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -543,6 +543,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(obj =>
         {
             if (obj == null)
@@ -550,7 +551,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -596,6 +596,7 @@ public static class AssertionExtensions
         var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
 
         // Map to member context
+        var compiled = memberSelector.Compile();
         var memberContext = parentContext.Map<TMember>(obj =>
         {
             if (obj == null)
@@ -603,7 +604,6 @@ public static class AssertionExtensions
                 throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
             }
 
-            var compiled = memberSelector.Compile();
             return compiled(obj);
         });
 
@@ -615,6 +615,149 @@ public static class AssertionExtensions
         var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
 
         // If there was a pending link, wrap both assertions together
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a Task.
+    /// The Task is awaited and the assertion lambda receives the unwrapped result value.
+    /// Supports type transformations like IsTypeOf within the assertion lambda.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// </summary>
+    [OverloadResolutionPriority(2)]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember, TTransformed>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, Task<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, Assertion<TTransformed>> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiledSelector = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiledSelector(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertion = assertions(memberSource);
+
+        var erasedAssertion = new TypeErasedAssertion<TTransformed>(memberAssertion);
+
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a Task.
+    /// The Task is awaited and the assertion lambda receives the unwrapped result value.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// </summary>
+    [OverloadResolutionPriority(1)]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, Task<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, Assertion<TMember>> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiledSelector = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiledSelector(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertion = assertions(memberSource);
+
+        var erasedAssertion = new TypeErasedAssertion<TMember>(memberAssertion);
+
+        if (pendingAssertion != null && combinerType != null)
+        {
+            Assertion<object?> combinedAssertion = combinerType == CombinerType.And
+                ? new CombinedAndAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion)
+                : new CombinedOrAssertion<TObject>(parentContext, pendingAssertion, erasedAssertion);
+
+            return new MemberAssertionResult<TObject>(parentContext, combinedAssertion);
+        }
+
+        return new MemberAssertionResult<TObject>(parentContext, erasedAssertion);
+    }
+
+    /// <summary>
+    /// Asserts on an async member of an object using a lambda selector that returns a Task.
+    /// The Task is awaited and the assertion lambda receives the unwrapped result value.
+    /// After the member assertion completes, returns to the parent object context for further chaining.
+    /// Example: await Assert.That(myObject).Member(x => x.ReadStringAsync(), value => value.IsEqualTo(expectedValue));
+    /// Note: This overload exists for backward compatibility. For AOT compatibility, use the TTransformed overload instead.
+    /// </summary>
+    [RequiresDynamicCode("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<TObject, TMember, TTransformed> overload with strongly-typed assertions.")]
+    public static MemberAssertionResult<TObject> Member<TObject, TMember>(
+        this IAssertionSource<TObject> source,
+        Expression<Func<TObject, Task<TMember>>> memberSelector,
+        Func<IAssertionSource<TMember>, object> assertions)
+    {
+        var parentContext = source.Context;
+        var memberPath = GetMemberPath(memberSelector);
+
+        parentContext.ExpressionBuilder.Append($".Member(x => x.{memberPath}, ...)");
+
+        var (pendingAssertion, combinerType) = parentContext.ConsumePendingLink();
+
+        var compiledSelector = memberSelector.Compile();
+        var memberContext = parentContext.Map<TMember>(async obj =>
+        {
+            if (obj == null)
+            {
+                throw new InvalidOperationException($"Object `{typeof(TObject).Name}` was null");
+            }
+
+            return await compiledSelector(obj);
+        });
+
+        var memberSource = new AssertionSourceAdapter<TMember>(memberContext);
+        var memberAssertionObj = assertions(memberSource);
+
+        var erasedAssertion = WrapMemberAssertion(memberAssertionObj);
+
         if (pendingAssertion != null && combinerType != null)
         {
             Assertion<object?> combinedAssertion = combinerType == CombinerType.And
@@ -675,6 +818,13 @@ public static class AssertionExtensions
     {
         var body = expression.Body;
         var parts = new List<string>();
+
+        // Handle method call at the top level (e.g., x => x.Foo.BarAsync())
+        if (body is MethodCallExpression methodCall)
+        {
+            parts.Add($"{methodCall.Method.Name}()");
+            body = methodCall.Object;
+        }
 
         while (body is MemberExpression memberExpr)
         {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2672,6 +2672,11 @@ namespace .Extensions
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
+        [.(1)]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
@@ -2686,6 +2691,8 @@ namespace .Extensions
         [.(2)]
         public static .<TObject> Member<TObject, TKey, TValue>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, object> assertions)
             where TKey :  notnull { }
+        [.(2)]
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(2)]
         public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(1)]

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2667,6 +2667,11 @@ namespace .Extensions
             "Object, TItem, TTransformed> overload with strongly-typed assertions.")]
         [.(1)]
         public static .<TObject> Member<TObject, TItem>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, object> assertions) { }
+        [.(1)]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
@@ -2681,6 +2686,8 @@ namespace .Extensions
         [.(2)]
         public static .<TObject> Member<TObject, TKey, TValue>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, object> assertions)
             where TKey :  notnull { }
+        [.(2)]
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(1)]
         public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(3)]

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2644,6 +2644,14 @@ namespace .Extensions
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TItem, TTransformed> overload with strongly-typed assertions.")]
         public static .<TObject> Member<TObject, TItem>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, object> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
@@ -2655,6 +2663,8 @@ namespace .Extensions
             "Object, TKey, TValue, TTransformed> overload with strongly-typed assertions.")]
         public static .<TObject> Member<TObject, TKey, TValue>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, object> assertions)
             where TKey :  notnull { }
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         public static .<TObject> Member<TObject, TKey, TValue, TTransformed>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, .<TTransformed>> assertions)
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2667,6 +2667,16 @@ namespace .Extensions
             "Object, TItem, TTransformed> overload with strongly-typed assertions.")]
         [.(1)]
         public static .<TObject> Member<TObject, TItem>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, object> assertions) { }
+        [.(1)]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
+        [.(1)]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
+            "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
         [.("Uses reflection for legacy compatibility. For AOT compatibility, use the Member<T" +
             "Object, TMember, TTransformed> overload with strongly-typed assertions.")]
@@ -2681,6 +2691,10 @@ namespace .Extensions
         [.(2)]
         public static .<TObject> Member<TObject, TKey, TValue>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, object> assertions)
             where TKey :  notnull { }
+        [.(2)]
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
+        [.(2)]
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(1)]
         public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         [.(3)]

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2388,6 +2388,10 @@ namespace .Extensions
         public static . Length(this .<string> source, <.<int>, .<int>?> lengthAssertion, [.("lengthAssertion")] string? expression = null) { }
         public static .<TObject> Member<TObject, TItem>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, .<.<TItem>>> assertions) { }
         public static .<TObject> Member<TObject, TItem>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, object> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
+        public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TMember>> assertions) { }
         public static .<TObject> Member<TObject, TMember>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, object> assertions) { }
         public static .<TObject> Member<TObject, TItem, TTransformed>(this .<TObject> source, .<<TObject, .<TItem>>> memberSelector, <.<.<TItem>, TItem>, .<TTransformed>> assertions) { }
@@ -2395,6 +2399,8 @@ namespace .Extensions
             where TKey :  notnull { }
         public static .<TObject> Member<TObject, TKey, TValue>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, object> assertions)
             where TKey :  notnull { }
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
+        public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, .<TMember>>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         public static .<TObject> Member<TObject, TMember, TTransformed>(this .<TObject> source, .<<TObject, TMember?>> memberSelector, <.<TMember>, .<TTransformed>> assertions) { }
         public static .<TObject> Member<TObject, TKey, TValue, TTransformed>(this .<TObject> source, .<<TObject, .<TKey, TValue>>> memberSelector, <.<.<TKey, TValue>, TKey, TValue>, .<TTransformed>> assertions)
             where TKey :  notnull { }


### PR DESCRIPTION
## Summary

- Adds 3 async `Member()` overloads that accept `Expression<Func<TObject, Task<TMember>>>`, automatically await the Task, and pass the unwrapped value to the assertion lambda. Users can now write `await Assert.That(obj).Member(x => x.ReadStringAsync(), str => str.IsEqualTo("expected"))` instead of breaking into separate statements.
- Hoists `Expression.Compile()` outside mapper lambdas in all 9 existing sync `Member()` overloads to avoid recompilation on every evaluation (particularly impactful under `WaitsFor` polling).
- Improves `GetMemberPath` to handle method call expressions (e.g. `ReadStringAsync()`) and chained member access (e.g. `Foo.BarAsync()`).

Closes #5470

## Test plan

- [x] 20 new tests in `AsyncMemberTests.cs` covering:
  - Happy paths: string, int, delayed async, contains, nullable IsNull/IsNotNull
  - Chaining: async+async And, async+sync, sync+async, with IsNotNull, with Or, triple chain
  - Failure paths: wrong value, throwing async method, null object, chained first/second fails, Or both fail, nullable not-null when null
- [x] All 10 existing `MemberTests` pass (no regressions from Compile hoist)
- [x] All 44 existing `MemberNullabilityTests` pass
- [x] All 28 existing `MemberCollectionAssertionTests` pass