### PR TITLE
feat(reporters): overhaul GitHub Actions step summary

### DIFF
--- a/TUnit.Engine/Extensions/TestApplicationBuilderExtensions.cs
+++ b/TUnit.Engine/Extensions/TestApplicationBuilderExtensions.cs
@@ -28,6 +28,8 @@ public static class TestApplicationBuilderExtensions
         var htmlReporter = new Reporters.Html.HtmlReporter(extension);
         var htmlReporterCommandProvider = new HtmlReporterCommandProvider(extension);
 
+        htmlReporter.SetGitHubReporter(githubReporter);
+
         testApplicationBuilder.RegisterTestFramework(
             serviceProvider => new TestFrameworkCapabilities(CreateCapabilities(serviceProvider)),
             (capabilities, serviceProvider) => new TUnitTestFramework(extension, serviceProvider, capabilities));

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -216,15 +216,11 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
             if (finalStateCount > 1 && last.TryGetValue(kvp.Key, out var lastUpdate))
             {
-                var passed = lastUpdate.TestNode.Properties.AsEnumerable().Any(p => p is PassedTestNodeStateProperty);
-                if (passed)
+                var props = lastUpdate.TestNode.Properties.AsEnumerable();
+                if (props.Any(p => p is PassedTestNodeStateProperty))
                 {
-                    var testMethodIdentifier = lastUpdate.TestNode.Properties.AsEnumerable()
-                        .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
-                    var className = testMethodIdentifier?.TypeName;
-                    var displayName = lastUpdate.TestNode.DisplayName;
-                    var name = string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
-                    var timing = lastUpdate.TestNode.Properties.AsEnumerable().OfType<TimingProperty>().FirstOrDefault();
+                    var name = GetTestDisplayName(lastUpdate.TestNode);
+                    var timing = props.OfType<TimingProperty>().FirstOrDefault();
                     flakyTests.Add((name, finalStateCount, timing?.GlobalTiming.Duration));
                 }
             }
@@ -315,18 +311,12 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         foreach (var testNodeUpdateMessage in last.Values)
         {
-            var passedProp = testNodeUpdateMessage.TestNode.Properties.OfType<PassedTestNodeStateProperty>().FirstOrDefault();
-            if (passedProp != null) continue;
+            var props = testNodeUpdateMessage.TestNode.Properties.AsEnumerable();
+            if (props.Any(p => p is PassedTestNodeStateProperty)) continue;
 
-            var testMethodIdentifier = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
-                .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
-            var className = testMethodIdentifier?.TypeName;
-            var displayName = testNodeUpdateMessage.TestNode.DisplayName;
-            var name = string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
-            var stateProperty = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
-                .FirstOrDefault(p => p is TestNodeStateProperty);
-            var timingProp = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
-                .OfType<TimingProperty>().FirstOrDefault();
+            var name = GetTestDisplayName(testNodeUpdateMessage.TestNode);
+            var stateProperty = props.FirstOrDefault(p => p is TestNodeStateProperty);
+            var timingProp = props.OfType<TimingProperty>().FirstOrDefault();
             var duration = FormatDuration(timingProp?.GlobalTiming.Duration);
 
             var isFailed = stateProperty is FailedTestNodeStateProperty or ErrorTestNodeStateProperty
@@ -559,6 +549,15 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             TimeoutTestNodeStateProperty => "Timed Out",
             _ => "Unknown"
         };
+    }
+
+    private static string GetTestDisplayName(TestNode testNode)
+    {
+        var testMethodIdentifier = testNode.Properties.AsEnumerable()
+            .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
+        var className = testMethodIdentifier?.TypeName;
+        var displayName = testNode.DisplayName;
+        return string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
     }
 
     private static string? GetSourceLink(TestNode testNode, string? repo, string? sha, string? workspace, string serverUrl)

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -266,73 +266,156 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             stringBuilder.AppendLine("> **Tip:** You can have HTML reports uploaded automatically as artifacts. [Learn more](https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload)");
         }
 
+        if (failed.Length > 0)
+        {
+            var failureGroups = failed
+                .Select(x =>
+                {
+                    var state = x.Value.TestNode.Properties.AsEnumerable().FirstOrDefault(p => p is TestNodeStateProperty);
+                    var exceptionType = state switch
+                    {
+                        FailedTestNodeStateProperty f => f.Exception?.GetType().Name ?? "Unknown",
+                        ErrorTestNodeStateProperty e => e.Exception?.GetType().Name ?? "Unknown",
+                        _ => "Unknown"
+                    };
+                    var method = x.Value.TestNode.Properties.AsEnumerable()
+                        .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
+                    return (ExceptionType: exceptionType, ClassName: method?.TypeName ?? "Unknown");
+                })
+                .GroupBy(x => x.ExceptionType)
+                .OrderByDescending(g => g.Count())
+                .Take(3);
+
+            var diagParts = failureGroups.Select(g =>
+            {
+                var topClass = g.GroupBy(x => x.ClassName).OrderByDescending(c => c.Count()).First();
+                return $"{g.Count()} \u00d7 `{g.Key}` in `{topClass.Key}`";
+            });
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine($"> **Quick diagnosis:** {string.Join(", ", diagParts)}");
+        }
+
         if (passedCount == last.Count)
         {
             return WriteFile(stringBuilder.ToString());
         }
 
