### PR TITLE
perf: engine-wide performance optimizations

### DIFF
--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -210,6 +210,11 @@ public partial class TestContext : Context,
     public static TestContext? GetById(string id) => _testContextsById.GetValueOrDefault(id);
 
     /// <summary>
+    /// Removes a test context from the static registry. Called when test execution completes.
+    /// </summary>
+    internal static void RemoveById(string id) => _testContextsById.TryRemove(id, out _);
+
+    /// <summary>
     /// Gets the dictionary of test parameters indexed by parameter name.
     /// </summary>
     public static IReadOnlyDictionary<string, List<string>> Parameters => InternalParametersDictionary;

--- a/TUnit.Engine/Models/ConstraintKeysCollection.cs
+++ b/TUnit.Engine/Models/ConstraintKeysCollection.cs
@@ -27,7 +27,19 @@ internal class ConstraintKeysCollection(IReadOnlyList<string> constraintKeys)
             return false;
         }
 
-        return _constraintKeys.Intersect(other._constraintKeys).Any();
+        // Constraint key lists are typically 1-2 items; nested loop beats HashSet allocation
+        foreach (var key in _constraintKeys)
+        {
+            foreach (var otherKey in other._constraintKeys)
+            {
+                if (StringComparer.Ordinal.Equals(key, otherKey))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public int CompareTo(ConstraintKeysCollection? other)
@@ -62,7 +74,14 @@ internal class ConstraintKeysCollection(IReadOnlyList<string> constraintKeys)
 
     public override int GetHashCode()
     {
-        return 1;
+        var hash = 0;
+
+        foreach (var key in _constraintKeys)
+        {
+            hash ^= StringComparer.Ordinal.GetHashCode(key);
+        }
+
+        return hash;
     }
 
     public int CompareTo(object? obj)
@@ -93,23 +112,15 @@ internal class ConstraintKeysCollection(IReadOnlyList<string> constraintKeys)
                 return true;
             }
 
-            if (x == null)
+            if (x == null || y == null)
             {
                 return false;
             }
 
-            if (y == null)
-            {
-                return false;
-            }
-
-            return x._constraintKeys.Intersect(y._constraintKeys).Any();
+            return x.Equals(y);
         }
 
-        public int GetHashCode(ConstraintKeysCollection obj)
-        {
-            return 1;
-        }
+        public int GetHashCode(ConstraintKeysCollection obj) => obj.GetHashCode();
     }
 
     public static IEqualityComparer<ConstraintKeysCollection> ConstraintKeysCollectionComparer { get; } = new ConstraintKeysCollectionEqualityComparer();

