### PR TITLE
fix: enforce ParallelLimiter semaphore in TestRunner to prevent DependsOn bypass

### DIFF
--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -246,7 +246,8 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
                 isFailFastEnabled,
                 FailFastCancellationSource,
                 Logger,
-                testStateManager));
+                testStateManager,
+                ParallelLimitLockProvider));
 
         // Create scheduler configuration from command line options
         var testGroupingService = Register<ITestGroupingService>(new TestGroupingService(Logger));
@@ -254,8 +255,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
 
         var constraintKeyScheduler = Register<IConstraintKeyScheduler>(new ConstraintKeyScheduler(
             testRunner,
-            Logger,
-            ParallelLimitLockProvider));
+            Logger));
 
         var staticPropertyHandler = Register(new StaticPropertyHandler(Logger, objectTracker, trackableObjectGraphProvider, disposer, lazyPropertyInjector, objectGraphDiscoveryService));
 
@@ -266,7 +266,6 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
             testGroupingService,
             MessageBus,
             CommandLineOptions,
-            ParallelLimitLockProvider,
             testStateManager,
             testRunner,
             circularDependencyDetector,

--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -9,16 +9,13 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
 {
     private readonly TestRunner _testRunner;
     private readonly TUnitFrameworkLogger _logger;
-    private readonly ParallelLimitLockProvider _parallelLimitLockProvider;
 
     public ConstraintKeyScheduler(
         TestRunner testRunner,
-        TUnitFrameworkLogger logger,
-        ParallelLimitLockProvider parallelLimitLockProvider)
+        TUnitFrameworkLogger logger)
     {
         _testRunner = testRunner;
         _logger = logger;
-        _parallelLimitLockProvider = parallelLimitLockProvider;
     }
 
     #if NET8_0_OR_GREATER
