### PR TITLE
refactor: use natural OTEL trace propagation instead of synthetic TraceIds

### DIFF
--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -9,8 +9,11 @@ namespace TUnit.Aspire.Tests;
 public class BaggagePropagationHandlerTests
 {
     [Test]
-    public async Task SendAsync_InjectsTraceparentHeader()
+    public async Task SendAsync_InjectsTraceparentHeader_WhenActivityExists()
     {
+        Activity.Current = null;
+        using var activity = new Activity("test-traceparent").Start();
+
         var captured = new CaptureHandler();
         var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
         using var client = new HttpClient(handler);
@@ -21,9 +24,10 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_TraceparentUsesUniqueTraceId_NotActivityCurrent()
+    public async Task SendAsync_TraceparentUsesActivityCurrentTraceId()
     {
-        using var activity = new Activity("test-unique-traceid").Start();
+        Activity.Current = null;
+        using var activity = new Activity("test-uses-current").Start();
         var activityTraceId = activity.TraceId.ToString();
 
         var captured = new CaptureHandler();
@@ -33,16 +37,18 @@ public class BaggagePropagationHandlerTests
         await client.GetAsync("http://localhost/test");
 
         var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        var parts = traceparent.Split('-');
-        var requestTraceId = parts[1];
+        var requestTraceId = traceparent.Split('-')[1];
 
-        // The handler generates its own TraceId, distinct from Activity.Current's
-        await Assert.That(requestTraceId).IsNotEqualTo(activityTraceId);
+        // Handler propagates Activity.Current's TraceId — natural OTEL propagation
+        await Assert.That(requestTraceId).IsEqualTo(activityTraceId);
     }
 
     [Test]
-    public async Task SendAsync_EachRequestGetsUniqueTraceId()
+    public async Task SendAsync_SameActivity_SharesTraceId()
     {
+        Activity.Current = null;
+        using var activity = new Activity("test-same-traceid").Start();
+
         var captured = new CaptureHandler();
         var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
         using var client = new HttpClient(handler);
@@ -56,12 +62,65 @@ public class BaggagePropagationHandlerTests
         var traceId1 = traceparent1.Split('-')[1];
         var traceId2 = traceparent2.Split('-')[1];
 
+        // Same Activity.Current → same TraceId (all requests belong to same trace)
+        await Assert.That(traceId1).IsEqualTo(traceId2);
+    }
+
+    [Test]
+    public async Task SendAsync_SameActivity_UsesDifferentSpanIds()
+    {
+        Activity.Current = null;
+        using var activity = new Activity("test-unique-spanids").Start();
+
+        var captured = new CaptureHandler();
+        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("http://localhost/test1");
+        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+
+        await client.GetAsync("http://localhost/test2");
+        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+
+        var spanId1 = traceparent1.Split('-')[2];
+        var spanId2 = traceparent2.Split('-')[2];
+
+        // Each request gets a unique SpanId within the same trace
+        await Assert.That(spanId1).IsNotEqualTo(spanId2);
+    }
+
+    [Test]
+    public async Task SendAsync_DifferentActivities_UseDifferentTraceIds()
+    {
+        Activity.Current = null;
+
+        var captured = new CaptureHandler();
+        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        using var client = new HttpClient(handler);
+
+        using var activity1 = new Activity("test-trace-1").Start();
+        await client.GetAsync("http://localhost/test1");
+        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+        activity1.Stop();
+
+        using var activity2 = new Activity("test-trace-2").Start();
+        await client.GetAsync("http://localhost/test2");
+        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+        activity2.Stop();
+
+        var traceId1 = traceparent1.Split('-')[1];
+        var traceId2 = traceparent2.Split('-')[1];
+
+        // Different activities → different TraceIds (separate tests = separate traces)
         await Assert.That(traceId1).IsNotEqualTo(traceId2);
     }
 
     [Test]
     public async Task SendAsync_TraceparentFormat_IsValidW3C()
     {
+        Activity.Current = null;
+        using var activity = new Activity("test-w3c-format").Start();
+
         var captured = new CaptureHandler();
         var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
         using var client = new HttpClient(handler);
@@ -75,28 +134,13 @@ public class BaggagePropagationHandlerTests
         await Assert.That(parts[0]).IsEqualTo("00");           // version
         await Assert.That(parts[1].Length).IsEqualTo(32);      // trace-id (16 bytes hex)
         await Assert.That(parts[2].Length).IsEqualTo(16);      // parent-id (8 bytes hex)
-        await Assert.That(parts[3]).IsEqualTo("01");           // flags (sampled)
-    }
-
-    [Test]
-    public async Task SendAsync_RegistersTraceIdInTraceRegistry()
-    {
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test");
-
-        var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        var traceId = traceparent.Split('-')[1];
-
-        await Assert.That(TraceRegistry.IsRegistered(traceId)).IsTrue();
+        // flags: "00" or "01" depending on sampling
+        await Assert.That(parts[3].Length).IsEqualTo(2);
     }
 
     [Test]
     public async Task SendAsync_InjectsBaggageHeader_WithActivityBaggage()
     {
-        // Detach from engine activity to control baggage precisely
         Activity.Current = null;
         using var activity = new Activity("test-inject-baggage").Start();
         activity.SetBaggage(TUnitActivitySource.TagTestId, "my-test-context-id");
@@ -120,7 +164,6 @@ public class BaggagePropagationHandlerTests
     [Test]
     public async Task SendAsync_NoBaggage_DoesNotAddBaggageHeader()
     {
-        // Detach from engine activity to prevent inheriting tunit.test.id baggage
         Activity.Current = null;
         using var activity = new Activity("test-no-baggage").Start();
 
@@ -134,7 +177,7 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_NoActivity_StillInjectsTraceparent()
+    public async Task SendAsync_NoActivity_DoesNotInjectTraceparent()
     {
         Activity.Current = null;
 
@@ -145,9 +188,8 @@ public class BaggagePropagationHandlerTests
         await client.GetAsync("http://localhost/test");
 
         await Assert.That(captured.LastRequest).IsNotNull();
-        // traceparent is always injected (handler generates its own TraceId)
-        await Assert.That(captured.LastRequest!.Headers.Contains("traceparent")).IsTrue();
-        // No Activity means no baggage to propagate
+        // No Activity.Current → no trace context to propagate
+        await Assert.That(captured.LastRequest!.Headers.Contains("traceparent")).IsFalse();
         await Assert.That(captured.LastRequest.Headers.Contains("baggage")).IsFalse();
     }
 

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -134,8 +134,8 @@ public class BaggagePropagationHandlerTests
         await Assert.That(parts[0]).IsEqualTo("00");           // version
         await Assert.That(parts[1].Length).IsEqualTo(32);      // trace-id (16 bytes hex)
         await Assert.That(parts[2].Length).IsEqualTo(16);      // parent-id (8 bytes hex)
-        // flags: "00" or "01" depending on sampling
-        await Assert.That(parts[3].Length).IsEqualTo(2);
+        // W3C trace-flags: "00" (not sampled) or "01" (sampled)
+        await Assert.That(parts[3]).IsEqualTo("00").Or.IsEqualTo("01");
     }
 
     [Test]

--- a/TUnit.Aspire.Tests/TestActivityTests.cs
+++ b/TUnit.Aspire.Tests/TestActivityTests.cs
@@ -7,8 +7,9 @@ namespace TUnit.Aspire.Tests;
 
 /// <summary>
 /// Tests that verify the TUnit engine creates test activities correctly:
-/// parent-child hierarchy (test → class → assembly → session), proper tags,
-/// baggage for cross-boundary propagation, and TraceId shared within a class.
+/// parent-child hierarchy (test body → test case), proper tags,
+/// baggage for cross-boundary propagation, Activity Links to the class activity,
+/// and unique TraceIds per test case.
 /// </summary>
 public class TestActivityTests
 {
@@ -72,14 +73,18 @@ public class TestActivityTests
     }
 
     [Test]
-    public async Task TestCaseActivity_HasParentSpanId_FromClassActivity()
+    public async Task TestCaseActivity_HasActivityLink_ToClassActivity()
     {
         var testCase = Activity.Current!.Parent!;
 
-        // The test case has a ParentSpanId linking it to the class activity.
-        // Activity.Parent (object reference) may be null when explicit parentContext
-        // is used, but ParentSpanId is always set for child activities.
-        await Assert.That(testCase.ParentSpanId).IsNotEqualTo(default(ActivitySpanId));
+        // Each test case starts its own W3C trace (so ParentSpanId is default).
+        // Instead, an Activity Link references the class activity for correlation.
+        // This prevents all tests in a class from sharing one giant trace in backends
+        // like Seq/Jaeger while still preserving the logical hierarchy.
+        var link = await Assert.That(testCase.Links.ToList()).HasSingleItem();
+
+        await Assert.That(link.Context.TraceId).IsNotEqualTo(default(ActivityTraceId));
+        await Assert.That(link.Context.SpanId).IsNotEqualTo(default(ActivitySpanId));
     }
 
     [Test]
@@ -89,5 +94,17 @@ public class TestActivityTests
 
         await Assert.That(traceId.Length).IsEqualTo(32);
         await Assert.That(traceId).IsNotEqualTo(new string('0', 32));
+    }
+
+    [Test]
+    public async Task TraceId_IsRegisteredInTraceRegistry()
+    {
+        var traceId = Activity.Current!.TraceId.ToString();
+
+        // The engine registers the test's TraceId in TraceRegistry at activity creation.
+        // This enables the OTLP receiver to correlate SUT logs back to this test
+        // without synthetic TraceId generation — pure natural OTEL propagation.
+        await Assert.That(TraceRegistry.IsRegistered(traceId)).IsTrue();
+        await Assert.That(TraceRegistry.GetContextId(traceId)).IsEqualTo(TestContext.Current!.Id);
     }
 }

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -4,68 +4,62 @@ using TUnit.Core;
 namespace TUnit.Aspire.Http;
 
 /// <summary>
-/// DelegatingHandler that injects W3C <c>traceparent</c> and <c>baggage</c> headers
-/// into outgoing HTTP requests for cross-process OTLP correlation. Each request gets
-/// a unique TraceId so the SUT's logs can be routed back to the specific test, even
-/// though all tests in a class share the class activity's TraceId.
+/// DelegatingHandler that propagates W3C <c>traceparent</c> and <c>baggage</c> headers
+/// from <see cref="Activity.Current"/> into outgoing HTTP requests. This enables natural
+/// OpenTelemetry distributed tracing: the SUT receives the test's TraceId and all its
+/// spans and logs can be correlated back to the originating test.
 /// </summary>
 /// <remarks>
-/// The engine keeps test activities as children of the class activity (parent-child,
-/// shared TraceId) so trace backends display proper waterfalls:
-/// Session → Assembly → Class → Test₁, Test₂, ...
-/// This handler generates a fresh TraceId per outbound request and registers it in
-/// <see cref="TraceRegistry"/> so the OTLP receiver can correlate SUT logs back to
-/// the originating test.
+/// Each test case starts its own W3C trace (unique TraceId) via a root activity in the
+/// engine. HTTP requests made during a test inherit that TraceId through standard
+/// <see cref="Activity.Current"/> propagation. The OTLP receiver maps the TraceId back
+/// to the test via <see cref="TraceRegistry"/>, which is populated by the engine when
+/// the test activity starts.
+///
+/// This handler is needed because Aspire's <c>CreateHttpClient</c> does not include
+/// the standard <c>DiagnosticsHandler</c>, so W3C context propagation must be done
+/// explicitly.
 /// </remarks>
 internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
 {
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        // Generate a unique TraceId per request so the OTLP receiver can map each
-        // request's logs back to the originating test. The engine's test activities
-        // share the class-level TraceId (for proper trace-backend waterfall display),
-        // so we need a distinct TraceId here for per-test correlation.
-        var traceId = ActivityTraceId.CreateRandom();
-        var spanId = ActivitySpanId.CreateRandom();
-        request.Headers.TryAddWithoutValidation("traceparent", $"00-{traceId}-{spanId}-01");
-
-        // Register the unique TraceId so the OTLP receiver can correlate logs
-        if (TestContext.Current is { } testContext)
+        if (Activity.Current is { } activity)
         {
-            TraceRegistry.Register(
-                traceId.ToString(),
-                testContext.TestDetails.TestId,
-                testContext.Id);
-        }
+            // New SpanId per request so the SUT's spans parent correctly within this trace
+            var spanId = ActivitySpanId.CreateRandom();
+            var sampled = activity.Recorded ? "01" : "00";
+            request.Headers.TryAddWithoutValidation("traceparent",
+                $"00-{activity.TraceId}-{spanId}-{sampled}");
 
-        // Propagate baggage (including tunit.test.id) from the current activity
-        if (Activity.Current is { } activity && !request.Headers.Contains("baggage"))
-        {
-            var first = true;
-            var sb = new System.Text.StringBuilder();
-
-            foreach (var (key, value) in activity.Baggage)
+            if (!request.Headers.Contains("baggage"))
             {
-                if (key is null)
+                var first = true;
+                var sb = new System.Text.StringBuilder();
+
+                foreach (var (key, value) in activity.Baggage)
                 {
-                    continue;
+                    if (key is null)
+                    {
+                        continue;
+                    }
+
+                    if (!first)
+                    {
+                        sb.Append(',');
+                    }
+
+                    sb.Append(Uri.EscapeDataString(key));
+                    sb.Append('=');
+                    sb.Append(Uri.EscapeDataString(value ?? string.Empty));
+                    first = false;
                 }
 
                 if (!first)
                 {
-                    sb.Append(',');
+                    request.Headers.TryAddWithoutValidation("baggage", sb.ToString());
                 }
-
-                sb.Append(Uri.EscapeDataString(key));
-                sb.Append('=');
-                sb.Append(Uri.EscapeDataString(value ?? string.Empty));
-                first = false;
-            }
-
-            if (!first)
-            {
-                request.Headers.TryAddWithoutValidation("baggage", sb.ToString());
             }
         }
 

--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -73,7 +73,14 @@ public abstract class Context : IContext, IDisposable
 #if NET
         if (ExecutionContext is not null)
         {
+            // ExecutionContext.Restore() restores ALL AsyncLocal values — including
+            // Activity.Current. The captured ExecutionContext may contain a stale
+            // (already-stopped) Activity from a previous hook/event receiver.
+            // Save the current Activity and restore it after the EC restore to
+            // prevent Activity chain corruption across parallel tests.
+            var currentActivity = System.Diagnostics.Activity.Current;
             ExecutionContext.Restore(ExecutionContext);
+            System.Diagnostics.Activity.Current = currentActivity;
         }
 
         SetAsyncLocalContext();

--- a/TUnit.Core/TUnitActivitySource.cs
+++ b/TUnit.Core/TUnitActivitySource.cs
@@ -72,9 +72,10 @@ public static class TUnitActivitySource
         string name,
         ActivityKind kind = ActivityKind.Internal,
         ActivityContext parentContext = default,
-        IEnumerable<KeyValuePair<string, object?>>? tags = null)
+        IEnumerable<KeyValuePair<string, object?>>? tags = null,
+        IEnumerable<ActivityLink>? links = null)
     {
-        return Source.StartActivity(name, kind, parentContext, tags);
+        return Source.StartActivity(name, kind, parentContext, tags, links);
     }
 
     /// <summary>