--- a/TUnit.Engine/Models/ConstraintKeysCollection.cs
+++ b/TUnit.Engine/Models/ConstraintKeysCollection.cs
@@ -74,14 +74,10 @@ internal class ConstraintKeysCollection(IReadOnlyList<string> constraintKeys)
 
     public override int GetHashCode()
     {
-        var hash = 0;
-
-        foreach (var key in _constraintKeys)
-        {
-            hash ^= StringComparer.Ordinal.GetHashCode(key);
-        }
-
-        return hash;
+        // Intentionally constant: Equals uses intersection semantics (shares any key),
+        // so two "equal" collections can have entirely different key sets.
+        // A content-based hash would violate the hash/equals contract.
+        return 0;
     }
 
     public int CompareTo(object? obj)

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -98,7 +98,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     public Task AfterRunAsync(int exitCode, CancellationToken cancellation)
     {
-        if (_updates.Count is 0)
+        if (_latestUpdates.IsEmpty)
         {
             return Task.CompletedTask;
         }
@@ -221,7 +221,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             var finalStateCount = 0;
             foreach (var update in kvp.Value)
             {
-                var state = update.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+                var state = update.TestNode.Properties.OfType<TestNodeStateProperty>().FirstOrDefault();
                 if (state is not null and not InProgressTestNodeStateProperty and not DiscoveredTestNodeStateProperty)
                 {
                     finalStateCount++;

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -72,13 +72,16 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     public string Description => extension.Description;
 
-    private readonly ConcurrentDictionary<string, List<TestNodeUpdateMessage>> _updates = [];
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
+    private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         var testNodeUpdateMessage = (TestNodeUpdateMessage) value;
 
-        _updates.GetOrAdd(testNodeUpdateMessage.TestNode.Uid.Value, []).Add(testNodeUpdateMessage);
+        var uid = testNodeUpdateMessage.TestNode.Uid.Value;
+        _updates.GetOrAdd(uid, static _ => []).Enqueue(testNodeUpdateMessage);
+        _latestUpdates[uid] = testNodeUpdateMessage;
 
         return Task.CompletedTask;
     }
@@ -104,42 +107,51 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
                 ?.FrameworkDisplayName
             ?? RuntimeInformation.FrameworkDescription;
 
-        var last = new Dictionary<string, TestNodeUpdateMessage>(_updates.Count);
-        foreach (var kvp in _updates)
+        var last = new Dictionary<string, TestNodeUpdateMessage>(_latestUpdates.Count);
+        foreach (var kvp in _latestUpdates)
         {
-            if (kvp.Value.Count > 0)
-            {
-                last[kvp.Key] = kvp.Value[kvp.Value.Count - 1];
-            }
+            last[kvp.Key] = kvp.Value;
         }
 
-        var passedCount = last.Count(x =>
-            x.Value.TestNode.Properties.AsEnumerable().Any(p => p is PassedTestNodeStateProperty));
+        var passedCount = 0;
+        var failed = new List<KeyValuePair<string, TestNodeUpdateMessage>>();
+        var cancelled = new List<KeyValuePair<string, TestNodeUpdateMessage>>();
+        var timeout = new List<KeyValuePair<string, TestNodeUpdateMessage>>();
+        var skipped = new List<KeyValuePair<string, TestNodeUpdateMessage>>();
+        var inProgress = new List<KeyValuePair<string, TestNodeUpdateMessage>>();
 
-        var failed = last.Where(x =>
-            x.Value.TestNode.Properties.AsEnumerable()
-                .Any(p => p is FailedTestNodeStateProperty or ErrorTestNodeStateProperty)).ToArray();
-
-#pragma warning disable CS0618 // CancelledTestNodeStateProperty is obsolete
-        var cancelled = last.Where(x =>
-            x.Value.TestNode.Properties.AsEnumerable().Any(p => p is CancelledTestNodeStateProperty)).ToArray();
+        foreach (var kvp in last)
+        {
+            var state = kvp.Value.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+            switch (state)
+            {
+                case PassedTestNodeStateProperty:
+                    passedCount++;
+                    break;
+                case FailedTestNodeStateProperty or ErrorTestNodeStateProperty:
+                    failed.Add(kvp);
+                    break;
+                case TimeoutTestNodeStateProperty:
+                    timeout.Add(kvp);
+                    break;
+                case SkippedTestNodeStateProperty:
+                    skipped.Add(kvp);
+                    break;
+                case InProgressTestNodeStateProperty:
+                    inProgress.Add(kvp);
+                    break;
+#pragma warning disable CS0618
+                case CancelledTestNodeStateProperty:
 #pragma warning restore CS0618
-
-        var timeout = last
-            .Where(x => x.Value.TestNode.Properties.AsEnumerable().Any(p => p is TimeoutTestNodeStateProperty))
-            .ToArray();
-
-        var skipped = last
-            .Where(x => x.Value.TestNode.Properties.AsEnumerable().Any(p => p is SkippedTestNodeStateProperty))
-            .ToArray();
-
-        var inProgress = last.Where(x =>
-            x.Value.TestNode.Properties.AsEnumerable().Any(p => p is InProgressTestNodeStateProperty)).ToArray();
+                    cancelled.Add(kvp);
+                    break;
+            }
+        }
 
         _runStopwatch?.Stop();
         var elapsed = _runStopwatch?.Elapsed;
 
-        var hasFailures = failed.Length > 0 || timeout.Length > 0 || cancelled.Length > 0;
+        var hasFailures = failed.Count > 0 || timeout.Count > 0 || cancelled.Count > 0;
         var statusEmoji = hasFailures ? "\u274C" : "\u2705";
 
         var stringBuilder = new StringBuilder();
@@ -172,29 +184,29 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         {
             var segments = new List<string> { $"\u2705 {passedCount} passed" };
 
-            if (failed.Length > 0)
+            if (failed.Count > 0)
             {
-                segments.Add($"\u274C {failed.Length} failed");
+                segments.Add($"\u274C {failed.Count} failed");
             }
 
-            if (skipped.Length > 0)
+            if (skipped.Count > 0)
             {
-                segments.Add($"\u23ED\uFE0F {skipped.Length} skipped");
+                segments.Add($"\u23ED\uFE0F {skipped.Count} skipped");
             }
 
-            if (timeout.Length > 0)
+            if (timeout.Count > 0)
             {
-                segments.Add($"\u23F1\uFE0F {timeout.Length} timed out");
+                segments.Add($"\u23F1\uFE0F {timeout.Count} timed out");
             }
 
-            if (cancelled.Length > 0)
+            if (cancelled.Count > 0)
             {
-                segments.Add($"\uD83D\uDEAB {cancelled.Length} cancelled");
+                segments.Add($"\uD83D\uDEAB {cancelled.Count} cancelled");
             }
 
-            if (inProgress.Length > 0)
+            if (inProgress.Count > 0)
             {
-                segments.Add($"\u26A0\uFE0F {inProgress.Length} in progress");
+                segments.Add($"\u26A0\uFE0F {inProgress.Count} in progress");
             }
 
             stringBuilder.AppendLine(string.Join(" \u00B7 ", segments));
@@ -236,7 +248,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
             }
         }
 
-        if (skipped.Length > 0)
+        if (skipped.Count > 0)
         {
             var skipGroups = skipped
                 .Select(x => x.Value.TestNode.Properties.AsEnumerable()
@@ -246,7 +258,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
             stringBuilder.AppendLine();
             stringBuilder.AppendLine("<details>");
-            stringBuilder.AppendLine($"<summary>\u23ed\ufe0f {skipped.Length} skipped {(skipped.Length == 1 ? "test" : "tests")}</summary>");
+            stringBuilder.AppendLine($"<summary>\u23ed\ufe0f {skipped.Count} skipped {(skipped.Count == 1 ? "test" : "tests")}</summary>");
             stringBuilder.AppendLine();
             foreach (var group in skipGroups)
             {

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -73,6 +73,8 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
     public string Description => extension.Description;
 
     private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
+    // Last-write-wins; not atomic with _updates.Enqueue but test state transitions are
+    // monotonic (InProgress → terminal), so a stale read is harmless at report time.
     private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
@@ -122,7 +124,7 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         foreach (var kvp in last)
         {
-            var state = kvp.Value.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+            var state = kvp.Value.TestNode.Properties.OfType<TestNodeStateProperty>().FirstOrDefault();
             switch (state)
             {
                 case PassedTestNodeStateProperty:

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -72,9 +72,8 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     public string Description => extension.Description;
 
-    private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
-    // Last-write-wins; not atomic with _updates.Enqueue but test state transitions are
-    // monotonic (InProgress → terminal), so a stale read is harmless at report time.
+    // Counts terminal state transitions per test UID (for flaky detection).
+    private readonly ConcurrentDictionary<string, int> _terminalStateCounts = [];
     private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
@@ -82,7 +81,13 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         var testNodeUpdateMessage = (TestNodeUpdateMessage) value;
 
         var uid = testNodeUpdateMessage.TestNode.Uid.Value;
-        _updates.GetOrAdd(uid, static _ => []).Enqueue(testNodeUpdateMessage);
+
+        var state = testNodeUpdateMessage.TestNode.Properties.OfType<TestNodeStateProperty>().FirstOrDefault();
+        if (state is not null and not InProgressTestNodeStateProperty and not DiscoveredTestNodeStateProperty)
+        {
+            _terminalStateCounts.AddOrUpdate(uid, 1, static (_, count) => count + 1);
+        }
+
         _latestUpdates[uid] = testNodeUpdateMessage;
 
         return Task.CompletedTask;
@@ -216,26 +221,16 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
         // Detect flaky tests (passed after retry)
         var flakyTests = new List<(string Name, int Attempts, TimeSpan? Duration)>();
-        foreach (var kvp in _updates)
+        foreach (var kvp in _terminalStateCounts)
         {
-            var finalStateCount = 0;
-            foreach (var update in kvp.Value)
-            {
-                var state = update.TestNode.Properties.OfType<TestNodeStateProperty>().FirstOrDefault();
-                if (state is not null and not InProgressTestNodeStateProperty and not DiscoveredTestNodeStateProperty)
-                {
-                    finalStateCount++;
-                }
-            }
-
-            if (finalStateCount > 1 && last.TryGetValue(kvp.Key, out var lastUpdate))
+            if (kvp.Value > 1 && last.TryGetValue(kvp.Key, out var lastUpdate))
             {
                 var props = lastUpdate.TestNode.Properties.AsEnumerable();
                 if (props.Any(p => p is PassedTestNodeStateProperty))
                 {
                     var name = GetTestDisplayName(lastUpdate.TestNode);
                     var timing = props.OfType<TimingProperty>().FirstOrDefault();
-                    flakyTests.Add((name, finalStateCount, timing?.GlobalTiming.Duration));
+                    flakyTests.Add((name, kvp.Value, timing?.GlobalTiming.Duration));
                 }
             }
         }

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -48,13 +48,16 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
 
     public string Description => extension.Description;
 
-    private readonly ConcurrentDictionary<string, List<TestNodeUpdateMessage>> _updates = [];
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
+    private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         var testNodeUpdateMessage = (TestNodeUpdateMessage)value;
 
-        _updates.GetOrAdd(testNodeUpdateMessage.TestNode.Uid.Value, []).Add(testNodeUpdateMessage);
+        var uid = testNodeUpdateMessage.TestNode.Uid.Value;
+        _updates.GetOrAdd(uid, static _ => []).Enqueue(testNodeUpdateMessage);
+        _latestUpdates[uid] = testNodeUpdateMessage;
 
         return Task.CompletedTask;
     }
@@ -74,10 +77,10 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
         }
 
         // Get the last update for each test
-        var lastUpdates = new List<TestNodeUpdateMessage>(_updates.Count);
-        foreach (var kvp in _updates.Where(kvp => kvp.Value.Count > 0))
+        var lastUpdates = new List<TestNodeUpdateMessage>(_latestUpdates.Count);
+        foreach (var kvp in _latestUpdates)
         {
-            lastUpdates.Add(kvp.Value[kvp.Value.Count - 1]);
+            lastUpdates.Add(kvp.Value);
         }
 
         // Generate JUnit XML

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -49,6 +49,8 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
     public string Description => extension.Description;
 
     private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
+    // Last-write-wins; not atomic with _updates.Enqueue but test state transitions are
+    // monotonic (InProgress → terminal), so a stale read is harmless at report time.
     private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -48,18 +48,13 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
 
     public string Description => extension.Description;
 
-    private readonly ConcurrentDictionary<string, ConcurrentQueue<TestNodeUpdateMessage>> _updates = [];
-    // Last-write-wins; not atomic with _updates.Enqueue but test state transitions are
-    // monotonic (InProgress → terminal), so a stale read is harmless at report time.
     private readonly ConcurrentDictionary<string, TestNodeUpdateMessage> _latestUpdates = [];
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         var testNodeUpdateMessage = (TestNodeUpdateMessage)value;
 
-        var uid = testNodeUpdateMessage.TestNode.Uid.Value;
-        _updates.GetOrAdd(uid, static _ => []).Enqueue(testNodeUpdateMessage);
-        _latestUpdates[uid] = testNodeUpdateMessage;
+        _latestUpdates[testNodeUpdateMessage.TestNode.Uid.Value] = testNodeUpdateMessage;
 
         return Task.CompletedTask;
     }
@@ -73,7 +68,7 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
 
     public async Task AfterRunAsync(int exitCode, CancellationToken cancellation)
     {
-        if (!_isEnabled || _updates.Count == 0)
+        if (!_isEnabled || _latestUpdates.IsEmpty)
         {
             return;
         }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -176,12 +176,13 @@ internal sealed class TestScheduler : ITestScheduler
 
         foreach (var group in groupedTests.ParallelGroups)
         {
-            var orderedTests = new List<AbstractExecutableTest>();
-            foreach (var kvp in group.Value.OrderBy(t => t.Key))
-            {
-                orderedTests.AddRange(kvp.Value);
-            }
-            var orderedTestsArray = orderedTests.ToArray();
+            var totalCount = 0;
+            foreach (var list in group.Value.Values) totalCount += list.Count;
+            var orderedTestsArray = new AbstractExecutableTest[totalCount];
+            var idx = 0;
+            foreach (var list in group.Value.Values)
+                foreach (var t in list)
+                    orderedTestsArray[idx++] = t;
 
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -181,8 +181,12 @@ internal sealed class TestScheduler : ITestScheduler
             var orderedTestsArray = new AbstractExecutableTest[totalCount];
             var idx = 0;
             foreach (var list in group.Value.Values)
+            {
                 foreach (var t in list)
+                {
                     orderedTestsArray[idx++] = t;
+                }
+            }
 
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting parallel group '{group.Key}' with {orderedTestsArray.Length} orders").ConfigureAwait(false);

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using TUnit.Core;
 using TUnit.Core.Data;
@@ -18,12 +19,12 @@ internal sealed class EventReceiverOrchestrator
     private readonly TUnitFrameworkLogger _logger;
 
     // Track which assemblies/classes/sessions have had their "first" event invoked
-    private ThreadSafeDictionary<string, Task> _firstTestInAssemblyTasks = new();
+    private ThreadSafeDictionary<Assembly, Task> _firstTestInAssemblyTasks = new();
     private ThreadSafeDictionary<Type, Task> _firstTestInClassTasks = new();
     private ThreadSafeDictionary<string, Task> _firstTestInSessionTasks = new();
 
     // Track remaining test counts for "last" events
-    private readonly ConcurrentDictionary<string, Counter> _assemblyTestCounts = new();
+    private readonly ConcurrentDictionary<Assembly, Counter> _assemblyTestCounts = new();
     private readonly ConcurrentDictionary<Type, Counter> _classTestCounts = new();
 
     // Accessed from multiple threads via Interlocked to ensure atomic updates
@@ -355,9 +356,9 @@ internal sealed class EventReceiverOrchestrator
             return default;
         }
 
-        var assemblyName = assemblyContext.Assembly.GetName().FullName ?? "";
+        var assembly = assemblyContext.Assembly;
 
-        var task = _firstTestInAssemblyTasks.GetOrAdd(assemblyName,
+        var task = _firstTestInAssemblyTasks.GetOrAdd(assembly,
             static (_, args) => args.self.InvokeFirstTestInAssemblyEventReceiversCoreAsync(args.context, args.assemblyContext, args.cancellationToken),
             (self: this, context, assemblyContext, cancellationToken));
         return new ValueTask(task);
@@ -459,11 +460,11 @@ internal sealed class EventReceiverOrchestrator
             return ValueTask.CompletedTask;
         }
 
-        var assemblyName = assemblyContext.Assembly.GetName().FullName ?? "";
+        var assembly = assemblyContext.Assembly;
 
-        if (!_assemblyTestCounts.TryGetValue(assemblyName, out var assemblyCounter))
+        if (!_assemblyTestCounts.TryGetValue(assembly, out var assemblyCounter))
         {
-            assemblyCounter = _assemblyTestCounts.GetOrAdd(assemblyName, static _ => new Counter());
+            assemblyCounter = _assemblyTestCounts.GetOrAdd(assembly, static _ => new Counter());
         }
 
         var assemblyCount = assemblyCounter.Decrement();
@@ -553,28 +554,20 @@ internal sealed class EventReceiverOrchestrator
         Interlocked.Exchange(ref _sessionTestCount, contexts.Count);
 
         // Clear first-event tracking to ensure clean state for each test execution
-        _firstTestInAssemblyTasks = new ThreadSafeDictionary<string, Task>();
+        _firstTestInAssemblyTasks = new ThreadSafeDictionary<Assembly, Task>();
         _firstTestInClassTasks = new ThreadSafeDictionary<Type, Task>();
         _firstTestInSessionTasks = new ThreadSafeDictionary<string, Task>();
 
-        foreach (var group in contexts.GroupBy(c => c.ClassContext.AssemblyContext.Assembly.GetName().FullName))
+        // Initialize assembly and class counters in a single pass
+        foreach (var context in contexts)
         {
-            if (!_assemblyTestCounts.TryGetValue(group.Key, out var counter))
-            {
-                counter = _assemblyTestCounts.GetOrAdd(group.Key, static _ => new Counter());
-            }
+            var assembly = context.ClassContext.AssemblyContext.Assembly;
+            var assemblyCounter = _assemblyTestCounts.GetOrAdd(assembly, static _ => new Counter());
+            assemblyCounter.Add(1);
 
-            counter.Add(group.Count());
-        }
-
-        foreach (var group in contexts.GroupBy(c => c.ClassContext.ClassType))
-        {
-            if (!_classTestCounts.TryGetValue(group.Key, out var counter))
-            {
-                counter = _classTestCounts.GetOrAdd(group.Key, static _ => new Counter());
-            }
-
-            counter.Add(group.Count());
+            var classType = context.ClassContext.ClassType;
+            var classCounter = _classTestCounts.GetOrAdd(classType, static _ => new Counter());
+            classCounter.Add(1);
         }
     }
 

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -558,7 +558,6 @@ internal sealed class EventReceiverOrchestrator
         _firstTestInClassTasks = new ThreadSafeDictionary<Type, Task>();
         _firstTestInSessionTasks = new ThreadSafeDictionary<string, Task>();
 
-        // Initialize assembly and class counters in a single pass
         foreach (var context in contexts)
         {
             var assembly = context.ClassContext.AssemblyContext.Assembly;

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
@@ -113,6 +115,15 @@ internal readonly struct FilterHints
 /// </summary>
 internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
 {
+#pragma warning disable TPEXP
+    private static readonly ConstructorInfo _treeNodeFilterConstructor =
+        typeof(TreeNodeFilter).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+#pragma warning restore TPEXP
+
+    private static readonly PropertyBag _emptyPropertyBag = new();
+
+    private static readonly ConcurrentDictionary<string, string> _strippedFilterCache = new();
+
     /// <summary>
     /// Extract hints from a filter that can be used to pre-filter test sources by type.
     /// </summary>
@@ -391,7 +402,8 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
         TreeNodeFilter pathOnlyFilter;
         if (filterString.Contains('['))
         {
-            var strippedFilterString = System.Text.RegularExpressions.Regex.Replace(filterString, @"\[([^\]]*)\]", "");
+            var strippedFilterString = _strippedFilterCache.GetOrAdd(filterString,
+                static fs => System.Text.RegularExpressions.Regex.Replace(fs, @"\[([^\]]*)\]", ""));
             pathOnlyFilter = CreateTreeNodeFilterViaReflection(strippedFilterString);
         }
         else
@@ -400,16 +412,12 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
         }
 
         var path = BuildPathFromMetadata(metadata);
-        var emptyPropertyBag = new PropertyBag();
-        return pathOnlyFilter.MatchesFilter(path, emptyPropertyBag);
+        return pathOnlyFilter.MatchesFilter(path, _emptyPropertyBag);
     }
 
     private static TreeNodeFilter CreateTreeNodeFilterViaReflection(string filterString)
     {
-        var constructor = typeof(TreeNodeFilter).GetConstructors(
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)[0];
-
-        return (TreeNodeFilter)constructor.Invoke([filterString]);
+        return (TreeNodeFilter)_treeNodeFilterConstructor.Invoke([filterString]);
     }
 #pragma warning restore TPEXP
 

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -117,7 +117,8 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
 {
 #pragma warning disable TPEXP
     private static readonly ConstructorInfo _treeNodeFilterConstructor =
-        typeof(TreeNodeFilter).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+        typeof(TreeNodeFilter).GetConstructor(
+            BindingFlags.NonPublic | BindingFlags.Instance, null, [typeof(string)], null)!;
 #pragma warning restore TPEXP
 
     private static readonly PropertyBag _emptyPropertyBag = new();

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -192,7 +192,14 @@ internal sealed class TestDependencyResolver
     /// </summary>
     public void BatchResolveDependencies(List<AbstractExecutableTest> tests)
     {
-        var testsWithDependencies = tests.Where(t => t.Metadata.Dependencies.Length > 0).ToList();
+        var testsWithDependencies = new List<AbstractExecutableTest>();
+        foreach (var test in tests)
+        {
+            if (test.Metadata.Dependencies.Length > 0)
+            {
+                testsWithDependencies.Add(test);
+            }
+        }
 
         if (testsWithDependencies.Count == 0)
         {

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -242,8 +242,6 @@ internal sealed class TestCoordinator : ITestCoordinator
                     throw new ArgumentOutOfRangeException();
             }
 
-            // Remove test context from static registry to prevent memory accumulation
-            // in long-running test host scenarios (e.g., MTP hot reload mode)
             TestContext.RemoveById(test.Context.Id);
         }
     }

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -98,9 +98,6 @@ internal sealed class TestCoordinator : ITestCoordinator
             // Note: test.Context._dependencies is already populated during discovery
             // in TestBuilder.InvokePostResolutionEventsAsync after dependencies are resolved
 
-            // Ensure TestSession hooks run before creating test instances
-            await _testExecutor.EnsureTestSessionHooksExecutedAsync(cancellationToken).ConfigureAwait(false);
-
             // Check if we can use the fast path (no retry, no timeout)
             // Note: retryLimit == 0 means "no retries" (run once), not "unlimited retries"
             var retryLimit = test.Context.Metadata.TestDetails.RetryLimit;
@@ -245,6 +242,9 @@ internal sealed class TestCoordinator : ITestCoordinator
                     throw new ArgumentOutOfRangeException();
             }
 
+            // Remove test context from static registry to prevent memory accumulation
+            // in long-running test host scenarios (e.g., MTP hot reload mode)
+            TestContext.RemoveById(test.Context.Id);
         }
     }
 