@@ -146,26 +143,12 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
         WaitingTestIndex waitingTestIndex,
         CancellationToken cancellationToken)
     {
-        SemaphoreSlim? parallelLimiterSemaphore = null;
-
         try
         {
-            // Two-phase acquisition: Acquire ParallelLimiter BEFORE executing
-            // This ensures constrained resources are acquired before holding constraint keys
-            if (test.Context.ParallelLimiter != null)
-            {
-                parallelLimiterSemaphore = _parallelLimitLockProvider.GetLock(test.Context.ParallelLimiter);
-                await parallelLimiterSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            // Execute the test (constraint keys are already held by caller)
             await _testRunner.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            // Release ParallelLimiter if we acquired it
-            parallelLimiterSemaphore?.Release();
-
             // Release the constraint keys and check if any waiting tests can now run
             var testsToStart = new List<WaitingTest>();
 

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -19,6 +19,7 @@ public sealed class TestRunner
     private readonly CancellationTokenSource _failFastCancellationSource;
     private readonly TUnitFrameworkLogger _logger;
     private readonly TestStateManager _testStateManager;
+    private readonly ParallelLimitLockProvider _parallelLimitLockProvider;
 
     internal TestRunner(
         ITestCoordinator testCoordinator,
@@ -26,7 +27,8 @@ public sealed class TestRunner
         bool isFailFastEnabled,
         CancellationTokenSource failFastCancellationSource,
         TUnitFrameworkLogger logger,
-        TestStateManager testStateManager)
+        TestStateManager testStateManager,
+        ParallelLimitLockProvider parallelLimitLockProvider)
     {
         _testCoordinator = testCoordinator;
         _tunitMessageBus = tunitMessageBus;
@@ -34,6 +36,7 @@ public sealed class TestRunner
         _failFastCancellationSource = failFastCancellationSource;
         _logger = logger;
         _testStateManager = testStateManager;
+        _parallelLimitLockProvider = parallelLimitLockProvider;
     }
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<bool>> _executingTests = new();
@@ -74,7 +77,8 @@ public sealed class TestRunner
     {
         try
         {
-            // First, execute all dependencies recursively
+            // First, execute all dependencies recursively (without holding the limiter
+            // semaphore — avoids deadlocks in dependency chains sharing a limiter).
             foreach (var dependency in test.Dependencies)
             {
                 await ExecuteTestAsync(dependency.Test, cancellationToken).ConfigureAwait(false);
@@ -87,21 +91,38 @@ public sealed class TestRunner
                 }
             }
 
-            test.State = TestState.Running;
-            test.StartTime = DateTimeOffset.UtcNow;
-
-            // TestCoordinator handles sending InProgress message
-            await _testCoordinator.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
-
-            if ((_isFailFastEnabled || TUnitSettings.Default.Execution.FailFast) && test.Result?.State == TestState.Failed)
+            // Acquired here (not in the scheduler) so the limit is enforced
+            // regardless of entry point — scheduler or dependency recursion.
+            SemaphoreSlim? acquiredLimiter = null;
+            try
             {
-                // Capture the first failure exception before triggering cancellation
-                if (test.Result.Exception != null)
+                if (test.Context.ParallelLimiter is { } parallelLimiter)
                 {
-                    Interlocked.CompareExchange(ref _firstFailFastException, test.Result.Exception, null);
+                    var limiter = _parallelLimitLockProvider.GetLock(parallelLimiter);
+                    await limiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    acquiredLimiter = limiter;
                 }
-                await _logger.LogErrorAsync($"Test {test.TestId} failed. Triggering fail-fast cancellation.").ConfigureAwait(false);
-                _failFastCancellationSource.Cancel();
+
+                test.State = TestState.Running;
+                test.StartTime = DateTimeOffset.UtcNow;
+
+                // TestCoordinator handles sending InProgress message
+                await _testCoordinator.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
+
+                if ((_isFailFastEnabled || TUnitSettings.Default.Execution.FailFast) && test.Result?.State == TestState.Failed)
+                {
+                    // Capture the first failure exception before triggering cancellation
+                    if (test.Result.Exception != null)
+                    {
+                        Interlocked.CompareExchange(ref _firstFailFastException, test.Result.Exception, null);
+                    }
+                    await _logger.LogErrorAsync($"Test {test.TestId} failed. Triggering fail-fast cancellation.").ConfigureAwait(false);
+                    _failFastCancellationSource.Cancel();
+                }
+            }
+            finally
+            {
+                acquiredLimiter?.Release();
             }
         }
         catch (Exception ex)

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using Microsoft.Testing.Platform.CommandLine;
 using TUnit.Core;
 using TUnit.Core.Exceptions;
@@ -19,7 +18,6 @@ internal sealed class TestScheduler : ITestScheduler
     private readonly TUnitFrameworkLogger _logger;
     private readonly ITestGroupingService _groupingService;
     private readonly ITUnitMessageBus _messageBus;
-    private readonly ParallelLimitLockProvider _parallelLimitLockProvider;
     private readonly TestStateManager _testStateManager;
     private readonly TestRunner _testRunner;
     private readonly CircularDependencyDetector _circularDependencyDetector;
@@ -36,7 +34,6 @@ internal sealed class TestScheduler : ITestScheduler
         ITestGroupingService groupingService,
         ITUnitMessageBus messageBus,
         ICommandLineOptions commandLineOptions,
-        ParallelLimitLockProvider parallelLimitLockProvider,
         TestStateManager testStateManager,
         TestRunner testRunner,
         CircularDependencyDetector circularDependencyDetector,
@@ -49,7 +46,6 @@ internal sealed class TestScheduler : ITestScheduler
         _logger = logger;
         _groupingService = groupingService;
         _messageBus = messageBus;
-        _parallelLimitLockProvider = parallelLimitLockProvider;
         _testStateManager = testStateManager;
         _testRunner = testRunner;
         _circularDependencyDetector = circularDependencyDetector;
@@ -330,7 +326,7 @@ internal sealed class TestScheduler : ITestScheduler
                 new ParallelOptions { CancellationToken = cancellationToken },
                 async (test, ct) =>
                 {
-                    test.ExecutionTask ??= ExecuteSingleTestAsync(test, ct);
+                    test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, ct).AsTask();
                     await test.ExecutionTask.ConfigureAwait(false);
                 }
             ).ConfigureAwait(false);