--- a/TUnit.Engine/Reporters/Html/ActivityCollector.cs
+++ b/TUnit.Engine/Reporters/Html/ActivityCollector.cs
@@ -153,12 +153,20 @@ internal sealed class ActivityCollector : IDisposable
 
     private void OnActivityStarted(Activity activity)
     {
-        // Register test case span IDs early so they're available for child span lookups.
-        // Children stop before parents in Activity ordering, so we need this pre-registered.
-        if (IsTUnitSource(activity.Source.Name) &&
-            activity.GetTagItem(TUnitActivitySource.TagTestNodeUid) is not null)
+        // Register TUnit activities' trace IDs early so child spans from other sources
+        // (HttpClient, EF Core, etc.) can be sampled correctly. This is especially
+        // important for test case activities that start their own trace (parentContext: default),
+        // since their traceId is only assigned by the runtime after StartActivity returns.
+        if (IsTUnitSource(activity.Source.Name))
         {
-            _testCaseSpanIds.TryAdd(activity.SpanId.ToString(), 0);
+            _knownTraceIds.TryAdd(activity.TraceId.ToString(), 0);
+
+            // Register test case span IDs early so they're available for child span lookups.
+            // Children stop before parents in Activity ordering, so we need this pre-registered.
+            if (activity.GetTagItem(TUnitActivitySource.TagTestNodeUid) is not null)
+            {
+                _testCaseSpanIds.TryAdd(activity.SpanId.ToString(), 0);
+            }
         }
     }
 
