### PR TITLE
docs: replace repeated benchmark link suffix with per-test descriptions

### DIFF
--- a/.github/scripts/process-benchmarks.js
+++ b/.github/scripts/process-benchmarks.js
@@ -6,6 +6,15 @@ const BUILD_DIR = 'benchmark-results/build';
 const OUTPUT_DIR = 'docs/docs/benchmarks';
 const STATIC_DIR = 'docs/static/benchmarks';
 
+const RUNTIME_DESCRIPTIONS = {
+  AsyncTests: 'Realistic async/await patterns with I/O simulation',
+  DataDrivenTests: 'Parameterized tests with multiple data sources',
+  MassiveParallelTests: 'Parallel execution stress tests',
+  MatrixTests: 'Combinatorial test generation and execution',
+  ScaleTests: 'Large test suites (150+ tests) measuring scalability',
+  SetupTeardownTests: 'Expensive test fixtures with setup/teardown overhead',
+};
+
 console.log('🚀 Processing benchmark results...\n');
 
 // Ensure output directories exist
@@ -371,7 +380,7 @@ These benchmarks were automatically generated on **${timestamp}** from the lates
 Click on any benchmark to view detailed results:
 
 ${Object.keys(categories.runtime).map(testClass =>
-  `- [${testClass}](./${testClass}.md) - Detailed performance analysis`
+  `- [${testClass}](./${testClass}.md)${RUNTIME_DESCRIPTIONS[testClass] ? ` — ${RUNTIME_DESCRIPTIONS[testClass]}` : ''}`
 ).join('\n')}
 
 ${Object.keys(categories.build).length > 0 ? `

--- a/docs/docs/benchmarks/index.md
+++ b/docs/docs/benchmarks/index.md
@@ -16,12 +16,12 @@ These benchmarks were automatically generated on **2026-04-17** from the latest 
 
 Click on any benchmark to view detailed results:
 
-- [AsyncTests](./AsyncTests.md) - Detailed performance analysis
-- [DataDrivenTests](./DataDrivenTests.md) - Detailed performance analysis
-- [MassiveParallelTests](./MassiveParallelTests.md) - Detailed performance analysis
-- [MatrixTests](./MatrixTests.md) - Detailed performance analysis
-- [ScaleTests](./ScaleTests.md) - Detailed performance analysis
-- [SetupTeardownTests](./SetupTeardownTests.md) - Detailed performance analysis
+- [AsyncTests](./AsyncTests.md) — Realistic async/await patterns with I/O simulation
+- [DataDrivenTests](./DataDrivenTests.md) — Parameterized tests with multiple data sources
+- [MassiveParallelTests](./MassiveParallelTests.md) — Parallel execution stress tests
+- [MatrixTests](./MatrixTests.md) — Combinatorial test generation and execution
+- [ScaleTests](./ScaleTests.md) — Large test suites (150+ tests) measuring scalability
+- [SetupTeardownTests](./SetupTeardownTests.md) — Expensive test fixtures with setup/teardown overhead
 
 
 ## 🔨 Build Benchmarks


### PR DESCRIPTION
## Summary
- Replace repeated \"Detailed performance analysis\" trailing text on runtime benchmark index with concrete per-benchmark descriptions (matches the Methodology section).
- Centralized in `process-benchmarks.js` so CI regenerations keep the fix.

## Test plan
- [ ] Verify `/docs/benchmarks/` index shows distinct descriptions per benchmark.