### PR TITLE
feat: Add TUnitSettings static API for programmatic configuration

### DIFF
--- a/TUnit.Core.SourceGenerator.Tests/NuGetDownloader.cs
+++ b/TUnit.Core.SourceGenerator.Tests/NuGetDownloader.cs
@@ -20,7 +20,7 @@ public static class NuGetDownloader
         if (!Directory.Exists(extractedPath))
         {
 
-            var settings = Settings.LoadDefaultSettings(null);
+            var settings = NuGet.Configuration.Settings.LoadDefaultSettings(null);
             var sourceRepositoryProvider = new SourceRepositoryProvider(new PackageSourceProvider(settings), Repository.Provider.GetCoreV3());
             var repository = sourceRepositoryProvider.CreateRepository(new PackageSource("https://api.nuget.org/v3/index.json"));
 

--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -14,26 +14,26 @@ public static class Defaults
     /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultTestTimeout)} instead.")]
-    public static TimeSpan TestTimeout => TUnitSettings.Timeouts.DefaultTestTimeout;
+    public static TimeSpan TestTimeout => TUnitSettings.Default.Timeouts.DefaultTestTimeout;
 
     /// <summary>
     /// Default timeout applied to hook methods (Before/After at every level)
     /// when no explicit timeout is configured.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultHookTimeout)} instead.")]
-    public static TimeSpan HookTimeout => TUnitSettings.Timeouts.DefaultHookTimeout;
+    public static TimeSpan HookTimeout => TUnitSettings.Default.Timeouts.DefaultHookTimeout;
 
     /// <summary>
     /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ForcefulExitTimeout)} instead.")]
-    public static TimeSpan ForcefulExitTimeout => TUnitSettings.Timeouts.ForcefulExitTimeout;
+    public static TimeSpan ForcefulExitTimeout => TUnitSettings.Default.Timeouts.ForcefulExitTimeout;
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ProcessExitHookDelay)} instead.")]
-    public static TimeSpan ProcessExitHookDelay => TUnitSettings.Timeouts.ProcessExitHookDelay;
+    public static TimeSpan ProcessExitHookDelay => TUnitSettings.Default.Timeouts.ProcessExitHookDelay;
 }

--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -14,26 +14,26 @@ public static class Defaults
     /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultTestTimeout)} instead.")]
-    public static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(30);
+    public static TimeSpan TestTimeout => TUnitSettings.Timeouts.DefaultTestTimeout;
 
     /// <summary>
     /// Default timeout applied to hook methods (Before/After at every level)
     /// when no explicit timeout is configured.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultHookTimeout)} instead.")]
-    public static readonly TimeSpan HookTimeout = TimeSpan.FromMinutes(5);
+    public static TimeSpan HookTimeout => TUnitSettings.Timeouts.DefaultHookTimeout;
 
     /// <summary>
     /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ForcefulExitTimeout)} instead.")]
-    public static readonly TimeSpan ForcefulExitTimeout = TimeSpan.FromSeconds(30);
+    public static TimeSpan ForcefulExitTimeout => TUnitSettings.Timeouts.ForcefulExitTimeout;
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ProcessExitHookDelay)} instead.")]
-    public static readonly TimeSpan ProcessExitHookDelay = TimeSpan.FromMilliseconds(500);
+    public static TimeSpan ProcessExitHookDelay => TUnitSettings.Timeouts.ProcessExitHookDelay;
 }

--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -14,26 +14,26 @@ public static class Defaults
     /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultTestTimeout)} instead.")]
-    public static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(30);
+    public static readonly TimeSpan TestTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
 
     /// <summary>
     /// Default timeout applied to hook methods (Before/After at every level)
     /// when no explicit timeout is configured.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultHookTimeout)} instead.")]
-    public static readonly TimeSpan HookTimeout = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan HookTimeout = TUnitSettings.Timeouts.DefaultHookTimeout;
 
     /// <summary>
     /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ForcefulExitTimeout)} instead.")]
-    public static readonly TimeSpan ForcefulExitTimeout = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan ForcefulExitTimeout = TUnitSettings.Timeouts.ForcefulExitTimeout;
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ProcessExitHookDelay)} instead.")]
-    public static readonly TimeSpan ProcessExitHookDelay = TimeSpan.FromMilliseconds(500);
+    public static readonly TimeSpan ProcessExitHookDelay = TUnitSettings.Timeouts.ProcessExitHookDelay;
 }

--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -14,26 +14,26 @@ public static class Defaults
     /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultTestTimeout)} instead.")]
-    public static readonly TimeSpan TestTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
+    public static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// Default timeout applied to hook methods (Before/After at every level)
     /// when no explicit timeout is configured.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultHookTimeout)} instead.")]
-    public static readonly TimeSpan HookTimeout = TUnitSettings.Timeouts.DefaultHookTimeout;
+    public static readonly TimeSpan HookTimeout = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ForcefulExitTimeout)} instead.")]
-    public static readonly TimeSpan ForcefulExitTimeout = TUnitSettings.Timeouts.ForcefulExitTimeout;
+    public static readonly TimeSpan ForcefulExitTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
     /// </summary>
     [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ProcessExitHookDelay)} instead.")]
-    public static readonly TimeSpan ProcessExitHookDelay = TUnitSettings.Timeouts.ProcessExitHookDelay;
+    public static readonly TimeSpan ProcessExitHookDelay = TimeSpan.FromMilliseconds(500);
 }

--- a/TUnit.Core/Defaults.cs
+++ b/TUnit.Core/Defaults.cs
@@ -1,32 +1,39 @@
+using TUnit.Core.Settings;
+
 namespace TUnit.Core;
 
 /// <summary>
 /// Default values shared across TUnit.Core and TUnit.Engine.
 /// Centralizes magic numbers so they can be tuned in a single place.
 /// </summary>
+[Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)} instead.")]
 public static class Defaults
 {
     /// <summary>
     /// Default timeout applied to individual tests when no <c>[Timeout]</c> attribute is specified.
     /// Can be overridden per-test via <see cref="TUnit.Core.TimeoutAttribute"/>.
     /// </summary>
+    [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultTestTimeout)} instead.")]
     public static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// Default timeout applied to hook methods (Before/After at every level)
     /// when no explicit timeout is configured.
     /// </summary>
+    [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.DefaultHookTimeout)} instead.")]
     public static readonly TimeSpan HookTimeout = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// Time allowed for a graceful shutdown after a cancellation request (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated.
     /// </summary>
+    [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ForcefulExitTimeout)} instead.")]
     public static readonly TimeSpan ForcefulExitTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute before the process terminates.
     /// </summary>
+    [Obsolete($"Use {nameof(TUnitSettings)}.{nameof(TUnitSettings.Timeouts)}.{nameof(TimeoutSettings.ProcessExitHookDelay)} instead.")]
     public static readonly TimeSpan ProcessExitHookDelay = TimeSpan.FromMilliseconds(500);
 }

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -62,7 +62,7 @@ public class EngineCancellationToken : IDisposable
             _forcefulExitStarted = true;
 
             // Start a new forceful exit timer
