### PR TITLE
fix: auto-register correlated logging for minimal API hosts (#5503)

### DIFF
--- a/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
+++ b/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
@@ -62,12 +62,23 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
 
         hostBuilder?.ConfigureHostConfiguration(ConfigureStartupConfiguration);
 
-        hostBuilder?.ConfigureServices(services =>
+        return hostBuilder;
+    }
+
+    /// <summary>
+    /// Registers <see cref="CorrelatedTUnitLoggingExtensions.AddCorrelatedTUnitLogging"/> here
+    /// (rather than in <see cref="CreateHostBuilder"/>) so that minimal API hosts — where
+    /// <see cref="CreateHostBuilder"/> returns <c>null</c> — also get correlated logging.
+    /// Subclasses overriding this method must call <c>base.ConfigureWebHost(builder)</c>.
+    /// </summary>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureServices(services =>
         {
             services.AddCorrelatedTUnitLogging();
         });
-
-        return hostBuilder;
     }
 
 }

--- a/TUnit.AspNetCore.Tests.MinimalApi/Program.cs
+++ b/TUnit.AspNetCore.Tests.MinimalApi/Program.cs
@@ -1,0 +1,27 @@
+// Program is namespaced (not global, no top-level statements) so this entry point can
+// coexist with TUnit.AspNetCore.Tests.WebApp's global Program in the same test assembly
+// without ambiguous-reference compile errors.
+
+namespace TUnit.AspNetCore.Tests.MinimalApi;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        var app = builder.Build();
+
+        var logger = app.Services
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MinimalApiEndpoints");
+
+        app.MapGet("/log/{marker}", (string marker) =>
+        {
+            logger.LogInformation("MINIMAL_API_LOG:{Marker}", marker);
+            return Results.Ok(new { Marker = marker });
+        });
+
+        app.Run();
+    }
+}

--- a/TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj
+++ b/TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>TUnit.AspNetCore.Tests.MinimalApi</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/TUnit.AspNetCore.Tests/MinimalApiAutoRegistrationTests.cs
+++ b/TUnit.AspNetCore.Tests/MinimalApiAutoRegistrationTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using TUnit.AspNetCore;
+using TUnit.Core;
+using TUnit.Core.Interfaces;
+
+namespace TUnit.AspNetCore.Tests.MinimalApi;
+
+/// <summary>
+/// Regression coverage for thomhurst/TUnit#5503: <see cref="TestWebApplicationFactory{TEntryPoint}"/>
+/// must auto-register correlated logging for minimal API hosts. <see cref="MinimalApiTestFactory"/>
+/// has zero overrides — if these tests pass, the base class wired up logging on its own.
+/// </summary>
+public class MinimalApiAutoRegistrationTests
+{
+    [ClassDataSource(Shared = [SharedType.PerTestSession])]
+    public MinimalApiTestFactory Factory { get; set; } = null!;
+
+    [Test]
+    public async Task ServerLog_AutoCorrelated_OnMinimalApiHost_WithoutSubclassConfig()
+    {
+        var marker = Guid.NewGuid().ToString("N");
+        using var client = Factory.CreateClientWithTestContext();
+
+        var response = await client.GetAsync($"/log/{marker}");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var output = TestContext.Current!.GetStandardOutput();
+        await Assert.That(output).Contains($"MINIMAL_API_LOG:{marker}");
+    }
+}
+
+public class MinimalApiTestFactory : TestWebApplicationFactory<Program>, IAsyncInitializer
+{
+    public Task InitializeAsync()
+    {
+        // Eagerly start the server to surface configuration errors early
+        _ = Server;
+        return Task.CompletedTask;
+    }
+}

--- a/TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj
+++ b/TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <ProjectReference Include="..\TUnit.AspNetCore\TUnit.AspNetCore.csproj" />
         <ProjectReference Include="..\TUnit.AspNetCore.Tests.WebApp\TUnit.AspNetCore.Tests.WebApp.csproj" />
+        <ProjectReference Include="..\TUnit.AspNetCore.Tests.MinimalApi\TUnit.AspNetCore.Tests.MinimalApi.csproj" />
         <ProjectReference Include="..\TUnit\TUnit.csproj" />
     </ItemGroup>
 

--- a/TUnit.AspNetCore.Tests/TestWebAppFactory.cs
+++ b/TUnit.AspNetCore.Tests/TestWebAppFactory.cs
@@ -1,16 +1,10 @@
-using Microsoft.AspNetCore.Hosting;
 using TUnit.AspNetCore;
-using TUnit.AspNetCore.Logging;
 using TUnit.Core.Interfaces;
 
 namespace TUnit.AspNetCore.Tests;
 
 /// <summary>
 /// Shared web application factory for integration tests.