--- a/TUnit.Engine/Services/TestFilterService.cs
+++ b/TUnit.Engine/Services/TestFilterService.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable TPEXP
 
+using System.Collections.Concurrent;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
@@ -12,6 +13,7 @@ namespace TUnit.Engine.Services;
 
 internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegistrationService testArgumentRegistrationService)
 {
+    private static readonly ConcurrentDictionary<Type, bool> _explicitClassCache = new();
     public IReadOnlyCollection<AbstractExecutableTest> FilterTests(ITestExecutionFilter? testExecutionFilter, IReadOnlyCollection<AbstractExecutableTest> testNodes)
     {
         if (testExecutionFilter is null or NopFilter)
@@ -227,7 +229,8 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         }
 
         var testClassType = test.Context.Metadata.TestDetails.ClassType;
-        return testClassType.GetCustomAttributes(typeof(ExplicitAttribute), true).Length > 0;
+        return _explicitClassCache.GetOrAdd(testClassType,
+            static t => t.GetCustomAttributes(typeof(ExplicitAttribute), true).Length > 0);
     }
 
     private IReadOnlyCollection<AbstractExecutableTest> FilterOutExplicitTests(IReadOnlyCollection<AbstractExecutableTest> testNodes)

--- a/TUnit.Engine/Services/TestGroupingService.cs
+++ b/TUnit.Engine/Services/TestGroupingService.cs
@@ -89,34 +89,31 @@ internal sealed class TestGroupingService : ITestGroupingService
             }
             var notInParallel = sortKey.NotInParallelConstraint;
 
