### PR TITLE
fix: cap test output at 1M chars to prevent OOM

### DIFF
--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -45,11 +45,12 @@ public abstract class Context : IContext, IDisposable
     private ReaderWriterLockSlim GetErrorOutputLock() =>
         LazyInitializer.EnsureInitialized(ref _errorOutputLock, static () => new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion))!;
 
-    [field: AllowNull, MaybeNull]
-    public TextWriter OutputWriter => field ??= new ConcurrentStringWriter(GetOutputBuilder(), GetOutputLock());
+    private ConcurrentStringWriter? _outputWriter;
+    private ConcurrentStringWriter? _errorOutputWriter;
 
-    [field: AllowNull, MaybeNull]
-    public TextWriter ErrorOutputWriter => field ??= new ConcurrentStringWriter(GetErrorOutputBuilder(), GetErrorOutputLock());
+    public TextWriter OutputWriter => _outputWriter ??= new ConcurrentStringWriter(GetOutputBuilder(), GetOutputLock());
+
+    public TextWriter ErrorOutputWriter => _errorOutputWriter ??= new ConcurrentStringWriter(GetErrorOutputBuilder(), GetErrorOutputLock());
 
     // Internal accessors for console interceptor line buffers
     internal ConsoleLineBuffer ConsoleStdOutLineBuffer =>
@@ -101,49 +102,9 @@ public abstract class Context : IContext, IDisposable
 #endif
     }
 
