### PR TITLE
fix: don't render test's own trace as Linked Trace in HTML report

### DIFF
--- a/TUnit.Engine.Tests/HtmlReporterTests.cs
+++ b/TUnit.Engine.Tests/HtmlReporterTests.cs
@@ -71,6 +71,48 @@ public class HtmlReporterTests
 
 
     [Test]
+    public void FilterAdditionalTraceIds_Removes_Primary_Trace_CaseInsensitive()
+    {
+        var primary = "abcdef0123456789abcdef0123456789";
+        var linked = "1111111111111111aaaaaaaaaaaaaaaa";
+        var all = new[] { primary.ToUpperInvariant(), linked };
+
+        var result = HtmlReporter.FilterAdditionalTraceIds(all, primary);
+
+        result.ShouldBe(new[] { linked });
+    }
+
+    [Test]
+    public void FilterAdditionalTraceIds_Returns_Input_When_Primary_Null()
+    {
+        var all = new[] { "aaaa", "bbbb" };
+
+        var result = HtmlReporter.FilterAdditionalTraceIds(all, primaryTraceId: null);
+
+        result.ShouldBeSameAs(all);
+    }
+
+    [Test]
+    public void FilterAdditionalTraceIds_Returns_Input_When_No_Match()
+    {
+        var all = new[] { "aaaa", "bbbb" };
+
+        var result = HtmlReporter.FilterAdditionalTraceIds(all, "cccc");
+
+        result.ShouldBeSameAs(all);
+    }
+
+    [Test]
+    public void FilterAdditionalTraceIds_Returns_Empty_When_Only_Primary()
+    {
+        var primary = "abcdef0123456789abcdef0123456789";
+
+        var result = HtmlReporter.FilterAdditionalTraceIds(new[] { primary }, primary);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Test]
     public async Task PublishArtifactAsync_Publishes_With_Correct_SessionUid()
     {
         var reporter = new HtmlReporter(new MockExtension());

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -268,7 +268,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             }
 
 #if NET
-            var additionalTraceIds = TraceRegistry.GetTraceIds(kvp.Key);
+            var additionalTraceIds = FilterAdditionalTraceIds(TraceRegistry.GetTraceIds(kvp.Key), traceId);
             string[]? additionalTraceIdsForResult = additionalTraceIds.Length > 0 ? additionalTraceIds : null;
 #else
             string[]? additionalTraceIdsForResult = null;
@@ -439,6 +439,30 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
                 break;
         }
     }
+
+#if NET
+    // The engine auto-registers the test's own traceId in TraceRegistry for OTLP correlation,
+    // so it shows up in GetTraceIds alongside any user-added traces. Strip it here so the
+    // primary trace (rendered as "Trace Timeline") isn't also rendered as a "Linked Trace".
+    internal static string[] FilterAdditionalTraceIds(string[] allTraceIds, string? primaryTraceId)
+    {
+        if (allTraceIds.Length == 0 || primaryTraceId is null)
+        {
+            return allTraceIds;
+        }
+
+        var filtered = new List<string>(allTraceIds.Length);
+        foreach (var tid in allTraceIds)
+        {
+            if (!string.Equals(tid, primaryTraceId, StringComparison.OrdinalIgnoreCase))
+            {
+                filtered.Add(tid);
+            }
+        }
+
+        return filtered.Count == allTraceIds.Length ? allTraceIds : filtered.ToArray();
+    }
+#endif
 
     private static ReportTestResult ExtractTestResult(string testId, TestNode testNode, string? traceId, string? spanId, int retryAttempt, string[]? additionalTraceIds)
     {


### PR DESCRIPTION
## Summary
- Engine auto-registers test's own `traceId` in `TraceRegistry` (for OTLP cross-process log correlation). `HtmlReporter` then read that same ID back as an "additional" trace, so the primary trace rendered twice — once as **Trace Timeline** (descendants of the test case span, flattens `test body`) and once as **Linked Trace: TUnit** (raw full trace, includes `test body`). Near-duplicate with a subtle difference, confusing for users.
- Added `HtmlReporter.FilterAdditionalTraceIds` to strip the primary `traceId` from the `TraceRegistry.GetTraceIds` result. Linked Traces now appear only when the user calls `TestContext.RegisterTrace` with a genuinely different trace, matching the documented behavior in `docs/docs/guides/html-report.md`.

## Test plan
- [x] New unit tests in `HtmlReporterTests` cover: case-insensitive match, null primary, no match (returns same array), only primary (returns empty).
- [x] All 9 `HtmlReporterTests` pass (4 new + 5 existing).