-            // Log parallel limiter if present
-            var parallelLimiterInfo = test.Context.ParallelLimiter != null
-                ? $" [ParallelLimiter: {test.Context.ParallelLimiter.GetType().Name} (limit: {test.Context.ParallelLimiter.Limit})]"
-                : "";
-
             if (parallelGroup != null && notInParallel != null)
             {
-                // Test has both ParallelGroup and NotInParallel constraints
-                await _logger.LogTraceAsync($"Test '{test.TestId}': → ConstrainedParallelGroup '{parallelGroup.Group}' + NotInParallel{parallelLimiterInfo}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Test '{test.TestId}': → ConstrainedParallelGroup '{parallelGroup.Group}' + NotInParallel{FormatParallelLimiterInfo(test)}").ConfigureAwait(false);
                 ProcessCombinedConstraints(test, sortKey.ClassFullName, parallelGroup, notInParallel, constrainedParallelGroups);
             }
             else if (parallelGroup != null)
             {
-                // Only ParallelGroup constraint
-                await _logger.LogTraceAsync($"Test '{test.TestId}': → ParallelGroup '{parallelGroup.Group}'{parallelLimiterInfo}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Test '{test.TestId}': → ParallelGroup '{parallelGroup.Group}'{FormatParallelLimiterInfo(test)}").ConfigureAwait(false);
                 ProcessParallelGroupConstraint(test, parallelGroup, parallelGroups);
             }
             else if (notInParallel != null)
             {
-                // Only NotInParallel constraint
-                var keys = notInParallel.NotInParallelConstraintKeys.Count > 0 ? $" (keys: {string.Join(", ", notInParallel.NotInParallelConstraintKeys)})" : "";
-                await _logger.LogTraceAsync($"Test '{test.TestId}': → NotInParallel{keys}{parallelLimiterInfo}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                {
+                    var keys = notInParallel.NotInParallelConstraintKeys.Count > 0 ? $" (keys: {string.Join(", ", notInParallel.NotInParallelConstraintKeys)})" : "";
+                    await _logger.LogTraceAsync($"Test '{test.TestId}': → NotInParallel{keys}{FormatParallelLimiterInfo(test)}").ConfigureAwait(false);
+                }
                 ProcessNotInParallelConstraint(test, sortKey.ClassFullName, notInParallel, notInParallelList, keyedNotInParallelList);
             }
             else
             {
-                // No constraints - can run in parallel
-                await _logger.LogTraceAsync($"Test '{test.TestId}': → Parallel (no constraints){parallelLimiterInfo}").ConfigureAwait(false);
+                if (_logger.IsTraceEnabled)
+                    await _logger.LogTraceAsync($"Test '{test.TestId}': → Parallel (no constraints){FormatParallelLimiterInfo(test)}").ConfigureAwait(false);
                 parallelTests.Add(test);
             }
         }
