### PR TITLE
feat(html-report): add flaky test detection and summary section

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
@@ -69,6 +69,9 @@ internal sealed class ReportSummary
 
     [JsonPropertyName("timedOut")]
     public int TimedOut { get; set; }
+
+    [JsonPropertyName("flaky")]
+    public int Flaky { get; set; }
 }
 
 internal sealed class ReportTestGroup

--- a/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
@@ -72,6 +72,12 @@ internal sealed class ReportSummary
 
     [JsonPropertyName("flaky")]
     public int Flaky { get; set; }
+
+    [JsonIgnore]
+    public int CleanPassed => Passed - Flaky;
+
+    [JsonIgnore]
+    public int TotalFailed => Failed + TimedOut;
 }
 
 internal sealed class ReportTestGroup

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -309,9 +309,11 @@ internal static partial class HtmlReportGenerator
         sb.Append(summary.Total);
         sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"passed\" aria-pressed=\"false\"><span class=\"dot emerald\"></span>Passed <span class=\"pill-count\">");
-        sb.Append(summary.Passed);
+        sb.Append(summary.Passed - summary.Flaky);
         sb.AppendLine("</span></button>");
-        sb.AppendLine("<button class=\"pill\" data-filter=\"flaky\" aria-pressed=\"false\" id=\"flakyPill\" style=\"display:none\"><span class=\"dot orange\"></span>Flaky <span class=\"pill-count\" id=\"flakyPillCount\">0</span></button>");
+        sb.Append("<button class=\"pill hidden\" data-filter=\"flaky\" aria-pressed=\"false\" id=\"flakyPill\"><span class=\"dot orange\"></span>Flaky <span class=\"pill-count\" id=\"flakyPillCount\">");
+        sb.Append(summary.Flaky);
+        sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"failed\" aria-pressed=\"false\"><span class=\"dot rose\"></span>Failed <span class=\"pill-count\">");
         sb.Append(summary.Failed + summary.TimedOut);
         sb.AppendLine("</span></button>");
@@ -718,6 +720,7 @@ body{
 }
 .pill:hover{border-color:var(--border-h);color:var(--text)}
 .pill.active{background:var(--indigo);border-color:var(--indigo);color:#fff}
+.pill.hidden{display:none}
 .dot{width:7px;height:7px;border-radius:50%;display:inline-block}
 .dot.emerald{background:var(--emerald)}
 .dot.rose{background:var(--rose)}
@@ -1812,7 +1815,7 @@ function renderFlakySection() {
     // Update pill visibility and count
     const pill = document.getElementById('flakyPill');
     const pillCount = document.getElementById('flakyPillCount');
-    if (pill) pill.style.display = flaky.length ? '' : 'none';
+    if (pill) { if (flaky.length) pill.classList.remove('hidden'); else pill.classList.add('hidden'); }
     if (pillCount) pillCount.textContent = flaky.length;
     // Update dashboard indicator
     const indicator = document.getElementById('flakyIndicator');

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -76,6 +76,7 @@ internal static partial class HtmlReportGenerator
 
         // Quick-access sections populated by JS
         sb.AppendLine("<div id=\"failedSection\" role=\"region\" aria-label=\"Failed tests\"></div>");
+        sb.AppendLine("<div id=\"flakySection\" role=\"region\" aria-label=\"Flaky tests\"></div>");
         sb.AppendLine("<div id=\"failureClusters\" role=\"region\" aria-label=\"Failure clusters\"></div>");
         sb.AppendLine("<div id=\"slowestSection\" role=\"region\" aria-label=\"Slowest tests\"></div>");
 
@@ -256,6 +257,8 @@ internal static partial class HtmlReportGenerator
         sb.AppendLine("<div id=\"durationHist\" class=\"dur-hist\"></div>");
         sb.AppendLine("</div>");
 
+        sb.AppendLine("<div class=\"flaky-indicator\" id=\"flakyIndicator\"></div>");
+
         sb.AppendLine("</section>");
     }
 
@@ -308,6 +311,7 @@ internal static partial class HtmlReportGenerator
         sb.Append("<button class=\"pill\" data-filter=\"passed\" aria-pressed=\"false\"><span class=\"dot emerald\"></span>Passed <span class=\"pill-count\">");
         sb.Append(summary.Passed);
         sb.AppendLine("</span></button>");
+        sb.AppendLine("<button class=\"pill\" data-filter=\"flaky\" aria-pressed=\"false\" id=\"flakyPill\" style=\"display:none\"><span class=\"dot orange\"></span>Flaky <span class=\"pill-count\" id=\"flakyPillCount\">0</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"failed\" aria-pressed=\"false\"><span class=\"dot rose\"></span>Failed <span class=\"pill-count\">");
         sb.Append(summary.Failed + summary.TimedOut);
         sb.AppendLine("</span></button>");
@@ -473,6 +477,8 @@ internal static partial class HtmlReportGenerator
   --indigo:    #818cf8;
   --indigo-d:  rgba(129,140,248,.10);
   --violet:    #a78bfa;
+  --orange:    #fb923c;
+  --orange-d:  rgba(251,146,60,.12);
 
   --font:      'Segoe UI Variable','Segoe UI',-apple-system,BlinkMacSystemFont,system-ui,sans-serif;
   --mono:      'Cascadia Code','JetBrains Mono','Fira Code','SF Mono',ui-monospace,monospace;
@@ -490,6 +496,7 @@ internal static partial class HtmlReportGenerator
   --emerald-d:rgba(52,211,153,.15);--rose-d:rgba(251,113,133,.15);
   --amber-d:rgba(251,191,36,.12);--slate-d:rgba(148,163,184,.12);
   --indigo-d:rgba(129,140,248,.12);--violet:#7c3aed;
+  --orange-d:rgba(251,146,60,.15);
 }
 :root[data-theme="light"] .grain{opacity:.008}
 
