### PR TITLE
fix: truncate large stdout/stderr in HTML report to prevent JSON serialization failure

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -454,10 +454,10 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
                     fileLocation = f;
                     break;
                 case StandardOutputProperty o:
-                    stdOut = o.StandardOutput;
+                    stdOut = TruncateOutput(o.StandardOutput);
                     break;
                 case StandardErrorProperty e:
-                    stdErr = e.StandardError;
+                    stdErr = TruncateOutput(e.StandardError);
                     break;
                 case TestMetadataProperty meta:
                     if (string.IsNullOrEmpty(meta.Key))
@@ -509,6 +509,20 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             SpanId = spanId,
             AdditionalTraceIds = additionalTraceIds
         };
+    }
+
+    // System.Text.Json's Utf8JsonWriter limits a single string token to int.MaxValue / 6 characters.
+    // Truncate large outputs early so report generation never fails for test suites with excessive logging.
+    private const int MaxOutputLength = 1 * 1024 * 1024; // 1 MB
+
+    private static string? TruncateOutput(string? value)
+    {
+        if (value is null || value.Length <= MaxOutputLength)
+        {
+            return value;
+        }
+
+        return value[..MaxOutputLength] + $"\n[... output truncated — {value.Length:N0} total characters]";
     }
 
     private static (string Status, ReportExceptionData? Exception, string? SkipReason) ExtractStatus(IProperty? stateProperty)

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -21,6 +21,10 @@ namespace TUnit.Engine.Reporters.Html;
 
 internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataProducer, ITestHostApplicationLifetime, ITestSessionLifetimeHandler, IFilterReceiver, IDisposable
 {
+    // System.Text.Json's Utf8JsonWriter limits a single string token to int.MaxValue / 6 characters.
+    // Truncate large outputs early so report generation never fails for test suites with excessive logging.
+    internal const int MaxOutputLength = 1 * 1024 * 1024; // 1 MB
+
     private string? _outputPath;
     private IMessageBus? _messageBus;
     private string _resultsDirectory = "TestResults";
@@ -511,18 +515,24 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         };
     }
 
-    // System.Text.Json's Utf8JsonWriter limits a single string token to int.MaxValue / 6 characters.
-    // Truncate large outputs early so report generation never fails for test suites with excessive logging.
-    private const int MaxOutputLength = 1 * 1024 * 1024; // 1 MB
-
-    private static string? TruncateOutput(string? value)
+    internal static string? TruncateOutput(string? value)
     {
         if (value is null || value.Length <= MaxOutputLength)
         {
             return value;
         }
 
-        return value[..MaxOutputLength] + $"\n[... output truncated — {value.Length:N0} total characters]";
+        // Back off one char if we would split a surrogate pair, which would produce invalid UTF-16.
+        var cutAt = MaxOutputLength;
+        if (char.IsHighSurrogate(value[cutAt - 1]))
+        {
+            cutAt--;
+        }
+
+        return new System.Text.StringBuilder(cutAt + 64)
+            .Append(value, 0, cutAt)
+            .Append($"\n[... output truncated \u2014 {value.Length:N0} total characters]")
+            .ToString();
     }
 
     private static (string Status, ReportExceptionData? Exception, string? SkipReason) ExtractStatus(IProperty? stateProperty)

--- a/TUnit.UnitTests/HtmlReporterTruncateOutputTests.cs
+++ b/TUnit.UnitTests/HtmlReporterTruncateOutputTests.cs
@@ -1,0 +1,78 @@
+using TUnit.Engine.Reporters.Html;
+
+namespace TUnit.UnitTests;
+
+public class HtmlReporterTruncateOutputTests
+{
+    [Test]
+    public async Task TruncateOutput_Null_ReturnsNull()
+    {
+        var result = HtmlReporter.TruncateOutput(null);
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task TruncateOutput_EmptyString_ReturnsEmpty()
+    {
+        var result = HtmlReporter.TruncateOutput(string.Empty);
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task TruncateOutput_ShortString_ReturnedAsIs()
+    {
+        var input = "short output";
+        var result = HtmlReporter.TruncateOutput(input);
+        await Assert.That(result).IsEqualTo(input);
+    }
+
+    [Test]
+    public async Task TruncateOutput_AtExactLimit_ReturnedAsIs()
+    {
+        var input = new string('a', HtmlReporter.MaxOutputLength);
+        var result = HtmlReporter.TruncateOutput(input);
+        await Assert.That(result).IsEqualTo(input);
+    }
+
+    [Test]
+    public async Task TruncateOutput_OneCharOverLimit_TruncatedWithNote()
+    {
+        var input = new string('a', HtmlReporter.MaxOutputLength + 1);
+        var result = HtmlReporter.TruncateOutput(input);
+        await Assert.That(result).IsNotNull();
+        // The truncated content before the note must be exactly MaxOutputLength chars.
+        var noteIndex = result!.IndexOf('\n');
+        await Assert.That(noteIndex).IsEqualTo(HtmlReporter.MaxOutputLength);
+        await Assert.That(result).Contains("output truncated");
+        await Assert.That(result).Contains((HtmlReporter.MaxOutputLength + 1).ToString("N0"));
+    }
+
+    [Test]
+    public async Task TruncateOutput_LargeString_TruncatedWithNote()
+    {
+        var input = new string('x', HtmlReporter.MaxOutputLength * 2);
+        var result = HtmlReporter.TruncateOutput(input);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!).StartsWith(new string('x', HtmlReporter.MaxOutputLength));
+        await Assert.That(result).Contains("output truncated");
+    }
+
+    [Test]
+    public async Task TruncateOutput_SurrogatePairAtBoundary_DoesNotSplitPair()
+    {
+        // Build a string where the char at MaxOutputLength-1 is a high surrogate
+        // by placing a surrogate pair straddling the cut point.
+        var prefix = new string('a', HtmlReporter.MaxOutputLength - 1);
+        // U+1F600 (😀) is encoded as a surrogate pair: \uD83D\uDE00
+        const string surrogateEmoji = "\uD83D\uDE00";
+        var input = prefix + surrogateEmoji + new string('b', 10);
+
+        var result = HtmlReporter.TruncateOutput(input);
+
+        await Assert.That(result).IsNotNull();
+        // The high surrogate at MaxOutputLength-1 should cause the cut to back off by 1,
+        // so the result must not end with an unpaired surrogate.
+        var truncatedPart = result![..result.IndexOf('\n')];
+        await Assert.That(char.IsHighSurrogate(truncatedPart[^1])).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5479

`System.Text.Json`'s `Utf8JsonWriter` limits a single string token to `int.MaxValue / 6 ≈ 357,913,941` characters (worst-case UTF-16 → `\uXXXX` escaping). Test suites with excessive per-test logging (~380MB+) hit this limit during HTML report serialization, producing:

\\\
Warning: HTML report generation failed: The JSON value of length 397639975 is too large and not supported.
\\\

## Fix

In `ExtractTestResult`, stdout and stderr are now passed through `TruncateOutput()` which caps each at **1 MB** (1,048,576 chars). If a value is truncated, a note with the original character count is appended:

\\\
[... output truncated — 397,639,975 total characters]
\\\

This ensures the HTML report always generates successfully, even for test suites with extremely verbose output.

## Files changed

- `TUnit.Engine/Reporters/Html/HtmlReporter.cs`