### PR TITLE
feat: TUnit0064 analyzer + code fix for direct WebApplicationFactory inheritance

### DIFF
--- a/TUnit.AspNetCore.Analyzers.CodeFixers/TUnit.AspNetCore.Analyzers.CodeFixers.csproj
+++ b/TUnit.AspNetCore.Analyzers.CodeFixers/TUnit.AspNetCore.Analyzers.CodeFixers.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <RootNamespace>TUnit.AspNetCore.Analyzers.CodeFixers</RootNamespace>
+    <AssemblyName>TUnit.AspNetCore.Analyzers.CodeFixers</AssemblyName>
+    <NoWarn>RS2003</NoWarn>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>TUnit.AspNetCore.Analyzers.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Remove="AnalyzerReleases.Unshipped.md" />
+    <AdditionalFiles Remove="AnalyzerReleases.Shipped.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TUnit.AspNetCore.Analyzers\TUnit.AspNetCore.Analyzers.csproj" />
+  </ItemGroup>
+</Project>

--- a/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
+++ b/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
@@ -1,0 +1,104 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using TUnit.AspNetCore.Analyzers;
+
+namespace TUnit.AspNetCore.Analyzers.CodeFixers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseTestWebApplicationFactoryCodeFixProvider)), Shared]
+public class UseTestWebApplicationFactoryCodeFixProvider : CodeFixProvider
+{
+    private const string Title = "Inherit from TestWebApplicationFactory<T>";
+    private const string TestWebApplicationFactoryName = "TestWebApplicationFactory";
+    private const string TestWebApplicationFactoryNamespace = "TUnit.AspNetCore";
+
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create(Rules.DirectWebApplicationFactoryInheritance.Id);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var baseTypeSyntax = root
+                .FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<BaseTypeSyntax>();
+
+            if (baseTypeSyntax is null)
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: c => ReplaceBaseTypeAsync(context.Document, baseTypeSyntax, c),
+                    equivalenceKey: Title),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ReplaceBaseTypeAsync(
+        Document document,
+        BaseTypeSyntax baseTypeSyntax,
+        CancellationToken cancellationToken)
+    {
+        var genericName = baseTypeSyntax.Type switch
+        {
+            GenericNameSyntax g => g,
+            QualifiedNameSyntax { Right: GenericNameSyntax q } => q,
+            AliasQualifiedNameSyntax { Name: GenericNameSyntax a } => a,
+            _ => null,
+        };
+
+        if (genericName is null)
+        {
+            return document;
+        }
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is not CompilationUnitSyntax compilationUnit)
+        {
+            return document;
+        }
+
+        var newTypeName = SyntaxFactory.GenericName(SyntaxFactory.Identifier(TestWebApplicationFactoryName))
+            .WithTypeArgumentList(genericName.TypeArgumentList);
+
+        var newBaseType = baseTypeSyntax.WithType(newTypeName)
+            .WithTriviaFrom(baseTypeSyntax)
+            .WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation);
+
+        var newCompilationUnit = compilationUnit.ReplaceNode(baseTypeSyntax, newBaseType);
+        newCompilationUnit = AddUsingIfMissing(newCompilationUnit, TestWebApplicationFactoryNamespace);
+
+        return document.WithSyntaxRoot(newCompilationUnit);
+    }
+
+    private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax compilationUnit, string namespaceName)
+    {
+        if (compilationUnit.Usings.Any(u => u.Name?.ToString() == namespaceName))
+        {
+            return compilationUnit;
+        }
+
+        var newUsing = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+
+        return compilationUnit.AddUsings(newUsing);
+    }
+}

