### PR TITLE
fix(docs): benchmark index links 404

### DIFF
--- a/.github/scripts/process-benchmarks.js
+++ b/.github/scripts/process-benchmarks.js
@@ -371,13 +371,13 @@ These benchmarks were automatically generated on **${timestamp}** from the lates
 Click on any benchmark to view detailed results:
 
 ${Object.keys(categories.runtime).map(testClass =>
-  `- [${testClass}](${testClass}) - Detailed performance analysis`
+  `- [${testClass}](./${testClass}.md) - Detailed performance analysis`
 ).join('\n')}
 
 ${Object.keys(categories.build).length > 0 ? `
 ## 🔨 Build Benchmarks
 
-- [Build Performance](BuildTime) - Compilation time comparison
+- [Build Performance](./BuildTime.md) - Compilation time comparison
 ` : ''}
 
 ---

--- a/.github/scripts/process-mock-benchmarks.js
+++ b/.github/scripts/process-mock-benchmarks.js
@@ -384,7 +384,7 @@ ${libraryTableRows}
 Click on any benchmark to view detailed results:
 
 ${Object.keys(categories).map(category =>
-  `- [${category}](${category}) - ${categoryDescriptions[category] || category}`
+  `- [${category}](./${category}.md) - ${categoryDescriptions[category] || category}`
 ).join('\n')}
 
 ## 📈 What's Measured

--- a/docs/docs/benchmarks/index.md
+++ b/docs/docs/benchmarks/index.md
@@ -16,17 +16,17 @@ These benchmarks were automatically generated on **2026-04-17** from the latest 
 
 Click on any benchmark to view detailed results:
 
-- [AsyncTests](AsyncTests) - Detailed performance analysis
-- [DataDrivenTests](DataDrivenTests) - Detailed performance analysis
-- [MassiveParallelTests](MassiveParallelTests) - Detailed performance analysis
-- [MatrixTests](MatrixTests) - Detailed performance analysis
-- [ScaleTests](ScaleTests) - Detailed performance analysis
-- [SetupTeardownTests](SetupTeardownTests) - Detailed performance analysis
+- [AsyncTests](./AsyncTests.md) - Detailed performance analysis
+- [DataDrivenTests](./DataDrivenTests.md) - Detailed performance analysis
+- [MassiveParallelTests](./MassiveParallelTests.md) - Detailed performance analysis
+- [MatrixTests](./MatrixTests.md) - Detailed performance analysis
+- [ScaleTests](./ScaleTests.md) - Detailed performance analysis
+- [SetupTeardownTests](./SetupTeardownTests.md) - Detailed performance analysis
 
 
 ## 🔨 Build Benchmarks
 
-- [Build Performance](BuildTime) - Compilation time comparison
+- [Build Performance](./BuildTime.md) - Compilation time comparison
 
 
 ---

--- a/docs/docs/benchmarks/mocks/index.md
+++ b/docs/docs/benchmarks/mocks/index.md
@@ -29,12 +29,12 @@ These benchmarks compare source-generated, AOT-compatible mocking libraries agai
 
 Click on any benchmark to view detailed results:
 
-- [Callback](Callback) - Callback registration and execution
-- [CombinedWorkflow](CombinedWorkflow) - Full workflow: create → setup → invoke → verify
-- [Invocation](Invocation) - Calling methods on mock objects
-- [MockCreation](MockCreation) - Mock instance creation performance
-- [Setup](Setup) - Mock behavior configuration (returns, matchers)
-- [Verification](Verification) - Verifying mock method calls
+- [Callback](./Callback.md) - Callback registration and execution
+- [CombinedWorkflow](./CombinedWorkflow.md) - Full workflow: create → setup → invoke → verify
+- [Invocation](./Invocation.md) - Calling methods on mock objects
+- [MockCreation](./MockCreation.md) - Mock instance creation performance
+- [Setup](./Setup.md) - Mock behavior configuration (returns, matchers)
+- [Verification](./Verification.md) - Verifying mock method calls
 
 ## 📈 What's Measured
 


### PR DESCRIPTION
## Summary
- Bare relative links on `/docs/benchmarks/` index resolved to `/docs/<Name>` (404) instead of `/docs/benchmarks/<Name>`.
- Switched links to `./<Name>.md` so Docusaurus resolves to the sibling route.
- Updated both generator scripts (`process-benchmarks.js`, `process-mock-benchmarks.js`) and regenerated `index.md` files so CI regenerations keep the fix.

Fixes #5585

## Test plan
- [ ] Verify links on `https://tunit.dev/docs/benchmarks/` point to `/docs/benchmarks/AsyncTests` etc.
- [ ] Verify mock benchmark links at `/docs/benchmarks/mocks/` resolve correctly.