@@ -512,6 +519,7 @@ internal static partial class HtmlReportGenerator
 @property --amber-d   { syntax:'<color>'; inherits:true; initial-value:rgba(251,191,36,.10) }
 @property --slate-d   { syntax:'<color>'; inherits:true; initial-value:rgba(148,163,184,.10) }
 @property --indigo-d  { syntax:'<color>'; inherits:true; initial-value:rgba(129,140,248,.10) }
+@property --orange-d  { syntax:'<color>'; inherits:true; initial-value:rgba(251,146,60,.12) }
 
 :root {
   transition:
@@ -520,7 +528,8 @@ internal static partial class HtmlReportGenerator
     --border .3s var(--ease), --border-h .3s var(--ease),
     --text .3s var(--ease), --text-2 .3s var(--ease), --text-3 .3s var(--ease),
     --emerald-d .3s var(--ease), --rose-d .3s var(--ease), --amber-d .3s var(--ease),
-    --slate-d .3s var(--ease), --indigo-d .3s var(--ease);
+    --slate-d .3s var(--ease), --indigo-d .3s var(--ease),
+    --orange-d .3s var(--ease);
 }
 /* Suppress per-element transitions during theme switch so only the
    @property variable interpolations drive the animation — no stagger. */
@@ -669,6 +678,8 @@ body{
 .dash-dur{text-align:center;padding:4px 20px;flex-shrink:0}
 .dash-dur-val{display:block;font-size:1.5rem;font-weight:800;font-family:var(--mono);letter-spacing:-.02em}
 .dash-dur-lbl{display:block;font-size:.68rem;color:var(--text-3);text-transform:uppercase;letter-spacing:.06em;margin-top:2px}
+.flaky-indicator{display:none;text-align:center;margin-top:6px;font-size:.78rem;font-weight:700;color:var(--orange)}
+.flaky-indicator.visible{display:block}
 
 /* ── Toolbar (search + pills) ──────────────────────── */
 .bar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px;justify-content:flex-end}
