### PR TITLE
fix: expand nested And/Or expectations in failure messages (#5573)

### DIFF
--- a/TUnit.Assertions.Tests/AssertConditions/BecauseTests.cs
+++ b/TUnit.Assertions.Tests/AssertConditions/BecauseTests.cs
@@ -76,7 +76,7 @@ public class BecauseTests
     {
         var expectedMessage = """
                               Expected to be true, because we only apply it to previous assertions
-                              and to be false
+                              	and to be false
                               but found True
 
                               at Assert.That(variable).IsTrue().Because("we only apply it to previous assertions").And.IsFalse()

--- a/TUnit.Assertions.Tests/AssertionBuilders/AndAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/AndAssertionTests.cs
@@ -307,4 +307,51 @@ public sealed class AndAssertionTests
             .And
             .Length().IsEqualTo(11);
     }
+
+    [Test]
+    public async Task Three_Way_And_Chain_Error_Message_Expands_All_Expectations()
+    {
+        var numbers = new[] { 1, 2, 3, 4, 1 };
+
+        var action = async () => await Assert.That(numbers)
+            .Count().IsEqualTo(5)
+            .And.Contains(3)
+            .And.IsInOrder();
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message)
+            .Contains("count equal to 5")
+            .And
+            .Contains("to contain 3")
+            .And
+            .Contains("to be in ascending order");
+
+        await Assert.That(exception.Message).DoesNotContain("both conditions");
+    }
+
+    [Test]
+    public async Task Four_Way_And_Chain_Error_Message_Expands_All_Expectations()
+    {
+        var value = 5;
+
+        var action = async () => await Assert.That(value)
+            .IsGreaterThan(3)
+            .And.IsLessThan(100)
+            .And.IsNotEqualTo(7)
+            .And.IsEqualTo(99);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message)
+            .Contains("to be greater than 3")
+            .And
+            .Contains("to be less than 100")
+            .And
+            .Contains("to not be equal to 7")
+            .And
+            .Contains("to be 99");
+
+        await Assert.That(exception.Message).DoesNotContain("both conditions");
+    }
 }

--- a/TUnit.Assertions.Tests/Assertions/Delegates/Throws.ExactlyTests.cs
+++ b/TUnit.Assertions.Tests/Assertions/Delegates/Throws.ExactlyTests.cs
@@ -143,7 +143,7 @@ public partial class Throws
 
             var expectedPrefix = """
                 Expected to throw exactly CustomException
-                and to have message equal to "Foo bar message!"
+                	and to have message equal to "Foo bar message!"
                 """;
 
             await Assert.That(assertionException.Message.NormalizeLineEndings()).StartsWith(expectedPrefix.NormalizeLineEndings());

--- a/TUnit.Assertions.Tests/Old/AssertMultipleTests.cs
+++ b/TUnit.Assertions.Tests/Old/AssertMultipleTests.cs
@@ -89,7 +89,7 @@ public class AssertMultipleTests
 
         await TUnitAssert.That(exception1.Message.NormalizeLineEndings()).IsEqualTo("""
                                                         Expected to be 2
-                                                        or to be 3
+                                                        	or to be 3
                                                         but found 1
 
                                                         at Assert.That(1).IsEqualTo(2).Or.IsEqualTo(3)
@@ -97,7 +97,7 @@ public class AssertMultipleTests
 
         await TUnitAssert.That(exception2.Message.NormalizeLineEndings()).IsEqualTo("""
                                                         Expected to be 3
-                                                        and to be 4
+                                                        	and to be 4
                                                         but found 2
 
                                                         at Assert.That(2).IsEqualTo(3).And.IsEqualTo(4)
@@ -105,7 +105,7 @@ public class AssertMultipleTests
 
         await TUnitAssert.That(exception3.Message.NormalizeLineEndings()).IsEqualTo("""
                                                         Expected to be 4
-                                                        or to be 5
+                                                        	or to be 5
                                                         but found 3
 
                                                         at Assert.That(3).IsEqualTo(4).Or.IsEqualTo(5)
@@ -113,7 +113,7 @@ public class AssertMultipleTests
 
         await TUnitAssert.That(exception4.Message.NormalizeLineEndings()).IsEqualTo("""
                                                         Expected to be 5
-                                                        and to be 6
+                                                        	and to be 6
                                                         but found 4
 
                                                         at Assert.That(4).IsEqualTo(5).And.IsEqualTo(6)
@@ -121,7 +121,7 @@ public class AssertMultipleTests
 
         await TUnitAssert.That(exception5.Message.NormalizeLineEndings()).IsEqualTo("""
                                                         Expected to be 6
-                                                        or to be 7
+                                                        	or to be 7
                                                         but found 5
 
                                                         at Assert.That(5).IsEqualTo(6).Or.IsEqualTo(7)

--- a/TUnit.Assertions/Chaining/AndAssertion.cs
+++ b/TUnit.Assertions/Chaining/AndAssertion.cs
@@ -139,11 +139,11 @@ public class AndAssertion<TValue> : Assertion<TValue>
             var becausePrefix = firstBecause.StartsWith("because ", StringComparison.OrdinalIgnoreCase)
                 ? firstBecause
                 : $"because {firstBecause}";
-            return $"{firstExpectation}, {becausePrefix}\nand {secondExpectation}";
+            return $"{firstExpectation}, {becausePrefix}\n\tand {secondExpectation}";
         }
 
-        return $"{firstExpectation}\nand {secondExpectation}";
+        return $"{firstExpectation}\n\tand {secondExpectation}";
     }
 
-    protected override string GetExpectation() => "both conditions";
+    protected override string GetExpectation() => BuildCombinedExpectation();
 }

--- a/TUnit.Assertions/Chaining/OrAssertion.cs
+++ b/TUnit.Assertions/Chaining/OrAssertion.cs
@@ -140,11 +140,11 @@ public class OrAssertion<TValue> : Assertion<TValue>
             var becausePrefix = firstBecause.StartsWith("because ", StringComparison.OrdinalIgnoreCase)
                 ? firstBecause
                 : $"because {firstBecause}";
-            return $"{firstExpectation}, {becausePrefix}\nor {secondExpectation}";
+            return $"{firstExpectation}, {becausePrefix}\n\tor {secondExpectation}";
         }
 
