### PR TITLE
fix: restore SourceLink and deterministic builds in published packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />


### PR DESCRIPTION
## Summary
- Remove explicit `Microsoft.SourceLink.GitHub` `GlobalPackageReference`; rely on SDK 10's implicit SourceLink SDK instead
- Fixes published `.nupkg`/`.snupkg` showing "No Source Link" and "Non deterministic" in NuGet Package Explorer

## Root cause
The `GlobalPackageReference "Microsoft.SourceLink.GitHub" PrivateAssets="all"` made NuGet:
1. Restore Common + Build.Tasks.Git transitively as `buildTransitive/_._` (empty marker — developmentDependency packages don't flow through private refs)
2. Still set `PkgMicrosoft_SourceLink_Common` path property

`Microsoft.NET.Sdk.SourceLink.props` then flips `SuppressImplicitGitSourceLink=true`, skipping SDK-bundled Common/Build.Tasks.Git imports. Only `Microsoft.SourceLink.GitHub.targets` imported → `LocateRepository` task and `InitializeSourceControlInformationFromSourceControlManager` target never ran → `@(SourceRoot)` empty → no SourceLink JSON generated, no PathMap normalization, non-deterministic paths in PE.

## Fix
Delete the `GlobalPackageReference`. .NET 10 SDK bundles SourceLink at `$(DotnetRoot)/sdk/<ver>/Sdks/Microsoft.SourceLink.*`. With no NuGet ref, `PkgMicrosoft_SourceLink_Common` stays empty, suppression doesn't fire, SDK auto-imports all three (Common + Build.Tasks.Git + GitHub).

## Test plan
- [x] MSBuild preprocess (`-pp`) shows SDK's implicit imports activating (`InitializeSourceControlInformationFromSourceControlManager`, `LocateRepository`, `GenerateSourceLinkFile`)
- [x] `obj/*/TUnit.Core.sourcelink.json` generated with `{"/_/*":"https://raw.githubusercontent.com/thomhurst/TUnit/<sha>/*"}`
- [x] Built TUnit.Core + TUnit.Assertions × {netstandard2.0, net8.0, net9.0, net10.0}: each DLL has `Reproducible` debug entry, each PDB has SourceLink CDI (`cc110556-a091-4d38-9fec-25ab9a351a6a`)
- [ ] CI build produces packages that pass "Source Link" and "Deterministic" checks in NuGet Package Explorer