### PR TITLE
feat: add Activity baggage-based test context correlation

### DIFF
--- a/TUnit.Core/TUnitActivitySource.cs
+++ b/TUnit.Core/TUnitActivitySource.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace TUnit.Core;
 
-internal static class TUnitActivitySource
+public static class TUnitActivitySource
 {
     private static readonly string Version =
         typeof(TUnitActivitySource).Assembly.GetName().Version?.ToString() ?? "0.0.0";
@@ -18,8 +18,14 @@ internal static class TUnitActivitySource
     internal const string SpanTestCase = "test case";
     internal const string SpanTestBody = "test body";
 
-    // Tag keys used across init/dispose spans and the HTML report.
-    internal const string TagTestId = "tunit.test.id";
+    // Tag and baggage keys used across init/dispose spans, HTML report, and cross-boundary correlation.
+
+    /// <summary>
+    /// The key used for the test context ID in both Activity span tags and Activity baggage.
+    /// Set as baggage on each test's Activity span to enable automatic
+    /// <see cref="TestContext.Current"/> resolution when OpenTelemetry propagation is configured.
+    /// </summary>
+    public const string TagTestId = "tunit.test.id";
     internal const string TagTestClass = "tunit.test.class";
     internal const string TagTraceScope = "tunit.trace.scope";
 

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -124,13 +124,29 @@ public partial class TestContext : Context,
     /// </example>
     public static new TestContext? Current
     {
-        get => TestContexts.Value;
+        get => TestContexts.Value
+#if NET
+            ?? ResolveFromActivityBaggage()
+#endif
+            ;
         internal set
         {
             TestContexts.Value = value;
             ClassHookContext.Current = value?.ClassContext;
         }
     }
+
+#if NET
+    private static TestContext? ResolveFromActivityBaggage()
+    {
+        if (System.Diagnostics.Activity.Current?.GetBaggageItem(TUnitActivitySource.TagTestId) is { } testId)
+        {
+            return GetById(testId);
+        }
+
+        return null;
+    }
+#endif
 
     /// <summary>
     /// Associates the current async scope with this test context so that console output

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -137,6 +137,12 @@ public partial class TestContext : Context,
     }
 
 #if NET
+    // Fallback: resolve test context from Activity.Current baggage when the AsyncLocal
+    // is null (e.g., on a server thread pool processing an OTel-propagated request).
+    // Note: GetBaggageItem only traverses in-process Activity.Parent references.
+    // When a child Activity is created with an ActivityContext (not an Activity object)
+    // as parent, it won't inherit the parent's baggage. This is fine for the cross-process
+    // case (OTel propagators attach baggage directly to the new root Activity).
     private static TestContext? ResolveFromActivityBaggage()
     {
         if (System.Diagnostics.Activity.Current?.GetBaggageItem(TUnitActivitySource.TagTestId) is { } testId)

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -138,6 +138,7 @@ internal class TestExecutor
                         new("tunit.test.categories", testDetails.Categories.ToArray())
                     ]);
 
+                // Same key as the span tag above — set as baggage for cross-boundary propagation via W3C headers
                 executableTest.Context.Activity?.SetBaggage(TUnitActivitySource.TagTestId, executableTest.Context.Id);
             }
 #endif

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -137,6 +137,8 @@ internal class TestExecutor
                         new("tunit.test.node_uid", testDetails.TestId),
                         new("tunit.test.categories", testDetails.Categories.ToArray())
                     ]);
+
+                executableTest.Context.Activity?.SetBaggage(TUnitActivitySource.TagTestId, executableTest.Context.Id);
             }
 #endif
 

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1321,6 +1321,10 @@ namespace
         [.("Data source initialization may require dynamic code generation")]
         public static . InitializeStaticPropertiesForType( type) { }
     }
+    public static class TUnitActivitySource
+    {
+        public const string TagTestId = ".id";
+    }
     public class TUnitAttribute :  { }
     [(.Method)]
     public sealed class TestAttribute : .BaseTestAttribute

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1321,6 +1321,10 @@ namespace
         [.("Data source initialization may require dynamic code generation")]
         public static . InitializeStaticPropertiesForType( type) { }
     }
+    public static class TUnitActivitySource
+    {
+        public const string TagTestId = ".id";
+    }
     public class TUnitAttribute :  { }
     [(.Method)]
     public sealed class TestAttribute : .BaseTestAttribute

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1321,6 +1321,10 @@ namespace
         [.("Data source initialization may require dynamic code generation")]
         public static . InitializeStaticPropertiesForType( type) { }
     }
+    public static class TUnitActivitySource
+    {
+        public const string TagTestId = ".id";
+    }
     public class TUnitAttribute :  { }
     [(.Method)]
     public sealed class TestAttribute : .BaseTestAttribute