@@ -340,36 +336,10 @@ internal sealed class TestScheduler : ITestScheduler
             for (var i = 0; i < tests.Length; i++)
             {
                 var test = tests[i];
-                tasks[i] = test.ExecutionTask ??= ExecuteSingleTestAsync(test, cancellationToken);
+                tasks[i] = test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
             }
             await Task.WhenAll(tasks).ConfigureAwait(false);
 #endif
-        }
-    }
-
-    #if NET8_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
-    #endif
-    private async Task ExecuteSingleTestAsync(
-        AbstractExecutableTest test,
-        CancellationToken cancellationToken)
-    {
-        if (test.Context.ParallelLimiter != null)
-        {
-            var semaphore = _parallelLimitLockProvider.GetLock(test.Context.ParallelLimiter);
-            await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                await _testRunner.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                semaphore.Release();
-            }
-        }
-        else
-        {
-            await _testRunner.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -382,7 +352,7 @@ internal sealed class TestScheduler : ITestScheduler
     {
         foreach (var test in tests)
         {
-            test.ExecutionTask ??= ExecuteSingleTestAsync(test, cancellationToken);
+            test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
             await test.ExecutionTask.ConfigureAwait(false);
         }
     }
@@ -395,110 +365,6 @@ internal sealed class TestScheduler : ITestScheduler
         var maxParallelism = _maxParallelism.Value;
 
 #if NET8_0_OR_GREATER
-        // PERFORMANCE OPTIMIZATION: Partition tests by whether they have parallel limiters
-        // Tests without limiters can run with unlimited parallelism (avoiding global semaphore overhead)
-        var testsWithLimiters = new List<AbstractExecutableTest>();
-        var testsWithoutLimiters = new List<AbstractExecutableTest>();
-
-        foreach (var test in tests)
-        {
-            if (test.Context.ParallelLimiter != null)
-            {
-                testsWithLimiters.Add(test);
-            }
-            else
-            {
-                testsWithoutLimiters.Add(test);
-            }
-        }
-
-        // Execute both groups concurrently
-        var limitedTask = testsWithLimiters.Count > 0
-            ? ExecuteWithLimitAsync(testsWithLimiters, maxParallelism, cancellationToken)
-            : Task.CompletedTask;
-
-        var unlimitedTask = testsWithoutLimiters.Count > 0
-            ? ExecuteUnlimitedAsync(testsWithoutLimiters, maxParallelism, cancellationToken)
-            : Task.CompletedTask;
-
-        await Task.WhenAll(limitedTask, unlimitedTask).ConfigureAwait(false);
-#else
-        // Fallback for netstandard2.0: Manual bounded concurrency using existing semaphore
-        var tasks = new Task[tests.Length];
-        for (var i = 0; i < tests.Length; i++)
-        {
-            var test = tests[i];
-            tasks[i] = Task.Run(async () =>
-            {
-                SemaphoreSlim? parallelLimiterSemaphore = null;
-
-                await globalSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    if (test.Context.ParallelLimiter != null)
-                    {
-                        parallelLimiterSemaphore = _parallelLimitLockProvider.GetLock(test.Context.ParallelLimiter);
-                        await parallelLimiterSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    }
-
-                    try
-                    {
-                        test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
-                        await test.ExecutionTask.ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        parallelLimiterSemaphore?.Release();
-                    }
-                }
-                finally
-                {
-                    globalSemaphore.Release();
-                }
-            }, CancellationToken.None);
-        }
-        await Task.WhenAll(tasks).ConfigureAwait(false);
-#endif
-    }
-
-#if NET8_0_OR_GREATER
-    private async Task ExecuteWithLimitAsync(
-        List<AbstractExecutableTest> tests,
-        int maxParallelism,
-        CancellationToken cancellationToken)
-    {
-        // Execute tests with parallel limiters using the global limit
-        await Parallel.ForEachAsync(
-            tests,
-            new ParallelOptions
-            {
-                MaxDegreeOfParallelism = maxParallelism,
-                CancellationToken = cancellationToken
-            },
-            async (test, ct) =>
-            {
-                var parallelLimiterSemaphore = _parallelLimitLockProvider.GetLock(test.Context.ParallelLimiter!);
-                await parallelLimiterSemaphore.WaitAsync(ct).ConfigureAwait(false);
-
-                try
-                {
-                    test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, ct).AsTask();
-                    await test.ExecutionTask.ConfigureAwait(false);
-                }
-                finally
-                {
-                    parallelLimiterSemaphore.Release();
-                }
-            }
-        ).ConfigureAwait(false);
-    }
-
-    private async Task ExecuteUnlimitedAsync(
-        List<AbstractExecutableTest> tests,
-        int maxParallelism,
-        CancellationToken cancellationToken)
-    {
-        // Execute tests without per-test limiters, but still apply global parallelism limit
         await Parallel.ForEachAsync(
             tests,
             new ParallelOptions
@@ -512,8 +378,29 @@ internal sealed class TestScheduler : ITestScheduler
                 await test.ExecutionTask.ConfigureAwait(false);
             }
         ).ConfigureAwait(false);