-/// Overrides <see cref="ConfigureWebHost"/> to register <see cref="CorrelatedTUnitLoggingExtensions.AddCorrelatedTUnitLogging"/>
-/// because the base class registers it in <c>CreateHostBuilder()</c>, which returns <c>null</c> for
-/// minimal API apps (top-level statements). This is a known gap in <c>TestWebApplicationFactory</c>
-/// — any minimal API host must register correlated logging via <c>ConfigureWebHost</c> instead.
 /// </summary>
 public class TestWebAppFactory : TestWebApplicationFactory<Program>, IAsyncInitializer
 {
@@ -19,16 +13,5 @@ public class TestWebAppFactory : TestWebApplicationFactory<Program>, IAsyncIniti
         // Eagerly start the server to catch configuration errors early
         _ = Server;
         return Task.CompletedTask;
-    }
-
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
-    {
-        // For minimal API apps, CreateHostBuilder() returns null so the base class's
-        // AddCorrelatedTUnitLogging() in CreateHostBuilder is never called.
-        // Register it here via ConfigureWebHost which IS called for minimal API apps.
-        builder.ConfigureServices(services =>
-        {
-            services.AddCorrelatedTUnitLogging();
-        });
     }
 }

--- a/TUnit.CI.slnx
+++ b/TUnit.CI.slnx
@@ -80,6 +80,7 @@
     <Project Path="TUnit.Aspire.Tests.AppHost/TUnit.Aspire.Tests.AppHost.csproj" />
     <Project Path="TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.WebApp/TUnit.AspNetCore.Tests.WebApp.csproj" />
+    <Project Path="TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj" />
   </Folder>
 
   <!-- Benchmarks -->

--- a/TUnit.slnx
+++ b/TUnit.slnx
@@ -82,6 +82,7 @@
     <Project Path="TUnit.Aspire.Tests.AppHost/TUnit.Aspire.Tests.AppHost.csproj" />
     <Project Path="TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.WebApp/TUnit.AspNetCore.Tests.WebApp.csproj" />
+    <Project Path="TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj" />
   </Folder>
 
   <!-- Benchmarks -->


### PR DESCRIPTION
## Summary

- Fixes thomhurst/TUnit#5503: `TestWebApplicationFactory<T>` was registering `AddCorrelatedTUnitLogging()` inside `CreateHostBuilder()`, which returns `null` for minimal API hosts (`WebApplication.CreateBuilder` / top-level statements). The null-propagating `hostBuilder?.ConfigureServices(...)` silently skipped registration, leaving server-side `ILogger` output uncorrelated to the owning `TestContext`.
- Move the registration to a `ConfigureWebHost(IWebHostBuilder)` override. `WebApplicationFactory<T>` invokes this hook for both `IHostBuilder`-based and minimal API hosts, so correlated logging is now wired up for both hosting models with no subclass cooperation required.
- Remove the pre-existing workaround in `TUnit.AspNetCore.Tests/TestWebAppFactory.cs` that manually registered logging via `ConfigureWebHost`.
- Add a new dedicated regression target `TUnit.AspNetCore.Tests.MinimalApi` (minimal API webapp with namespaced `Program` so it can coexist with the existing `TUnit.AspNetCore.Tests.WebApp`'s global `Program` in the same test assembly) plus `MinimalApiAutoRegistrationTests` with a **zero-override** `MinimalApiTestFactory` — the existence of the no-override factory is the regression test.

## Test plan

- [x] `dotnet build` clean across `TUnit.AspNetCore.Core`, `TUnit.AspNetCore.Tests.MinimalApi`, and `TUnit.AspNetCore.Tests`
- [x] `TUnit.AspNetCore.Tests` 6/6 passing on `net10.0` (5 existing `CorrelatedLoggingResolverTests` + 1 new `ServerLog_AutoCorrelated_OnMinimalApiHost_WithoutSubclassConfig`)
- [x] **Negative-test verification:** temporarily reverted the base-class fix (`git stash`), reran the new test, confirmed it fails with the marker missing from `TestContext.Current.GetStandardOutput()`. Restored the fix and the test passes again — proves the test catches the exact bug
- [ ] CI green on `net8.0`, `net9.0`, `net10.0`

## Notes for reviewers

- Subclasses overriding `ConfigureWebHost` now must call `base.ConfigureWebHost(builder)` to inherit logging registration. This is documented in the XML doc on the override. The new no-override regression test catches accidental drift in the base behavior.
- The existing `CorrelatedLoggingResolverTests` (which use `TestWebAppFactory` against the existing minimal API `TUnit.AspNetCore.Tests.WebApp`) would have started failing once the workaround in `TestWebAppFactory` was removed if the base class fix were absent, so they also serve as additional regression coverage.