@@ -199,13 +196,16 @@ internal sealed class TestGroupingService : ITestGroupingService
         };
 
         // Log summary of test categorization
-        await _logger.LogTraceAsync("═══ Test Grouping Summary ═══").ConfigureAwait(false);
-        await _logger.LogTraceAsync($"  Parallel (no constraints): {parallelTests.Count} tests").ConfigureAwait(false);
-        await _logger.LogTraceAsync($"  ParallelGroups: {parallelGroups.Count} groups").ConfigureAwait(false);
-        await _logger.LogTraceAsync($"  ConstrainedParallelGroups: {finalConstrainedGroups.Count} groups").ConfigureAwait(false);
-        await _logger.LogTraceAsync($"  NotInParallel (global): {sortedNotInParallel.Length} tests").ConfigureAwait(false);
-        await _logger.LogTraceAsync($"  KeyedNotInParallel: {keyedArrays.Length} tests").ConfigureAwait(false);
-        await _logger.LogTraceAsync("════════════════════════════").ConfigureAwait(false);
+        if (_logger.IsTraceEnabled)
+        {
+            await _logger.LogTraceAsync("═══ Test Grouping Summary ═══").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"  Parallel (no constraints): {parallelTests.Count} tests").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"  ParallelGroups: {parallelGroups.Count} groups").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"  ConstrainedParallelGroups: {finalConstrainedGroups.Count} groups").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"  NotInParallel (global): {sortedNotInParallel.Length} tests").ConfigureAwait(false);
+            await _logger.LogTraceAsync($"  KeyedNotInParallel: {keyedArrays.Length} tests").ConfigureAwait(false);
+            await _logger.LogTraceAsync("════════════════════════════").ConfigureAwait(false);
+        }
 
         return result;
     }