-        return $"{firstExpectation}\nor {secondExpectation}";
+        return $"{firstExpectation}\n\tor {secondExpectation}";
     }
 
-    protected override string GetExpectation() => "either condition";
+    protected override string GetExpectation() => BuildCombinedExpectation();
 }


### PR DESCRIPTION
## Summary
- Fix #5573: chaining 3+ `.And` / `.Or` produced confusing `Expected both conditions and to be X` messages because the nested combinator returned a placeholder (`both conditions` / `either condition`) when its enclosing combinator asked for its expectation.
- Override `GetExpectation()` on `AndAssertion` / `OrAssertion` to return the combined expansion, so nested chains flatten into a readable multi-line expectation.
- Indent continuation lines with a tab so chained clauses are visually grouped under the leading `Expected`.

### Before
```
Expected both conditions
and to be in ascending order
but item at index 4 (1) was less than previous item (4)
```

### After
```
Expected to have count equal to 5
	and to contain 3
	and to be in ascending order
but item at index 4 (1) was less than previous item (4)
```

## Test plan
- [x] New `Three_Way_And_Chain_Error_Message_Expands_All_Expectations` reproduces the issue and now passes.
- [x] New `Four_Way_And_Chain_Error_Message_Expands_All_Expectations` covers deeper nesting.
- [x] Existing `BecauseTests`, `Throws.ExactlyTests`, and `AssertMultipleTests` updated to match the new tab-indented format.
- [x] Full `TUnit.Assertions.Tests` suite: 1974/1974 passing.