-        // Build the details table
-        var detailsBuilder = new StringBuilder();
-        detailsBuilder.AppendLine();
-        detailsBuilder.AppendLine();
-        detailsBuilder.AppendLine("### Details");
-        detailsBuilder.AppendLine();
-        detailsBuilder.AppendLine("""<table role="table" tabindex="0">""");
-        detailsBuilder.AppendLine("<thead><tr><th>Test</th><th>Status</th><th>Details</th><th>Duration</th></tr></thead>");
-        detailsBuilder.AppendLine("<tbody>");
+        // Separate failures from other non-passing tests
+        var failureMessages = new List<(string Name, string? SourceLink, string Details, string Duration)>();
+        var otherMessages = new List<(string Name, string Status, string Details, string Duration)>();
 
         foreach (var testNodeUpdateMessage in last.Values)
         {
-            var testMethodIdentifier = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
-                .OfType<TestMethodIdentifierProperty>()
-                .FirstOrDefault();
+            var passedProp = testNodeUpdateMessage.TestNode.Properties.OfType<PassedTestNodeStateProperty>().FirstOrDefault();
+            if (passedProp != null) continue;
 
+            var testMethodIdentifier = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
+                .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
             var className = testMethodIdentifier?.TypeName;
             var displayName = testNodeUpdateMessage.TestNode.DisplayName;
             var name = string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
+            var stateProperty = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
+                .FirstOrDefault(p => p is TestNodeStateProperty);
+            var timingProp = testNodeUpdateMessage.TestNode.Properties.AsEnumerable()
+                .OfType<TimingProperty>().FirstOrDefault();
+            var duration = FormatDuration(timingProp?.GlobalTiming.Duration);
 
-            var passedProperty = testNodeUpdateMessage.TestNode.Properties.OfType<PassedTestNodeStateProperty>().FirstOrDefault();
+            var isFailed = stateProperty is FailedTestNodeStateProperty or ErrorTestNodeStateProperty
+                or TimeoutTestNodeStateProperty;
 
-            if (passedProperty != null)
+            if (isFailed)
             {
-                continue;
+                var sourceLink = GetSourceLink(testNodeUpdateMessage.TestNode);
+                var details = GetDetails(stateProperty, testNodeUpdateMessage.TestNode.Properties);
+                failureMessages.Add((name, sourceLink, details, duration));
+            }
+            else
+            {
+                var status = GetStatus(stateProperty);
+                var details = GetDetails(stateProperty, testNodeUpdateMessage.TestNode.Properties);
+                otherMessages.Add((name, status, details, duration));
+            }
+        }
+
+        // Show top failures inline
+        const int maxInlineFailures = 5;
+        if (failureMessages.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("#### Failures");
+            stringBuilder.AppendLine();
+
+            var inlineCount = Math.Min(failureMessages.Count, maxInlineFailures);
+            for (int i = 0; i < inlineCount; i++)
+            {
+                var (name, sourceLink, details, duration) = failureMessages[i];
+                var sourcePart = sourceLink is not null ? $" \u2014 {sourceLink}" : "";
+                stringBuilder.AppendLine("<details>");
+                stringBuilder.AppendLine($"<summary><code>{name}</code> ({duration}){sourcePart}</summary>");
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine(details);
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("</details>");
             }
 
-            var stateProperty = testNodeUpdateMessage.TestNode.Properties.AsEnumerable().FirstOrDefault(p => p is TestNodeStateProperty);
-
-            var status = GetStatus(stateProperty);
-
-            var details = GetDetails(stateProperty, testNodeUpdateMessage.TestNode.Properties);
-
-            var timingProperty = testNodeUpdateMessage.TestNode.Properties.AsEnumerable().OfType<TimingProperty>().FirstOrDefault();
-
-            var duration = timingProperty?.GlobalTiming.Duration;
-
-            detailsBuilder.AppendLine("<tr>");
-            detailsBuilder.AppendLine($"<td>{name}</td>");
-            detailsBuilder.AppendLine($"<td>{status}</td>");
-            detailsBuilder.AppendLine($"<td>{details}</td>");
-            detailsBuilder.AppendLine($"<td>{duration}</td>");
-            detailsBuilder.AppendLine("</tr>");
+            if (failureMessages.Count > maxInlineFailures)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine($"*...and {failureMessages.Count - maxInlineFailures} more failures*");
+            }
         }
-        detailsBuilder.AppendLine("</tbody></table>");
 