-    }
+#else
+        // Fallback for netstandard2.0: Manual bounded concurrency using existing semaphore
+        var tasks = new Task[tests.Length];
+        for (var i = 0; i < tests.Length; i++)
+        {
+            var test = tests[i];
+            tasks[i] = Task.Run(async () =>
+            {
+                await globalSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
+                    await test.ExecutionTask.ConfigureAwait(false);
+                }
+                finally
+                {
+                    globalSemaphore.Release();
+                }
+            }, CancellationToken.None);
+        }
+        await Task.WhenAll(tasks).ConfigureAwait(false);
 #endif
+    }
 
     private async Task WaitForTasksWithFailFastHandling(IEnumerable<Task> tasks, CancellationToken cancellationToken)
     {

--- a/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
+++ b/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
@@ -59,6 +59,27 @@ public class ParallelLimiterExceedsLimitTests
         await Assert.That(s_peak).IsLessThanOrEqualTo(2);
     }
 
+    /// <summary>
+    /// Same assertion but this test also carries the limiter — verifies the
+    /// two-phase acquire (deps first, then limiter) works when the depending
+    /// test shares the same limiter as its dependencies.
+    /// </summary>
+    [Test, ParallelLimiter<Limit2>]
+    [DependsOn(nameof(T01)), DependsOn(nameof(T02)),
+     DependsOn(nameof(T03)), DependsOn(nameof(T04)),
+     DependsOn(nameof(T05)), DependsOn(nameof(T06)),
+     DependsOn(nameof(T07)), DependsOn(nameof(T08)),
+     DependsOn(nameof(T09)), DependsOn(nameof(T10)),
+     DependsOn(nameof(T11)), DependsOn(nameof(T12)),
+     DependsOn(nameof(T13)), DependsOn(nameof(T14)),
+     DependsOn(nameof(T15)), DependsOn(nameof(T16)),
+     DependsOn(nameof(T17)), DependsOn(nameof(T18)),
+     DependsOn(nameof(T19)), DependsOn(nameof(T20))]
+    public async Task PeakIsAtMostLimitWithSameLimiterOnDependent()
+    {
+        await Assert.That(s_peak).IsLessThanOrEqualTo(2);
+    }
+
     private static async Task MeasureAsync()
     {
         var current = Interlocked.Increment(ref s_concurrent);

--- a/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
+++ b/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
@@ -1,0 +1,79 @@
+using TUnit.Core;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5525;
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/issues/5525
+/// ParallelLimiter with Limit=2 must cap concurrency at 2 even when
+/// a [DependsOn] test triggers dependency execution.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class ParallelLimiterExceedsLimitTests
+{
+    private static int s_concurrent;
+    private static int s_peak;
+
+    [Test, ParallelLimiter<Limit2>] public Task T01() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T02() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T03() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T04() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T05() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T06() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T07() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T08() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T09() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T10() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T11() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T12() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T13() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T14() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T15() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T16() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T17() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T18() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T19() => MeasureAsync();
+    [Test, ParallelLimiter<Limit2>] public Task T20() => MeasureAsync();
+
+    [Test]
+    [DependsOn(nameof(T01)), DependsOn(nameof(T02)),
+     DependsOn(nameof(T03)), DependsOn(nameof(T04)),
+     DependsOn(nameof(T05)), DependsOn(nameof(T06)),
+     DependsOn(nameof(T07)), DependsOn(nameof(T08)),
+     DependsOn(nameof(T09)), DependsOn(nameof(T10)),
+     DependsOn(nameof(T11)), DependsOn(nameof(T12)),
+     DependsOn(nameof(T13)), DependsOn(nameof(T14)),
+     DependsOn(nameof(T15)), DependsOn(nameof(T16)),
+     DependsOn(nameof(T17)), DependsOn(nameof(T18)),
+     DependsOn(nameof(T19)), DependsOn(nameof(T20))]
+    public async Task PeakIsAtMostLimit()
+    {
+        await Assert.That(s_peak).IsLessThanOrEqualTo(2);
+    }
+
+    private static async Task MeasureAsync()
+    {
+        var current = Interlocked.Increment(ref s_concurrent);
+
+        int old;
+        do
+        {
+            old = s_peak;
+            if (current <= old)
+            {
+                break;
+            }
+        }
+        while (Interlocked.CompareExchange(ref s_peak, current, old) != old);
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Interlocked.Decrement(ref s_concurrent);
+    }
+}
+
+internal sealed class Limit2 : IParallelLimit
+{
+    public int Limit => 2;
+}

--- a/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
+++ b/TUnit.TestProject/Bugs/5525/ParallelLimiterExceedsLimitTests.cs
@@ -15,6 +15,13 @@ public class ParallelLimiterExceedsLimitTests
     private static int s_concurrent;
     private static int s_peak;
 
+    [Before(Class)]
+    public static void Reset()
+    {
+        s_concurrent = 0;
+        s_peak = 0;
+    }
+
     [Test, ParallelLimiter<Limit2>] public Task T01() => MeasureAsync();
     [Test, ParallelLimiter<Limit2>] public Task T02() => MeasureAsync();
     [Test, ParallelLimiter<Limit2>] public Task T03() => MeasureAsync();


### PR DESCRIPTION
## Summary

Fixes #5525 — `[ParallelLimiter<T>]` with `Limit=2` allowed 3 concurrent tests when `[DependsOn]` was present.

- **Root cause:** The parallel limiter semaphore was acquired in `TestScheduler` and `ConstraintKeyScheduler`, but `TestRunner.ExecuteTestInternalAsync` executes dependency tests via a direct recursive call to `ExecuteTestAsync` that bypassed the semaphore. When a test without `[ParallelLimiter]` but with `[DependsOn]` triggered its dependencies, those could run without holding a semaphore slot.
- **Fix:** Move semaphore acquisition into `TestRunner.ExecuteTestInternalAsync` — after dependency resolution but before the test body — so it applies regardless of entry point (scheduler or dependency recursion). Remove the now-redundant semaphore logic from `TestScheduler` and `ConstraintKeyScheduler`.
- **Regression test:** `TUnit.TestProject/Bugs/5525/` — 20 tests with `[ParallelLimiter<Limit2>]` plus a check test with `[DependsOn]` asserting `peak <= 2`. Fails 5/5 before the fix, passes 10/10 after.

## Test plan

- [x] Regression test `ParallelLimiterExceedsLimitTests` passes consistently (10/10 runs)
- [x] Existing `ParallelLimiterTests` pass
- [x] Existing `LimitedParallelTests`, `StrictlySerialTests`, `HighParallelismTests` pass
- [x] Existing `DependsOnTests`, `DependsOnAndNotInParallelTests` pass
- [x] Existing `ConstraintKeyStressTests` pass
- [x] Existing `NotInParallelExecutionTests` pass