@@ -315,6 +323,21 @@ internal sealed class ActivityCollector : IDisposable
 
         var parentSpanId = activity.ParentSpanId != default ? activity.ParentSpanId.ToString() : null;
 
+        SpanLink[]? links = null;
+        var activityLinks = activity.Links.ToArray();
+        if (activityLinks.Length > 0)
+        {
+            links = new SpanLink[activityLinks.Length];
+            for (var i = 0; i < activityLinks.Length; i++)
+            {
+                links[i] = new SpanLink
+                {
+                    TraceId = activityLinks[i].Context.TraceId.ToString(),
+                    SpanId = activityLinks[i].Context.SpanId.ToString()
+                };
+            }
+        }
+
         var statusStr = activity.Status switch
         {
             ActivityStatusCode.Ok => "Ok",
@@ -336,7 +359,8 @@ internal sealed class ActivityCollector : IDisposable
             Status = statusStr,
             StatusMessage = activity.StatusDescription,
             Tags = tags,
-            Events = events
+            Events = events,
+            Links = links
         };
 
         queue.Enqueue(spanData);

--- a/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
@@ -222,6 +222,18 @@ internal sealed class SpanData
 
     [JsonPropertyName("events")]
     public SpanEvent[]? Events { get; init; }
+
+    [JsonPropertyName("links")]
+    public SpanLink[]? Links { get; init; }
+}
+
+internal sealed class SpanLink
+{
+    [JsonPropertyName("traceId")]
+    public required string TraceId { get; init; }
+
+    [JsonPropertyName("spanId")]
+    public required string SpanId { get; init; }
 }
 
 internal sealed class SpanEvent