-        // Wrap in collapsible section if using collapsible style
-        if (_reporterStyle == GitHubReporterStyle.Collapsible)
+        // Build the full details table for remaining items
+        var remainingFailures = failureMessages.Count > maxInlineFailures
+            ? failureMessages.Skip(maxInlineFailures).ToList()
+            : new List<(string Name, string? SourceLink, string Details, string Duration)>();
+        var hasRemainingDetails = remainingFailures.Count > 0 || otherMessages.Count > 0;
+
+        if (hasRemainingDetails)
         {
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("<details>");
-            stringBuilder.AppendLine("<summary>📊 Test Details (click to expand)</summary>");
-            stringBuilder.Append(detailsBuilder.ToString());
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine("</details>");
-            stringBuilder.AppendLine();
-        }
-        else
-        {
-            // Full style - append details directly
-            stringBuilder.Append(detailsBuilder.ToString());
+            var detailsBuilder = new StringBuilder();
+            detailsBuilder.AppendLine();
+            detailsBuilder.AppendLine("""<table role="table" tabindex="0">""");
+            detailsBuilder.AppendLine("<thead><tr><th>Test</th><th>Status</th><th>Details</th><th>Duration</th></tr></thead>");
+            detailsBuilder.AppendLine("<tbody>");
+
+            foreach (var (name, sourceLink, details, duration) in remainingFailures)
+            {
+                detailsBuilder.AppendLine("<tr>");
+                detailsBuilder.AppendLine($"<td>{name}</td>");
+                detailsBuilder.AppendLine("<td>Failed</td>");
+                detailsBuilder.AppendLine($"<td>{details}</td>");
+                detailsBuilder.AppendLine($"<td>{duration}</td>");
+                detailsBuilder.AppendLine("</tr>");
+            }
+
+            foreach (var (name, status, details, duration) in otherMessages)
+            {
+                detailsBuilder.AppendLine("<tr>");
+                detailsBuilder.AppendLine($"<td>{name}</td>");
+                detailsBuilder.AppendLine($"<td>{status}</td>");
+                detailsBuilder.AppendLine($"<td>{details}</td>");
+                detailsBuilder.AppendLine($"<td>{duration}</td>");
+                detailsBuilder.AppendLine("</tr>");
+            }
+
+            detailsBuilder.AppendLine("</tbody></table>");
+
+            if (_reporterStyle == GitHubReporterStyle.Collapsible)
+            {
+                var totalNonPassing = failureMessages.Count + otherMessages.Count;
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("<details>");
+                stringBuilder.AppendLine($"<summary>All non-passing tests ({totalNonPassing} total)</summary>");
+                stringBuilder.Append(detailsBuilder.ToString());
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("</details>");
+            }
+            else
+            {
+                stringBuilder.Append(detailsBuilder.ToString());
+            }
         }
 
         return WriteFile(stringBuilder.ToString());
@@ -465,6 +548,29 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             TimeoutTestNodeStateProperty => "Timed Out",
             _ => "Unknown"
         };
+    }
+
+    private static string? GetSourceLink(TestNode testNode)
+    {
+        var fileLocation = testNode.Properties.AsEnumerable()
+            .OfType<TestFileLocationProperty>().FirstOrDefault();
+        if (fileLocation is null) return null;
+
+        var repo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
+        var sha = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubSha);
+        if (string.IsNullOrEmpty(repo) || string.IsNullOrEmpty(sha)) return null;
+
+        var filePath = fileLocation.FilePath.Replace('\\', '/');
+        var repoName = repo.Split('/').LastOrDefault() ?? "";
+        var repoIndex = filePath.IndexOf($"/{repoName}/", StringComparison.OrdinalIgnoreCase);
+        if (repoIndex >= 0)
+        {
+            filePath = filePath[(repoIndex + repoName.Length + 2)..];
+        }
+
+        var line = fileLocation.LineSpan.Start.Line + 1; // 0-based to 1-based
+        var fileName = Path.GetFileName(fileLocation.FilePath);
+        return $"[{fileName}:{line}](https://github.com/{repo}/blob/{sha}/{filePath}#L{line})";
     }
 
     public string? Filter { get; set; }

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -200,6 +200,66 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         stringBuilder.AppendLine(string.Join(" \u00B7 ", segments));
 