--- a/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
+++ b/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
@@ -91,7 +91,8 @@ public class UseTestWebApplicationFactoryCodeFixProvider : CodeFixProvider
 
     private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax compilationUnit, string namespaceName)
     {
-        if (compilationUnit.Usings.Any(u => u.Name?.ToString() == namespaceName))
+        if (ContainsUsing(compilationUnit.Usings, namespaceName) ||
+            compilationUnit.Members.Any(m => ContainsUsingInNamespace(m, namespaceName)))
         {
             return compilationUnit;
         }
@@ -100,5 +101,28 @@ public class UseTestWebApplicationFactoryCodeFixProvider : CodeFixProvider
             .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
 
         return compilationUnit.AddUsings(newUsing);
+    }
+
+    private static bool ContainsUsingInNamespace(MemberDeclarationSyntax member, string namespaceName) => member switch
+    {
+        BaseNamespaceDeclarationSyntax ns =>
+            ContainsUsing(ns.Usings, namespaceName) ||
+            ns.Members.Any(m => ContainsUsingInNamespace(m, namespaceName)),
+        _ => false,
+    };
+
+    private static bool ContainsUsing(SyntaxList<UsingDirectiveSyntax> usings, string namespaceName)
+    {
+        foreach (var directive in usings)
+        {
+            if (directive.Alias is null &&
+                directive.StaticKeyword.IsKind(SyntaxKind.None) &&
+                directive.Name?.ToString() == namespaceName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/TUnit.AspNetCore.Analyzers.Tests/DirectWebApplicationFactoryInheritanceAnalyzerTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/DirectWebApplicationFactoryInheritanceAnalyzerTests.cs
@@ -1,0 +1,66 @@
+using Verifier = TUnit.AspNetCore.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<TUnit.AspNetCore.Analyzers.DirectWebApplicationFactoryInheritanceAnalyzer>;
+
+namespace TUnit.AspNetCore.Analyzers.Tests;
+
+public class DirectWebApplicationFactoryInheritanceAnalyzerTests
+{
+    [Test]
+    public async Task Warning_When_Direct_WebApplicationFactory_Inheritance()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+            {
+            }
+            """,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+
+    [Test]
+    public async Task No_Warning_When_Using_TestWebApplicationFactory()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : TUnit.AspNetCore.TestWebApplicationFactory<Program>
+            {
+            }
+            """);
+    }
+
+    [Test]
+    public async Task No_Warning_When_Transitively_Inherits_Via_TestWebApplicationFactory()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class BaseFactory : TUnit.AspNetCore.TestWebApplicationFactory<Program>
+            {
+            }
+
+            public class MyFactory : BaseFactory
+            {
+            }
+            """);
+    }
+
+    [Test]
+    public async Task Warning_On_Base_Type_Location()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class A : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|} { }
+            public class B : {|#1:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|} { }
+            """,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance).WithLocation(0).WithArguments("A"),
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance).WithLocation(1).WithArguments("B"));
+    }
+}

--- a/TUnit.AspNetCore.Analyzers.Tests/DirectWebApplicationFactoryInheritanceAnalyzerTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/DirectWebApplicationFactoryInheritanceAnalyzerTests.cs
@@ -51,6 +51,26 @@ public class DirectWebApplicationFactoryInheritanceAnalyzerTests
     }
 
     [Test]