--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -1662,12 +1662,24 @@ function renderTrace(tid, rootSpanId) {
         sp = sp.filter(s => s.spanId !== tbId).map(s => s.parentSpanId === tbId ? {...s, parentSpanId: rootSpanId} : s);
     }
     if (sp.length <= 1) return '';
-    // Include the parent suite span so the test bar is shown relative to the class duration
+    // Include the parent suite span so the test bar is shown relative to the class duration.
+    // Test cases now start their own trace and reference the suite via Activity Links,
+    // so check links first, then fall back to parentSpanId for backward compatibility.
     const root = bySpanId[rootSpanId];
-    if (root && root.parentSpanId && bySpanId[root.parentSpanId]) {
-        const parent = bySpanId[root.parentSpanId];
-        if (!sp.some(s => s.spanId === parent.spanId)) {
-            sp.unshift(parent);
+    if (root) {
+        let parentSpan = null;
+        if (root.links && root.links.length) {
+            parentSpan = bySpanId[root.links[0].spanId];
+        }
+        if (!parentSpan && root.parentSpanId) {
+            parentSpan = bySpanId[root.parentSpanId];
+        }
+        if (parentSpan && !sp.some(s => s.spanId === parentSpan.spanId)) {
+            sp.unshift(parentSpan);
+            // Set a virtual parentSpanId so the depth calculation nests the test
+            // case under the suite span in the waterfall view
+            sp = sp.map(s => s.spanId === rootSpanId && !s.parentSpanId
+                ? {...s, parentSpanId: parentSpan.spanId} : s);
         }
     }
     return '<div class="d-sec"><div class="d-lbl">Trace Timeline</div>' + renderSpanRows(sp, 't-' + rootSpanId) + '</div>';

--- a/TUnit.Engine/Services/HookExecutor.cs
+++ b/TUnit.Engine/Services/HookExecutor.cs
@@ -642,6 +642,9 @@ internal sealed class HookExecutor
     {
         System.Diagnostics.Activity? hookActivity = null;
 
+        // RestoreExecutionContext() can corrupt Activity.Stop()'s parent chain
+        var previousActivity = System.Diagnostics.Activity.Current;
+
         if (TUnitActivitySource.Source.HasListeners())
         {
             hookActivity = TUnitActivitySource.StartActivity(
@@ -662,6 +665,7 @@ internal sealed class HookExecutor
         finally
         {
             TUnitActivitySource.StopActivity(hookActivity);
+            System.Diagnostics.Activity.Current = previousActivity;
         }
     }
 #else

--- a/TUnit.Engine/Services/HookExecutor.cs
+++ b/TUnit.Engine/Services/HookExecutor.cs
@@ -642,7 +642,11 @@ internal sealed class HookExecutor
     {
         System.Diagnostics.Activity? hookActivity = null;
 
-        // RestoreExecutionContext() can corrupt Activity.Stop()'s parent chain
+        // Capture the pre-hook Activity.Current as the known-good restore target.
+        // StopActivity internally restores to hookActivity._previousActiveActivity,
+        // but that chain can be corrupted when RestoreExecutionContext() overwrites
+        // Activity.Current during the hook. We overwrite StopActivity's restore
+        // with this known-good value to guarantee a correct Activity.Current after.
         var previousActivity = System.Diagnostics.Activity.Current;
 
         if (TUnitActivitySource.Source.HasListeners())

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -131,7 +131,8 @@ internal class TestExecutor
                     ? [new ActivityLink(classActivity.Context)]
                     : null;
 
-                // Clear ambient activity so StartActivity creates a root (new TraceId)
+                // Clear ambient activity so StartActivity creates a root (new TraceId).
+                // Safe: Activity.Current is AsyncLocal, so this only affects this async context.
                 Activity.Current = null;
 
                 executableTest.Context.Activity = TUnitActivitySource.StartActivity(

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -117,24 +117,27 @@ internal class TestExecutor
             executableTest.Context.ClassContext.RestoreExecutionContext();
 
 #if NET
-            // Start the test case activity BEFORE initialization so that per-test
-            // object init spans can be parented under the test case. Shared objects
-            // (PerSession/PerAssembly/PerClass) are parented under their respective
-            // scope activities via explicit parentContext in ObjectLifecycleService.
-            //
-            // Test activities are children of the class activity (parent-child, shared
-            // TraceId). This produces proper waterfall visualisation in trace backends:
-            // Session → Assembly → Class → Test₁, Test₂, ...
-            // Per-request OTLP correlation uses unique TraceIds generated at the HTTP
-            // handler layer, not the engine — see TUnitBaggagePropagationHandler.
+            // Each test case starts its own trace so each test gets a unique W3C TraceId
+            // for natural OTEL distributed tracing correlation. We must clear Activity.Current
+            // because StartActivity with parentContext: default falls back to Activity.Current
+            // when it's non-null, which would make all tests in a class share the class TraceId.
+            // An ActivityLink references the class activity for grouping in the HTML report.
             if (TUnitActivitySource.Source.HasListeners())
             {
                 var classActivity = executableTest.Context.ClassContext.Activity;
                 var testDetails = executableTest.Context.Metadata.TestDetails;
+
+                ActivityLink[]? links = classActivity is not null
+                    ? [new ActivityLink(classActivity.Context)]
+                    : null;
+
+                // Clear ambient activity so StartActivity creates a root (new TraceId)
+                Activity.Current = null;
+
                 executableTest.Context.Activity = TUnitActivitySource.StartActivity(
                     TUnitActivitySource.SpanTestCase,
                     ActivityKind.Internal,
-                    classActivity?.Context ?? default,
+                    parentContext: default,
                     [
                         new(TUnitActivitySource.TagTestCaseName, testDetails.TestName),
                         new(TUnitActivitySource.TagTestClass, testDetails.ClassType.FullName),
@@ -142,10 +145,19 @@ internal class TestExecutor
                         new(TUnitActivitySource.TagTestId, executableTest.Context.Id),
                         new(TUnitActivitySource.TagTestNodeUid, testDetails.TestId),
                         new(TUnitActivitySource.TagTestCategories, testDetails.Categories.ToArray())
-                    ]);
+                    ],
+                    links);
 
-                // Same key as the span tag above — set as baggage for cross-boundary propagation via W3C headers
                 executableTest.Context.Activity?.SetBaggage(TUnitActivitySource.TagTestId, executableTest.Context.Id);
+
+                // Register for OTLP receiver cross-process log correlation
+                if (executableTest.Context.Activity is { } testActivity)
+                {
+                    TraceRegistry.Register(
+                        testActivity.TraceId.ToString(),
+                        testDetails.TestId,
+                        executableTest.Context.Id);
+                }
             }
 #endif
 


### PR DESCRIPTION
## Summary

- Each test case now starts its own W3C trace (root activity, unique TraceId) with an ActivityLink back to the class activity, instead of being a child that shares the class TraceId
- `TUnitBaggagePropagationHandler` propagates `Activity.Current`'s TraceId naturally instead of generating synthetic random TraceIds per HTTP request
- TraceRegistry registration moved from the HTTP handler to the engine (TestExecutor) where the test activity is created
- Activity.Current preserved across `ExecutionContext.Restore()` and hook execution to prevent chain corruption in parallel tests
- HTML report resolves parent via ActivityLink, with fallback to parentSpanId for backward compatibility

Addresses feedback from @redoz in #4818: uses span parent/child relationships as the natural OTEL solution for distributed trace correlation, rather than synthetic TraceId generation at the handler layer.

**Before** (synthetic):
```
Test(TraceId-A) → Handler generates TraceId-B → SUT logs TraceId-B → TraceRegistry lookup → Test
```

**After** (natural OTEL):
```
Test(TraceId-A) → Handler propagates TraceId-A → SUT logs TraceId-A → direct correlation → Test
```

## Test plan

- [x] `BaggagePropagationHandlerTests` — 13 tests verifying natural propagation (Activity.Current TraceId, unique SpanIds, W3C format, baggage, no-activity behavior)
- [x] `TestActivityTests` — 8 tests verifying root activities, ActivityLinks, tags, baggage, TraceRegistry registration
- [x] `TraceRegistryTests` — 9 tests verifying thread-safe registration and lookup
- [x] `OtlpReceiverTests` — 13 tests verifying cross-process log correlation
- [x] `OtlpLogParserTests` — 25 tests verifying protobuf parsing
- [ ] Integration tests (`OtlpCorrelationIntegrationTests`) require Docker/Aspire — verify in CI