@@ -251,6 +251,11 @@ internal sealed class TestGroupingService : ITestGroupingService
         tests.Add(test);
     }
     
+    private static string FormatParallelLimiterInfo(AbstractExecutableTest test) =>
+        test.Context.ParallelLimiter != null
+            ? $" [ParallelLimiter: {test.Context.ParallelLimiter.GetType().Name} (limit: {test.Context.ParallelLimiter.Limit})]"
+            : "";
+
     private static void ProcessCombinedConstraints(
         AbstractExecutableTest test,
         string className,

--- a/TUnit.Engine/Services/TestLifecycleCoordinator.cs
+++ b/TUnit.Engine/Services/TestLifecycleCoordinator.cs
@@ -32,7 +32,6 @@ internal sealed class TestLifecycleCoordinator
         // Initialize session counter
         _sessionTestCount.Add(testList.Count);
 
-        // Initialize assembly and class counters in a single pass
         foreach (var test in testList)
         {
             var assembly = test.Metadata.TestClassType.Assembly;

--- a/TUnit.Engine/Services/TestLifecycleCoordinator.cs
+++ b/TUnit.Engine/Services/TestLifecycleCoordinator.cs
@@ -32,18 +32,16 @@ internal sealed class TestLifecycleCoordinator
         // Initialize session counter
         _sessionTestCount.Add(testList.Count);
 
-        // Initialize assembly counters
-        foreach (var assemblyGroup in testList.GroupBy(t => t.Metadata.TestClassType.Assembly))
+        // Initialize assembly and class counters in a single pass
+        foreach (var test in testList)
         {
-            var counter = _assemblyTestCounts.GetOrAdd(assemblyGroup.Key, static _ => new Counter());
-            counter.Add(assemblyGroup.Count());
-        }
+            var assembly = test.Metadata.TestClassType.Assembly;
+            var assemblyCounter = _assemblyTestCounts.GetOrAdd(assembly, static _ => new Counter());
+            assemblyCounter.Add(1);
 
-        // Initialize class counters
-        foreach (var classGroup in testList.GroupBy(t => t.Metadata.TestClassType))
-        {
-            var counter = _classTestCounts.GetOrAdd(classGroup.Key, static _ => new Counter());
-            counter.Add(classGroup.Count());
+            var classType = test.Metadata.TestClassType;
+            var classCounter = _classTestCounts.GetOrAdd(classType, static _ => new Counter());
+            classCounter.Add(1);
         }
     }
 

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -321,7 +321,9 @@ internal sealed class TestDiscoveryService : IDataProducer
             }
         }
 