+        // Detect flaky tests (passed after retry)
+        var flakyTests = new List<(string Name, int Attempts, TimeSpan? Duration)>();
+        foreach (var kvp in _updates)
+        {
+            var finalStateCount = 0;
+            foreach (var update in kvp.Value)
+            {
+                var state = update.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+                if (state is not null and not InProgressTestNodeStateProperty and not DiscoveredTestNodeStateProperty)
+                {
+                    finalStateCount++;
+                }
+            }
+
+            if (finalStateCount > 1 && last.TryGetValue(kvp.Key, out var lastUpdate))
+            {
+                var passed = lastUpdate.TestNode.Properties.AsEnumerable().Any(p => p is PassedTestNodeStateProperty);
+                if (passed)
+                {
+                    var testMethodIdentifier = lastUpdate.TestNode.Properties.AsEnumerable()
+                        .OfType<TestMethodIdentifierProperty>().FirstOrDefault();
+                    var className = testMethodIdentifier?.TypeName;
+                    var displayName = lastUpdate.TestNode.DisplayName;
+                    var name = string.IsNullOrEmpty(className) ? displayName : $"{className}.{displayName}";
+                    var timing = lastUpdate.TestNode.Properties.AsEnumerable().OfType<TimingProperty>().FirstOrDefault();
+                    flakyTests.Add((name, finalStateCount, timing?.GlobalTiming.Duration));
+                }
+            }
+        }
+
+        if (flakyTests.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine($"> **\u26a0\ufe0f {flakyTests.Count} flaky {(flakyTests.Count == 1 ? "test" : "tests")}** passed after retry:");
+            foreach (var (name, attempts, duration) in flakyTests)
+            {
+                stringBuilder.AppendLine($"> - `{name}` \u2014 {attempts} attempts ({FormatDuration(duration)})");
+            }
+        }
+
+        if (skipped.Length > 0)
+        {
+            var skipGroups = skipped
+                .Select(x => x.Value.TestNode.Properties.AsEnumerable()
+                    .OfType<SkippedTestNodeStateProperty>().FirstOrDefault()?.Explanation ?? "No reason provided")
+                .GroupBy(reason => reason)
+                .OrderByDescending(g => g.Count());
+
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("<details>");
+            stringBuilder.AppendLine($"<summary>\u23ed\ufe0f {skipped.Length} skipped {(skipped.Length == 1 ? "test" : "tests")}</summary>");
+            stringBuilder.AppendLine();
+            foreach (var group in skipGroups)
+            {
+                stringBuilder.AppendLine($"- **{group.Count()}** \u2014 {group.Key}");
+            }
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("</details>");
+        }
+
         if (ShowArtifactUploadTip)
         {
             stringBuilder.AppendLine();

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -24,6 +25,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
     private const long MaxFileSizeInBytes = EngineDefaults.GitHubSummaryMaxFileSizeBytes;
     private string _outputSummaryFilePath = null!;
     private GitHubReporterStyle _reporterStyle = GitHubReporterStyle.Collapsible;
+    private Stopwatch? _runStopwatch;
 
     public async Task<bool> IsEnabledAsync()
     {
@@ -85,6 +87,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     public Task BeforeRunAsync(CancellationToken cancellationToken)
     {
+        _runStopwatch = Stopwatch.StartNew();
         return Task.CompletedTask;
     }
 
@@ -133,15 +136,8 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         var inProgress = last.Where(x =>
             x.Value.TestNode.Properties.AsEnumerable().Any(p => p is InProgressTestNodeStateProperty)).ToArray();
 
-        var totalDuration = TimeSpan.Zero;
-        foreach (var msg in last.Values)
-        {
-            var timing = msg.TestNode.Properties.AsEnumerable().OfType<TimingProperty>().FirstOrDefault();
-            if (timing is not null)
-            {
-                totalDuration += timing.GlobalTiming.Duration;
-            }
-        }
+        _runStopwatch?.Stop();
+        var elapsed = _runStopwatch?.Elapsed;
 
         var hasFailures = failed.Length > 0 || timeout.Length > 0 || cancelled.Length > 0;
         var statusEmoji = hasFailures ? "\u274C" : "\u2705";
@@ -168,7 +164,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         var passRate = totalCount > 0 ? (double)passedCount / totalCount * 100 : 0;
 
         stringBuilder.AppendLine();
-        stringBuilder.AppendLine($"**{totalCount} tests** completed in **{FormatDuration(totalDuration)}** \u2014 **{passRate:F1}%** passed");
+        stringBuilder.AppendLine($"**{totalCount} tests** completed in **{FormatDuration(elapsed)}** \u2014 **{passRate:F1}%** passed");
         stringBuilder.AppendLine();
 
         var segments = new List<string> { $"\u2705 {passedCount} passed" };

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -303,6 +303,11 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             return WriteFile(stringBuilder.ToString());
         }
 
+        // Cache env vars for source links (read once, not per test)
+        var githubRepo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
+        var githubSha = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubSha);
+        var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE")?.Replace('\\', '/');
+
         // Separate failures from other non-passing tests
         var failureMessages = new List<(string Name, string? SourceLink, string Details, string Duration)>();
         var otherMessages = new List<(string Name, string Status, string Details, string Duration)>();
@@ -328,7 +333,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
             if (isFailed)
             {
-                var sourceLink = GetSourceLink(testNodeUpdateMessage.TestNode);
+                var sourceLink = GetSourceLink(testNodeUpdateMessage.TestNode, githubRepo, githubSha, githubWorkspace);
                 var details = GetDetails(stateProperty, testNodeUpdateMessage.TestNode.Properties);
                 failureMessages.Add((name, sourceLink, details, duration));
             }
@@ -406,7 +411,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
             if (_reporterStyle == GitHubReporterStyle.Collapsible)
             {
-                var totalNonPassing = failureMessages.Count + otherMessages.Count;
+                var totalNonPassing = remainingFailures.Count + otherMessages.Count;
                 stringBuilder.AppendLine();
                 stringBuilder.AppendLine("<details>");
                 stringBuilder.AppendLine($"<summary>All non-passing tests ({totalNonPassing} total)</summary>");
@@ -555,22 +560,29 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         };
     }
 
