### PR TITLE
fix: include XML documentation files in NuGet packages

### DIFF
--- a/Library.props
+++ b/Library.props
@@ -4,6 +4,11 @@
 
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- Suppress XML doc warnings — not all public APIs are documented yet,
+             and some existing comments have minor formatting issues -->
+        <NoWarn>$(NoWarn);CS1591;CS1570;CS1572;CS1573;CS1574;CS1584;CS1587;CS1658;CS1734;CS0419</NoWarn>
+
         <TrimmerSingleWarn>false</TrimmerSingleWarn>
 
         <!-- Suppress AD0001 analyzer crash in .NET 9 ILLink DynamicallyAccessedMembersAnalyzer.


### PR DESCRIPTION
## Summary

- Enable `GenerateDocumentationFile` in `Library.props` so all library projects generate XML doc files
- XML doc files are automatically included in NuGet packages by SDK convention, providing IntelliSense for consumers
- Suppress XML doc warnings (CS1591, CS1570, etc.) since not all public APIs are documented yet and `TreatWarningsAsErrors` is enabled

Closes #5563

## Test plan

- [x] `TUnit.Core` builds clean with XML doc generation enabled
- [x] `TUnit.Assertions` builds clean
- [x] `TUnit.Engine` builds clean
- [x] Verified `TUnit.Core.xml` file generated in output directory