-        // Cycle-break fallback: yield any remaining tests that were not reached
+        // Cycle-break fallback: if some tests remain, their dependency graph has a cycle.
+        // Yield them without respecting order — CircularDependencyDetector will report
+        // the cycle with a proper error during scheduling.
         if (yieldedCount < dependentTests.Count)
         {
             foreach (var test in dependentTests)

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -30,7 +30,7 @@ internal sealed class TestDiscoveryService : IDataProducer
     private readonly TestBuilderPipeline _testBuilderPipeline;
     private readonly TestFilterService _testFilterService;
     private readonly MetadataDependencyExpander _dependencyExpander;
-    private readonly ConcurrentBag<AbstractExecutableTest> _cachedTests = [];
+    private readonly ConcurrentQueue<AbstractExecutableTest> _cachedTests = new();
     private readonly TestDependencyResolver _dependencyResolver = new();
 
     public string Uid => "TUnit";
@@ -156,7 +156,7 @@ internal sealed class TestDiscoveryService : IDataProducer
 
                 foreach (var test in testsList)
                 {
-                    _cachedTests.Add(test);
+                    _cachedTests.Enqueue(test);
                     _dependencyResolver.RegisterTest(test);
                 }
 
@@ -202,7 +202,7 @@ internal sealed class TestDiscoveryService : IDataProducer
         foreach (var test in tests)
         {
             _dependencyResolver.RegisterTest(test);
-            _cachedTests.Add(test);
+            _cachedTests.Enqueue(test);
             yield return test;
         }
     }
@@ -256,42 +256,83 @@ internal sealed class TestDiscoveryService : IDataProducer
         }
 
         var yieldedTests = new HashSet<string>(independentTests.Select(static t => t.TestId));
-        var remainingTests = new List<AbstractExecutableTest>(dependentTests);
 
-        while (remainingTests.Count > 0)
+        // Kahn's algorithm: build in-degree map and reverse-dependency map for O(V+E) topological sort
+        var inDegree = new Dictionary<string, int>(dependentTests.Count);
+        var reverseDeps = new Dictionary<string, List<AbstractExecutableTest>>();
+
+        foreach (var test in dependentTests)
         {
-            var readyTests = new List<AbstractExecutableTest>();
-
-            foreach (var test in remainingTests)
+            var pendingCount = 0;
+            foreach (var dep in test.Dependencies)
             {
-                var allDependenciesYielded = test.Dependencies.All(dep => yieldedTests.Contains(dep.Test.TestId));
-
-                if (allDependenciesYielded)
+                if (!yieldedTests.Contains(dep.Test.TestId))
                 {
-                    readyTests.Add(test);
+                    pendingCount++;
                 }
+
+                // Build reverse map: when dep.Test is yielded, this test's in-degree decreases
+                var depId = dep.Test.TestId;
+                if (!reverseDeps.TryGetValue(depId, out var dependents))
+                {
+                    dependents = [];
+                    reverseDeps[depId] = dependents;
+                }
+                dependents.Add(test);
             }
 
-            if (readyTests.Count == 0 && remainingTests.Count > 0)
+            inDegree[test.TestId] = pendingCount;
+        }
+
+        // Seed queue with dependent tests whose dependencies are all already yielded
+        var readyQueue = new Queue<AbstractExecutableTest>();
+        foreach (var test in dependentTests)
+        {
+            if (inDegree[test.TestId] == 0)
             {
-                foreach (var test in remainingTests)
+                readyQueue.Enqueue(test);
+            }
+        }
+
+        var yieldedCount = 0;
+        while (readyQueue.Count > 0)
+        {
+            var test = readyQueue.Dequeue();
+            yieldedCount++;
+
+            if (_testFilterService.MatchesTest(filter, test))
+            {
+                yield return test;
+            }
+
+            yieldedTests.Add(test.TestId);
+
+            // Decrement in-degree for all tests that depend on this one
+            if (reverseDeps.TryGetValue(test.TestId, out var dependentsOfTest))
+            {
+                foreach (var dependent in dependentsOfTest)
+                {
+                    var newDegree = --inDegree[dependent.TestId];
+                    if (newDegree == 0)
+                    {
+                        readyQueue.Enqueue(dependent);
+                    }
+                }
+            }
+        }
+
+        // Cycle-break fallback: yield any remaining tests that were not reached
+        if (yieldedCount < dependentTests.Count)
+        {
+            foreach (var test in dependentTests)
+            {
+                if (!yieldedTests.Contains(test.TestId))
                 {
                     if (_testFilterService.MatchesTest(filter, test))
                     {
                         yield return test;
                     }
                 }
-                break;
-            }
-
-            foreach (var test in readyTests)
-            {
-                if (_testFilterService.MatchesTest(filter, test))
-                {
-                    yield return test;
-                }
-                yieldedTests.Add(test.TestId);
-                remainingTests.Remove(test);
             }
         }
     }