-    private static string? GetSourceLink(TestNode testNode)
+    private static string? GetSourceLink(TestNode testNode, string? repo, string? sha, string? workspace)
     {
         var fileLocation = testNode.Properties.AsEnumerable()
             .OfType<TestFileLocationProperty>().FirstOrDefault();
         if (fileLocation is null) return null;
 
-        var repo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
-        var sha = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubSha);
         if (string.IsNullOrEmpty(repo) || string.IsNullOrEmpty(sha)) return null;
 
         var filePath = fileLocation.FilePath.Replace('\\', '/');
-        var repoName = repo.Split('/').LastOrDefault() ?? "";
-        var repoIndex = filePath.IndexOf($"/{repoName}/", StringComparison.OrdinalIgnoreCase);
-        if (repoIndex >= 0)
+
+        // Prefer GITHUB_WORKSPACE for reliable path stripping; fall back to repo name matching
+        if (!string.IsNullOrEmpty(workspace) && filePath.StartsWith(workspace!, StringComparison.OrdinalIgnoreCase))
         {
-            filePath = filePath[(repoIndex + repoName.Length + 2)..];
+            filePath = filePath[workspace!.Length..].TrimStart('/');
+        }
+        else
+        {
+            var repoName = repo!.Split('/').LastOrDefault() ?? "";
+            var repoIndex = filePath.IndexOf($"/{repoName}/", StringComparison.OrdinalIgnoreCase);
+            if (repoIndex >= 0)
+            {
+                filePath = filePath[(repoIndex + repoName.Length + 2)..];
+            }
         }
 
         var line = fileLocation.LineSpan.Start.Line + 1; // 0-based to 1-based
@@ -596,6 +608,6 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         { TotalSeconds: < 1 } d => $"{d.TotalMilliseconds:F0}ms",
         { TotalMinutes: < 1 } d => $"{d.TotalSeconds:F1}s",
         { TotalHours: < 1 } d => $"{d.Minutes}m {d.Seconds}s",
-        var d => $"{d.Value.TotalHours:F0}h {d.Value.Minutes}m"
+        var d => $"{(int)d.Value.TotalHours}h {d.Value.Minutes}m"
     };
 }

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -133,17 +133,30 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         var inProgress = last.Where(x =>
             x.Value.TestNode.Properties.AsEnumerable().Any(p => p is InProgressTestNodeStateProperty)).ToArray();
 
+        var totalDuration = TimeSpan.Zero;
+        foreach (var msg in last.Values)
+        {
+            var timing = msg.TestNode.Properties.AsEnumerable().OfType<TimingProperty>().FirstOrDefault();
+            if (timing is not null)
+            {
+                totalDuration += timing.GlobalTiming.Duration;
+            }
+        }
+
+        var hasFailures = failed.Length > 0 || timeout.Length > 0 || cancelled.Length > 0;
+        var statusEmoji = hasFailures ? "\u274C" : "\u2705";
+
         var stringBuilder = new StringBuilder();
 
         var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
 
         if (!string.IsNullOrEmpty(ArtifactUrl))
         {
-            stringBuilder.AppendLine($"### {assemblyName} ({targetFramework}) [(View Report)]({ArtifactUrl})");
+            stringBuilder.AppendLine($"### {statusEmoji} {assemblyName} ({targetFramework}) [(View Report)]({ArtifactUrl})");
         }
         else
         {
-            stringBuilder.AppendLine($"### {assemblyName} ({targetFramework})");
+            stringBuilder.AppendLine($"### {statusEmoji} {assemblyName} ({targetFramework})");
         }
 
         if (!string.IsNullOrEmpty(Filter))
@@ -151,31 +164,41 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             stringBuilder.AppendLine($"#### Filter: `{Filter}`");
         }
 
+        var totalCount = last.Count;
+        var passRate = totalCount > 0 ? (double)passedCount / totalCount * 100 : 0;
+
         stringBuilder.AppendLine();
-        stringBuilder.AppendLine("| Test Count | Status |");
-        stringBuilder.AppendLine("| --- | --- |");
-        stringBuilder.AppendLine($"| {passedCount} | Passed |");
-        stringBuilder.AppendLine($"| {failed.Length} | Failed |");
+        stringBuilder.AppendLine($"**{totalCount} tests** completed in **{FormatDuration(totalDuration)}** \u2014 **{passRate:F1}%** passed");
+        stringBuilder.AppendLine();
+
+        var segments = new List<string> { $"\u2705 {passedCount} passed" };
+
+        if (failed.Length > 0)
+        {
+            segments.Add($"\u274C {failed.Length} failed");
+        }
 
         if (skipped.Length > 0)
         {
-            stringBuilder.AppendLine($"| {skipped.Length} | Skipped |");
+            segments.Add($"\u23ED\uFE0F {skipped.Length} skipped");
         }
 
         if (timeout.Length > 0)
         {
-            stringBuilder.AppendLine($"| {timeout.Length} | Timed Out |");
+            segments.Add($"\u23F1\uFE0F {timeout.Length} timed out");
         }
 
         if (cancelled.Length > 0)
         {
-            stringBuilder.AppendLine($"| {cancelled.Length} | Cancelled |");
+            segments.Add($"\uD83D\uDEAB {cancelled.Length} cancelled");
         }
 
         if (inProgress.Length > 0)
         {
-            stringBuilder.AppendLine($"| {inProgress.Length} | In Progress (never completed) |");
+            segments.Add($"\u26A0\uFE0F {inProgress.Length} in progress");
         }