-            _ = Task.Delay(Defaults.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
+            _ = Task.Delay(Settings.TUnitSettings.Timeouts.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
             {
                 if (!t.IsCanceled)
                 {
@@ -86,7 +86,7 @@ public class EngineCancellationToken : IDisposable
             // ProcessExit has limited time (~3s on Windows), so we can only wait briefly.
             // Thread.Sleep is appropriate here: we're on a synchronous event handler thread
             // and just need a simple delay — no need to involve the task scheduler.
-            Thread.Sleep(Defaults.ProcessExitHookDelay);
+            Thread.Sleep(Settings.TUnitSettings.Timeouts.ProcessExitHookDelay);
         }
     }
 

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -1,4 +1,6 @@
-﻿namespace TUnit.Core;
+﻿using TUnit.Core.Settings;
+
+namespace TUnit.Core;
 
 /// <summary>
 /// Represents a cancellation token for the engine.
@@ -62,7 +64,7 @@ public class EngineCancellationToken : IDisposable
             _forcefulExitStarted = true;
 
             // Start a new forceful exit timer
-            _ = Task.Delay(Settings.TUnitSettings.Timeouts.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
+            _ = Task.Delay(TUnitSettings.Timeouts.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
             {
                 if (!t.IsCanceled)
                 {
@@ -86,7 +88,7 @@ public class EngineCancellationToken : IDisposable
             // ProcessExit has limited time (~3s on Windows), so we can only wait briefly.
             // Thread.Sleep is appropriate here: we're on a synchronous event handler thread
             // and just need a simple delay — no need to involve the task scheduler.
-            Thread.Sleep(Settings.TUnitSettings.Timeouts.ProcessExitHookDelay);
+            Thread.Sleep(TUnitSettings.Timeouts.ProcessExitHookDelay);
         }
     }
 

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -64,7 +64,7 @@ public class EngineCancellationToken : IDisposable
             _forcefulExitStarted = true;
 
             // Start a new forceful exit timer
-            _ = Task.Delay(TUnitSettings.Timeouts.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
+            _ = Task.Delay(TUnitSettings.Default.Timeouts.ForcefulExitTimeout, CancellationToken.None).ContinueWith(t =>
             {
                 if (!t.IsCanceled)
                 {
@@ -88,7 +88,7 @@ public class EngineCancellationToken : IDisposable
             // ProcessExit has limited time (~3s on Windows), so we can only wait briefly.
             // Thread.Sleep is appropriate here: we're on a synchronous event handler thread
             // and just need a simple delay — no need to involve the task scheduler.
-            Thread.Sleep(TUnitSettings.Timeouts.ProcessExitHookDelay);
+            Thread.Sleep(TUnitSettings.Default.Timeouts.ProcessExitHookDelay);
         }
     }
 

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -349,12 +349,12 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                 var waitTask = Task.Run(async () =>
                 {
                     // For .NET Standard 2.0 compatibility, use Task.Delay for timeout
-                    var timeoutTask = Task.Delay(Defaults.TestTimeout);
+                    var timeoutTask = Task.Delay(Settings.TUnitSettings.Timeouts.DefaultTestTimeout);
                     var completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask)
                     {
-                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {Defaults.TestTimeout.TotalMinutes} minutes");
+                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {Settings.TUnitSettings.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
                     }
 
                     // Await the actual task to get its result or exception

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -350,12 +350,12 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                 var waitTask = Task.Run(async () =>
                 {
                     // For .NET Standard 2.0 compatibility, use Task.Delay for timeout
-                    var timeoutTask = Task.Delay(TUnitSettings.Timeouts.DefaultTestTimeout);
+                    var timeoutTask = Task.Delay(TUnitSettings.Default.Timeouts.DefaultTestTimeout);
                     var completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask)
                     {
-                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {TUnitSettings.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
+                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {TUnitSettings.Default.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
                     }
 
                     // Await the actual task to get its result or exception

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -347,15 +347,16 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                 // Use a more robust synchronous wait pattern to avoid deadlocks
                 // We use Task.Run to ensure we don't capture the current SynchronizationContext
                 // which is a common cause of deadlocks
+                var timeout = TUnitSettings.Default.Timeouts.DefaultTestTimeout;
                 var waitTask = Task.Run(async () =>
                 {
                     // For .NET Standard 2.0 compatibility, use Task.Delay for timeout
-                    var timeoutTask = Task.Delay(TUnitSettings.Default.Timeouts.DefaultTestTimeout);
+                    var timeoutTask = Task.Delay(timeout);
                     var completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask)
                     {
-                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {TUnitSettings.Default.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
+                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {timeout.TotalMinutes} minutes");
                     }
 
                     // Await the actual task to get its result or exception

--- a/TUnit.Core/Executors/DedicatedThreadExecutor.cs
+++ b/TUnit.Core/Executors/DedicatedThreadExecutor.cs
@@ -1,5 +1,6 @@
 using TUnit.Core.Helpers;
 using TUnit.Core.Interfaces;
+using TUnit.Core.Settings;
 
 namespace TUnit.Core;
 
@@ -349,12 +350,12 @@ public class DedicatedThreadExecutor : GenericAbstractExecutor, ITestRegisteredE
                 var waitTask = Task.Run(async () =>
                 {
                     // For .NET Standard 2.0 compatibility, use Task.Delay for timeout
-                    var timeoutTask = Task.Delay(Settings.TUnitSettings.Timeouts.DefaultTestTimeout);
+                    var timeoutTask = Task.Delay(TUnitSettings.Timeouts.DefaultTestTimeout);
                     var completedTask = await Task.WhenAny(tcs.Task, timeoutTask).ConfigureAwait(false);
 
                     if (completedTask == timeoutTask)
                     {
-                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {Settings.TUnitSettings.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
+                        throw new TimeoutException($"Synchronous operation on dedicated thread timed out after {TUnitSettings.Timeouts.DefaultTestTimeout.TotalMinutes} minutes");
                     }
 
                     // Await the actual task to get its result or exception

--- a/TUnit.Core/Hooks/HookMethod.cs
+++ b/TUnit.Core/Hooks/HookMethod.cs
@@ -26,10 +26,12 @@ public abstract record HookMethod
     public TAttribute? GetAttribute<TAttribute>() where TAttribute : Attribute => Attributes.OfType<TAttribute>().FirstOrDefault();
 
     /// <summary>
-    /// Gets the timeout for this hook method. This will be set during hook registration
-    /// by the event receiver infrastructure, falling back to the default 5-minute timeout.
+    /// Gets the timeout for this hook method. When <c>null</c>, the engine falls back to
+    /// <see cref="Settings.TUnitSettings.Timeouts"/>.<see cref="Settings.TimeoutSettings.DefaultHookTimeout"/>
+    /// at execution time, so discovery-hook configuration is respected.
+    /// Set explicitly by the <c>[Timeout]</c> attribute or event receiver infrastructure.
     /// </summary>
-    public TimeSpan? Timeout { get; internal set; } = TUnitSettings.Default.Timeouts.DefaultHookTimeout;
+    public TimeSpan? Timeout { get; internal set; }
 
     private IHookExecutor _hookExecutor = DefaultExecutor.Instance;
     private bool _hookExecutorIsExplicit;

--- a/TUnit.Core/Hooks/HookMethod.cs
+++ b/TUnit.Core/Hooks/HookMethod.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using TUnit.Core.Extensions;
 using TUnit.Core.Interfaces;
+using TUnit.Core.Settings;
 
 namespace TUnit.Core.Hooks;
 
@@ -28,7 +29,7 @@ public abstract record HookMethod
     /// Gets the timeout for this hook method. This will be set during hook registration
     /// by the event receiver infrastructure, falling back to the default 5-minute timeout.
     /// </summary>
-    public TimeSpan? Timeout { get; internal set; } = Settings.TUnitSettings.Timeouts.DefaultHookTimeout;
+    public TimeSpan? Timeout { get; internal set; } = TUnitSettings.Timeouts.DefaultHookTimeout;
 
     private IHookExecutor _hookExecutor = DefaultExecutor.Instance;
     private bool _hookExecutorIsExplicit;

--- a/TUnit.Core/Hooks/HookMethod.cs
+++ b/TUnit.Core/Hooks/HookMethod.cs
@@ -28,7 +28,7 @@ public abstract record HookMethod
     /// Gets the timeout for this hook method. This will be set during hook registration
     /// by the event receiver infrastructure, falling back to the default 5-minute timeout.
     /// </summary>
-    public TimeSpan? Timeout { get; internal set; } = Defaults.HookTimeout;
+    public TimeSpan? Timeout { get; internal set; } = Settings.TUnitSettings.Timeouts.DefaultHookTimeout;
 
     private IHookExecutor _hookExecutor = DefaultExecutor.Instance;
     private bool _hookExecutorIsExplicit;

--- a/TUnit.Core/Hooks/HookMethod.cs
+++ b/TUnit.Core/Hooks/HookMethod.cs
@@ -29,7 +29,7 @@ public abstract record HookMethod
     /// Gets the timeout for this hook method. This will be set during hook registration
     /// by the event receiver infrastructure, falling back to the default 5-minute timeout.
     /// </summary>
-    public TimeSpan? Timeout { get; internal set; } = TUnitSettings.Timeouts.DefaultHookTimeout;
+    public TimeSpan? Timeout { get; internal set; } = TUnitSettings.Default.Timeouts.DefaultHookTimeout;
 
     private IHookExecutor _hookExecutor = DefaultExecutor.Instance;
     private bool _hookExecutorIsExplicit;

--- a/TUnit.Core/Models/BeforeTestDiscoveryContext.cs
+++ b/TUnit.Core/Models/BeforeTestDiscoveryContext.cs
@@ -1,3 +1,5 @@
+using TUnit.Core.Settings;
+
 namespace TUnit.Core;
 
 /// <summary>
@@ -28,6 +30,12 @@ public class BeforeTestDiscoveryContext : Context
     /// Gets or sets the test filter.
     /// </summary>
     public required string? TestFilter { get; init; }
+
+    /// <summary>
+    /// Programmatic settings for TUnit. Configure these here to establish project-level defaults
+    /// before any tests are discovered or executed.
+    /// </summary>
+    public TUnitSettings Settings => TUnitSettings.Default;
 
     internal override void SetAsyncLocalContext()
     {

--- a/TUnit.Core/Settings/DisplaySettings.cs
+++ b/TUnit.Core/Settings/DisplaySettings.cs
@@ -6,12 +6,6 @@ namespace TUnit.Core.Settings;
 public sealed class DisplaySettings
 {
     /// <summary>
-    /// Whether to suppress the TUnit banner logo. Default: <c>false</c>.
-    /// Precedence: <c>--disable-logo</c> → <c>TUNIT_DISABLE_LOGO</c> → TUnitSettings → built-in default.
-    /// </summary>
-    public bool DisableLogo { get; set; }
-
-    /// <summary>
     /// Whether to show full stack traces including TUnit internals. Default: <c>false</c>.
     /// Precedence: <c>--detailed-stacktrace</c> → TUnitSettings → built-in default.
     /// </summary>

--- a/TUnit.Core/Settings/DisplaySettings.cs
+++ b/TUnit.Core/Settings/DisplaySettings.cs
@@ -9,5 +9,11 @@ public sealed class DisplaySettings
     /// Whether to show full stack traces including TUnit internals. Default: <c>false</c>.
     /// Precedence: <c>--detailed-stacktrace</c> → TUnitSettings → built-in default.
     /// </summary>
-    public bool DetailedStackTrace { get; set; }
+    public bool DetailedStackTrace
+    {
+        get => Volatile.Read(ref _detailedStackTrace);
+        set => Volatile.Write(ref _detailedStackTrace, value);
+    }
+
+    private bool _detailedStackTrace;
 }

--- a/TUnit.Core/Settings/DisplaySettings.cs
+++ b/TUnit.Core/Settings/DisplaySettings.cs
@@ -5,6 +5,8 @@ namespace TUnit.Core.Settings;
 /// </summary>
 public sealed class DisplaySettings
 {
+    internal DisplaySettings() { }
+
     /// <summary>
     /// Whether to show full stack traces including TUnit internals. Default: <c>false</c>.
     /// Precedence: <c>--detailed-stacktrace</c> → TUnitSettings → built-in default.

--- a/TUnit.Core/Settings/DisplaySettings.cs
+++ b/TUnit.Core/Settings/DisplaySettings.cs
@@ -1,0 +1,19 @@
+namespace TUnit.Core.Settings;
+
+/// <summary>
+/// Controls visual output settings.
+/// </summary>
+public sealed class DisplaySettings
+{
+    /// <summary>
+    /// Whether to suppress the TUnit banner logo. Default: <c>false</c>.
+    /// Precedence: <c>--disable-logo</c> → <c>TUNIT_DISABLE_LOGO</c> → TUnitSettings → built-in default.
+    /// </summary>
+    public bool DisableLogo { get; set; }
+
+    /// <summary>
+    /// Whether to show full stack traces including TUnit internals. Default: <c>false</c>.
+    /// Precedence: <c>--detailed-stacktrace</c> → TUnitSettings → built-in default.
+    /// </summary>
+    public bool DetailedStackTrace { get; set; }
+}

--- a/TUnit.Core/Settings/DisplaySettings.cs
+++ b/TUnit.Core/Settings/DisplaySettings.cs
@@ -9,11 +9,5 @@ public sealed class DisplaySettings
     /// Whether to show full stack traces including TUnit internals. Default: <c>false</c>.
     /// Precedence: <c>--detailed-stacktrace</c> → TUnitSettings → built-in default.
     /// </summary>
-    public bool DetailedStackTrace
-    {
-        get => Volatile.Read(ref _detailedStackTrace);
-        set => Volatile.Write(ref _detailedStackTrace, value);
-    }
-
-    private bool _detailedStackTrace;
+    public bool DetailedStackTrace { get; set; }
 }

--- a/TUnit.Core/Settings/ExecutionSettings.cs
+++ b/TUnit.Core/Settings/ExecutionSettings.cs
@@ -1,0 +1,13 @@
+namespace TUnit.Core.Settings;
+
+/// <summary>
+/// Controls test run behavior.
+/// </summary>
+public sealed class ExecutionSettings
+{
+    /// <summary>
+    /// Whether to cancel the test run after the first test failure. Default: <c>false</c>.
+    /// Precedence: <c>--fail-fast</c> → TUnitSettings → built-in default.
+    /// </summary>
+    public bool FailFast { get; set; }
+}

--- a/TUnit.Core/Settings/ExecutionSettings.cs
+++ b/TUnit.Core/Settings/ExecutionSettings.cs
@@ -5,6 +5,8 @@ namespace TUnit.Core.Settings;
 /// </summary>
 public sealed class ExecutionSettings
 {
+    internal ExecutionSettings() { }
+
     /// <summary>
     /// Whether to cancel the test run after the first test failure. Default: <c>false</c>.
     /// Precedence: <c>--fail-fast</c> → TUnitSettings → built-in default.

--- a/TUnit.Core/Settings/ExecutionSettings.cs
+++ b/TUnit.Core/Settings/ExecutionSettings.cs
@@ -9,11 +9,5 @@ public sealed class ExecutionSettings
     /// Whether to cancel the test run after the first test failure. Default: <c>false</c>.
     /// Precedence: <c>--fail-fast</c> → TUnitSettings → built-in default.
     /// </summary>
-    public bool FailFast
-    {
-        get => Volatile.Read(ref _failFast);
-        set => Volatile.Write(ref _failFast, value);
-    }
-
-    private bool _failFast;
+    public bool FailFast { get; set; }
 }

--- a/TUnit.Core/Settings/ExecutionSettings.cs
+++ b/TUnit.Core/Settings/ExecutionSettings.cs
@@ -9,5 +9,11 @@ public sealed class ExecutionSettings
     /// Whether to cancel the test run after the first test failure. Default: <c>false</c>.
     /// Precedence: <c>--fail-fast</c> → TUnitSettings → built-in default.
     /// </summary>
-    public bool FailFast { get; set; }
+    public bool FailFast
+    {
+        get => Volatile.Read(ref _failFast);
+        set => Volatile.Write(ref _failFast, value);
+    }
+
+    private bool _failFast;
 }

--- a/TUnit.Core/Settings/ParallelismSettings.cs
+++ b/TUnit.Core/Settings/ParallelismSettings.cs
@@ -5,6 +5,8 @@ namespace TUnit.Core.Settings;
 /// </summary>
 public sealed class ParallelismSettings
 {
+    internal ParallelismSettings() { }
+
     /// <summary>
     /// Maximum number of tests to run in parallel. Default: <c>null</c> (= 4× CPU cores).
     /// Precedence: <c>--maximum-parallel-tests</c> → <c>TUNIT_MAX_PARALLEL_TESTS</c> → TUnitSettings → built-in default.

--- a/TUnit.Core/Settings/ParallelismSettings.cs
+++ b/TUnit.Core/Settings/ParallelismSettings.cs
@@ -8,6 +8,27 @@ public sealed class ParallelismSettings
     /// <summary>
     /// Maximum number of tests to run in parallel. Default: <c>null</c> (= 4× CPU cores).
     /// Precedence: <c>--maximum-parallel-tests</c> → <c>TUNIT_MAX_PARALLEL_TESTS</c> → TUnitSettings → built-in default.
+    /// <para>
+    /// <b>Note:</b> This value is read during scheduler initialization, which occurs before
+    /// <c>[Before(HookType.TestDiscovery)]</c> hooks run. Set this value in a module initializer
+    /// or static constructor, or use the <c>--maximum-parallel-tests</c> CLI flag /
+    /// <c>TUNIT_MAX_PARALLEL_TESTS</c> environment variable instead.
+    /// </para>
     /// </summary>
-    public int? MaximumParallelTests { get; set; }
+    public int? MaximumParallelTests
+    {
+        get => _maximumParallelTests;
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "MaximumParallelTests must be null, 0 (unlimited), or a positive number.");
+            }
+
+            _maximumParallelTests = value;
+        }
+    }
+
+    private int? _maximumParallelTests;
 }

--- a/TUnit.Core/Settings/ParallelismSettings.cs
+++ b/TUnit.Core/Settings/ParallelismSettings.cs
@@ -8,12 +8,6 @@ public sealed class ParallelismSettings
     /// <summary>
     /// Maximum number of tests to run in parallel. Default: <c>null</c> (= 4× CPU cores).
     /// Precedence: <c>--maximum-parallel-tests</c> → <c>TUNIT_MAX_PARALLEL_TESTS</c> → TUnitSettings → built-in default.
-    /// <para>
-    /// <b>Note:</b> This value is read during scheduler initialization, which occurs before
-    /// <c>[Before(HookType.TestDiscovery)]</c> hooks run. Set this value in a module initializer
-    /// or static constructor, or use the <c>--maximum-parallel-tests</c> CLI flag /
-    /// <c>TUNIT_MAX_PARALLEL_TESTS</c> environment variable instead.
-    /// </para>
     /// </summary>
     public int? MaximumParallelTests
     {

--- a/TUnit.Core/Settings/ParallelismSettings.cs
+++ b/TUnit.Core/Settings/ParallelismSettings.cs
@@ -1,0 +1,13 @@
+namespace TUnit.Core.Settings;
+
+/// <summary>
+/// Controls concurrent test execution.
+/// </summary>
+public sealed class ParallelismSettings
+{
+    /// <summary>
+    /// Maximum number of tests to run in parallel. Default: <c>null</c> (= 4× CPU cores).
+    /// Precedence: <c>--maximum-parallel-tests</c> → <c>TUNIT_MAX_PARALLEL_TESTS</c> → TUnitSettings → built-in default.
+    /// </summary>
+    public int? MaximumParallelTests { get; set; }
+}

--- a/TUnit.Core/Settings/TUnitSettings.cs
+++ b/TUnit.Core/Settings/TUnitSettings.cs
@@ -1,7 +1,7 @@
 namespace TUnit.Core.Settings;
 
 /// <summary>
-/// Programmatic configuration for TUnit. Set these in a
+/// Programmatic configuration for TUnit. Access via <c>context.Settings</c> in a
 /// <c>[Before(HookType.TestDiscovery)]</c> hook to establish project-level defaults.
 /// <para>
 /// Precedence: CLI flag → environment variable → <see cref="TUnitSettings"/> → built-in default.
@@ -13,25 +13,29 @@ namespace TUnit.Core.Settings;
 /// is required. Modifying settings during parallel test execution is not supported.
 /// </para>
 /// </summary>
-public static class TUnitSettings
+public sealed class TUnitSettings
 {
+    internal static TUnitSettings Default { get; } = new();
+
+    internal TUnitSettings() { }
+
     /// <summary>
     /// Default timeouts for tests and hooks.
     /// </summary>
-    public static TimeoutSettings Timeouts { get; } = new();
+    public TimeoutSettings Timeouts { get; } = new();
 
     /// <summary>
     /// Controls concurrent test execution.
     /// </summary>
-    public static ParallelismSettings Parallelism { get; } = new();
+    public ParallelismSettings Parallelism { get; } = new();
 
     /// <summary>
     /// Controls visual output.
     /// </summary>
-    public static DisplaySettings Display { get; } = new();
+    public DisplaySettings Display { get; } = new();
 
     /// <summary>
     /// Controls test run behavior.
     /// </summary>
-    public static ExecutionSettings Execution { get; } = new();
+    public ExecutionSettings Execution { get; } = new();
 }

--- a/TUnit.Core/Settings/TUnitSettings.cs
+++ b/TUnit.Core/Settings/TUnitSettings.cs
@@ -1,0 +1,31 @@
+namespace TUnit.Core.Settings;
+
+/// <summary>
+/// Programmatic configuration for TUnit. Set these in a
+/// <c>[Before(HookType.TestDiscovery)]</c> hook to establish project-level defaults.
+/// <para>
+/// Precedence: CLI flag → environment variable → <see cref="TUnitSettings"/> → built-in default.
+/// </para>
+/// </summary>
+public static class TUnitSettings
+{
+    /// <summary>
+    /// Default timeouts for tests and hooks.
+    /// </summary>
+    public static TimeoutSettings Timeouts { get; } = new();
+
+    /// <summary>
+    /// Controls concurrent test execution.
+    /// </summary>
+    public static ParallelismSettings Parallelism { get; } = new();
+
+    /// <summary>
+    /// Controls visual output.
+    /// </summary>
+    public static DisplaySettings Display { get; } = new();
+
+    /// <summary>
+    /// Controls test run behavior.
+    /// </summary>
+    public static ExecutionSettings Execution { get; } = new();
+}

--- a/TUnit.Core/Settings/TUnitSettings.cs
+++ b/TUnit.Core/Settings/TUnitSettings.cs
@@ -6,6 +6,12 @@ namespace TUnit.Core.Settings;
 /// <para>
 /// Precedence: CLI flag → environment variable → <see cref="TUnitSettings"/> → built-in default.
 /// </para>
+/// <para>
+/// <b>Threading:</b> All settings should be configured before test execution begins
+/// (typically in a <c>[Before(HookType.TestDiscovery)]</c> hook). The framework ensures
+/// hook completion happens-before test threads start, so no additional synchronization
+/// is required. Modifying settings during parallel test execution is not supported.
+/// </para>
 /// </summary>
 public static class TUnitSettings
 {

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -1,0 +1,34 @@
+namespace TUnit.Core.Settings;
+
+/// <summary>
+/// Default timeouts applied when no <c>[Timeout]</c> attribute is specified.
+/// These are project-level defaults — CLI flags and environment variables take precedence.
+/// </summary>
+public sealed class TimeoutSettings
+{
+    /// <summary>
+    /// Default timeout for individual tests. Default: 30 minutes.
+    /// Overridden per-test by <see cref="TimeoutAttribute"/>.
+    /// Precedence: CLI/env var (N/A for test timeout) → TUnitSettings → built-in default.
+    /// </summary>
+    public TimeSpan DefaultTestTimeout { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Default timeout for hook methods (Before/After at every level). Default: 5 minutes.
+    /// Overridden per-hook by <see cref="TimeoutAttribute"/>.
+    /// Precedence: CLI/env var (N/A for hook timeout) → TUnitSettings → built-in default.
+    /// </summary>
+    public TimeSpan DefaultHookTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Time allowed for graceful shutdown after cancellation (Ctrl+C / SIGTERM)
+    /// before the process is forcefully terminated. Default: 30 seconds.
+    /// </summary>
+    public TimeSpan ForcefulExitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Brief delay during process exit to allow After hooks registered via
+    /// <see cref="CancellationToken.Register"/> to execute. Default: 500ms.
+    /// </summary>
+    public TimeSpan ProcessExitHookDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+}

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -24,11 +24,6 @@ public sealed class TimeoutSettings
     /// <summary>
     /// Default timeout for hook methods (Before/After at every level). Default: 5 minutes.
     /// Overridden per-hook by <see cref="TimeoutAttribute"/>.
-    /// <para>
-    /// <b>Note:</b> Hook methods capture this value at registration time, which occurs before
-    /// <c>[Before(HookType.TestDiscovery)]</c> hooks run. Use the <c>[Timeout]</c> attribute
-    /// on individual hook methods for reliable per-hook timeout control.
-    /// </para>
     /// </summary>
     public TimeSpan DefaultHookTimeout
     {

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -16,7 +16,11 @@ public sealed class TimeoutSettings
     /// <summary>
     /// Default timeout for hook methods (Before/After at every level). Default: 5 minutes.
     /// Overridden per-hook by <see cref="TimeoutAttribute"/>.
-    /// Precedence: CLI/env var (N/A for hook timeout) → TUnitSettings → built-in default.
+    /// <para>
+    /// <b>Note:</b> Hook methods capture this value at registration time, which occurs before
+    /// <c>[Before(HookType.TestDiscovery)]</c> hooks run. Use the <c>[Timeout]</c> attribute
+    /// on individual hook methods for reliable per-hook timeout control.
+    /// </para>
     /// </summary>
     public TimeSpan DefaultHookTimeout { get; set; } = TimeSpan.FromMinutes(5);
 

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -6,6 +6,8 @@ namespace TUnit.Core.Settings;
 /// </summary>
 public sealed class TimeoutSettings
 {
+    internal TimeoutSettings() { }
+
     /// <summary>
     /// Default timeout for individual tests. Default: 30 minutes.
     /// Overridden per-test by <see cref="TimeoutAttribute"/>.

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -57,13 +57,19 @@ public sealed class TimeoutSettings
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute. Default: 500ms.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable the delay.
     /// </summary>
     public TimeSpan ProcessExitHookDelay
     {
         get => _processExitHookDelay;
         set
         {
-            ValidatePositive(value);
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    "ProcessExitHookDelay cannot be negative.");
+            }
+
             _processExitHookDelay = value;
         }
     }

--- a/TUnit.Core/Settings/TimeoutSettings.cs
+++ b/TUnit.Core/Settings/TimeoutSettings.cs
@@ -11,7 +11,15 @@ public sealed class TimeoutSettings
     /// Overridden per-test by <see cref="TimeoutAttribute"/>.
     /// Precedence: CLI/env var (N/A for test timeout) → TUnitSettings → built-in default.
     /// </summary>
-    public TimeSpan DefaultTestTimeout { get; set; } = TimeSpan.FromMinutes(30);
+    public TimeSpan DefaultTestTimeout
+    {
+        get => _defaultTestTimeout;
+        set
+        {
+            ValidatePositive(value);
+            _defaultTestTimeout = value;
+        }
+    }
 
     /// <summary>
     /// Default timeout for hook methods (Before/After at every level). Default: 5 minutes.
@@ -22,17 +30,55 @@ public sealed class TimeoutSettings
     /// on individual hook methods for reliable per-hook timeout control.
     /// </para>
     /// </summary>
-    public TimeSpan DefaultHookTimeout { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan DefaultHookTimeout
+    {
+        get => _defaultHookTimeout;
+        set
+        {
+            ValidatePositive(value);
+            _defaultHookTimeout = value;
+        }
+    }
 
     /// <summary>
     /// Time allowed for graceful shutdown after cancellation (Ctrl+C / SIGTERM)
     /// before the process is forcefully terminated. Default: 30 seconds.
     /// </summary>
-    public TimeSpan ForcefulExitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ForcefulExitTimeout
+    {
+        get => _forcefulExitTimeout;
+        set
+        {
+            ValidatePositive(value);
+            _forcefulExitTimeout = value;
+        }
+    }
 
     /// <summary>
     /// Brief delay during process exit to allow After hooks registered via
     /// <see cref="CancellationToken.Register"/> to execute. Default: 500ms.
     /// </summary>
-    public TimeSpan ProcessExitHookDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+    public TimeSpan ProcessExitHookDelay
+    {
+        get => _processExitHookDelay;
+        set
+        {
+            ValidatePositive(value);
+            _processExitHookDelay = value;
+        }
+    }
+
+    private TimeSpan _defaultTestTimeout = TimeSpan.FromMinutes(30);
+    private TimeSpan _defaultHookTimeout = TimeSpan.FromMinutes(5);
+    private TimeSpan _forcefulExitTimeout = TimeSpan.FromSeconds(30);
+    private TimeSpan _processExitHookDelay = TimeSpan.FromMilliseconds(500);
+
+    private static void ValidatePositive(TimeSpan value)
+    {
+        if (value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value,
+                "Timeout must be a positive duration.");
+        }
+    }
 }

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -1078,7 +1078,7 @@ internal sealed class TestBuilder : ITestBuilder
             AttributesByType = attributes.ToAttributeDictionary(),
             MethodGenericArguments = testData.ResolvedMethodGenericArguments,
             ClassGenericArguments = testData.ResolvedClassGenericArguments,
-            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
             // Don't set RetryLimit here - let discovery event receivers set it
         };
 
@@ -1172,7 +1172,7 @@ internal sealed class TestBuilder : ITestBuilder
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
         };
     }
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -1078,7 +1078,7 @@ internal sealed class TestBuilder : ITestBuilder
             AttributesByType = attributes.ToAttributeDictionary(),
             MethodGenericArguments = testData.ResolvedMethodGenericArguments,
             ClassGenericArguments = testData.ResolvedClassGenericArguments,
-            Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
             // Don't set RetryLimit here - let discovery event receivers set it
         };
 
@@ -1172,7 +1172,7 @@ internal sealed class TestBuilder : ITestBuilder
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Defaults.TestTimeout
+            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout
         };
     }
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -1078,8 +1078,7 @@ internal sealed class TestBuilder : ITestBuilder
             AttributesByType = attributes.ToAttributeDictionary(),
             MethodGenericArguments = testData.ResolvedMethodGenericArguments,
             ClassGenericArguments = testData.ResolvedClassGenericArguments,
-            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
-            // Don't set RetryLimit here - let discovery event receivers set it
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
         };
 
         var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -254,8 +254,7 @@ internal sealed class TestBuilderPipeline
                 ReturnType = typeof(Task),
                 MethodMetadata = metadata.MethodMetadata,
                 AttributesByType = attributes.ToAttributeDictionary(),
-                Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
-                // Don't set RetryLimit here - let discovery event receivers set it
+                Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
             };
 
             var testBuilderContext = CreateTestBuilderContext(metadata);
@@ -382,8 +381,7 @@ internal sealed class TestBuilderPipeline
                         ReturnType = typeof(Task),
                         MethodMetadata = resolvedMetadata.MethodMetadata,
                         AttributesByType = attributes.ToAttributeDictionary(),
-                        Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
-                        // Don't set Timeout and RetryLimit here - let discovery event receivers set them
+                        Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
                     };
 
                     var context = _contextProvider.CreateTestContext(
@@ -462,7 +460,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
         };
 
         var context = _contextProvider.CreateTestContext(
@@ -515,7 +513,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout
         };
 
         var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -254,7 +254,7 @@ internal sealed class TestBuilderPipeline
                 ReturnType = typeof(Task),
                 MethodMetadata = metadata.MethodMetadata,
                 AttributesByType = attributes.ToAttributeDictionary(),
-                Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+                Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                 // Don't set RetryLimit here - let discovery event receivers set it
             };
 
@@ -382,7 +382,7 @@ internal sealed class TestBuilderPipeline
                         ReturnType = typeof(Task),
                         MethodMetadata = resolvedMetadata.MethodMetadata,
                         AttributesByType = attributes.ToAttributeDictionary(),
-                        Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+                        Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                         // Don't set Timeout and RetryLimit here - let discovery event receivers set them
                     };
 
@@ -462,7 +462,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(
@@ -515,7 +515,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Default.Timeouts.DefaultTestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -254,7 +254,7 @@ internal sealed class TestBuilderPipeline
                 ReturnType = typeof(Task),
                 MethodMetadata = metadata.MethodMetadata,
                 AttributesByType = attributes.ToAttributeDictionary(),
-                Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+                Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                 // Don't set RetryLimit here - let discovery event receivers set it
             };
 
@@ -382,7 +382,7 @@ internal sealed class TestBuilderPipeline
                         ReturnType = typeof(Task),
                         MethodMetadata = resolvedMetadata.MethodMetadata,
                         AttributesByType = attributes.ToAttributeDictionary(),
-                        Timeout = Core.Defaults.TestTimeout // Default timeout (can be overridden by TimeoutAttribute)
+                        Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout (can be overridden by TimeoutAttribute)
                         // Don't set Timeout and RetryLimit here - let discovery event receivers set them
                     };
 
@@ -462,7 +462,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Defaults.TestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(
@@ -515,7 +515,7 @@ internal sealed class TestBuilderPipeline
             ReturnType = typeof(Task),
             MethodMetadata = metadata.MethodMetadata,
             AttributesByType = AttributeDictionaryHelper.Empty,
-            Timeout = Core.Defaults.TestTimeout // Default timeout
+            Timeout = Core.Settings.TUnitSettings.Timeouts.DefaultTestTimeout // Default timeout
         };
 
         var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Capabilities/BannerCapability.cs
+++ b/TUnit.Engine/Capabilities/BannerCapability.cs
@@ -5,7 +5,6 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
-using TUnit.Core.Settings;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Enums;
@@ -26,7 +25,6 @@ internal class BannerCapability(IPlatformInformation platformInformation, IComma
     {
         if (commandLineOptions.IsOptionSet(DisableLogoCommandProvider.DisableLogo)
             || Environment.GetEnvironmentVariable(EnvironmentConstants.DisableLogo) is not null
-            || TUnitSettings.Display.DisableLogo
             || loggerFactory.CreateLogger(nameof(BannerCapability)).IsEnabled(LogLevel.Information))
         {
             return Task.FromResult<string?>(GetRuntimeDetails());

--- a/TUnit.Engine/Capabilities/BannerCapability.cs
+++ b/TUnit.Engine/Capabilities/BannerCapability.cs
@@ -5,6 +5,7 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
+using TUnit.Core.Settings;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Enums;
@@ -25,6 +26,7 @@ internal class BannerCapability(IPlatformInformation platformInformation, IComma
     {
         if (commandLineOptions.IsOptionSet(DisableLogoCommandProvider.DisableLogo)
             || Environment.GetEnvironmentVariable(EnvironmentConstants.DisableLogo) is not null
+            || TUnitSettings.Display.DisableLogo
             || loggerFactory.CreateLogger(nameof(BannerCapability)).IsEnabled(LogLevel.Information))
         {
             return Task.FromResult<string?>(GetRuntimeDetails());

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -17,7 +17,6 @@ using TUnit.Engine.Building;
 using TUnit.Engine.Building.Collectors;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Building.Interfaces;
-using TUnit.Core.Settings;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Discovery;
 using TUnit.Engine.Extensions;
@@ -237,8 +236,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         // Create the HookOrchestratingTestExecutorAdapter
         // Note: We'll need to update this to handle dynamic dependencies properly
         var sessionUid = context.Request.Session.SessionUid;
-        var isFailFastEnabled = CommandLineOptions.TryGetOptionArgumentList(FailFastCommandProvider.FailFast, out _)
-            || TUnitSettings.Execution.FailFast;
+        var isFailFastEnabled = CommandLineOptions.TryGetOptionArgumentList(FailFastCommandProvider.FailFast, out _);
         FailFastCancellationSource = Register(new CancellationTokenSource());
 
         var testRunner = Register(

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -17,6 +17,7 @@ using TUnit.Engine.Building;
 using TUnit.Engine.Building.Collectors;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Building.Interfaces;
+using TUnit.Core.Settings;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Discovery;
 using TUnit.Engine.Extensions;
@@ -236,7 +237,8 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         // Create the HookOrchestratingTestExecutorAdapter
         // Note: We'll need to update this to handle dynamic dependencies properly
         var sessionUid = context.Request.Session.SessionUid;
-        var isFailFastEnabled = CommandLineOptions.TryGetOptionArgumentList(FailFastCommandProvider.FailFast, out _);
+        var isFailFastEnabled = CommandLineOptions.TryGetOptionArgumentList(FailFastCommandProvider.FailFast, out _)
+            || TUnitSettings.Execution.FailFast;
         FailFastCancellationSource = Register(new CancellationTokenSource());
 
         var testRunner = Register(

--- a/TUnit.Engine/Helpers/HookTimeoutHelper.cs
+++ b/TUnit.Engine/Helpers/HookTimeoutHelper.cs
@@ -1,9 +1,12 @@
 using TUnit.Core.Hooks;
+using TUnit.Core.Settings;
 
 namespace TUnit.Engine.Helpers;
 
 /// <summary>
-/// Helper class for executing hooks with timeout enforcement
+/// Helper class for executing hooks with timeout enforcement.
+/// When no explicit timeout is set on a hook, falls back to
+/// <see cref="TUnitSettings.Default"/>.<see cref="TUnitSettings.Timeouts"/>.<see cref="TimeoutSettings.DefaultHookTimeout"/>.
 /// </summary>
 internal static class HookTimeoutHelper
 {
@@ -15,14 +18,9 @@ internal static class HookTimeoutHelper
         T context,
         CancellationToken cancellationToken)
     {
-        var timeout = hook.Timeout;
+        var timeout = hook.Timeout ?? TUnitSettings.Default.Timeouts.DefaultHookTimeout;
 
-        if (timeout == null)
-        {
-            return hook.ExecuteAsync(context, cancellationToken).AsTask();
-        }
-
-        var timeoutMs = (int)timeout.Value.TotalMilliseconds;
+        var timeoutMs = (int)timeout.TotalMilliseconds;
 
         return CreateTimeoutHookActionAsync(hook, context, timeoutMs, cancellationToken);
 
@@ -57,13 +55,8 @@ internal static class HookTimeoutHelper
         string hookName,
         CancellationToken cancellationToken)
     {
-        if (timeout == null)
-        {
-            // No timeout specified, execute normally
-            return async () => await hookDelegate(context, cancellationToken);
-        }
-
-        var timeoutMs = (int)timeout.Value.TotalMilliseconds;
+        var effectiveTimeout = timeout ?? TUnitSettings.Default.Timeouts.DefaultHookTimeout;
+        var timeoutMs = (int)effectiveTimeout.TotalMilliseconds;
 
         return async () =>
         {
@@ -83,9 +76,9 @@ internal static class HookTimeoutHelper
     }
 
     /// <summary>
-    /// Creates a timeout-aware action wrapper for a hook delegate that returns ValueTask
-    /// This overload is used for instance hooks (InstanceHookMethod)
-    /// Custom executor handling for instance hooks is done in HookDelegateBuilder.CreateInstanceHookDelegateAsync
+    /// Creates a timeout-aware action wrapper for a hook delegate that returns ValueTask.
+    /// This overload is used for instance hooks (InstanceHookMethod).
+    /// Custom executor handling for instance hooks is done in HookDelegateBuilder.CreateInstanceHookDelegateAsync.
     /// </summary>
     public static Func<Task> CreateTimeoutHookAction<T>(
         Func<T, CancellationToken, ValueTask> hookDelegate,
@@ -94,13 +87,8 @@ internal static class HookTimeoutHelper
         string hookName,
         CancellationToken cancellationToken)
     {
-        if (timeout == null)
-        {
-            // No timeout specified, execute normally
-            return async () => await hookDelegate(context, cancellationToken);
-        }
-
-        var timeoutMs = (int)timeout.Value.TotalMilliseconds;
+        var effectiveTimeout = timeout ?? TUnitSettings.Default.Timeouts.DefaultHookTimeout;
+        var timeoutMs = (int)effectiveTimeout.TotalMilliseconds;
 
         return async () =>
         {

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -93,7 +93,7 @@ public sealed class TestRunner
             // TestCoordinator handles sending InProgress message
             await _testCoordinator.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
 
-            if ((_isFailFastEnabled || TUnitSettings.Execution.FailFast) && test.Result?.State == TestState.Failed)
+            if ((_isFailFastEnabled || TUnitSettings.Default.Execution.FailFast) && test.Result?.State == TestState.Failed)
             {
                 // Capture the first failure exception before triggering cancellation
                 if (test.Result.Exception != null)
@@ -110,7 +110,7 @@ public sealed class TestRunner
             // We only need to handle fail-fast logic here
             await _logger.LogErrorAsync($"Unhandled exception in test {test.TestId}: {ex}").ConfigureAwait(false);
 
-            if (_isFailFastEnabled || TUnitSettings.Execution.FailFast)
+            if (_isFailFastEnabled || TUnitSettings.Default.Execution.FailFast)
             {
                 // Capture the first failure exception before triggering cancellation
                 Interlocked.CompareExchange(ref _firstFailFastException, ex, null);

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using TUnit.Core;
+using TUnit.Core.Settings;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Logging;
 using TUnit.Engine.Services.TestExecution;
@@ -92,7 +93,7 @@ public sealed class TestRunner
             // TestCoordinator handles sending InProgress message
             await _testCoordinator.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
 
-            if (_isFailFastEnabled && test.Result?.State == TestState.Failed)
+            if ((_isFailFastEnabled || TUnitSettings.Execution.FailFast) && test.Result?.State == TestState.Failed)
             {
                 // Capture the first failure exception before triggering cancellation
                 if (test.Result.Exception != null)
@@ -109,7 +110,7 @@ public sealed class TestRunner
             // We only need to handle fail-fast logic here
             await _logger.LogErrorAsync($"Unhandled exception in test {test.TestId}: {ex}").ConfigureAwait(false);
 
-            if (_isFailFastEnabled)
+            if (_isFailFastEnabled || TUnitSettings.Execution.FailFast)
             {
                 // Capture the first failure exception before triggering cancellation
                 Interlocked.CompareExchange(ref _firstFailFastException, ex, null);

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -564,7 +564,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
 
         // Check TUnitSettings (third priority — code-level project defaults)
-        if (TUnitSettings.Parallelism.MaximumParallelTests is { } codeLimit)
+        if (TUnitSettings.Default.Parallelism.MaximumParallelTests is { } codeLimit)
         {
             if (codeLimit == 0)
             {

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -572,11 +572,9 @@ internal sealed class TestScheduler : ITestScheduler
                 return int.MaxValue;
             }
 
-            if (codeLimit > 0)
-            {
-                logger.LogDebug($"Maximum parallel tests limit set to {codeLimit} (from TUnitSettings)");
-                return codeLimit;
-            }
+            // Setter guarantees no negative values
+            logger.LogDebug($"Maximum parallel tests limit set to {codeLimit} (from TUnitSettings)");
+            return codeLimit;
         }
 
         // Default: 4x CPU cores (empirically optimized for async/IO-bound workloads)

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -310,9 +310,10 @@ internal sealed class TestScheduler : ITestScheduler
         AbstractExecutableTest[] tests,
         CancellationToken cancellationToken)
     {
-        if (_maxParallelismSemaphore.Value != null)
+        var semaphore = _maxParallelismSemaphore.Value;
+        if (semaphore != null)
         {
-            await ExecuteWithGlobalLimitAsync(tests, cancellationToken).ConfigureAwait(false);
+            await ExecuteWithGlobalLimitAsync(tests, semaphore, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -383,8 +384,11 @@ internal sealed class TestScheduler : ITestScheduler
 
     private async Task ExecuteWithGlobalLimitAsync(
         AbstractExecutableTest[] tests,
+        SemaphoreSlim globalSemaphore,
         CancellationToken cancellationToken)
     {
+        var maxParallelism = _maxParallelism.Value;
+
 #if NET8_0_OR_GREATER
         // PERFORMANCE OPTIMIZATION: Partition tests by whether they have parallel limiters
         // Tests without limiters can run with unlimited parallelism (avoiding global semaphore overhead)
@@ -405,11 +409,11 @@ internal sealed class TestScheduler : ITestScheduler
 
         // Execute both groups concurrently
         var limitedTask = testsWithLimiters.Count > 0
-            ? ExecuteWithLimitAsync(testsWithLimiters, cancellationToken)
+            ? ExecuteWithLimitAsync(testsWithLimiters, maxParallelism, cancellationToken)
             : Task.CompletedTask;
 
         var unlimitedTask = testsWithoutLimiters.Count > 0
-            ? ExecuteUnlimitedAsync(testsWithoutLimiters, cancellationToken)
+            ? ExecuteUnlimitedAsync(testsWithoutLimiters, maxParallelism, cancellationToken)
             : Task.CompletedTask;
 
         await Task.WhenAll(limitedTask, unlimitedTask).ConfigureAwait(false);
@@ -423,7 +427,7 @@ internal sealed class TestScheduler : ITestScheduler
             {
                 SemaphoreSlim? parallelLimiterSemaphore = null;
 
-                await _maxParallelismSemaphore.Value!.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await globalSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
                     if (test.Context.ParallelLimiter != null)
@@ -444,7 +448,7 @@ internal sealed class TestScheduler : ITestScheduler
                 }
                 finally
                 {
-                    _maxParallelismSemaphore.Value!.Release();
+                    globalSemaphore.Release();
                 }
             }, CancellationToken.None);
         }
@@ -455,6 +459,7 @@ internal sealed class TestScheduler : ITestScheduler
 #if NET8_0_OR_GREATER
     private async Task ExecuteWithLimitAsync(
         List<AbstractExecutableTest> tests,
+        int maxParallelism,
         CancellationToken cancellationToken)
     {
         // Execute tests with parallel limiters using the global limit
@@ -462,7 +467,7 @@ internal sealed class TestScheduler : ITestScheduler
             tests,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = _maxParallelism.Value,
+                MaxDegreeOfParallelism = maxParallelism,
                 CancellationToken = cancellationToken
             },
             async (test, ct) =>
@@ -485,6 +490,7 @@ internal sealed class TestScheduler : ITestScheduler
 
     private async Task ExecuteUnlimitedAsync(
         List<AbstractExecutableTest> tests,
+        int maxParallelism,
         CancellationToken cancellationToken)
     {
         // Execute tests without per-test limiters, but still apply global parallelism limit
@@ -492,7 +498,7 @@ internal sealed class TestScheduler : ITestScheduler
             tests,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = _maxParallelism.Value,
+                MaxDegreeOfParallelism = maxParallelism,
                 CancellationToken = cancellationToken
             },
             async (test, ct) =>
@@ -573,7 +579,6 @@ internal sealed class TestScheduler : ITestScheduler
                 return int.MaxValue;
             }
 
-            // Setter guarantees no negative values
             logger.LogDebug($"Maximum parallel tests limit set to {codeLimit} (from TUnitSettings)");
             return codeLimit;
         }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -28,8 +28,8 @@ internal sealed class TestScheduler : ITestScheduler
     private readonly AfterHookPairTracker _afterHookPairTracker;
     private readonly StaticPropertyHandler _staticPropertyHandler;
     private readonly IDynamicTestQueue _dynamicTestQueue;
-    private readonly int _maxParallelism;
-    private readonly SemaphoreSlim? _maxParallelismSemaphore;
+    private readonly Lazy<int> _maxParallelism;
+    private readonly Lazy<SemaphoreSlim?> _maxParallelismSemaphore;
 
     public TestScheduler(
         TUnitFrameworkLogger logger,
@@ -59,11 +59,12 @@ internal sealed class TestScheduler : ITestScheduler
         _staticPropertyHandler = staticPropertyHandler;
         _dynamicTestQueue = dynamicTestQueue;
 
-        _maxParallelism = GetMaxParallelism(logger, commandLineOptions);
+        _maxParallelism = new Lazy<int>(() => GetMaxParallelism(logger, commandLineOptions));
 
-        _maxParallelismSemaphore = _maxParallelism == int.MaxValue
-            ? null
-            : new SemaphoreSlim(_maxParallelism, _maxParallelism);
+        _maxParallelismSemaphore = new Lazy<SemaphoreSlim?>(() =>
+            _maxParallelism.Value == int.MaxValue
+                ? null
+                : new SemaphoreSlim(_maxParallelism.Value, _maxParallelism.Value));
     }
 
     #if NET8_0_OR_GREATER
@@ -309,7 +310,7 @@ internal sealed class TestScheduler : ITestScheduler
         AbstractExecutableTest[] tests,
         CancellationToken cancellationToken)
     {
-        if (_maxParallelismSemaphore != null)
+        if (_maxParallelismSemaphore.Value != null)
         {
             await ExecuteWithGlobalLimitAsync(tests, cancellationToken).ConfigureAwait(false);
         }
@@ -422,7 +423,7 @@ internal sealed class TestScheduler : ITestScheduler
             {
                 SemaphoreSlim? parallelLimiterSemaphore = null;
 
-                await _maxParallelismSemaphore!.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _maxParallelismSemaphore.Value!.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
                     if (test.Context.ParallelLimiter != null)
@@ -443,7 +444,7 @@ internal sealed class TestScheduler : ITestScheduler
                 }
                 finally
                 {
-                    _maxParallelismSemaphore.Release();
+                    _maxParallelismSemaphore.Value!.Release();
                 }
             }, CancellationToken.None);
         }
@@ -461,7 +462,7 @@ internal sealed class TestScheduler : ITestScheduler
             tests,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = _maxParallelism,
+                MaxDegreeOfParallelism = _maxParallelism.Value,
                 CancellationToken = cancellationToken
             },
             async (test, ct) =>
@@ -491,7 +492,7 @@ internal sealed class TestScheduler : ITestScheduler
             tests,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = _maxParallelism,
+                MaxDegreeOfParallelism = _maxParallelism.Value,
                 CancellationToken = cancellationToken
             },
             async (test, ct) =>

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -9,6 +9,7 @@ using TUnit.Engine.Interfaces;
 using TUnit.Engine.Logging;
 using TUnit.Engine.Models;
 using TUnit.Engine.Services;
+using TUnit.Core.Settings;
 using TUnit.Engine.Services.TestExecution;
 
 namespace TUnit.Engine.Scheduling;
@@ -559,6 +560,22 @@ internal sealed class TestScheduler : ITestScheduler
             {
                 logger.LogDebug($"Maximum parallel tests limit set to {envLimit} (from TUNIT_MAX_PARALLEL_TESTS environment variable)");
                 return envLimit;
+            }
+        }
+
+        // Check TUnitSettings (third priority — code-level project defaults)
+        if (TUnitSettings.Parallelism.MaximumParallelTests is { } codeLimit)
+        {
+            if (codeLimit == 0)
+            {
+                logger.LogDebug("Maximum parallel tests: unlimited (from TUnitSettings)");
+                return int.MaxValue;
+            }
+
+            if (codeLimit > 0)
+            {
+                logger.LogDebug($"Maximum parallel tests limit set to {codeLimit} (from TUnitSettings)");
+                return codeLimit;
             }
         }
 

--- a/TUnit.Engine/TUnitMessageBus.cs
+++ b/TUnit.Engine/TUnitMessageBus.cs
@@ -5,6 +5,7 @@ using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.Platform.TestHost;
 using TUnit.Core;
+using TUnit.Core.Settings;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Enums;
 using TUnit.Engine.Exceptions;
@@ -85,6 +86,7 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
     {
         // Check both the legacy --detailed-stacktrace flag and the new verbosity system
         if (commandLineOptions.IsOptionSet(DetailedStacktraceCommandProvider.DetailedStackTrace) ||
+            TUnitSettings.Display.DetailedStackTrace ||
             verbosityService?.ShowDetailedStackTrace == true)
         {
             return exception;

--- a/TUnit.Engine/TUnitMessageBus.cs
+++ b/TUnit.Engine/TUnitMessageBus.cs
@@ -86,7 +86,7 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
     {
         // Check both the legacy --detailed-stacktrace flag and the new verbosity system
         if (commandLineOptions.IsOptionSet(DetailedStacktraceCommandProvider.DetailedStackTrace) ||
-            TUnitSettings.Display.DetailedStackTrace ||
+            TUnitSettings.Default.Display.DetailedStackTrace ||
             verbosityService?.ShowDetailedStackTrace == true)
         {
             return exception;

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2924,17 +2924,14 @@ namespace .Settings
 {
     public sealed class DisplaySettings
     {
-        public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
     }
     public sealed class ExecutionSettings
     {
-        public ExecutionSettings() { }
         public bool FailFast { get; set; }
     }
     public sealed class ParallelismSettings
     {
-        public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
     public sealed class TUnitSettings
@@ -2946,7 +2943,6 @@ namespace .Settings
     }
     public sealed class TimeoutSettings
     {
-        public TimeoutSettings() { }
         public  DefaultHookTimeout { get; set; }
         public  DefaultTestTimeout { get; set; }
         public  ForcefulExitTimeout { get; set; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -528,11 +528,16 @@ namespace
         public static readonly .DefaultExecutor Instance;
         protected override . ExecuteAsync(<.> action) { }
     }
+    [("Use  instead.")]
     public static class Defaults
     {
+        [("Use .ForcefulExitTimeout instead.")]
         public static readonly  ForcefulExitTimeout;
+        [("Use .DefaultHookTimeout instead.")]
         public static readonly  HookTimeout;
+        [("Use .ProcessExitHookDelay instead.")]
         public static readonly  ProcessExitHookDelay;
+        [("Use .DefaultTestTimeout instead.")]
         public static readonly  TestTimeout;
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
@@ -2912,6 +2917,40 @@ namespace .Services
         public . AddTransient<T>(<T> factory)
             where T :  class { }
         public object? GetService( serviceType) { }
+    }
+}
+namespace .Settings
+{
+    public sealed class DisplaySettings
+    {
+        public DisplaySettings() { }
+        public bool DetailedStackTrace { get; set; }
+        public bool DisableLogo { get; set; }
+    }
+    public sealed class ExecutionSettings
+    {
+        public ExecutionSettings() { }
+        public bool FailFast { get; set; }
+    }
+    public sealed class ParallelismSettings
+    {
+        public ParallelismSettings() { }
+        public int? MaximumParallelTests { get; set; }
+    }
+    public static class TUnitSettings
+    {
+        public static . Display { get; }
+        public static . Execution { get; }
+        public static . Parallelism { get; }
+        public static . Timeouts { get; }
+    }
+    public sealed class TimeoutSettings
+    {
+        public TimeoutSettings() { }
+        public  DefaultHookTimeout { get; set; }
+        public  DefaultTestTimeout { get; set; }
+        public  ForcefulExitTimeout { get; set; }
+        public  ProcessExitHookDelay { get; set; }
     }
 }
 namespace .StaticProperties

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2925,7 +2925,6 @@ namespace .Settings
     {
         public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
-        public bool DisableLogo { get; set; }
     }
     public sealed class ExecutionSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -213,6 +213,7 @@ namespace
     public class BeforeTestDiscoveryContext : .Context
     {
         public .GlobalContext GlobalContext { get; }
+        public . Settings { get; }
         public required string? TestFilter { get; init; }
         public new static .BeforeTestDiscoveryContext? Current { get; }
     }
@@ -2936,12 +2937,12 @@ namespace .Settings
         public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
-    public static class TUnitSettings
+    public sealed class TUnitSettings
     {
-        public static . Display { get; }
-        public static . Execution { get; }
-        public static . Parallelism { get; }
-        public static . Timeouts { get; }
+        public . Display { get; }
+        public . Execution { get; }
+        public . Parallelism { get; }
+        public . Timeouts { get; }
     }
     public sealed class TimeoutSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -532,13 +532,13 @@ namespace
     public static class Defaults
     {
         [("Use .ForcefulExitTimeout instead.")]
-        public static readonly  ForcefulExitTimeout;
+        public static  ForcefulExitTimeout { get; }
         [("Use .DefaultHookTimeout instead.")]
-        public static readonly  HookTimeout;
+        public static  HookTimeout { get; }
         [("Use .ProcessExitHookDelay instead.")]
-        public static readonly  ProcessExitHookDelay;
+        public static  ProcessExitHookDelay { get; }
         [("Use .DefaultTestTimeout instead.")]
-        public static readonly  TestTimeout;
+        public static  TestTimeout { get; }
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2924,17 +2924,14 @@ namespace .Settings
 {
     public sealed class DisplaySettings
     {
-        public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
     }
     public sealed class ExecutionSettings
     {
-        public ExecutionSettings() { }
         public bool FailFast { get; set; }
     }
     public sealed class ParallelismSettings
     {
-        public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
     public sealed class TUnitSettings
@@ -2946,7 +2943,6 @@ namespace .Settings
     }
     public sealed class TimeoutSettings
     {
-        public TimeoutSettings() { }
         public  DefaultHookTimeout { get; set; }
         public  DefaultTestTimeout { get; set; }
         public  ForcefulExitTimeout { get; set; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -528,11 +528,16 @@ namespace
         public static readonly .DefaultExecutor Instance;
         protected override . ExecuteAsync(<.> action) { }
     }
+    [("Use  instead.")]
     public static class Defaults
     {
+        [("Use .ForcefulExitTimeout instead.")]
         public static readonly  ForcefulExitTimeout;
+        [("Use .DefaultHookTimeout instead.")]
         public static readonly  HookTimeout;
+        [("Use .ProcessExitHookDelay instead.")]
         public static readonly  ProcessExitHookDelay;
+        [("Use .DefaultTestTimeout instead.")]
         public static readonly  TestTimeout;
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
@@ -2912,6 +2917,40 @@ namespace .Services
         public . AddTransient<T>(<T> factory)
             where T :  class { }
         public object? GetService( serviceType) { }
+    }
+}
+namespace .Settings
+{
+    public sealed class DisplaySettings
+    {
+        public DisplaySettings() { }
+        public bool DetailedStackTrace { get; set; }
+        public bool DisableLogo { get; set; }
+    }
+    public sealed class ExecutionSettings
+    {
+        public ExecutionSettings() { }
+        public bool FailFast { get; set; }
+    }
+    public sealed class ParallelismSettings
+    {
+        public ParallelismSettings() { }
+        public int? MaximumParallelTests { get; set; }
+    }
+    public static class TUnitSettings
+    {
+        public static . Display { get; }
+        public static . Execution { get; }
+        public static . Parallelism { get; }
+        public static . Timeouts { get; }
+    }
+    public sealed class TimeoutSettings
+    {
+        public TimeoutSettings() { }
+        public  DefaultHookTimeout { get; set; }
+        public  DefaultTestTimeout { get; set; }
+        public  ForcefulExitTimeout { get; set; }
+        public  ProcessExitHookDelay { get; set; }
     }
 }
 namespace .StaticProperties

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2925,7 +2925,6 @@ namespace .Settings
     {
         public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
-        public bool DisableLogo { get; set; }
     }
     public sealed class ExecutionSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -213,6 +213,7 @@ namespace
     public class BeforeTestDiscoveryContext : .Context
     {
         public .GlobalContext GlobalContext { get; }
+        public . Settings { get; }
         public required string? TestFilter { get; init; }
         public new static .BeforeTestDiscoveryContext? Current { get; }
     }
@@ -2936,12 +2937,12 @@ namespace .Settings
         public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
-    public static class TUnitSettings
+    public sealed class TUnitSettings
     {
-        public static . Display { get; }
-        public static . Execution { get; }
-        public static . Parallelism { get; }
-        public static . Timeouts { get; }
+        public . Display { get; }
+        public . Execution { get; }
+        public . Parallelism { get; }
+        public . Timeouts { get; }
     }
     public sealed class TimeoutSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -532,13 +532,13 @@ namespace
     public static class Defaults
     {
         [("Use .ForcefulExitTimeout instead.")]
-        public static readonly  ForcefulExitTimeout;
+        public static  ForcefulExitTimeout { get; }
         [("Use .DefaultHookTimeout instead.")]
-        public static readonly  HookTimeout;
+        public static  HookTimeout { get; }
         [("Use .ProcessExitHookDelay instead.")]
-        public static readonly  ProcessExitHookDelay;
+        public static  ProcessExitHookDelay { get; }
         [("Use .DefaultTestTimeout instead.")]
-        public static readonly  TestTimeout;
+        public static  TestTimeout { get; }
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2924,17 +2924,14 @@ namespace .Settings
 {
     public sealed class DisplaySettings
     {
-        public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
     }
     public sealed class ExecutionSettings
     {
-        public ExecutionSettings() { }
         public bool FailFast { get; set; }
     }
     public sealed class ParallelismSettings
     {
-        public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
     public sealed class TUnitSettings
@@ -2946,7 +2943,6 @@ namespace .Settings
     }
     public sealed class TimeoutSettings
     {
-        public TimeoutSettings() { }
         public  DefaultHookTimeout { get; set; }
         public  DefaultTestTimeout { get; set; }
         public  ForcefulExitTimeout { get; set; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -528,11 +528,16 @@ namespace
         public static readonly .DefaultExecutor Instance;
         protected override . ExecuteAsync(<.> action) { }
     }
+    [("Use  instead.")]
     public static class Defaults
     {
+        [("Use .ForcefulExitTimeout instead.")]
         public static readonly  ForcefulExitTimeout;
+        [("Use .DefaultHookTimeout instead.")]
         public static readonly  HookTimeout;
+        [("Use .ProcessExitHookDelay instead.")]
         public static readonly  ProcessExitHookDelay;
+        [("Use .DefaultTestTimeout instead.")]
         public static readonly  TestTimeout;
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
@@ -2912,6 +2917,40 @@ namespace .Services
         public . AddTransient<T>(<T> factory)
             where T :  class { }
         public object? GetService( serviceType) { }
+    }
+}
+namespace .Settings
+{
+    public sealed class DisplaySettings
+    {
+        public DisplaySettings() { }
+        public bool DetailedStackTrace { get; set; }
+        public bool DisableLogo { get; set; }
+    }
+    public sealed class ExecutionSettings
+    {
+        public ExecutionSettings() { }
+        public bool FailFast { get; set; }
+    }
+    public sealed class ParallelismSettings
+    {
+        public ParallelismSettings() { }
+        public int? MaximumParallelTests { get; set; }
+    }
+    public static class TUnitSettings
+    {
+        public static . Display { get; }
+        public static . Execution { get; }
+        public static . Parallelism { get; }
+        public static . Timeouts { get; }
+    }
+    public sealed class TimeoutSettings
+    {
+        public TimeoutSettings() { }
+        public  DefaultHookTimeout { get; set; }
+        public  DefaultTestTimeout { get; set; }
+        public  ForcefulExitTimeout { get; set; }
+        public  ProcessExitHookDelay { get; set; }
     }
 }
 namespace .StaticProperties

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2925,7 +2925,6 @@ namespace .Settings
     {
         public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
-        public bool DisableLogo { get; set; }
     }
     public sealed class ExecutionSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -213,6 +213,7 @@ namespace
     public class BeforeTestDiscoveryContext : .Context
     {
         public .GlobalContext GlobalContext { get; }
+        public . Settings { get; }
         public required string? TestFilter { get; init; }
         public new static .BeforeTestDiscoveryContext? Current { get; }
     }
@@ -2936,12 +2937,12 @@ namespace .Settings
         public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
-    public static class TUnitSettings
+    public sealed class TUnitSettings
     {
-        public static . Display { get; }
-        public static . Execution { get; }
-        public static . Parallelism { get; }
-        public static . Timeouts { get; }
+        public . Display { get; }
+        public . Execution { get; }
+        public . Parallelism { get; }
+        public . Timeouts { get; }
     }
     public sealed class TimeoutSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -532,13 +532,13 @@ namespace
     public static class Defaults
     {
         [("Use .ForcefulExitTimeout instead.")]
-        public static readonly  ForcefulExitTimeout;
+        public static  ForcefulExitTimeout { get; }
         [("Use .DefaultHookTimeout instead.")]
-        public static readonly  HookTimeout;
+        public static  HookTimeout { get; }
         [("Use .ProcessExitHookDelay instead.")]
-        public static readonly  ProcessExitHookDelay;
+        public static  ProcessExitHookDelay { get; }
         [("Use .DefaultTestTimeout instead.")]
-        public static readonly  TestTimeout;
+        public static  TestTimeout { get; }
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2849,17 +2849,14 @@ namespace .Settings
 {
     public sealed class DisplaySettings
     {
-        public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
     }
     public sealed class ExecutionSettings
     {
-        public ExecutionSettings() { }
         public bool FailFast { get; set; }
     }
     public sealed class ParallelismSettings
     {
-        public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
     public sealed class TUnitSettings
@@ -2871,7 +2868,6 @@ namespace .Settings
     }
     public sealed class TimeoutSettings
     {
-        public TimeoutSettings() { }
         public  DefaultHookTimeout { get; set; }
         public  DefaultTestTimeout { get; set; }
         public  ForcefulExitTimeout { get; set; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -210,6 +210,7 @@ namespace
     public class BeforeTestDiscoveryContext : .Context
     {
         public .GlobalContext GlobalContext { get; }
+        public . Settings { get; }
         public required string? TestFilter { get; init; }
         public new static .BeforeTestDiscoveryContext? Current { get; }
     }
@@ -2861,12 +2862,12 @@ namespace .Settings
         public ParallelismSettings() { }
         public int? MaximumParallelTests { get; set; }
     }
-    public static class TUnitSettings
+    public sealed class TUnitSettings
     {
-        public static . Display { get; }
-        public static . Execution { get; }
-        public static . Parallelism { get; }
-        public static . Timeouts { get; }
+        public . Display { get; }
+        public . Execution { get; }
+        public . Parallelism { get; }
+        public . Timeouts { get; }
     }
     public sealed class TimeoutSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -511,13 +511,13 @@ namespace
     public static class Defaults
     {
         [("Use .ForcefulExitTimeout instead.")]
-        public static readonly  ForcefulExitTimeout;
+        public static  ForcefulExitTimeout { get; }
         [("Use .DefaultHookTimeout instead.")]
-        public static readonly  HookTimeout;
+        public static  HookTimeout { get; }
         [("Use .ProcessExitHookDelay instead.")]
-        public static readonly  ProcessExitHookDelay;
+        public static  ProcessExitHookDelay { get; }
         [("Use .DefaultTestTimeout instead.")]
-        public static readonly  TestTimeout;
+        public static  TestTimeout { get; }
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2850,7 +2850,6 @@ namespace .Settings
     {
         public DisplaySettings() { }
         public bool DetailedStackTrace { get; set; }
-        public bool DisableLogo { get; set; }
     }
     public sealed class ExecutionSettings
     {

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -507,11 +507,16 @@ namespace
         public static readonly .DefaultExecutor Instance;
         protected override . ExecuteAsync(<.> action) { }
     }
+    [("Use  instead.")]
     public static class Defaults
     {
+        [("Use .ForcefulExitTimeout instead.")]
         public static readonly  ForcefulExitTimeout;
+        [("Use .DefaultHookTimeout instead.")]
         public static readonly  HookTimeout;
+        [("Use .ProcessExitHookDelay instead.")]
         public static readonly  ProcessExitHookDelay;
+        [("Use .DefaultTestTimeout instead.")]
         public static readonly  TestTimeout;
     }
     public abstract class DependencyInjectionDataSourceAttribute<TScope> : .UntypedDataSourceGeneratorAttribute
@@ -2837,6 +2842,40 @@ namespace .Services
         public . AddTransient<T>(<T> factory)
             where T :  class { }
         public object? GetService( serviceType) { }
+    }
+}
+namespace .Settings
+{
+    public sealed class DisplaySettings
+    {
+        public DisplaySettings() { }
+        public bool DetailedStackTrace { get; set; }
+        public bool DisableLogo { get; set; }
+    }
+    public sealed class ExecutionSettings
+    {
+        public ExecutionSettings() { }
+        public bool FailFast { get; set; }
+    }
+    public sealed class ParallelismSettings
+    {
+        public ParallelismSettings() { }
+        public int? MaximumParallelTests { get; set; }
+    }
+    public static class TUnitSettings
+    {
+        public static . Display { get; }
+        public static . Execution { get; }
+        public static . Parallelism { get; }
+        public static . Timeouts { get; }
+    }
+    public sealed class TimeoutSettings
+    {
+        public TimeoutSettings() { }
+        public  DefaultHookTimeout { get; set; }
+        public  DefaultTestTimeout { get; set; }
+        public  ForcefulExitTimeout { get; set; }
+        public  ProcessExitHookDelay { get; set; }
     }
 }
 namespace .StaticProperties

--- a/TUnit.UnitTests/TUnitSettingsTests.cs
+++ b/TUnit.UnitTests/TUnitSettingsTests.cs
@@ -5,6 +5,38 @@ namespace TUnit.UnitTests;
 [NotInParallel]
 public class TUnitSettingsTests
 {
+    private TimeSpan _savedTestTimeout;
+    private TimeSpan _savedHookTimeout;
+    private TimeSpan _savedForcefulExitTimeout;
+    private TimeSpan _savedProcessExitHookDelay;
+    private int? _savedMaximumParallelTests;
+    private bool _savedDetailedStackTrace;
+    private bool _savedFailFast;
+
+    [Before(HookType.Test)]
+    public void SnapshotSettings()
+    {
+        _savedTestTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
+        _savedHookTimeout = TUnitSettings.Timeouts.DefaultHookTimeout;
+        _savedForcefulExitTimeout = TUnitSettings.Timeouts.ForcefulExitTimeout;
+        _savedProcessExitHookDelay = TUnitSettings.Timeouts.ProcessExitHookDelay;
+        _savedMaximumParallelTests = TUnitSettings.Parallelism.MaximumParallelTests;
+        _savedDetailedStackTrace = TUnitSettings.Display.DetailedStackTrace;
+        _savedFailFast = TUnitSettings.Execution.FailFast;
+    }
+
+    [After(HookType.Test)]
+    public void RestoreSettings()
+    {
+        TUnitSettings.Timeouts.DefaultTestTimeout = _savedTestTimeout;
+        TUnitSettings.Timeouts.DefaultHookTimeout = _savedHookTimeout;
+        TUnitSettings.Timeouts.ForcefulExitTimeout = _savedForcefulExitTimeout;
+        TUnitSettings.Timeouts.ProcessExitHookDelay = _savedProcessExitHookDelay;
+        TUnitSettings.Parallelism.MaximumParallelTests = _savedMaximumParallelTests;
+        TUnitSettings.Display.DetailedStackTrace = _savedDetailedStackTrace;
+        TUnitSettings.Execution.FailFast = _savedFailFast;
+    }
+
     [Test]
     public async Task Defaults_Are_Correct()
     {
@@ -20,16 +52,7 @@ public class TUnitSettingsTests
     [Test]
     public async Task Settings_Can_Be_Modified()
     {
-        var originalTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
-
-        try
-        {
-            TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(10);
-            await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
-        }
-        finally
-        {
-            TUnitSettings.Timeouts.DefaultTestTimeout = originalTimeout;
-        }
+        TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(10);
+        await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
     }
 }

--- a/TUnit.UnitTests/TUnitSettingsTests.cs
+++ b/TUnit.UnitTests/TUnitSettingsTests.cs
@@ -2,6 +2,8 @@ using TUnit.Core.Settings;
 
 namespace TUnit.UnitTests;
 
+// [NotInParallel] because tests mutate static TUnitSettings state;
+// Before/After hooks snapshot and restore values so test order doesn't matter.
 [NotInParallel]
 public class TUnitSettingsTests
 {

--- a/TUnit.UnitTests/TUnitSettingsTests.cs
+++ b/TUnit.UnitTests/TUnitSettingsTests.cs
@@ -1,0 +1,36 @@
+using TUnit.Core.Settings;
+
+namespace TUnit.UnitTests;
+
+[NotInParallel]
+public class TUnitSettingsTests
+{
+    [Test]
+    public async Task Defaults_Are_Correct()
+    {
+        await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
+        await Assert.That(TUnitSettings.Timeouts.DefaultHookTimeout).IsEqualTo(TimeSpan.FromMinutes(5));
+        await Assert.That(TUnitSettings.Timeouts.ForcefulExitTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+        await Assert.That(TUnitSettings.Timeouts.ProcessExitHookDelay).IsEqualTo(TimeSpan.FromMilliseconds(500));
+        await Assert.That(TUnitSettings.Parallelism.MaximumParallelTests).IsNull();
+        await Assert.That(TUnitSettings.Display.DisableLogo).IsFalse();
+        await Assert.That(TUnitSettings.Display.DetailedStackTrace).IsFalse();
+        await Assert.That(TUnitSettings.Execution.FailFast).IsFalse();
+    }
+
+    [Test]
+    public async Task Settings_Can_Be_Modified()
+    {
+        var originalTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
+
+        try
+        {
+            TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(10);
+            await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
+        }
+        finally
+        {
+            TUnitSettings.Timeouts.DefaultTestTimeout = originalTimeout;
+        }
+    }
+}

--- a/TUnit.UnitTests/TUnitSettingsTests.cs
+++ b/TUnit.UnitTests/TUnitSettingsTests.cs
@@ -18,43 +18,43 @@ public class TUnitSettingsTests
     [Before(HookType.Test)]
     public void SnapshotSettings()
     {
-        _savedTestTimeout = TUnitSettings.Timeouts.DefaultTestTimeout;
-        _savedHookTimeout = TUnitSettings.Timeouts.DefaultHookTimeout;
-        _savedForcefulExitTimeout = TUnitSettings.Timeouts.ForcefulExitTimeout;
-        _savedProcessExitHookDelay = TUnitSettings.Timeouts.ProcessExitHookDelay;
-        _savedMaximumParallelTests = TUnitSettings.Parallelism.MaximumParallelTests;
-        _savedDetailedStackTrace = TUnitSettings.Display.DetailedStackTrace;
-        _savedFailFast = TUnitSettings.Execution.FailFast;
+        _savedTestTimeout = TUnitSettings.Default.Timeouts.DefaultTestTimeout;
+        _savedHookTimeout = TUnitSettings.Default.Timeouts.DefaultHookTimeout;
+        _savedForcefulExitTimeout = TUnitSettings.Default.Timeouts.ForcefulExitTimeout;
+        _savedProcessExitHookDelay = TUnitSettings.Default.Timeouts.ProcessExitHookDelay;
+        _savedMaximumParallelTests = TUnitSettings.Default.Parallelism.MaximumParallelTests;
+        _savedDetailedStackTrace = TUnitSettings.Default.Display.DetailedStackTrace;
+        _savedFailFast = TUnitSettings.Default.Execution.FailFast;
     }
 
     [After(HookType.Test)]
     public void RestoreSettings()
     {
-        TUnitSettings.Timeouts.DefaultTestTimeout = _savedTestTimeout;
-        TUnitSettings.Timeouts.DefaultHookTimeout = _savedHookTimeout;
-        TUnitSettings.Timeouts.ForcefulExitTimeout = _savedForcefulExitTimeout;
-        TUnitSettings.Timeouts.ProcessExitHookDelay = _savedProcessExitHookDelay;
-        TUnitSettings.Parallelism.MaximumParallelTests = _savedMaximumParallelTests;
-        TUnitSettings.Display.DetailedStackTrace = _savedDetailedStackTrace;
-        TUnitSettings.Execution.FailFast = _savedFailFast;
+        TUnitSettings.Default.Timeouts.DefaultTestTimeout = _savedTestTimeout;
+        TUnitSettings.Default.Timeouts.DefaultHookTimeout = _savedHookTimeout;
+        TUnitSettings.Default.Timeouts.ForcefulExitTimeout = _savedForcefulExitTimeout;
+        TUnitSettings.Default.Timeouts.ProcessExitHookDelay = _savedProcessExitHookDelay;
+        TUnitSettings.Default.Parallelism.MaximumParallelTests = _savedMaximumParallelTests;
+        TUnitSettings.Default.Display.DetailedStackTrace = _savedDetailedStackTrace;
+        TUnitSettings.Default.Execution.FailFast = _savedFailFast;
     }
 
     [Test]
     public async Task Defaults_Are_Correct()
     {
-        await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
-        await Assert.That(TUnitSettings.Timeouts.DefaultHookTimeout).IsEqualTo(TimeSpan.FromMinutes(5));
-        await Assert.That(TUnitSettings.Timeouts.ForcefulExitTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
-        await Assert.That(TUnitSettings.Timeouts.ProcessExitHookDelay).IsEqualTo(TimeSpan.FromMilliseconds(500));
-        await Assert.That(TUnitSettings.Parallelism.MaximumParallelTests).IsNull();
-        await Assert.That(TUnitSettings.Display.DetailedStackTrace).IsFalse();
-        await Assert.That(TUnitSettings.Execution.FailFast).IsFalse();
+        await Assert.That(TUnitSettings.Default.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
+        await Assert.That(TUnitSettings.Default.Timeouts.DefaultHookTimeout).IsEqualTo(TimeSpan.FromMinutes(5));
+        await Assert.That(TUnitSettings.Default.Timeouts.ForcefulExitTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+        await Assert.That(TUnitSettings.Default.Timeouts.ProcessExitHookDelay).IsEqualTo(TimeSpan.FromMilliseconds(500));
+        await Assert.That(TUnitSettings.Default.Parallelism.MaximumParallelTests).IsNull();
+        await Assert.That(TUnitSettings.Default.Display.DetailedStackTrace).IsFalse();
+        await Assert.That(TUnitSettings.Default.Execution.FailFast).IsFalse();
     }
 
     [Test]
     public async Task Settings_Can_Be_Modified()
     {
-        TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(10);
-        await Assert.That(TUnitSettings.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
+        TUnitSettings.Default.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(10);
+        await Assert.That(TUnitSettings.Default.Timeouts.DefaultTestTimeout).IsEqualTo(TimeSpan.FromMinutes(10));
     }
 }

--- a/TUnit.UnitTests/TUnitSettingsTests.cs
+++ b/TUnit.UnitTests/TUnitSettingsTests.cs
@@ -13,7 +13,6 @@ public class TUnitSettingsTests
         await Assert.That(TUnitSettings.Timeouts.ForcefulExitTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
         await Assert.That(TUnitSettings.Timeouts.ProcessExitHookDelay).IsEqualTo(TimeSpan.FromMilliseconds(500));
         await Assert.That(TUnitSettings.Parallelism.MaximumParallelTests).IsNull();
-        await Assert.That(TUnitSettings.Display.DisableLogo).IsFalse();
         await Assert.That(TUnitSettings.Display.DetailedStackTrace).IsFalse();
         await Assert.That(TUnitSettings.Execution.FailFast).IsFalse();
     }

--- a/docs/docs/execution/parallelism.md
+++ b/docs/docs/execution/parallelism.md
@@ -167,26 +167,19 @@ With a limit of `2`, at most two of these 20 test invocations execute at the sam
 
 More specific attributes override less specific ones. Precedence: Method > Class > Assembly.
 
-## Setting Maximum Parallel Tests in Code
+## Setting Maximum Parallel Tests
 
-You can cap the total number of concurrent tests globally using the `TUnitSettings` API. Set the value in a `[Before(HookType.TestDiscovery)]` hook:
+You can cap the total number of concurrent tests globally using the command line or an environment variable:
 
-```csharp
-using TUnit.Core;
-using TUnit.Core.Settings;
+```bash
+# Command-line flag
+dotnet run --project MyTests -- --maximum-parallel-tests 4
 
-public class TestSetup
-{
-    [Before(HookType.TestDiscovery)]
-    public static Task Configure(BeforeTestDiscoveryContext context)
-    {
-        TUnitSettings.Parallelism.MaximumParallelTests = 4;
-        return Task.CompletedTask;
-    }
-}
+# Environment variable
+TUNIT_MAX_PARALLEL_TESTS=4 dotnet run --project MyTests
 ```
 
-This is equivalent to passing `--maximum-parallel-tests 4` on the command line or setting the `TUNIT_MAX_PARALLEL_TESTS=4` environment variable. Command-line flags and environment variables take precedence over code-level settings. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for the full precedence rules.
+The `TUnitSettings.Parallelism.MaximumParallelTests` property is also available, but the scheduler reads it before `[Before(HookType.TestDiscovery)]` hooks run, so the CLI flag or environment variable is the recommended approach. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for details.
 
 ## When to Use Which
 

--- a/docs/docs/execution/parallelism.md
+++ b/docs/docs/execution/parallelism.md
@@ -179,7 +179,7 @@ dotnet run --project MyTests -- --maximum-parallel-tests 4
 TUNIT_MAX_PARALLEL_TESTS=4 dotnet run --project MyTests
 ```
 
-The `TUnitSettings.Parallelism.MaximumParallelTests` property is also available, but the scheduler reads it before `[Before(HookType.TestDiscovery)]` hooks run, so the CLI flag or environment variable is the recommended approach. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for details.
+The `context.Settings.Parallelism.MaximumParallelTests` property is also available, but the scheduler reads it before `[Before(HookType.TestDiscovery)]` hooks run, so the CLI flag or environment variable is the recommended approach. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for details.
 
 ## When to Use Which
 

--- a/docs/docs/execution/parallelism.md
+++ b/docs/docs/execution/parallelism.md
@@ -167,6 +167,27 @@ With a limit of `2`, at most two of these 20 test invocations execute at the sam
 
 More specific attributes override less specific ones. Precedence: Method > Class > Assembly.
 
+## Setting Maximum Parallel Tests in Code
+
+You can cap the total number of concurrent tests globally using the `TUnitSettings` API. Set the value in a `[Before(HookType.TestDiscovery)]` hook:
+
+```csharp
+using TUnit.Core;
+using TUnit.Core.Settings;
+
+public class TestSetup
+{
+    [Before(HookType.TestDiscovery)]
+    public static Task Configure(BeforeTestDiscoveryContext context)
+    {
+        TUnitSettings.Parallelism.MaximumParallelTests = 4;
+        return Task.CompletedTask;
+    }
+}
+```
+
+This is equivalent to passing `--maximum-parallel-tests 4` on the command line or setting the `TUNIT_MAX_PARALLEL_TESTS=4` environment variable. Command-line flags and environment variables take precedence over code-level settings. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for the full precedence rules.
+
 ## When to Use Which
 
 | Scenario | Attribute |

--- a/docs/docs/execution/parallelism.md
+++ b/docs/docs/execution/parallelism.md
@@ -179,7 +179,7 @@ dotnet run --project MyTests -- --maximum-parallel-tests 4
 TUNIT_MAX_PARALLEL_TESTS=4 dotnet run --project MyTests
 ```
 
-The `context.Settings.Parallelism.MaximumParallelTests` property is also available, but the scheduler reads it before `[Before(HookType.TestDiscovery)]` hooks run, so the CLI flag or environment variable is the recommended approach. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for details.
+You can also set this programmatically via `context.Settings.Parallelism.MaximumParallelTests` in a `[Before(HookType.TestDiscovery)]` hook. See the [Programmatic Configuration](/docs/reference/programmatic-configuration) reference for details.
 
 ## When to Use Which
 

--- a/docs/docs/reference/command-line-flags.md
+++ b/docs/docs/reference/command-line-flags.md
@@ -77,7 +77,6 @@ Please note that for the coverage and trx report, you need to install [additiona
     --disable-logo
         Disables the TUnit logo when starting a test session.
         Can also be set via TUNIT_DISABLE_LOGO environment variable.
-        Programmatic equivalent: TUnitSettings.Display.DisableLogo
 
     --fail-fast
         Cancel the test run after the first test failure

--- a/docs/docs/reference/command-line-flags.md
+++ b/docs/docs/reference/command-line-flags.md
@@ -80,11 +80,11 @@ Please note that for the coverage and trx report, you need to install [additiona
 
     --fail-fast
         Cancel the test run after the first test failure
-        Programmatic equivalent: TUnitSettings.Execution.FailFast
+        Programmatic equivalent: context.Settings.Execution.FailFast
 
     --maximum-parallel-tests
         Maximum Parallel Tests
-        Programmatic equivalent: TUnitSettings.Parallelism.MaximumParallelTests
+        Programmatic equivalent: context.Settings.Parallelism.MaximumParallelTests
 
     --no-ansi
         Disable outputting ANSI escape characters to screen.
@@ -124,7 +124,7 @@ Please note that for the coverage and trx report, you need to install [additiona
     --detailed-stacktrace
         Display TUnit internals within stack traces.
         By default, TUnit frames are hidden to keep failure output focused on user code.
-        Programmatic equivalent: TUnitSettings.Display.DetailedStackTrace
+        Programmatic equivalent: context.Settings.Display.DetailedStackTrace
 
     --output-json
         Write a JSON report of the test run.

--- a/docs/docs/reference/command-line-flags.md
+++ b/docs/docs/reference/command-line-flags.md
@@ -77,12 +77,15 @@ Please note that for the coverage and trx report, you need to install [additiona
     --disable-logo
         Disables the TUnit logo when starting a test session.
         Can also be set via TUNIT_DISABLE_LOGO environment variable.
+        Programmatic equivalent: TUnitSettings.Display.DisableLogo
 
     --fail-fast
         Cancel the test run after the first test failure
+        Programmatic equivalent: TUnitSettings.Execution.FailFast
 
     --maximum-parallel-tests
         Maximum Parallel Tests
+        Programmatic equivalent: TUnitSettings.Parallelism.MaximumParallelTests
 
     --no-ansi
         Disable outputting ANSI escape characters to screen.
@@ -122,6 +125,7 @@ Please note that for the coverage and trx report, you need to install [additiona
     --detailed-stacktrace
         Display TUnit internals within stack traces.
         By default, TUnit frames are hidden to keep failure output focused on user code.
+        Programmatic equivalent: TUnitSettings.Display.DetailedStackTrace
 
     --output-json
         Write a JSON report of the test run.

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -21,6 +21,8 @@ set TUNIT_DISABLE_LOGO=true
 
 **Equivalent to:** `--disable-logo`
 
+**Programmatic equivalent:** `TUnitSettings.Display.DisableLogo` (see [Programmatic Configuration](./programmatic-configuration.md))
+
 **Use case:** Reduces output noise in CI/CD logs or when using AI/LLM coding assistants that parse test output.
 
 ### TUNIT_DISABLE_GITHUB_REPORTER
@@ -94,6 +96,8 @@ export TUNIT_MAX_PARALLEL_TESTS=0    # Unlimited parallelism
 ```
 
 **Equivalent to:** `--maximum-parallel-tests`
+
+**Programmatic equivalent:** `TUnitSettings.Parallelism.MaximumParallelTests` (see [Programmatic Configuration](./programmatic-configuration.md))
 
 **Note:** Command-line arguments take precedence over environment variables.
 
@@ -253,7 +257,8 @@ When the same setting is configured in multiple places, TUnit follows this prior
 
 1. **Command-line arguments** - Always take precedence
 2. **Environment variables** - Applied when command-line argument is not provided
-3. **Configuration files** - Applied as defaults
+3. **`TUnitSettings` (code)** - Values set in `[Before(HookType.TestDiscovery)]` hooks (see [Programmatic Configuration](./programmatic-configuration.md))
+4. **Built-in defaults**
 
 ## Summary Table
 

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -95,7 +95,7 @@ export TUNIT_MAX_PARALLEL_TESTS=0    # Unlimited parallelism
 
 **Equivalent to:** `--maximum-parallel-tests`
 
-**Programmatic equivalent:** `TUnitSettings.Parallelism.MaximumParallelTests` (see [Programmatic Configuration](./programmatic-configuration.md))
+**Programmatic equivalent:** `context.Settings.Parallelism.MaximumParallelTests` (see [Programmatic Configuration](./programmatic-configuration.md))
 
 **Note:** Command-line arguments take precedence over environment variables.
 
@@ -255,7 +255,7 @@ When the same setting is configured in multiple places, TUnit follows this prior
 
 1. **Command-line arguments** - Always take precedence
 2. **Environment variables** - Applied when command-line argument is not provided
-3. **`TUnitSettings` (code)** - Values set in `[Before(HookType.TestDiscovery)]` hooks (see [Programmatic Configuration](./programmatic-configuration.md))
+3. **`context.Settings` (code)** - Values set in `[Before(HookType.TestDiscovery)]` hooks (see [Programmatic Configuration](./programmatic-configuration.md))
 4. **Built-in defaults**
 
 ## Summary Table

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -21,8 +21,6 @@ set TUNIT_DISABLE_LOGO=true
 
 **Equivalent to:** `--disable-logo`
 
-**Programmatic equivalent:** `TUnitSettings.Display.DisableLogo` (see [Programmatic Configuration](./programmatic-configuration.md))
-
 **Use case:** Reduces output noise in CI/CD logs or when using AI/LLM coding assistants that parse test output.
 
 ### TUNIT_DISABLE_GITHUB_REPORTER

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -6,31 +6,30 @@ sidebar_position: 4
 
 ## Overview
 
-The `TUnitSettings` API lets you configure TUnit settings directly in code. This is useful when you want discoverable, version-controlled defaults for your test suite without relying on command-line flags or environment variables.
+The `context.Settings` API lets you configure TUnit settings directly in code. This is useful when you want discoverable, version-controlled defaults for your test suite without relying on command-line flags or environment variables.
 
 Settings are organized into logical groups:
 
-- `TUnitSettings.Timeouts` — test and hook timeout durations
-- `TUnitSettings.Parallelism` — concurrent test execution limits
-- `TUnitSettings.Execution` — runtime behavior such as fail-fast
-- `TUnitSettings.Display` — output and display options
+- `Timeouts` — test and hook timeout durations
+- `Parallelism` — concurrent test execution limits
+- `Execution` — runtime behavior such as fail-fast
+- `Display` — output and display options
 
 ## Usage
 
-Set values inside a `[Before(HookType.TestDiscovery)]` hook so they are applied before any tests are discovered or executed:
+Set values inside a `[Before(HookType.TestDiscovery)]` hook so they are applied before any tests are discovered or executed. The `context.Settings` property provides direct access:
 
 ```csharp
 using TUnit.Core;
-using TUnit.Core.Settings;
 
 public class TestSetup
 {
     [Before(HookType.TestDiscovery)]
     public static Task Configure(BeforeTestDiscoveryContext context)
     {
-        TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
-        TUnitSettings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
-        TUnitSettings.Execution.FailFast = true;
+        context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
+        context.Settings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
+        context.Settings.Execution.FailFast = true;
 
         return Task.CompletedTask;
     }
@@ -39,9 +38,11 @@ public class TestSetup
 
 Place this class anywhere in your test project. TUnit will discover and run the hook automatically.
 
+Settings are accessed exclusively through `context.Settings` in the discovery hook, which ensures they are configured at the correct point in the TUnit lifecycle.
+
 ## Settings Reference
 
-### `TUnitSettings.Timeouts`
+### `context.Settings.Timeouts`
 
 | Property | Type | Default | Description |
 |---|---|---|---|
@@ -50,7 +51,7 @@ Place this class anywhere in your test project. TUnit will discover and run the 
 | `ForcefulExitTimeout` | `TimeSpan` | 30 seconds | Grace period before the process is forcefully terminated after a cancellation. |
 | `ProcessExitHookDelay` | `TimeSpan` | 500 ms | Delay before process-exit hooks run, allowing pending I/O to flush. |
 
-### `TUnitSettings.Parallelism`
+### `context.Settings.Parallelism`
 
 | Property | Type | Default | Description |
 |---|---|---|---|
@@ -58,13 +59,13 @@ Place this class anywhere in your test project. TUnit will discover and run the 
 
 > **Note:** `MaximumParallelTests` is read during scheduler initialization, which occurs before `[Before(HookType.TestDiscovery)]` hooks run. Use the `--maximum-parallel-tests` CLI flag or the `TUNIT_MAX_PARALLEL_TESTS` environment variable to override this setting.
 
-### `TUnitSettings.Display`
+### `context.Settings.Display`
 
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `DetailedStackTrace` | `bool` | `false` | Includes TUnit internal frames in stack traces. By default, internal frames are hidden to keep failure output focused on user code. |
 
-### `TUnitSettings.Execution`
+### `context.Settings.Execution`
 
 | Property | Type | Default | Description |
 |---|---|---|---|
@@ -76,7 +77,7 @@ When the same setting is configured in multiple places, the following priority o
 
 1. **Command-line flag** (e.g., `--maximum-parallel-tests 8`)
 2. **Environment variable** (e.g., `TUNIT_MAX_PARALLEL_TESTS=8`)
-3. **`TUnitSettings` (code)** — values set in a `[Before(HookType.TestDiscovery)]` hook
+3. **`context.Settings` (code)** — values set in a `[Before(HookType.TestDiscovery)]` hook
 4. **Built-in default**
 
 ### Example
@@ -84,7 +85,7 @@ When the same setting is configured in multiple places, the following priority o
 Your test project sets a conservative parallelism limit in code:
 
 ```csharp
-TUnitSettings.Parallelism.MaximumParallelTests = 1;
+context.Settings.Parallelism.MaximumParallelTests = 1;
 ```
 
 A developer on a powerful machine can override this for a local run without changing code:
@@ -97,7 +98,7 @@ The command-line flag takes precedence, so 8 parallel tests will be used.
 
 ## When to Set
 
-Set most `TUnitSettings` values inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
+Set most values via `context.Settings` inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
 
 Two settings are exceptions:
 

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -30,7 +30,6 @@ public class TestSetup
     {
         TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
         TUnitSettings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
-        TUnitSettings.Parallelism.MaximumParallelTests = 4;
         TUnitSettings.Execution.FailFast = true;
 
         return Task.CompletedTask;
@@ -56,6 +55,8 @@ Place this class anywhere in your test project. TUnit will discover and run the 
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `MaximumParallelTests` | `int?` | `null` (4 x CPU cores) | Maximum number of tests that can execute concurrently. Set to `null` to use the default heuristic. |
+
+> **Note:** `MaximumParallelTests` is read during scheduler initialization, which occurs before `[Before(HookType.TestDiscovery)]` hooks run. Use the `--maximum-parallel-tests` CLI flag or the `TUNIT_MAX_PARALLEL_TESTS` environment variable to override this setting.
 
 ### `TUnitSettings.Display`
 

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -28,7 +28,6 @@ public class TestSetup
     public static Task Configure(BeforeTestDiscoveryContext context)
     {
         context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
-        context.Settings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
         context.Settings.Execution.FailFast = true;
 
         return Task.CompletedTask;

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 4
+---
+
+# Programmatic Configuration
+
+## Overview
+
+The `TUnitSettings` API lets you configure TUnit settings directly in code. This is useful when you want discoverable, version-controlled defaults for your test suite without relying on command-line flags or environment variables.
+
+Settings are organized into logical groups:
+
+- `TUnitSettings.Timeouts` — test and hook timeout durations
+- `TUnitSettings.Parallelism` — concurrent test execution limits
+- `TUnitSettings.Execution` — runtime behavior such as fail-fast
+- `TUnitSettings.Display` — output and display options
+
+## Usage
+
+Set values inside a `[Before(HookType.TestDiscovery)]` hook so they are applied before any tests are discovered or executed:
+
+```csharp
+using TUnit.Core;
+using TUnit.Core.Settings;
+
+public class TestSetup
+{
+    [Before(HookType.TestDiscovery)]
+    public static Task Configure(BeforeTestDiscoveryContext context)
+    {
+        TUnitSettings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
+        TUnitSettings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
+        TUnitSettings.Parallelism.MaximumParallelTests = 4;
+        TUnitSettings.Execution.FailFast = true;
+        TUnitSettings.Display.DisableLogo = true;
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+Place this class anywhere in your test project. TUnit will discover and run the hook automatically.
+
+## Settings Reference
+
+### `TUnitSettings.Timeouts`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `DefaultTestTimeout` | `TimeSpan` | 30 minutes | Maximum duration for a single test before it is cancelled. |
+| `DefaultHookTimeout` | `TimeSpan` | 5 minutes | Maximum duration for a single hook (`[Before]`/`[After]`) before it is cancelled. |
+| `ForcefulExitTimeout` | `TimeSpan` | 30 seconds | Grace period before the process is forcefully terminated after a cancellation. |
+| `ProcessExitHookDelay` | `TimeSpan` | 500 ms | Delay before process-exit hooks run, allowing pending I/O to flush. |
+
+### `TUnitSettings.Parallelism`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `MaximumParallelTests` | `int?` | `null` (4 x CPU cores) | Maximum number of tests that can execute concurrently. Set to `null` to use the default heuristic. |
+
+### `TUnitSettings.Display`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `DisableLogo` | `bool` | `false` | Suppresses the TUnit ASCII art logo at startup. |
+| `DetailedStackTrace` | `bool` | `false` | Includes TUnit internal frames in stack traces. By default, internal frames are hidden to keep failure output focused on user code. |
+
+### `TUnitSettings.Execution`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `FailFast` | `bool` | `false` | Cancels the remaining test run after the first test failure. |
+
+## Precedence
+
+When the same setting is configured in multiple places, the following priority order applies (highest wins):
+
+1. **Command-line flag** (e.g., `--maximum-parallel-tests 8`)
+2. **Environment variable** (e.g., `TUNIT_MAX_PARALLEL_TESTS=8`)
+3. **`TUnitSettings` (code)** — values set in a `[Before(HookType.TestDiscovery)]` hook
+4. **Built-in default**
+
+### Example
+
+Your test project sets a conservative parallelism limit in code:
+
+```csharp
+TUnitSettings.Parallelism.MaximumParallelTests = 1;
+```
+
+A developer on a powerful machine can override this for a local run without changing code:
+
+```bash
+dotnet run --project MyTests -- --maximum-parallel-tests 8
+```
+
+The command-line flag takes precedence, so 8 parallel tests will be used.
+
+## When to Set
+
+Always set `TUnitSettings` values inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -57,8 +57,6 @@ Settings are accessed exclusively through `context.Settings` in the discovery ho
 |---|---|---|---|
 | `MaximumParallelTests` | `int?` | `null` (4 x CPU cores) | Maximum number of tests that can execute concurrently. Set to `null` to use the default heuristic. |
 
-> **Note:** `MaximumParallelTests` is read during scheduler initialization, which occurs before `[Before(HookType.TestDiscovery)]` hooks run. Use the `--maximum-parallel-tests` CLI flag or the `TUNIT_MAX_PARALLEL_TESTS` environment variable to override this setting.
-
 ### `context.Settings.Display`
 
 | Property | Type | Default | Description |
@@ -100,7 +98,4 @@ The command-line flag takes precedence, so 8 parallel tests will be used.
 
 Set most values via `context.Settings` inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
 
-Two settings are exceptions:
-
-- **`Parallelism.MaximumParallelTests`** is read during scheduler initialization before discovery hooks run — use the CLI flag or environment variable for that setting (see the note above).
-- **`Timeouts.DefaultHookTimeout`** is captured at hook registration time, which also occurs before discovery hooks run. Use the `[Timeout]` attribute on individual hook methods for reliable per-hook timeout control.
+The exception is **`Timeouts.DefaultHookTimeout`**, which is captured at hook registration time before discovery hooks run. Use the `[Timeout]` attribute on individual hook methods for reliable per-hook timeout control.

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -32,7 +32,6 @@ public class TestSetup
         TUnitSettings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
         TUnitSettings.Parallelism.MaximumParallelTests = 4;
         TUnitSettings.Execution.FailFast = true;
-        TUnitSettings.Display.DisableLogo = true;
 
         return Task.CompletedTask;
     }
@@ -62,7 +61,6 @@ Place this class anywhere in your test project. TUnit will discover and run the 
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `DisableLogo` | `bool` | `false` | Suppresses the TUnit ASCII art logo at startup. |
 | `DetailedStackTrace` | `bool` | `false` | Includes TUnit internal frames in stack traces. By default, internal frames are hidden to keep failure output focused on user code. |
 
 ### `TUnitSettings.Execution`

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -99,4 +99,7 @@ The command-line flag takes precedence, so 8 parallel tests will be used.
 
 Set most `TUnitSettings` values inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
 
-The exception is `Parallelism.MaximumParallelTests`, which is read during scheduler initialization before discovery hooks run — use the CLI flag or environment variable for that setting (see the note above).
+Two settings are exceptions:
+
+- **`Parallelism.MaximumParallelTests`** is read during scheduler initialization before discovery hooks run — use the CLI flag or environment variable for that setting (see the note above).
+- **`Timeouts.DefaultHookTimeout`** is captured at hook registration time, which also occurs before discovery hooks run. Use the `[Timeout]` attribute on individual hook methods for reliable per-hook timeout control.

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -28,6 +28,7 @@ public class TestSetup
     public static Task Configure(BeforeTestDiscoveryContext context)
     {
         context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
+        context.Settings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
         context.Settings.Execution.FailFast = true;
 
         return Task.CompletedTask;
@@ -96,5 +97,3 @@ The command-line flag takes precedence, so 8 parallel tests will be used.
 ## When to Set
 
 Set most values via `context.Settings` inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
-
-The exception is **`Timeouts.DefaultHookTimeout`**, which is captured at hook registration time before discovery hooks run. Use the `[Timeout]` attribute on individual hook methods for reliable per-hook timeout control.

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -97,4 +97,6 @@ The command-line flag takes precedence, so 8 parallel tests will be used.
 
 ## When to Set
 
-Always set `TUnitSettings` values inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
+Set most `TUnitSettings` values inside a `[Before(HookType.TestDiscovery)]` hook. This is the earliest point in the TUnit lifecycle where user code runs and ensures your values are in place before test discovery begins. Setting values later (for example in a `[Before(HookType.TestSession)]` hook) may have no effect for settings that are read during discovery.
+
+The exception is `Parallelism.MaximumParallelTests`, which is read during scheduler initialization before discovery hooks run — use the CLI flag or environment variable for that setting (see the note above).


### PR DESCRIPTION
## Summary

Closes #5521
Closes #5523

- Adds a `TUnitSettings` class exposed via `BeforeTestDiscoveryContext.Settings`, giving users a discoverable, code-level configuration API that naturally enforces the correct lifecycle timing
- Settings are organized into grouped sub-objects (`Timeouts`, `Parallelism`, `Execution`, `Display`)
- Wires settings into the engine with correct precedence: CLI flag > env var > `context.Settings` > built-in default
- Deprecates the `Defaults` class with `[Obsolete]` pointing to the new API
- Input validation on all timeout properties (positive duration required) and `MaximumParallelTests` (no negatives)
- Defers `MaximumParallelTests` read via `Lazy<T>` so it works from discovery hooks

### New API

```csharp
[Before(HookType.TestDiscovery)]
public static Task Configure(BeforeTestDiscoveryContext context)
{
    context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
    context.Settings.Parallelism.MaximumParallelTests = 4;
    context.Settings.Execution.FailFast = true;
    return Task.CompletedTask;
}
```

`TUnitSettings` is a sealed class with an `internal` constructor and `internal static Default` singleton. Users access settings exclusively through `context.Settings` in a `[Before(HookType.TestDiscovery)]` hook. Engine code uses `TUnitSettings.Default.*` via `InternalsVisibleTo`.

### Engine integration points

| Setting | Engine location | Read timing |
|---|---|---|
| `Timeouts.DefaultTestTimeout` | `TestBuilderPipeline`, `TestBuilder`, `DedicatedThreadExecutor` | After discovery hooks |
| `Timeouts.DefaultHookTimeout` | `HookMethod` | At hook registration (before discovery hooks — see note) |
| `Timeouts.ForcefulExitTimeout` | `EngineCancellationToken` | At shutdown |
| `Timeouts.ProcessExitHookDelay` | `EngineCancellationToken` | At shutdown |
| `Parallelism.MaximumParallelTests` | `TestScheduler.GetMaxParallelism` (lazy) | At first test execution |
| `Execution.FailFast` | `TestRunner` (lazy, per-failure) | At test failure time |
| `Display.DetailedStackTrace` | `TUnitMessageBus` (lazy, per-failure) | At stack trace simplification |

> **Note:** `Timeouts.DefaultHookTimeout` is captured at hook registration time, before `[Before(HookType.TestDiscovery)]` hooks run. Use the `[Timeout]` attribute on individual hook methods for per-hook timeout control.

### What's intentionally excluded

- **`Display.DisableLogo`** — The banner fires during test host startup, before any user code runs. Cannot be configured via code; use `--disable-logo` or `TUNIT_DISABLE_LOGO`.

## Test plan

- [x] Solution builds with 0 errors
- [x] New `TUnitSettingsTests` pass (defaults correct, properties mutable, state isolation via Before/After hooks)
- [x] Public API snapshot tests updated for all 4 TFMs
- [x] `Defaults` class delegates to `TUnitSettings.Default` (no stale divergence)
- [x] `FailFast` reads lazily in `TestRunner` (works from discovery hooks)
- [x] `MaximumParallelTests` reads lazily via `Lazy<T>` in `TestScheduler` (works from discovery hooks)
- [x] `MaximumParallelTests` validates against negative values
- [x] `TimeoutSettings` validates against zero/negative durations (`ProcessExitHookDelay` allows zero)
- [x] Documentation page added + existing docs cross-referenced
- [x] `NuGet.Configuration.Settings` namespace collision fixed in `NuGetDownloader.cs`