+    public async Task Warning_Fires_Once_For_Partial_Class()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public partial class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+            {
+            }
+
+            public partial class MyFactory
+            {
+            }
+            """,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+
+    [Test]
     public async Task Warning_On_Base_Type_Location()
     {
         await Verifier.VerifyAnalyzerAsync(

--- a/TUnit.AspNetCore.Analyzers.Tests/TUnit.AspNetCore.Analyzers.Tests.csproj
+++ b/TUnit.AspNetCore.Analyzers.Tests/TUnit.AspNetCore.Analyzers.Tests.csproj
@@ -8,12 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.8.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TUnit.AspNetCore.Analyzers\TUnit.AspNetCore.Analyzers.csproj" />
+    <ProjectReference Include="..\TUnit.AspNetCore.Analyzers.CodeFixers\TUnit.AspNetCore.Analyzers.CodeFixers.csproj" />
     <ProjectReference Include="..\TUnit.Engine\TUnit.Engine.csproj" />
     <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" />
   </ItemGroup>

--- a/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
@@ -7,6 +7,72 @@ namespace TUnit.AspNetCore.Analyzers.Tests;
 public class UseTestWebApplicationFactoryCodeFixProviderTests
 {
     [Test]
+    public async Task Does_Not_Duplicate_Existing_Using()
+    {
+        var source = $$"""
+            using TUnit.AspNetCore;
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+            {
+            }
+            """;
+
+        var fixedSource = $$"""
+            using TUnit.AspNetCore;
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : TestWebApplicationFactory<Program>
+            {
+            }
+            """;
+
+        await Verifier.VerifyCodeFixAsync(
+            source,
+            fixedSource,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+
+    [Test]
+    public async Task Does_Not_Duplicate_Using_When_Imported_Inside_Namespace()
+    {
+        var source = $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            namespace App
+            {
+                using TUnit.AspNetCore;
+
+                public class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+                {
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            namespace App
+            {
+                using TUnit.AspNetCore;
+
+                public class MyFactory : TestWebApplicationFactory<Program>
+                {
+                }
+            }
+            """;
+
+        await Verifier.VerifyCodeFixAsync(
+            source,
+            fixedSource,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+
+    [Test]
     public async Task Rewrites_Base_Type_To_TestWebApplicationFactory()
     {
         var source = $$"""

--- a/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
@@ -73,6 +73,38 @@ public class UseTestWebApplicationFactoryCodeFixProviderTests
     }
 
     [Test]
+    public async Task Does_Not_Duplicate_Using_In_File_Scoped_Namespace()
+    {
+        var source = """
+            namespace App;
+
+            using TUnit.AspNetCore;
+
+            public class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+            {
+            }
+            """;
+
+        var fixedSource = """
+            namespace App;
+
+            using TUnit.AspNetCore;
+
+            public class MyFactory : TestWebApplicationFactory<Program>
+            {
+            }
+            """;
+
+        await Verifier.VerifyCodeFixAsync(
+            source,
+            fixedSource,
+            stubsSource: WebApplicationFactoryStubs.Source,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+
+    [Test]
     public async Task Rewrites_Base_Type_To_TestWebApplicationFactory()
     {
         var source = $$"""

--- a/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/UseTestWebApplicationFactoryCodeFixProviderTests.cs
@@ -1,0 +1,37 @@
+using Verifier = TUnit.AspNetCore.Analyzers.Tests.Verifiers.CSharpCodeFixVerifier<
+    TUnit.AspNetCore.Analyzers.DirectWebApplicationFactoryInheritanceAnalyzer,
+    TUnit.AspNetCore.Analyzers.CodeFixers.UseTestWebApplicationFactoryCodeFixProvider>;
+
+namespace TUnit.AspNetCore.Analyzers.Tests;
+
+public class UseTestWebApplicationFactoryCodeFixProviderTests
+{
+    [Test]
+    public async Task Rewrites_Base_Type_To_TestWebApplicationFactory()
+    {
+        var source = $$"""
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : {|#0:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>|}
+            {
+            }
+            """;
+
+        var fixedSource = $$"""
+            using TUnit.AspNetCore;
+
+            {{WebApplicationFactoryStubs.Source}}
+
+            public class MyFactory : TestWebApplicationFactory<Program>
+            {
+            }
+            """;
+
+        await Verifier.VerifyCodeFixAsync(
+            source,
+            fixedSource,
+            Verifier.Diagnostic(Rules.DirectWebApplicationFactoryInheritance)
+                .WithLocation(0)
+                .WithArguments("MyFactory"));
+    }
+}

--- a/TUnit.AspNetCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+
+namespace TUnit.AspNetCore.Analyzers.Tests.Verifiers;
+
+public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
+{
+    public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, LineEndingNormalizingVerifier>.Diagnostic(descriptor);
+
+    public static async Task VerifyCodeFixAsync(
+        [StringSyntax("c#")] string source,
+        [StringSyntax("c#")] string fixedSource,
+        params DiagnosticResult[] expected)
+    {
+        var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, LineEndingNormalizingVerifier>
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/.editorconfig", SourceText.From("""
+            is_global = true
+            end_of_line = lf
+            """)));
+
+        test.SolutionTransforms.Add((solution, projectId) =>
+        {
+            var project = solution.GetProject(projectId);
+            if (project?.ParseOptions is not CSharpParseOptions parseOptions)
+            {
+                return solution;
+            }
+
+            return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Preview));
+        });
+
+        test.ExpectedDiagnostics.AddRange(expected);
+
+        await test.RunAsync(CancellationToken.None);
+    }
+}

--- a/TUnit.AspNetCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/Verifiers/CSharpCodeFixVerifier.cs
@@ -16,9 +16,16 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
         => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, LineEndingNormalizingVerifier>.Diagnostic(descriptor);
 
+    public static Task VerifyCodeFixAsync(
+        [StringSyntax("c#")] string source,
+        [StringSyntax("c#")] string fixedSource,
+        params DiagnosticResult[] expected)
+        => VerifyCodeFixAsync(source, fixedSource, stubsSource: null, expected);
+
     public static async Task VerifyCodeFixAsync(
         [StringSyntax("c#")] string source,
         [StringSyntax("c#")] string fixedSource,
+        [StringSyntax("c#")] string? stubsSource,
         params DiagnosticResult[] expected)
     {
         var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, LineEndingNormalizingVerifier>
@@ -27,6 +34,12 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
             FixedCode = fixedSource,
             ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
         };
+
+        if (stubsSource is not null)
+        {
+            test.TestState.Sources.Add(stubsSource);
+            test.FixedState.Sources.Add(stubsSource);
+        }
 
         test.TestState.AnalyzerConfigFiles.Add(("/.editorconfig", SourceText.From("""
             is_global = true

--- a/TUnit.AspNetCore.Analyzers.Tests/WebApplicationFactoryStubs.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/WebApplicationFactoryStubs.cs
@@ -1,0 +1,23 @@
+namespace TUnit.AspNetCore.Analyzers.Tests;
+
+internal static class WebApplicationFactoryStubs
+{
+    public const string Source = """
+        namespace Microsoft.AspNetCore.Mvc.Testing
+        {
+            public class WebApplicationFactory<TEntryPoint> where TEntryPoint : class
+            {
+            }
+        }
+
+        namespace TUnit.AspNetCore
+        {
+            public class TestWebApplicationFactory<TEntryPoint> : Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint>
+                where TEntryPoint : class
+            {
+            }
+        }
+
+        public class Program { }
+        """;
+}

--- a/TUnit.AspNetCore.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/TUnit.AspNetCore.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,6 +4,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TUnit0062 | Usage | Error | Factory property accessed before initialization in WebApplicationTest
 TUnit0063 | Usage | Error | GlobalFactory member access breaks test isolation
+TUnit0064 | Usage | Warning | Inherit from TestWebApplicationFactory&lt;T&gt; instead of WebApplicationFactory&lt;T&gt;
 
 ### Removed Rules
 

--- a/TUnit.AspNetCore.Analyzers/DirectWebApplicationFactoryInheritanceAnalyzer.cs
+++ b/TUnit.AspNetCore.Analyzers/DirectWebApplicationFactoryInheritanceAnalyzer.cs
@@ -1,0 +1,93 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TUnit.AspNetCore.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class DirectWebApplicationFactoryInheritanceAnalyzer : ConcurrentDiagnosticAnalyzer
+{
+    private const string WebApplicationFactoryMetadataName = "Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1";
+    private const string TestWebApplicationFactoryMetadataName = "TUnit.AspNetCore.TestWebApplicationFactory`1";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rules.DirectWebApplicationFactoryInheritance);
+
+    protected override void InitializeInternal(AnalysisContext context)
+    {
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var webApplicationFactory = compilationContext.Compilation
+                .GetTypeByMetadataName(WebApplicationFactoryMetadataName);
+
+            if (webApplicationFactory is null)
+            {
+                return;
+            }
+
+            var testWebApplicationFactory = compilationContext.Compilation
+                .GetTypeByMetadataName(TestWebApplicationFactoryMetadataName);
+
+            compilationContext.RegisterSymbolAction(
+                symbolContext => AnalyzeNamedType(symbolContext, webApplicationFactory, testWebApplicationFactory),
+                SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeNamedType(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol webApplicationFactory,
+        INamedTypeSymbol? testWebApplicationFactory)
+    {
+        if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Class, BaseType: { } baseType } type)
+        {
+            return;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(baseType.OriginalDefinition, webApplicationFactory))
+        {
+            return;
+        }
+
+        if (testWebApplicationFactory is not null &&
+            SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, testWebApplicationFactory))
+        {
+            return;
+        }
+
+        var location = GetBaseTypeLocation(type) ?? type.Locations.FirstOrDefault();
+        if (location is null)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rules.DirectWebApplicationFactoryInheritance,
+            location,
+            type.Name));
+    }
+
+    private static Location? GetBaseTypeLocation(INamedTypeSymbol type)
+    {
+        foreach (var syntaxRef in type.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is not TypeDeclarationSyntax typeDeclaration)
+            {
+                continue;
+            }
+
+            var baseList = typeDeclaration.BaseList;
+            if (baseList is null || baseList.Types.Count == 0)
+            {
+                continue;
+            }
+
+            return baseList.Types[0].GetLocation();
+        }
+
+        return null;
+    }
+}