+
+        stringBuilder.AppendLine(string.Join(" \u00B7 ", segments));
 
         if (ShowArtifactUploadTip)
         {
@@ -394,4 +417,14 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
     {
         _reporterStyle = style;
     }
+
+    private static string FormatDuration(TimeSpan? duration) => duration switch
+    {
+        null => "-",
+        { TotalMilliseconds: < 1 } => "< 1ms",
+        { TotalSeconds: < 1 } d => $"{d.TotalMilliseconds:F0}ms",
+        { TotalMinutes: < 1 } d => $"{d.TotalSeconds:F1}s",
+        { TotalHours: < 1 } d => $"{d.Minutes}m {d.Seconds}s",
+        var d => $"{d.Value.TotalHours:F0}h {d.Value.Minutes}m"
+    };
 }

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -177,7 +177,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             stringBuilder.AppendLine($"| {inProgress.Length} | In Progress (never completed) |");
         }
 
-        if (string.IsNullOrEmpty(ArtifactUrl))
+        if (ShowArtifactUploadTip)
         {
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("> **Tip:** You can have HTML reports uploaded automatically as artifacts. [Learn more](https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload)");
@@ -388,6 +388,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     // Set by HtmlReporter during OnTestSessionFinishingAsync, which MTP invokes before AfterRunAsync.
     internal string? ArtifactUrl { get; set; }
+    internal bool ShowArtifactUploadTip { get; set; }
 
     internal void SetReporterStyle(GitHubReporterStyle style)
     {

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -298,6 +298,8 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         if (passedCount == last.Count)
         {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("---");
             return WriteFile(stringBuilder.ToString());
         }
 
@@ -417,6 +419,9 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
                 stringBuilder.Append(detailsBuilder.ToString());
             }
         }
+
+        stringBuilder.AppendLine();
+        stringBuilder.AppendLine("---");
 
         return WriteFile(stringBuilder.ToString());
     }

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -307,6 +307,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         var githubRepo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
         var githubSha = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubSha);
         var githubWorkspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE")?.Replace('\\', '/');
+        var githubServerUrl = Environment.GetEnvironmentVariable("GITHUB_SERVER_URL") ?? "https://github.com";
 
         // Separate failures from other non-passing tests
         var failureMessages = new List<(string Name, string? SourceLink, string Details, string Duration)>();
@@ -333,7 +334,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
             if (isFailed)
             {
-                var sourceLink = GetSourceLink(testNodeUpdateMessage.TestNode, githubRepo, githubSha, githubWorkspace);
+                var sourceLink = GetSourceLink(testNodeUpdateMessage.TestNode, githubRepo, githubSha, githubWorkspace, githubServerUrl);
                 var details = GetDetails(stateProperty, testNodeUpdateMessage.TestNode.Properties);
                 failureMessages.Add((name, sourceLink, details, duration));
             }
@@ -560,7 +561,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         };
     }
 
-    private static string? GetSourceLink(TestNode testNode, string? repo, string? sha, string? workspace)
+    private static string? GetSourceLink(TestNode testNode, string? repo, string? sha, string? workspace, string serverUrl)
     {
         var fileLocation = testNode.Properties.AsEnumerable()
             .OfType<TestFileLocationProperty>().FirstOrDefault();
@@ -587,7 +588,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         var line = fileLocation.LineSpan.Start.Line + 1; // 0-based to 1-based
         var fileName = Path.GetFileName(fileLocation.FilePath);
-        return $"[{fileName}:{line}](https://github.com/{repo}/blob/{sha}/{filePath}#L{line})";
+        return $"[{fileName}:{line}]({serverUrl.TrimEnd('/')}/{repo}/blob/{sha}/{filePath}#L{line})";
     }
 
     public string? Filter { get; set; }

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -167,34 +167,38 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         stringBuilder.AppendLine($"**{totalCount} tests** completed in **{FormatDuration(elapsed)}** \u2014 **{passRate:F1}%** passed");
         stringBuilder.AppendLine();
 
-        var segments = new List<string> { $"\u2705 {passedCount} passed" };
-
-        if (failed.Length > 0)
+        // Only show the segment breakdown when there's more than just "N passed"
+        if (passedCount != totalCount)
         {
-            segments.Add($"\u274C {failed.Length} failed");
-        }
+            var segments = new List<string> { $"\u2705 {passedCount} passed" };
 
-        if (skipped.Length > 0)
-        {
-            segments.Add($"\u23ED\uFE0F {skipped.Length} skipped");
-        }
+            if (failed.Length > 0)
+            {
+                segments.Add($"\u274C {failed.Length} failed");
+            }
 
