### PR TITLE
feat(html-report): omit redundant test body span from trace timeline

### DIFF
--- a/TUnit.Core/TUnitActivitySource.cs
+++ b/TUnit.Core/TUnitActivitySource.cs
@@ -16,6 +16,7 @@ internal static class TUnitActivitySource
     internal const string SpanTestAssembly = "test assembly";
     internal const string SpanTestSuite = "test suite";
     internal const string SpanTestCase = "test case";
+    internal const string SpanTestBody = "test body";
 
     // Tag keys used across init/dispose spans and the HTML report.
     internal const string TagTestId = "tunit.test.id";

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1487,9 +1487,7 @@ function renderTrace(tid, rootSpanId) {
     if (!allSpans || !allSpans.length) return '';
     let sp = getDescendants(allSpans, rootSpanId);
     if (!sp.length) return '';
-    // If the only direct child of the test case is "test body", the span itself is
-    // redundant — remove it and re-parent its children directly under the test case.
-    // Note: 'test body' must match TUnitActivitySource.SpanTestBody in C#.
+    // 'test body' must match TUnitActivitySource.SpanTestBody in C#
     const directChildren = sp.filter(s => s.parentSpanId === rootSpanId);
     if (directChildren.length === 1 && directChildren[0].name === 'test body') {
         const tbId = directChildren[0].spanId;

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1488,11 +1488,12 @@ function renderTrace(tid, rootSpanId) {
     let sp = getDescendants(allSpans, rootSpanId);
     if (!sp.length) return '';
     // If the only direct child of the test case is "test body", the span itself is
-    // redundant — remove it and re-parent its children directly under the test case
+    // redundant — remove it and re-parent its children directly under the test case.
+    // Note: 'test body' must match TUnitActivitySource.SpanTestBody in C#.
     const directChildren = sp.filter(s => s.parentSpanId === rootSpanId);
     if (directChildren.length === 1 && directChildren[0].name === 'test body') {
         const tbId = directChildren[0].spanId;
-        sp = sp.filter(s => s.spanId !== tbId).map(s => s.parentSpanId === tbId ? Object.assign({}, s, {parentSpanId: rootSpanId}) : s);
+        sp = sp.filter(s => s.spanId !== tbId).map(s => s.parentSpanId === tbId ? {...s, parentSpanId: rootSpanId} : s);
     }
     if (sp.length <= 1) return '';
     // Include the parent suite span so the test bar is shown relative to the class duration

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1485,8 +1485,16 @@ function renderSpanRows(sp, uid) {
 function renderTrace(tid, rootSpanId) {
     const allSpans = spansByTrace[tid];
     if (!allSpans || !allSpans.length) return '';
-    const sp = getDescendants(allSpans, rootSpanId);
+    let sp = getDescendants(allSpans, rootSpanId);
     if (!sp.length) return '';
+    // If the only direct child of the test case is "test body", the span itself is
+    // redundant — remove it and re-parent its children directly under the test case
+    const directChildren = sp.filter(s => s.parentSpanId === rootSpanId);
+    if (directChildren.length === 1 && directChildren[0].name === 'test body') {
+        const tbId = directChildren[0].spanId;
+        sp = sp.filter(s => s.spanId !== tbId).map(s => s.parentSpanId === tbId ? Object.assign({}, s, {parentSpanId: rootSpanId}) : s);
+    }
+    if (sp.length <= 1) return '';
     // Include the parent suite span so the test bar is shown relative to the class duration
     const root = bySpanId[rootSpanId];
     if (root && root.parentSpanId && bySpanId[root.parentSpanId]) {

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -166,7 +166,7 @@ internal class TestExecutor
             if (TUnitActivitySource.Source.HasListeners())
             {
                 testBodyActivity = TUnitActivitySource.StartActivity(
-                    "test body",
+                    TUnitActivitySource.SpanTestBody,
                     ActivityKind.Internal,
                     executableTest.Context.Activity?.Context ?? default);
             }


### PR DESCRIPTION
## Summary
- When a test has no before/after hooks, the "test body" span is the only child of the test case span and adds no useful information to the trace timeline — omit it
- If the test body has child spans (e.g. HTTP calls, DB queries), those are re-parented directly under the test case span so they remain visible
- Add `SpanTestBody` constant to `TUnitActivitySource` alongside the other span name constants, eliminating the magic string in `TestExecutor`

## Test plan
- [ ] Run a test with no hooks — verify the trace timeline is hidden (no redundant "test body" bar)
- [ ] Run a test with before/after hooks — verify all spans (hooks + test body) still appear
- [ ] Run a test whose body produces child spans (e.g. HttpClient activity) — verify child spans appear directly under the test case span