--- a/TUnit.AspNetCore.Analyzers/DirectWebApplicationFactoryInheritanceAnalyzer.cs
+++ b/TUnit.AspNetCore.Analyzers/DirectWebApplicationFactoryInheritanceAnalyzer.cs
@@ -31,6 +31,11 @@ public class DirectWebApplicationFactoryInheritanceAnalyzer : ConcurrentDiagnost
             var testWebApplicationFactory = compilationContext.Compilation
                 .GetTypeByMetadataName(TestWebApplicationFactoryMetadataName);
 
+            if (testWebApplicationFactory is null)
+            {
+                return;
+            }
+
             compilationContext.RegisterSymbolAction(
                 symbolContext => AnalyzeNamedType(symbolContext, webApplicationFactory, testWebApplicationFactory),
                 SymbolKind.NamedType);
@@ -40,7 +45,7 @@ public class DirectWebApplicationFactoryInheritanceAnalyzer : ConcurrentDiagnost
     private static void AnalyzeNamedType(
         SymbolAnalysisContext context,
         INamedTypeSymbol webApplicationFactory,
-        INamedTypeSymbol? testWebApplicationFactory)
+        INamedTypeSymbol testWebApplicationFactory)
     {
         if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Class, BaseType: { } baseType } type)
         {
@@ -52,8 +57,7 @@ public class DirectWebApplicationFactoryInheritanceAnalyzer : ConcurrentDiagnost
             return;
         }
 