-        if (timeout.Length > 0)
-        {
-            segments.Add($"\u23F1\uFE0F {timeout.Length} timed out");
-        }
+            if (skipped.Length > 0)
+            {
+                segments.Add($"\u23ED\uFE0F {skipped.Length} skipped");
+            }
 
-        if (cancelled.Length > 0)
-        {
-            segments.Add($"\uD83D\uDEAB {cancelled.Length} cancelled");
-        }
+            if (timeout.Length > 0)
+            {
+                segments.Add($"\u23F1\uFE0F {timeout.Length} timed out");
+            }
 
-        if (inProgress.Length > 0)
-        {
-            segments.Add($"\u26A0\uFE0F {inProgress.Length} in progress");
-        }
+            if (cancelled.Length > 0)
+            {
+                segments.Add($"\uD83D\uDEAB {cancelled.Length} cancelled");
+            }
 
-        stringBuilder.AppendLine(string.Join(" \u00B7 ", segments));
+            if (inProgress.Length > 0)
+            {
+                segments.Add($"\u26A0\uFE0F {inProgress.Length} in progress");
+            }
+
+            stringBuilder.AppendLine(string.Join(" \u00B7 ", segments));
+        }
 
         // Detect flaky tests (passed after retry)
         var flakyTests = new List<(string Name, int Attempts, TimeSpan? Duration)>();

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -134,7 +134,17 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             x.Value.TestNode.Properties.AsEnumerable().Any(p => p is InProgressTestNodeStateProperty)).ToArray();
 
         var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"### {Assembly.GetEntryAssembly()?.GetName().Name} ({targetFramework})");
+
+        var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
+
+        if (!string.IsNullOrEmpty(ArtifactUrl))
+        {
+            stringBuilder.AppendLine($"### {assemblyName} ({targetFramework}) [(View Report)]({ArtifactUrl})");
+        }
+        else
+        {
+            stringBuilder.AppendLine($"### {assemblyName} ({targetFramework})");
+        }
 
         if (!string.IsNullOrEmpty(Filter))
         {
@@ -165,6 +175,12 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         if (inProgress.Length > 0)
         {
             stringBuilder.AppendLine($"| {inProgress.Length} | In Progress (never completed) |");
+        }
+
+        if (string.IsNullOrEmpty(ArtifactUrl))
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("> **Tip:** You can have HTML reports uploaded automatically as artifacts. [Learn more](https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload)");
         }
 
         if (passedCount == last.Count)
@@ -369,6 +385,9 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
     }
 
     public string? Filter { get; set; }
+
+    // Set by HtmlReporter during OnTestSessionFinishingAsync, which MTP invokes before AfterRunAsync.
+    internal string? ArtifactUrl { get; set; }
 
     internal void SetReporterStyle(GitHubReporterStyle style)
     {

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -661,7 +661,6 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             return;
         }
 
-        var summaryPath = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubStepSummary);
         var repo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
         var runId = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRunId);
 
@@ -698,39 +697,11 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             }
         }
 
-        // Write to step summary
-        if (!string.IsNullOrEmpty(summaryPath))
+        if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
         {
-            try
+            if (_githubReporter is not null)
             {
-                var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? Path.GetFileNameWithoutExtension(filePath);
-                string line;
-
-                if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
-                {
-                    var artifactUrl = $"https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
-
-                    if (_githubReporter is not null)
-                    {
-                        _githubReporter.ArtifactUrl = artifactUrl;
-                    }
-
-                    line = $"\n\ud83d\udcca [{assemblyName} — View HTML Report]({artifactUrl})\n";
-                }
-                else
-                {
-                    line = $"\n\ud83d\udcca **{assemblyName}** HTML report was generated — [Enable automatic artifact upload](https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload)\n";
-                }
-
-#if NET
-                await File.AppendAllTextAsync(summaryPath, line, cancellationToken);
-#else
-                File.AppendAllText(summaryPath, line);
-#endif
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Warning: Failed to write GitHub step summary: {ex.Message}");
+                _githubReporter.ArtifactUrl = $"https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
             }
         }
     }

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -699,7 +699,8 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             }
             else if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
             {
-                _githubReporter.ArtifactUrl = $"https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
+                var serverUrl = (Environment.GetEnvironmentVariable("GITHUB_SERVER_URL") ?? "https://github.com").TrimEnd('/');
+                _githubReporter.ArtifactUrl = $"{serverUrl}/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
             }
         }
     }

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -25,6 +25,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
     private IMessageBus? _messageBus;
     private string _resultsDirectory = "TestResults";
     private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
+    private GitHubReporter? _githubReporter;
 
 #if NET
     private ActivityCollector? _activityCollector;
@@ -177,6 +178,11 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
     internal void SetMessageBus(IMessageBus? messageBus)
     {
         _messageBus = messageBus;
+    }
+
+    internal void SetGitHubReporter(GitHubReporter githubReporter)
+    {
+        _githubReporter = githubReporter;
     }
 
     // Called by the AddTestSessionLifetimeHandler factory at startup, before any session events fire,