-    public virtual string GetStandardOutput()
-    {
-        if (_outputBuilder == null)
-        {
-            return string.Empty;
-        }
+    public virtual string GetStandardOutput() => _outputWriter?.GetContent() ?? string.Empty;
 
-        var outputLock = GetOutputLock();
-        outputLock.EnterReadLock();
-
-        try
-        {
-            return _outputBuilder.Length == 0
-                ? string.Empty
-                : _outputBuilder.ToString();
-        }
-        finally
-        {
-            outputLock.ExitReadLock();
-        }
-    }
-
-    public virtual string GetErrorOutput()
-    {
-        if (_errorOutputBuilder == null)
-        {
-            return string.Empty;
-        }
-
-        var errorOutputLock = GetErrorOutputLock();
-        errorOutputLock.EnterReadLock();
-
-        try
-        {
-            return _errorOutputBuilder.Length == 0
-                ? string.Empty
-                : _errorOutputBuilder.ToString();
-        }
-        finally
-        {
-            errorOutputLock.ExitReadLock();
-        }
-    }
+    public virtual string GetErrorOutput() => _errorOutputWriter?.GetContent() ?? string.Empty;
 
     public DefaultLogger GetDefaultLogger()
     {
@@ -167,8 +128,17 @@ public abstract class Context : IContext, IDisposable
 /// </summary>
 internal sealed class ConcurrentStringWriter : TextWriter
 {
+    private const int MaxOutputLength = 1_048_576; // 1M chars (~2MB)
+
+    // Trim to 75% of max to avoid re-trimming on every subsequent write
+    private const int TrimTarget = MaxOutputLength * 3 / 4;
+
+    private static readonly string TruncationNotice =
+        $"[... output truncated — exceeded {MaxOutputLength:N0} character limit, showing most recent output ...]{Environment.NewLine}";
+
     private readonly StringBuilder _builder;
     private readonly ReaderWriterLockSlim _lock;
+    private bool _truncated;
 
     public ConcurrentStringWriter(StringBuilder builder, ReaderWriterLockSlim lockSlim)
     {
@@ -184,6 +154,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -199,6 +170,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
             try
             {
                 _builder.Append(value);
+                TrimIfNeeded();
             }
             finally
             {
@@ -215,6 +187,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
             try
             {
                 _builder.Append(buffer, index, count);
+                TrimIfNeeded();
             }
             finally
             {
@@ -229,6 +202,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.AppendLine();
+            TrimIfNeeded();
         }
         finally
         {
@@ -242,6 +216,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.AppendLine(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -257,6 +232,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
             try
             {
                 _builder.Append(buffer);
+                TrimIfNeeded();
             }
             finally
             {
@@ -271,6 +247,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -284,6 +261,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -297,6 +275,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -310,6 +289,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -323,6 +303,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -336,6 +317,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -349,6 +331,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -362,6 +345,7 @@ internal sealed class ConcurrentStringWriter : TextWriter
         try
         {
             _builder.Append(value);
+            TrimIfNeeded();
         }
         finally
         {
@@ -377,11 +361,40 @@ internal sealed class ConcurrentStringWriter : TextWriter
             try
             {
                 _builder.Append(value);
+                TrimIfNeeded();
             }
             finally
             {
                 _lock.ExitWriteLock();
             }
+        }
+    }
+
+    private void TrimIfNeeded()
+    {
+        if (_builder.Length > MaxOutputLength)
+        {
+            _builder.Remove(0, _builder.Length - TrimTarget);
+            _truncated = true;
+        }
+    }
+
+    internal string GetContent()
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            if (_builder.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var content = _builder.ToString();
+            return _truncated ? string.Concat(TruncationNotice, content) : content;
+        }
+        finally
+        {
+            _lock.ExitReadLock();
         }
     }
 

--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -47,10 +47,14 @@ public abstract class Context : IContext, IDisposable
 
     private ConcurrentStringWriter? _outputWriter;
     private ConcurrentStringWriter? _errorOutputWriter;
+    private ConcurrentStringWriter GetOutputWriter() =>
+        LazyInitializer.EnsureInitialized(ref _outputWriter, () => new ConcurrentStringWriter(GetOutputBuilder(), GetOutputLock()))!;
+    private ConcurrentStringWriter GetErrorOutputWriter() =>
+        LazyInitializer.EnsureInitialized(ref _errorOutputWriter, () => new ConcurrentStringWriter(GetErrorOutputBuilder(), GetErrorOutputLock()))!;
 
-    public TextWriter OutputWriter => _outputWriter ??= new ConcurrentStringWriter(GetOutputBuilder(), GetOutputLock());
+    public TextWriter OutputWriter => GetOutputWriter();
 
-    public TextWriter ErrorOutputWriter => _errorOutputWriter ??= new ConcurrentStringWriter(GetErrorOutputBuilder(), GetErrorOutputLock());
+    public TextWriter ErrorOutputWriter => GetErrorOutputWriter();
 
     // Internal accessors for console interceptor line buffers
     internal ConsoleLineBuffer ConsoleStdOutLineBuffer =>

--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -378,7 +378,15 @@ internal sealed class ConcurrentStringWriter : TextWriter
     {
         if (_builder.Length > MaxOutputLength)
         {
-            _builder.Remove(0, _builder.Length - TrimTarget);
+            var removeCount = _builder.Length - TrimTarget;
+
+            // Avoid splitting a surrogate pair at the trim boundary
+            if (removeCount > 0 && char.IsHighSurrogate(_builder[removeCount - 1]))
+            {
+                removeCount--;
+            }
+
+            _builder.Remove(0, removeCount);
             _truncated = true;
         }
     }


### PR DESCRIPTION
## Summary

Closes #5560

- Cap per-test output at 1M characters (~2MB) in `ConcurrentStringWriter` to prevent `OutOfMemoryException` when tests produce excessive output
- Keep most recent output (trim oldest) — most useful for debugging
- Trim to 75% on overflow to avoid re-trimming on every subsequent write
- Prepend `[... output truncated ...]` notice when reading back truncated output

### Root cause

`ConcurrentStringWriter` backed by `StringBuilder` had no size limit. When tests produced large output, `ValueStringBuilder.Grow()` in the reporting path (`ToTestNode` → `GetStandardOutput`) tried to allocate arrays too large for `ArrayPool`, causing OOM.

### Design

- **Where**: Capping at write time in `ConcurrentStringWriter.TrimIfNeeded()` — all 14 Write/WriteLine overrides call it after each append, under the existing write lock
- **How much**: 1M chars max, trim to 768K (75%) on overflow — single int comparison per write, `StringBuilder.Remove(0, N)` amortized by 25% headroom
- **Read path**: `ConcurrentStringWriter.GetContent()` owns lock acquisition, content retrieval, and truncation notice — `Context.GetStandardOutput()`/`GetErrorOutput()` are now one-liners

## Test plan

- [x] `ContextThreadSafetyTests` — concurrent read/write safety
- [x] `CaptureOutputTests` — 80 output capture scenarios
- [x] `ParallelConsoleOutputTests` — 44 parallel console tests
- [x] `ConsoleTests` — console interception
- [x] `TestBuildContextOutputCaptureTests` — build-time output
- [x] TUnit.Core and TUnit.Engine build with 0 warnings