--- a/TUnit.TestProject/TestContextTests.cs
+++ b/TUnit.TestProject/TestContextTests.cs
@@ -1,4 +1,5 @@
-﻿using TUnit.TestProject.Attributes;
+﻿using System.Diagnostics;
+using TUnit.TestProject.Attributes;
 
 namespace TUnit.TestProject;
 
@@ -14,4 +15,48 @@ public class TestContextTests
 
         await Assert.That(context).IsNotNull();
     }
+
+#if NET
+    [Test]
+    public async Task TestContext_Resolves_From_Activity_Baggage_When_AsyncLocal_Is_Null()
+    {
+        var context = TestContext.Current!;
+        var testId = context.Id;
+
+        // Suppress execution context flow to simulate a server thread pool
+        // where AsyncLocal<TestContext> was never set.
+        // Undo() must happen on the same thread as SuppressFlow(), so
+        // launch the task inside the suppressed scope but await it outside.
+        Task<TestContext?> task;
+        var flowControl = ExecutionContext.SuppressFlow();
+        try
+        {
+            task = Task.Run(() =>
+            {
+                // Simulate what OTel does on the receiving side:
+                // create a new Activity with baggage extracted from W3C headers
+                using var listener = new ActivityListener
+                {
+                    ShouldListenTo = _ => true,
+                    Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                        ActivitySamplingResult.AllDataAndRecorded
+                };
+                ActivitySource.AddActivityListener(listener);
+
+                using var source = new ActivitySource("test-otel-simulation");
+                using var activity = source.StartActivity("incoming-request");
+                activity?.SetBaggage("tunit.test.id", testId);
+
+                return TestContext.Current;
+            });
+        }
+        finally
+        {
+            flowControl.Undo();
+        }
+
+        var resolved = await task;
+        await Assert.That(resolved).IsSameReferenceAs(context);
+    }
+#endif
 }

--- a/TUnit.TestProject/TestContextTests.cs
+++ b/TUnit.TestProject/TestContextTests.cs
@@ -35,16 +35,20 @@ public class TestContextTests
             {
                 // Simulate what OTel does on the receiving side:
                 // create a new Activity with baggage extracted from W3C headers
+                const string sourceName = "test-otel-simulation";
                 using var listener = new ActivityListener
                 {
-                    ShouldListenTo = _ => true,
+                    ShouldListenTo = source => source.Name == sourceName,
                     Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
                         ActivitySamplingResult.AllDataAndRecorded
                 };
                 ActivitySource.AddActivityListener(listener);
 
-                using var source = new ActivitySource("test-otel-simulation");
+                using var source = new ActivitySource(sourceName);
                 using var activity = source.StartActivity("incoming-request");
+                // Matches TUnitActivitySource.TagTestId ("tunit.test.id") — the key
+                // the engine sets as baggage and ResolveFromActivityBaggage reads.
+                // TUnitActivitySource is internal so we use the literal here.
                 activity?.SetBaggage("tunit.test.id", testId);
 
                 return TestContext.Current;

--- a/TUnit.TestProject/TestContextTests.cs
+++ b/TUnit.TestProject/TestContextTests.cs
@@ -46,10 +46,7 @@ public class TestContextTests
 
                 using var source = new ActivitySource(sourceName);
                 using var activity = source.StartActivity("incoming-request");
-                // Matches TUnitActivitySource.TagTestId ("tunit.test.id") — the key
-                // the engine sets as baggage and ResolveFromActivityBaggage reads.
-                // TUnitActivitySource is internal so we use the literal here.
-                activity?.SetBaggage("tunit.test.id", testId);
+                activity?.SetBaggage(TUnitActivitySource.TagTestId, testId);
 
                 return TestContext.Current;
             });

--- a/docs/docs/examples/opentelemetry.md
+++ b/docs/docs/examples/opentelemetry.md
@@ -175,6 +175,31 @@ dotnet add package OpenTelemetry.Exporter.Zipkin
 .AddZipkinExporter(opts => opts.Endpoint = new Uri("http://localhost:9411/api/v2/spans"))
 ```
 
+## Test Context Correlation via Activity Baggage
+
+TUnit stores the test context ID as Activity baggage (`tunit.test.id`) on each test case span. This enables automatic `TestContext.Current` resolution across service boundaries when Activity propagation is in place.
+
+When a test triggers work in a shared service host (e.g., via HTTP, gRPC, or messaging), the `AsyncLocal<TestContext>` doesn't flow because the server processes requests on its own thread pool. However, if OpenTelemetry propagation is configured, `Activity.Current` **does** flow via W3C `traceparent`/`baggage` headers. TUnit uses this: when `TestContext.Current` finds no AsyncLocal value, it falls back to checking `Activity.Current` for the `tunit.test.id` baggage item and resolves the originating test context automatically.
+
+This means console output, `ILogger` calls, and any code that reads `TestContext.Current` on the server side will automatically correlate to the correct test — with no manual setup beyond enabling OpenTelemetry propagation.
+
+```csharp
+// No extra code needed — just having OTel configured is sufficient.
+// The test's Activity carries tunit.test.id baggage, which propagates
+// automatically via W3C headers to OTel-instrumented services.
+
+[Test]
+public async Task Api_Returns_Expected_Result()
+{
+    // Activity baggage propagates via HTTP headers automatically
+    var response = await _httpClient.GetAsync("/api/data");
+
+    await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+}
+```
+
+For scenarios without OpenTelemetry, see [Cross-Thread Output Correlation](/docs/extending/logging#cross-thread-output-correlation) for the manual `TestContext.MakeCurrent()` approach.
+
 ## HTML Report Integration
 
 TUnit's built-in [HTML test report](/docs/guides/html-report) automatically captures activity spans and renders them as trace timelines — no OpenTelemetry SDK required. The report also captures spans from instrumented libraries like HttpClient, ASP.NET Core, and EF Core when they execute within a test's context.

--- a/docs/docs/extending/logging.md
+++ b/docs/docs/extending/logging.md
@@ -68,6 +68,42 @@ using (testContext.MakeCurrent())
 // Previous context is automatically restored
 ```
 