@@ -648,7 +654,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
                exception.Message.Contains("access denied", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static async Task TryGitHubIntegrationAsync(string filePath, CancellationToken cancellationToken)
+    private async Task TryGitHubIntegrationAsync(string filePath, CancellationToken cancellationToken)
     {
         if (Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubActions) is not "true")
         {
@@ -697,7 +703,14 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
 
                 if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
                 {
-                    line = $"\n\ud83d\udcca [{assemblyName} — View HTML Report](https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId})\n";
+                    var artifactUrl = $"https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
+
+                    if (_githubReporter is not null)
+                    {
+                        _githubReporter.ArtifactUrl = artifactUrl;
+                    }
+
+                    line = $"\n\ud83d\udcca [{assemblyName} — View HTML Report]({artifactUrl})\n";
                 }
                 else
                 {

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -673,6 +673,11 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
 
         if (!hasRuntimeToken)
         {
+            if (_githubReporter is not null)
+            {
+                _githubReporter.ShowArtifactUploadTip = true;
+            }
+
             Console.WriteLine("Tip: To enable automatic HTML report artifact upload, see https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload");
         }
 

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -672,15 +672,9 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
 
         if (!hasRuntimeToken)
         {
-            if (_githubReporter is not null)
-            {
-                _githubReporter.ShowArtifactUploadTip = true;
-            }
-
             Console.WriteLine("Tip: To enable automatic HTML report artifact upload, see https://tunit.dev/docs/guides/html-report#enabling-automatic-artifact-upload");
         }
-
-        if (hasRuntimeToken)
+        else
         {
             try
             {
@@ -697,9 +691,13 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             }
         }
 
-        if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
+        if (_githubReporter is not null)
         {
-            if (_githubReporter is not null)
+            if (!hasRuntimeToken)
+            {
+                _githubReporter.ShowArtifactUploadTip = true;
+            }
+            else if (artifactId is not null && !string.IsNullOrEmpty(repo) && !string.IsNullOrEmpty(runId))
             {
                 _githubReporter.ArtifactUrl = $"https://github.com/{repo}/actions/runs/{runId}/artifacts/{artifactId}";
             }


### PR DESCRIPTION
## Summary

Comprehensive overhaul of the GitHub Actions step summary output for richer, more actionable CI feedback.

### Changes

- **Status emoji header** — title line shows ✅ or ❌ with optional **(View Report)** link when the HTML artifact was uploaded
- **Compact inline summary** — replaces the old markdown table with a single line showing total tests, duration, and pass rate, plus a segmented breakdown (passed · failed · skipped · timed out · cancelled)
- **Flaky test detection** — tests that passed after retry are highlighted in a blockquote with attempt count and duration
- **Skipped test grouping** — collapsible section groups skipped tests by reason with counts
- **Quick diagnosis** — one-liner showing top exception types and the most-affected class
- **Inline top failures** — up to 5 failures shown as collapsible `<details>` blocks with error messages and source links (links to the exact file/line on GitHub)
- **Source links** — uses `GITHUB_WORKSPACE` for reliable path stripping, with repo-name fallback
- **Artifact upload tip** — when HTML reporter runs but artifact upload isn't configured, shows a tip linking to setup docs
- **Horizontal rule separators** — `---` between projects for multi-TFM runs
- **Removed standalone emoji links** — old "View HTML Report" links removed from HtmlReporter; the link is now in the GitHubReporter title
- **Human-readable durations** — `FormatDuration` helper (e.g., `1.2s`, `3m 12s`, `2h 5m`)
- **Env var caching** — `GITHUB_REPOSITORY`, `GITHUB_SHA`, `GITHUB_WORKSPACE` read once per run, not per test

### Architecture

- HtmlReporter pushes `ArtifactUrl` and `ShowArtifactUploadTip` to GitHubReporter via simple properties (GitHubReporter has no knowledge of HtmlReporter)
- Wiring done in `TestApplicationBuilderExtensions.AddTUnit()` via `htmlReporter.SetGitHubReporter(githubReporter)`
- MTP lifecycle guarantees `OnTestSessionFinishingAsync` (HtmlReporter) runs before `AfterRunAsync` (GitHubReporter)

### Files changed

- `TUnit.Engine/Reporters/GitHubReporter.cs` — main overhaul
- `TUnit.Engine/Reporters/Html/HtmlReporter.cs` — removed standalone links, added push to GitHubReporter
- `TUnit.Engine/Extensions/TestApplicationBuilderExtensions.cs` — wiring

## Test plan

- [ ] Verify summary renders with all tests passing (✅ emoji, no failures section)
- [ ] Verify summary renders with failures (❌ emoji, inline failures with source links, quick diagnosis)
- [ ] Verify flaky test detection (retry a test, confirm blockquote appears)
- [ ] Verify skipped tests grouped by reason in collapsible section
- [ ] Verify **(View Report)** link appears when artifact upload is configured
- [ ] Verify artifact upload tip appears when HTML reporter runs without runtime token
- [ ] Verify multi-TFM runs show `---` separators between projects
- [ ] Verify source links point to correct file/line on GitHub