### PR TITLE
fix(tests): clear reporter env vars before each GitHubReporterTest to fix flaky CI on macOS/Windows

### DIFF
--- a/TUnit.Engine.Tests/GitHubReporterTests.cs
+++ b/TUnit.Engine.Tests/GitHubReporterTests.cs
@@ -10,9 +10,14 @@ public class GitHubReporterTests
 {
     private readonly List<string> _tempFiles = [];
 
-    [After(Test)]
-    public void CleanupAfterTest()
+    [Before(Test)]
+    public void ResetEnvironmentBeforeTest()
     {
+        // The CI pipeline (RunEngineTestsModule) launches this process with
+        // TUNIT_DISABLE_GITHUB_REPORTER=true to prevent the test-runner's own
+        // GitHubReporter from writing to the step summary.  Clear ALL reporter-
+        // related env vars before every test so each test starts from a known
+        // clean state regardless of execution order.
         Environment.SetEnvironmentVariable("TUNIT_DISABLE_GITHUB_REPORTER", null);
         Environment.SetEnvironmentVariable("DISABLE_GITHUB_REPORTER", null);
         Environment.SetEnvironmentVariable("TUNIT_GITHUB_REPORTER_STYLE", null);
@@ -20,6 +25,12 @@ public class GitHubReporterTests
         Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", null);
         Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", null);
         Environment.SetEnvironmentVariable("GITHUB_SHA", null);
+    }
+
+    [After(Test)]
+    public void CleanupAfterTest()
+    {
+        ResetEnvironmentBeforeTest();
 
         foreach (var file in _tempFiles)
         {


### PR DESCRIPTION
## Summary

- Fixes intermittent CI failures on macOS and Windows in `GitHubReporterTests` introduced by #5491
- Adds a `[Before(Test)]` hook that clears all reporter-related environment variables before each test, guaranteeing a known-clean state regardless of test execution order

## Root Cause

The CI pipeline (`RunEngineTestsModule`) launches `TUnit.Engine.Tests` with `TUNIT_DISABLE_GITHUB_REPORTER=true` to prevent the test runner's own `GitHubReporter` from writing to the GitHub step summary.

The `AfterRunAsync_*` tests call `SetupReporter()`, which sets `GITHUB_ACTIONS` and `GITHUB_STEP_SUMMARY` but **never cleared** the `TUNIT_DISABLE_GITHUB_REPORTER` flag inherited from the process environment. If any `AfterRunAsync_*` test ran before the `IsEnabledAsync_*` tests' `[After(Test)]` cleanup had cleared it, `IsEnabledAsync()` returned `false` and the test failed with:

`Reporter should be enabled — check env var setup`

This was order-dependent: exactly **one** test failed on macOS (`AfterRunAsync_Groups_Timeouts_As_Timeout`) and **one** on Windows (`AfterRunAsync_Orders_Groups_By_Count_Descending`), while Ubuntu happened to run `IsEnabledAsync_*` tests first and passed consistently.

## Fix

Added a `[Before(Test)]` hook `ResetEnvironmentBeforeTest()` that clears all reporter-related env vars before every test. The existing `[After(Test)]` cleanup delegates to the same method (DRY). This ensures each test starts from a clean state regardless of execution order.

## Testing

- All 13 `GitHubReporterTests` pass locally
- Verified with `TUNIT_DISABLE_GITHUB_REPORTER=true` pre-set in the process environment (exact CI condition) — all 13 still pass