--- a/TUnit.Engine/Xml/JUnitXmlWriter.cs
+++ b/TUnit.Engine/Xml/JUnitXmlWriter.cs
@@ -22,9 +22,24 @@ internal static class JUnitXmlWriter
             return string.Empty;
         }
 
-        // At this point, value is guaranteed to not be null
-        var builder = new StringBuilder(value!.Length);
+        // Fast path: check if sanitization is needed
         foreach (var ch in value!)
+        {
+            if (!(ch == 0x9 || ch == 0xA || ch == 0xD ||
+                  (ch >= 0x20 && ch <= 0xD7FF) ||
+                  (ch >= 0xE000 && ch <= 0xFFFD)))
+            {
+                return SanitizeForXmlSlow(value);
+            }
+        }
+
+        return value; // Return original string unchanged — zero allocation
+    }
+
+    private static string SanitizeForXmlSlow(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
         {
             // Check if character is valid according to XML 1.0 spec
             if (ch == 0x9 || ch == 0xA || ch == 0xD ||


### PR DESCRIPTION
## Summary

- **Fix ConstraintKeysCollection hash/equals**: `GetHashCode()` was returning constant `1` with no documentation. Replaced LINQ `Intersect().Any()` in `Equals` with allocation-free nested loop (optimized for typical 1-2 constraint keys). Hash remains a constant (`0`) with a comment explaining why — intersection-based equality makes content-based hashing impossible.
- **Replace O(n²) topological sort** in `TestDiscoveryService.DiscoverTestsFullyStreamingAsync` with Kahn's algorithm using in-degree counting and reverse-dependency map — O(V+E).
- **Replace ConcurrentBag with ConcurrentQueue** in `TestDiscoveryService._cachedTests` for O(n) enumeration without snapshot copying.
- **Single-pass categorization** in `GitHubReporter.AfterRunAsync` — replaces 6 separate LINQ passes over all test results with one switch-based loop.
- **Thread-safety fixes** in GitHubReporter and JUnitReporter — `List<T>` replaced with `ConcurrentQueue<T>`, with a parallel `_latestUpdates` dictionary for O(1) last-element access. Removed dead `_updates` field from JUnitReporter.
- **Eliminate GroupBy + Count()** in `EventReceiverOrchestrator` and `TestLifecycleCoordinator` — replaced with single-pass counter initialization loops.
- **Cache reflection results**: `ExplicitAttribute` class lookup, `ConstructorInfo` for `TreeNodeFilter` (with explicit typed lookup), static `PropertyBag`, and regex-stripped filter strings in `MetadataFilterMatcher`.
- **Guard trace logging** in `TestGroupingService` — wrap all trace log sites with `IsTraceEnabled` checks to avoid string interpolation when tracing is off. Extract `FormatParallelLimiterInfo` helper to deduplicate 4 identical snippets.
- **Prevent memory leak**: Add `TestContext.RemoveById()` and call it after test completion to clean up the static `_testContextsById` dictionary in long-running test host scenarios.
- **Remove redundant hook call**: `EnsureTestSessionHooksExecutedAsync` was called in `TestCoordinator` but already runs unconditionally in `TestExecutor.ExecuteAsync`.
- **Fast-path XML sanitization**: Scan for invalid chars first in `JUnitXmlWriter.SanitizeForXml`; return original string unchanged (zero allocation) when clean.
- **Static lambdas**: Make factory lambdas `static` in reporters to avoid delegate allocations.
- **Remove LINQ from BatchResolveDependencies**: Replace `.Where().ToList()` with manual loop.
- **Pre-allocated array fill** in `TestScheduler` — remove redundant `.OrderBy()` on already-sorted `SortedDictionary`.
- **Comparer deduplication**: `ConstraintKeysCollectionEqualityComparer` now delegates to instance `Equals`/`GetHashCode` instead of duplicating the logic.
- **Use Assembly reference as dictionary key** in `EventReceiverOrchestrator` instead of `Assembly.GetName().FullName` string.

## Test plan

- [ ] Full CI passes (all target frameworks: net8.0, net9.0, net10.0)
- [ ] Run TUnit.TestProject with filtered tests to verify discovery and execution
- [ ] Verify GitHubReporter output in a GitHub Actions run
- [ ] Verify JUnit XML output is well-formed
- [ ] Run tests with `[DependsOn]` to verify topological sort correctness
- [ ] Run tests with `[NotInParallel]` constraint keys to verify hash-based grouping