+### Automatic Correlation via OpenTelemetry
+
+If your application uses OpenTelemetry (or any framework that propagates W3C `traceparent`/`baggage` headers), test context correlation works **automatically** — no `MakeCurrent()` or manual header-passing needed.
+
+TUnit sets the test context ID as `Activity` baggage (`tunit.test.id`) on each test's span. When a framework propagates that Activity across a boundary (e.g., an HTTP call from a test to a shared service host), `TestContext.Current` on the receiving side automatically resolves the originating test from the propagated baggage.
+
+This works out of the box with OTel-instrumented:
+- **HTTP** (via `HttpClient` / ASP.NET Core)
+- **gRPC** (via `Grpc.Net.Client` / ASP.NET Core gRPC)
+- **Messaging** (via libraries like MassTransit or NServiceBus with OTel support)
+
+```csharp
+// Test side — nothing special needed beyond normal OTel setup
+[Test]
+public async Task MyTest()
+{
+    // HttpClient propagates Activity automatically when OTel is configured
+    var response = await _httpClient.GetAsync("/api/process");
+}
+
+// Server side — TestContext.Current resolves automatically
+public async Task<IResult> HandleProcess()
+{
+    // TestContext.Current is non-null here because the Activity
+    // carrying tunit.test.id baggage was propagated via HTTP headers
+    Console.WriteLine("This output is attributed to the test");
+    return Results.Ok();
+}
+```
+
+:::note
+This requires .NET 8+ and an active OpenTelemetry `TracerProvider` (or `ActivityListener`) subscribed to the `"TUnit"` source. See [OpenTelemetry Tracing](/docs/examples/opentelemetry) for setup instructions.
+:::
+
+For applications **without** Activity propagation, use the manual `MakeCurrent()` approach described below.
+
 ### How to Get the Test Context
 
 Your background service needs a way to know **which test** to correlate to. The typical pattern is to propagate the test's unique ID through your protocol (HTTP header, gRPC metadata, message property, etc.), then look it up on the receiving side with `TestContext.GetById()`.

--- a/docs/docs/extending/logging.md
+++ b/docs/docs/extending/logging.md
@@ -99,7 +99,7 @@ public async Task<IResult> HandleProcess()
 ```
 
 :::note
-This requires .NET 8+ and an active OpenTelemetry `TracerProvider` (or `ActivityListener`) subscribed to the `"TUnit"` source. See [OpenTelemetry Tracing](/docs/examples/opentelemetry) for setup instructions.
+This requires .NET 8+ and an active OpenTelemetry `TracerProvider` (or `ActivityListener`) subscribed to the `"TUnit"` source **on the test runner side**. The baggage is only set when the test runner's ActivitySource has listeners — without this, no Activity is created and the baggage cannot propagate. See [OpenTelemetry Tracing](/docs/examples/opentelemetry) for setup instructions.
 :::
 
 For applications **without** Activity propagation, use the manual `MakeCurrent()` approach described below.


### PR DESCRIPTION
## Summary

- Sets the test context ID as `Activity` baggage (`tunit.test.id`) when the per-test Activity is created, enabling automatic propagation across boundaries via W3C trace context (OpenTelemetry, gRPC, HTTP, message queues)
- Adds an Activity baggage fallback in `TestContext.Current` so that when the `AsyncLocal` is null (e.g., on a shared service host's thread pool), the context is resolved automatically from `Activity.Current` baggage — no manual `MakeCurrent()` call needed
- Zero overhead in the common path: the fallback only triggers when `AsyncLocal` value is null

Closes #5501

## Test plan

- [x] `TUnit.Core` builds across all targets (netstandard2.0, net8.0, net9.0, net10.0)
- [x] `TUnit.Engine` builds cleanly
- [x] Source generator snapshot tests pass (468 tests, 0 failures)
- [ ] CI pipeline passes