@@ -712,6 +723,7 @@ body{
 .dot.rose{background:var(--rose)}
 .dot.amber{background:var(--amber)}
 .dot.slate{background:var(--slate)}
+.dot.orange{background:var(--orange)}
 .bar-info{font-size:.8rem;color:var(--text-3);margin-left:auto}
 
 /* Category filter pills — extends .pill with smaller sizing and violet accent */
@@ -787,6 +799,7 @@ body{
 .t-badge.failed,.t-badge.error,.t-badge.timedOut{background:var(--rose-d);color:var(--rose);box-shadow:0 0 6px rgba(251,113,133,.15)}
 .t-badge.skipped{background:var(--amber-d);color:var(--amber);box-shadow:0 0 6px rgba(251,191,36,.12)}
 .t-badge.cancelled{background:var(--slate-d);color:var(--slate)}
+.t-badge.flaky{background:var(--orange-d);color:var(--orange);box-shadow:0 0 6px rgba(251,146,60,.15)}
 .t-badge.inProgress,.t-badge.unknown{background:var(--surface-2);color:var(--text-3)}
 .t-name{flex:1;font-size:.88rem;word-break:break-word;color:var(--text)}
 .t-dur{font-size:.78rem;color:var(--text-3);font-family:var(--mono);white-space:nowrap;font-variant-numeric:tabular-nums}
@@ -1379,9 +1392,14 @@ spans.forEach(s => {
     if (tag) suiteSpanByClass[tag.value] = s;
 });
 
+function isFlaky(t) { return t.status === 'passed' && t.retryAttempt > 0; }
 function matchesFilter(t) {
     if (activeFilter !== 'all') {
-        if (activeFilter === 'failed') {
+        if (activeFilter === 'flaky') {
+            if (!isFlaky(t)) return false;
+        } else if (activeFilter === 'passed') {
+            if (t.status !== 'passed' || isFlaky(t)) return false;
+        } else if (activeFilter === 'failed') {
             if (t.status !== 'failed' && t.status !== 'error' && t.status !== 'timedOut') return false;
         } else if (t.status !== activeFilter) return false;
     }
@@ -1782,6 +1800,46 @@ function renderSlowestSection() {
     sec.innerHTML = h;
 }
 
+function renderFlakySection() {
+    const sec = document.getElementById('flakySection');
+    if (!sec) return;
+    const flaky = [];
+    groups.forEach(function(g){
+        g.tests.forEach(function(t){
+            if (isFlaky(t)) flaky.push({t:t,cls:g.className});
+        });
+    });
+    // Update pill visibility and count
+    const pill = document.getElementById('flakyPill');
+    const pillCount = document.getElementById('flakyPillCount');
+    if (pill) pill.style.display = flaky.length ? '' : 'none';
+    if (pillCount) pillCount.textContent = flaky.length;
+    // Update dashboard indicator
+    const indicator = document.getElementById('flakyIndicator');
+    if (indicator) {
+        if (flaky.length) {
+            indicator.textContent = flaky.length + ' flaky';
+            indicator.classList.add('visible');
+        } else {
+            indicator.classList.remove('visible');
+        }
+    }
+    if (!flaky.length) { sec.innerHTML=''; return; }
+    flaky.sort(function(a,b){ return b.t.retryAttempt - a.t.retryAttempt; });
+    let h = '<div class="qa-section"><div class="tl-toggle">'+tlArrow+' Flaky Tests ('+flaky.length+')</div><div class="tl-content"><div class="tl-content-inner"><div class="tl-content-pad">';
+    flaky.forEach(function(f){
+        h += '<div class="qa-item" data-scroll-tid="'+f.t.id+'">';
+        h += '<span class="t-badge flaky">flaky</span>';
+        h += '<div class="qa-info"><div class="qa-info-name">'+esc(f.t.displayName)+'</div>';
+        h += '<div class="qa-info-class">'+esc(f.cls)+'</div></div>';
+        h += '<span class="retry-tag">'+f.t.retryAttempt+' '+(f.t.retryAttempt===1?'retry':'retries')+'</span>';
+        h += '<span class="qa-dur">'+fmt(f.t.durationMs)+'</span>';
+        h += '</div>';
+    });
+    h += '</div></div></div></div>';
+    sec.innerHTML = h;
+}
+
 function sortGroups(grps) {
     if (sortMode === 'duration') {
         const maxDur = new Map(grps.map(g => [g, g.tests.length ? Math.max(...g.tests.map(t => t.durationMs)) : 0]));
@@ -2081,6 +2139,7 @@ loadFromHash();
 if(catNames.length > 0) buildCatPills();
 render();
 renderFailedSection();
+renderFlakySection();
 renderFailureClusters();
 renderSlowestSection();
 checkHash();

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -191,12 +191,14 @@ internal static partial class HtmlReportGenerator
     private static void AppendSummaryDashboard(StringBuilder sb, ReportSummary summary, double totalDurationMs)
     {
         var passRate = summary.Total > 0 ? (double)summary.Passed / summary.Total * 100 : 0;
+        var cleanPassed = summary.Passed - summary.Flaky;
 
         sb.AppendLine("<section class=\"dash\" data-anim=\"fade-up\" aria-label=\"Test summary\">");
 
         // Ring chart — SVG
         var circumference = 2 * Math.PI * 54; // r=54
-        var passLen = summary.Total > 0 ? circumference * summary.Passed / summary.Total : 0;
+        var cleanPassLen = summary.Total > 0 ? circumference * cleanPassed / summary.Total : 0;
+        var flakyLen = summary.Total > 0 ? circumference * summary.Flaky / summary.Total : 0;
         var failLen = summary.Total > 0 ? circumference * (summary.Failed + summary.TimedOut) / summary.Total : 0;
         var skipLen = summary.Total > 0 ? circumference * summary.Skipped / summary.Total : 0;
         var cancelLen = summary.Total > 0 ? circumference * summary.Cancelled / summary.Total : 0;
@@ -208,10 +210,16 @@ internal static partial class HtmlReportGenerator
 
         // Segments — stacked with dasharray/dashoffset
         double offset = 0;
-        if (passLen > 0)
+        if (cleanPassLen > 0)
         {
-            AppendRingSegment(sb, "var(--emerald)", passLen, offset, circumference);
-            offset += passLen;
+            AppendRingSegment(sb, "var(--emerald)", cleanPassLen, offset, circumference);
+            offset += cleanPassLen;
+        }
+
+        if (flakyLen > 0)
+        {
+            AppendRingSegment(sb, "var(--orange)", flakyLen, offset, circumference);
+            offset += flakyLen;
         }
 
         if (failLen > 0)
@@ -242,7 +250,7 @@ internal static partial class HtmlReportGenerator
         // Stat cards
         sb.AppendLine("<div class=\"stats\">");
         AppendStatCard(sb, "total", summary.Total.ToString(), "Total", null);
-        AppendStatCard(sb, "passed", summary.Passed.ToString(), "Passed", "var(--emerald)");
+        AppendStatCard(sb, "passed", cleanPassed.ToString(), "Passed", "var(--emerald)");
         AppendStatCard(sb, "failed", (summary.Failed + summary.TimedOut).ToString(), "Failed", "var(--rose)");
         AppendStatCard(sb, "skipped", summary.Skipped.ToString(), "Skipped", "var(--amber)");
         AppendStatCard(sb, "cancelled", summary.Cancelled.ToString(), "Cancelled", "var(--slate)");
@@ -1396,6 +1404,7 @@ spans.forEach(s => {
 });
 
 function isFlaky(t) { return t.status === 'passed' && t.retryAttempt > 0; }
+function badgeLabel(t) { return isFlaky(t) ? 'flaky' : t.status; }
 function matchesFilter(t) {
     if (activeFilter !== 'all') {
         if (activeFilter === 'flaky') {
@@ -1766,7 +1775,7 @@ function renderFailedSection() {
         const errMsg = f.t.exception ? (f.t.exception.type+': '+f.t.exception.message) : '';
         const truncErr = errMsg.length > 120 ? errMsg.substring(0,120)+'…' : errMsg;
         h += '<div class="qa-item" data-scroll-tid="'+f.t.id+'">';
-        h += '<span class="t-badge '+f.t.status+'">'+esc(f.t.status)+'</span>';
+        var bl=badgeLabel(f.t);h += '<span class="t-badge '+bl+'">'+esc(bl)+'</span>';
         h += '<div class="qa-info"><div class="qa-info-name">'+esc(f.t.displayName)+'</div>';
         h += '<div class="qa-info-class">'+esc(f.cls)+'</div></div>';
         if (truncErr) h += '<span class="qa-err" title="'+esc(errMsg)+'">'+esc(truncErr)+'</span>';
@@ -1815,7 +1824,7 @@ function renderFlakySection() {
     // Update pill visibility and count
     const pill = document.getElementById('flakyPill');
     const pillCount = document.getElementById('flakyPillCount');
-    if (pill) { if (flaky.length) pill.classList.remove('hidden'); else pill.classList.add('hidden'); }
+    if (pill) pill.classList.toggle('hidden', !flaky.length);
     if (pillCount) pillCount.textContent = flaky.length;
     // Update dashboard indicator
     const indicator = document.getElementById('flakyIndicator');
@@ -1883,7 +1892,7 @@ function render() {
         }
         ft.forEach((t,ti)=>{
             html += '<div class="t-row" id="test-'+t.id+'" data-gi="'+gi+'" data-ti="'+ti+'" data-tid="'+t.id+'" style="--row-idx:'+Math.min(ti,7)+'">';
-            html += '<span class="t-badge '+t.status+'">'+esc(t.status)+'</span>';
+            var bl=badgeLabel(t);html += '<span class="t-badge '+bl+'">'+esc(bl)+'</span>';
             html += '<span class="t-name">'+(searchText?highlight(t.displayName,searchText):esc(t.displayName))+'</span>';
             if(t.retryAttempt>0) html += '<span class="retry-tag">retry '+t.retryAttempt+'</span>';
             html += '<button class="t-link-btn" data-link-tid="'+t.id+'" title="Copy link">'+linkIcon+'</button>';
@@ -2279,7 +2288,7 @@ function renderFailureClusters() {
         h += '<div class="fc-body"><div class="fc-body-inner"><div class="fc-tests">';
         c.tests.forEach(function(f){
             h += '<div class="fc-test" data-scroll-tid="'+esc(f.t.id)+'">';
-            h += '<span class="t-badge '+safeClass(f.t.status)+'">'+esc(f.t.status)+'</span>';
+            var bl=badgeLabel(f.t);h += '<span class="t-badge '+safeClass(bl)+'">'+esc(bl)+'</span>';
             h += '<span class="fc-test-name" title="'+esc(f.t.displayName)+'">'+esc(f.t.displayName)+'</span>';
             h += '<span class="fc-test-class">'+esc(f.cls)+'</span>';
             h += '<span class="fc-test-dur">'+fmt(f.t.durationMs)+'</span>';

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -190,16 +190,15 @@ internal static partial class HtmlReportGenerator
 
     private static void AppendSummaryDashboard(StringBuilder sb, ReportSummary summary, double totalDurationMs)
     {
-        var cleanPassed = summary.Passed - summary.Flaky;
-        var passRate = summary.Total > 0 ? (double)cleanPassed / summary.Total * 100 : 0;
+        var passRate = summary.Total > 0 ? (double)summary.Passed / summary.Total * 100 : 0;
 
         sb.AppendLine("<section class=\"dash\" data-anim=\"fade-up\" aria-label=\"Test summary\">");
 
         // Ring chart — SVG
         var circumference = 2 * Math.PI * 54; // r=54
-        var cleanPassLen = summary.Total > 0 ? circumference * cleanPassed / summary.Total : 0;
+        var cleanPassLen = summary.Total > 0 ? circumference * summary.CleanPassed / summary.Total : 0;
         var flakyLen = summary.Total > 0 ? circumference * summary.Flaky / summary.Total : 0;
-        var failLen = summary.Total > 0 ? circumference * (summary.Failed + summary.TimedOut) / summary.Total : 0;
+        var failLen = summary.Total > 0 ? circumference * summary.TotalFailed / summary.Total : 0;
         var skipLen = summary.Total > 0 ? circumference * summary.Skipped / summary.Total : 0;
         var cancelLen = summary.Total > 0 ? circumference * summary.Cancelled / summary.Total : 0;
 
@@ -250,13 +249,13 @@ internal static partial class HtmlReportGenerator
         // Stat cards
         sb.AppendLine("<div class=\"stats\">");
         AppendStatCard(sb, "total", summary.Total.ToString(), "Total", null);
-        AppendStatCard(sb, "passed", cleanPassed.ToString(), "Passed", "var(--emerald)");
+        AppendStatCard(sb, "passed", summary.CleanPassed.ToString(), "Passed", "var(--emerald)");
         if (summary.Flaky > 0)
         {
             AppendStatCard(sb, "flaky", summary.Flaky.ToString(), "Flaky", "var(--orange)");
         }
 
-        AppendStatCard(sb, "failed", (summary.Failed + summary.TimedOut).ToString(), "Failed", "var(--rose)");
+        AppendStatCard(sb, "failed", summary.TotalFailed.ToString(), "Failed", "var(--rose)");
         AppendStatCard(sb, "skipped", summary.Skipped.ToString(), "Skipped", "var(--amber)");
         AppendStatCard(sb, "cancelled", summary.Cancelled.ToString(), "Cancelled", "var(--slate)");
         sb.AppendLine("</div>");
@@ -320,13 +319,13 @@ internal static partial class HtmlReportGenerator
         sb.Append(summary.Total);
         sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"passed\" aria-pressed=\"false\"><span class=\"dot emerald\"></span>Passed <span class=\"pill-count\">");
-        sb.Append(summary.Passed - summary.Flaky);
+        sb.Append(summary.CleanPassed);
         sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill hidden\" data-filter=\"flaky\" aria-pressed=\"false\" id=\"flakyPill\"><span class=\"dot orange\"></span>Flaky <span class=\"pill-count\" id=\"flakyPillCount\">");
         sb.Append(summary.Flaky);
         sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"failed\" aria-pressed=\"false\"><span class=\"dot rose\"></span>Failed <span class=\"pill-count\">");
-        sb.Append(summary.Failed + summary.TimedOut);
+        sb.Append(summary.TotalFailed);
         sb.AppendLine("</span></button>");
         sb.Append("<button class=\"pill\" data-filter=\"skipped\" aria-pressed=\"false\"><span class=\"dot amber\"></span>Skipped <span class=\"pill-count\">");
         sb.Append(summary.Skipped);

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -190,8 +190,8 @@ internal static partial class HtmlReportGenerator
 
     private static void AppendSummaryDashboard(StringBuilder sb, ReportSummary summary, double totalDurationMs)
     {
-        var passRate = summary.Total > 0 ? (double)summary.Passed / summary.Total * 100 : 0;
         var cleanPassed = summary.Passed - summary.Flaky;
+        var passRate = summary.Total > 0 ? (double)cleanPassed / summary.Total * 100 : 0;
 
         sb.AppendLine("<section class=\"dash\" data-anim=\"fade-up\" aria-label=\"Test summary\">");
 
@@ -251,6 +251,11 @@ internal static partial class HtmlReportGenerator
         sb.AppendLine("<div class=\"stats\">");
         AppendStatCard(sb, "total", summary.Total.ToString(), "Total", null);
         AppendStatCard(sb, "passed", cleanPassed.ToString(), "Passed", "var(--emerald)");
+        if (summary.Flaky > 0)
+        {
+            AppendStatCard(sb, "flaky", summary.Flaky.ToString(), "Flaky", "var(--orange)");
+        }
+
         AppendStatCard(sb, "failed", (summary.Failed + summary.TimedOut).ToString(), "Failed", "var(--rose)");
         AppendStatCard(sb, "skipped", summary.Skipped.ToString(), "Skipped", "var(--amber)");
         AppendStatCard(sb, "cancelled", summary.Cancelled.ToString(), "Cancelled", "var(--slate)");
@@ -264,8 +269,6 @@ internal static partial class HtmlReportGenerator
         sb.AppendLine("<span class=\"dash-dur-lbl\">duration</span>");
         sb.AppendLine("<div id=\"durationHist\" class=\"dur-hist\"></div>");
         sb.AppendLine("</div>");
-
-        sb.AppendLine("<div class=\"flaky-indicator\" id=\"flakyIndicator\"></div>");
 
         sb.AppendLine("</section>");
     }
@@ -688,8 +691,6 @@ body{
 .dash-dur{text-align:center;padding:4px 20px;flex-shrink:0}
 .dash-dur-val{display:block;font-size:1.5rem;font-weight:800;font-family:var(--mono);letter-spacing:-.02em}
 .dash-dur-lbl{display:block;font-size:.68rem;color:var(--text-3);text-transform:uppercase;letter-spacing:.06em;margin-top:2px}
-.flaky-indicator{display:none;text-align:center;margin-top:6px;font-size:.78rem;font-weight:700;color:var(--orange)}
-.flaky-indicator.visible{display:block}
 
 /* ── Toolbar (search + pills) ──────────────────────── */
 .bar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px;justify-content:flex-end}
@@ -1826,16 +1827,6 @@ function renderFlakySection() {
     const pillCount = document.getElementById('flakyPillCount');
     if (pill) pill.classList.toggle('hidden', !flaky.length);
     if (pillCount) pillCount.textContent = flaky.length;
-    // Update dashboard indicator
-    const indicator = document.getElementById('flakyIndicator');
-    if (indicator) {
-        if (flaky.length) {
-            indicator.textContent = flaky.length + ' flaky';
-            indicator.classList.add('visible');
-        } else {
-            indicator.classList.remove('visible');
-        }
-    }
     if (!flaky.length) { sec.innerHTML=''; return; }
     flaky.sort(function(a,b){ return b.t.retryAttempt - a.t.retryAttempt; });
     let h = '<div class="qa-section"><div class="tl-toggle">'+tlArrow+' Flaky Tests ('+flaky.length+')</div><div class="tl-content"><div class="tl-content-inner"><div class="tl-content-pad">';

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -276,7 +276,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
 
             var testResult = ExtractTestResult(kvp.Key, testNode, traceId, spanId, retryAttempt, additionalTraceIdsForResult);
 
-            AccumulateStatus(summary, testResult.Status);
+            AccumulateStatus(summary, testResult.Status, testResult.RetryAttempt);
 
             // Group by class name
             var className = testResult.ClassName;
@@ -327,7 +327,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             var groupSummary = new ReportSummary();
             foreach (var test in kvp.Value)
             {
-                AccumulateStatus(groupSummary, test.Status);
+                AccumulateStatus(groupSummary, test.Status, test.RetryAttempt);
             }
 
             groups[i++] = new ReportTestGroup
@@ -413,11 +413,15 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         return (commitSha, branch, prNumber, repoSlug);
     }
 
-    private static void AccumulateStatus(ReportSummary summary, string status)
+    private static void AccumulateStatus(ReportSummary summary, string status, int retryAttempt)
     {
         summary.Total++;
         switch (status)
         {
+            case "passed" when retryAttempt > 0:
+                summary.Passed++;
+                summary.Flaky++;
+                break;
             case "passed":
                 summary.Passed++;
                 break;

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -276,7 +276,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
 
             var testResult = ExtractTestResult(kvp.Key, testNode, traceId, spanId, retryAttempt, additionalTraceIdsForResult);
 
-            AccumulateStatus(summary, testResult.Status, testResult.RetryAttempt);
+            AccumulateStatus(summary, testResult);
 
             // Group by class name
             var className = testResult.ClassName;
@@ -327,7 +327,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             var groupSummary = new ReportSummary();
             foreach (var test in kvp.Value)
             {
-                AccumulateStatus(groupSummary, test.Status, test.RetryAttempt);
+                AccumulateStatus(groupSummary, test);
             }
 
             groups[i++] = new ReportTestGroup
@@ -413,12 +413,12 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         return (commitSha, branch, prNumber, repoSlug);
     }
 
-    private static void AccumulateStatus(ReportSummary summary, string status, int retryAttempt)
+    private static void AccumulateStatus(ReportSummary summary, ReportTestResult testResult)
     {
         summary.Total++;
-        switch (status)
+        switch (testResult.Status)
         {
-            case "passed" when retryAttempt > 0:
+            case "passed" when testResult.RetryAttempt > 0:
                 summary.Passed++;
                 summary.Flaky++;
                 break;


### PR DESCRIPTION
## Summary

- Adds flaky test detection to the HTML report — a test is considered flaky when it has `status === 'passed'` and `retryAttempt > 0`
- Adds a collapsible "Flaky Tests" quick-access section (alongside Failed and Slowest) showing test name, class, retry count, and click-to-scroll navigation
- Adds an orange "Flaky" filter pill to the status bar (auto-hidden when no flaky tests exist) and excludes flaky tests from the "Passed" filter for clearer separation
- Adds a flaky count indicator in the summary dashboard and full orange color theming (CSS variables, badge, dot, light/dark mode support)

Closes #5487