-        if (testWebApplicationFactory is not null &&
-            SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, testWebApplicationFactory))
+        if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, testWebApplicationFactory))
         {
             return;
         }

--- a/TUnit.AspNetCore.Analyzers/Resources.Designer.cs
+++ b/TUnit.AspNetCore.Analyzers/Resources.Designer.cs
@@ -108,5 +108,32 @@ namespace TUnit.AspNetCore.Analyzers {
                 return ResourceManager.GetString("TUnit0063Title", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Classes inheriting directly from Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory&lt;T&gt;...
+        /// </summary>
+        internal static string TUnit0064Description {
+            get {
+                return ResourceManager.GetString("TUnit0064Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to '{0}' inherits directly from WebApplicationFactory&lt;T&gt;...
+        /// </summary>
+        internal static string TUnit0064MessageFormat {
+            get {
+                return ResourceManager.GetString("TUnit0064MessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Inherit from TestWebApplicationFactory&lt;T&gt; instead of WebApplicationFactory&lt;T&gt;.
+        /// </summary>
+        internal static string TUnit0064Title {
+            get {
+                return ResourceManager.GetString("TUnit0064Title", resourceCulture);
+            }
+        }
     }
 }

--- a/TUnit.AspNetCore.Analyzers/Resources.resx
+++ b/TUnit.AspNetCore.Analyzers/Resources.resx
@@ -36,4 +36,13 @@
     <data name="TUnit0063Title" xml:space="preserve">
         <value>GlobalFactory member access breaks test isolation</value>
     </data>
+    <data name="TUnit0064Description" xml:space="preserve">
+        <value>Classes inheriting directly from Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory&lt;T&gt; silently lose distributed tracing propagation, per-test logging correlation, and TestContext.Current resolution inside request handlers. Inherit from TUnit.AspNetCore.TestWebApplicationFactory&lt;T&gt; (or wrap an existing factory with TracedWebApplicationFactory&lt;T&gt;) to restore these behaviours.</value>
+    </data>
+    <data name="TUnit0064MessageFormat" xml:space="preserve">
+        <value>'{0}' inherits directly from WebApplicationFactory&lt;T&gt;. Inherit from TestWebApplicationFactory&lt;T&gt; to preserve tracing, log correlation, and TestContext.Current.</value>
+    </data>
+    <data name="TUnit0064Title" xml:space="preserve">
+        <value>Inherit from TestWebApplicationFactory&lt;T&gt; instead of WebApplicationFactory&lt;T&gt;</value>
+    </data>
 </root>

--- a/TUnit.AspNetCore.Analyzers/Rules.cs
+++ b/TUnit.AspNetCore.Analyzers/Rules.cs
@@ -12,7 +12,18 @@ public static class Rules
     public static readonly DiagnosticDescriptor GlobalFactoryMemberAccess =
         CreateDescriptor("TUnit0063", UsageCategory, DiagnosticSeverity.Error);
 
-    private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity)
+    public static readonly DiagnosticDescriptor DirectWebApplicationFactoryInheritance =
+        CreateDescriptor(
+            "TUnit0064",
+            UsageCategory,
+            DiagnosticSeverity.Warning,
+            helpLinkUri: "https://tunit.dev/docs/guides/distributed-tracing");
+
+    private static DiagnosticDescriptor CreateDescriptor(
+        string diagnosticId,
+        string category,
+        DiagnosticSeverity severity,
+        string? helpLinkUri = null)
     {
         return new DiagnosticDescriptor(
             id: diagnosticId,
@@ -24,7 +35,8 @@ public static class Rules
             defaultSeverity: severity,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(diagnosticId + "Description", Resources.ResourceManager,
-                typeof(Resources))
+                typeof(Resources)),
+            helpLinkUri: helpLinkUri
         );
     }
 }

--- a/TUnit.AspNetCore.Core/TUnit.AspNetCore.Core.csproj
+++ b/TUnit.AspNetCore.Core/TUnit.AspNetCore.Core.csproj
@@ -36,6 +36,8 @@
   <ItemGroup>
     <ProjectReference Include="..\TUnit.AspNetCore.Analyzers\TUnit.AspNetCore.Analyzers.csproj" OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\TUnit.AspNetCore.Analyzers.CodeFixers\TUnit.AspNetCore.Analyzers.CodeFixers.csproj" OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Pack AspNetCore Analyzers for different Roslyn versions -->
@@ -51,6 +53,10 @@
     <None
       Include="$(MSBuildProjectDirectory)\..\TUnit.AspNetCore.Analyzers.Roslyn414\bin\$(Configuration)\netstandard2.0\TUnit.AspNetCore.Analyzers.dll"
       Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs" Visible="false" />
+
+    <None
+      Include="$(MSBuildProjectDirectory)\..\TUnit.AspNetCore.Analyzers.CodeFixers\bin\$(Configuration)\netstandard2.0\TUnit.AspNetCore.Analyzers.CodeFixers.dll"
+      Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <Import Project="..\Library.targets" />

--- a/TUnit.CI.slnx
+++ b/TUnit.CI.slnx
@@ -36,6 +36,7 @@
     <Project Path="TUnit.Analyzers.Roslyn44/TUnit.Analyzers.Roslyn44.csproj" />
     <Project Path="TUnit.Analyzers.Roslyn47/TUnit.Analyzers.Roslyn47.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers/TUnit.AspNetCore.Analyzers.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.CodeFixers/TUnit.AspNetCore.Analyzers.CodeFixers.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn414/TUnit.AspNetCore.Analyzers.Roslyn414.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn44/TUnit.AspNetCore.Analyzers.Roslyn44.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn47/TUnit.AspNetCore.Analyzers.Roslyn47.csproj" />

--- a/TUnit.Dev.slnx
+++ b/TUnit.Dev.slnx
@@ -33,6 +33,7 @@
     <Project Path="TUnit.Analyzers/TUnit.Analyzers.csproj" />
     <Project Path="TUnit.Analyzers.CodeFixers/TUnit.Analyzers.CodeFixers.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers/TUnit.AspNetCore.Analyzers.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.CodeFixers/TUnit.AspNetCore.Analyzers.CodeFixers.csproj" />
     <Project Path="TUnit.Assertions.Analyzers/TUnit.Assertions.Analyzers.csproj" />
     <Project Path="TUnit.Assertions.Analyzers.CodeFixers/TUnit.Assertions.Analyzers.CodeFixers.csproj" />
     <Project Path="TUnit.Mocks.Analyzers/TUnit.Mocks.Analyzers.csproj" />

--- a/TUnit.slnx
+++ b/TUnit.slnx
@@ -36,6 +36,7 @@
     <Project Path="TUnit.Analyzers.Roslyn44/TUnit.Analyzers.Roslyn44.csproj" />
     <Project Path="TUnit.Analyzers.Roslyn47/TUnit.Analyzers.Roslyn47.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers/TUnit.AspNetCore.Analyzers.csproj" />
+    <Project Path="TUnit.AspNetCore.Analyzers.CodeFixers/TUnit.AspNetCore.Analyzers.CodeFixers.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn414/TUnit.AspNetCore.Analyzers.Roslyn414.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn44/TUnit.AspNetCore.Analyzers.Roslyn44.csproj" />
     <Project Path="TUnit.AspNetCore.Analyzers.Roslyn47/TUnit.AspNetCore.Analyzers.Roslyn47.csproj" />

--- a/docs/docs/examples/aspnet.md
+++ b/docs/docs/examples/aspnet.md
@@ -16,6 +16,8 @@ var traced = new TracedWebApplicationFactory<Program>(myExistingFactory);
 var client = traced.CreateClient(); // tracing + logging now wired up
 ```
 
+The `TUnit0064` analyzer (warning) flags direct `WebApplicationFactory<T>` inheritance and offers a code fix that rewrites the base type to `TestWebApplicationFactory<T>`.
+
 See [Distributed Tracing](/docs/guides/distributed-tracing) for what happens under the hood.
 :::
 

--- a/docs/docs/guides/distributed-tracing.md
+++ b/docs/docs/guides/distributed-tracing.md
@@ -129,7 +129,7 @@ Some libraries (message brokers like DotPulsar, EF providers, connection pools) 
 
 The vanilla `WebApplicationFactory<T>` returns an `HttpClient` that skips .NET's HTTP tracing. No `traceparent` is injected and the server starts a fresh trace.
 
-Use [`TestWebApplicationFactory<T>`](/docs/examples/aspnet) or wrap with `TracedWebApplicationFactory<T>`.
+Use [`TestWebApplicationFactory<T>`](/docs/examples/aspnet) or wrap with `TracedWebApplicationFactory<T>`. The `TUnit0064` analyzer raises a warning (with a code fix) when a class inherits directly from `WebApplicationFactory<T>`.
 
 ### `IHttpClientFactory` clients in the SUT
 


### PR DESCRIPTION
## Summary

- New analyzer `TUnit0064` (Warning) — flags classes directly inheriting `Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<T>` instead of `TUnit.AspNetCore.TestWebApplicationFactory<T>`.
- New code fix — rewrites the base type to `TestWebApplicationFactory<T>` and adds `using TUnit.AspNetCore;`.
- New `TUnit.AspNetCore.Analyzers.CodeFixers` project, bundled into the `TUnit.AspNetCore` nupkg.
- Docs updated in `examples/aspnet.md` and `guides/distributed-tracing.md`.

Closes #5596.

## Details

Direct inheritance silently loses:

- **Distributed tracing** — server-side spans no longer link back to the triggering test.
- **Per-test logging** — `ILogger` output from inside the app isn't routed to the right test output.
- **Test context** — `TestContext.Current` won't resolve inside request handlers.

The analyzer reports on the base type location (not the class identifier) so the squiggle sits where the offending inheritance is declared. It ignores `TestWebApplicationFactory<T>` itself. Transitive cases (class inherits a user type that inherits `TestWebApplicationFactory<T>`) are implicitly safe: the direct base isn't `WebApplicationFactory`, so the analyzer exits early.

## Test plan

- [x] Analyzer warns on direct inheritance
- [x] No warning when using `TestWebApplicationFactory<T>`
- [x] No warning on transitive `TestWebApplicationFactory<T>` inheritance
- [x] Diagnostic reports at base-type location (not class identifier)
- [x] Code fix rewrites base type and adds `using TUnit.AspNetCore;`
- [x] Verified codefix DLL is bundled at `analyzers/dotnet/cs/` in the `TUnit.AspNetCore` nupkg
- [x] 21/21 analyzer tests pass (net9.0)