### PR TITLE
feat: TUnit.OpenTelemetry zero-config tracing package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,6 +65,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,6 +66,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />

--- a/TUnit.Aspire.Tests/TestTraceExporterTests.cs
+++ b/TUnit.Aspire.Tests/TestTraceExporterTests.cs
@@ -57,41 +57,6 @@ public class TestTraceExporterTests
     }
 
     [Test]
-    public async Task CreateTracerProvider_ExportsTracesForRegisteredSource()
-    {
-        await using var server = new OtlpTraceCaptureServer();
-        server.Start();
-
-        // Per-test ActivitySource name keeps spans isolated from any other test or production
-        // listener, so this test stays parallel-safe even though OpenTelemetry exporters are
-        // process-wide.
-        var sourceName = $"TUnit.Tests.{Guid.NewGuid():N}";
-        var endpoint = new Uri($"http://127.0.0.1:{server.Port}");
-
-        using (var activitySource = new ActivitySource(sourceName))
-        using (var provider = TestTraceExporter.CreateTracerProvider(
-            endpoint, GetCurrentSessionContext(), sourceName))
-        {
-            using var testCase = activitySource.StartActivity("test case", ActivityKind.Internal);
-            using var testBody = activitySource.StartActivity("test body", ActivityKind.Internal);
-
-            await Assert.That(testCase).IsNotNull();
-            await Assert.That(testBody).IsNotNull();
-
-            testBody?.Stop();
-            testCase?.Stop();
-        }
-        // Disposing the provider flushes pending spans to the exporter.
-
-        var request = await server.WaitForRequestAsync("/v1/traces");
-        var body = Encoding.UTF8.GetString(request.Body);
-
-        await Assert.That(body).Contains("test case");
-        await Assert.That(body).Contains("test body");
-        await Assert.That(body).Contains(typeof(TestTraceExporterTests).Assembly.GetName().Name!);
-    }
-
-    [Test]
     public async Task GetTracesEndpoint_AppendsSignalPathWithoutDroppingBasePath()
     {
         var endpoint = new Uri("http://127.0.0.1:5341/ingest/otlp");

--- a/TUnit.Aspire.Tests/TestTraceExporterTests.cs
+++ b/TUnit.Aspire.Tests/TestTraceExporterTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Text;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using TUnit.Aspire.Telemetry;
 using TUnit.Aspire.Tests.Helpers;
 using TUnit.Assertions;
@@ -27,6 +29,31 @@ public class TestTraceExporterTests
     {
         await Assert.That(TestTraceExporter.TryParseDashboardEndpoint("http://127.0.0.1:4317"))
             .IsEqualTo(new Uri("http://127.0.0.1:4317"));
+    }
+
+    [Test]
+    public async Task AddToBuilder_ExportsTracesForRegisteredSource()
+    {
+        await using var server = new OtlpTraceCaptureServer();
+        server.Start();
+
+        var sourceName = $"TUnit.Tests.{Guid.NewGuid():N}";
+        var endpoint = new Uri($"http://127.0.0.1:{server.Port}");
+
+        var builder = Sdk.CreateTracerProviderBuilder().AddSource(sourceName);
+        TestTraceExporter.AddToBuilder(builder, GetCurrentSessionContext(), endpoint);
+
+        using (var activitySource = new ActivitySource(sourceName))
+        using (var provider = builder.Build())
+        {
+            using var testCase = activitySource.StartActivity("add-to-builder case", ActivityKind.Internal);
+            testCase?.Stop();
+        }
+
+        var request = await server.WaitForRequestAsync("/v1/traces");
+        var body = Encoding.UTF8.GetString(request.Body);
+
+        await Assert.That(body).Contains("add-to-builder case");
     }
 
     [Test]

--- a/TUnit.Aspire/AspireTelemetryHooks.cs
+++ b/TUnit.Aspire/AspireTelemetryHooks.cs
@@ -1,23 +1,26 @@
 using TUnit.Aspire.Telemetry;
 using TUnit.Core;
+using TUnit.OpenTelemetry;
 
 namespace TUnit.Aspire;
 
 /// <summary>
-/// Starts and stops the Aspire runner trace exporter for the current test session.
-/// This keeps per-test TUnit spans visible in external OTLP backends alongside SUT spans.
+/// Registers a Configure callback on <see cref="TUnitOpenTelemetry"/> so that the shared
+/// auto-wired TracerProvider exports spans to the Aspire dashboard's OTLP endpoint when
+/// <c>DOTNET_DASHBOARD_OTLP_ENDPOINT_URL</c> is present.
 /// </summary>
 public static class AspireTelemetryHooks
 {
-    [Before(HookType.TestSession, Order = int.MaxValue)]
-    public static void StartRunnerTraceExport(TestSessionContext context)
+    [Before(HookType.TestDiscovery, Order = AutoStart.AutoStartOrder - 1)]
+    public static void RegisterAspireExporter(TestSessionContext context)
     {
-        TestTraceExporter.TryStart(context);
-    }
+        var endpoint = TestTraceExporter.TryGetDashboardEndpoint();
+        if (endpoint is null)
+        {
+            return;
+        }
 
-    [After(HookType.TestSession, Order = int.MaxValue)]
-    public static void StopRunnerTraceExport()
-    {
-        TestTraceExporter.Stop();
+        TUnitOpenTelemetry.Configure(builder =>
+            TestTraceExporter.AddToBuilder(builder, context, endpoint));
     }
 }

--- a/TUnit.Aspire/TUnit.Aspire.csproj
+++ b/TUnit.Aspire/TUnit.Aspire.csproj
@@ -17,11 +17,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TUnit\TUnit.csproj" />
+    <ProjectReference Include="..\TUnit.OpenTelemetry\TUnit.OpenTelemetry.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TUnit.Aspire/Telemetry/TestTraceExporter.cs
+++ b/TUnit.Aspire/Telemetry/TestTraceExporter.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
@@ -8,86 +7,39 @@ using TUnit.Core;
 namespace TUnit.Aspire.Telemetry;
 
 /// <summary>
-/// Exports TUnit's per-test spans to the same OTLP backend used by the Aspire dashboard.
-/// This keeps backend trace trees navigable without requiring users to configure a separate
-/// tracer provider in their test project.
+/// Helpers that wire the Aspire dashboard's OTLP endpoint into a
+/// <see cref="TracerProviderBuilder"/>. The provider itself is owned by
+/// <c>TUnit.OpenTelemetry.AutoStart</c>; this class only contributes configuration.
 /// </summary>
 internal static class TestTraceExporter
 {
     private const string DashboardOtlpEndpointEnvVar = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
-    private const string TUnitSourceName = "TUnit";
     private const string DefaultServiceName = "TUnit.Tests";
 
-    private static readonly Lock SyncLock = new();
-    private static TracerProvider? _tracerProvider;
+    internal static Uri? TryGetDashboardEndpoint()
+        => TryParseDashboardEndpoint(Environment.GetEnvironmentVariable(DashboardOtlpEndpointEnvVar));
 
-    internal static bool IsStarted
+    internal static void AddToBuilder(TracerProviderBuilder builder, TestSessionContext context, Uri endpoint)
     {
-        get
-        {
-            lock (SyncLock)
-            {
-                return _tracerProvider is not null;
-            }
-        }
-    }
-
-    internal static void TryStart(TestSessionContext context)
-    {
-        var endpoint = TryParseDashboardEndpoint(
-            Environment.GetEnvironmentVariable(DashboardOtlpEndpointEnvVar));
-
-        if (endpoint is null)
-        {
-            return;
-        }
-
-        lock (SyncLock)
-        {
-            if (_tracerProvider is not null)
-            {
-                return;
-            }
-
-            _tracerProvider = CreateTracerProvider(endpoint, context, TUnitSourceName);
-        }
-    }
-
-    /// <summary>
-    /// Builds a standalone <see cref="TracerProvider"/> for the given endpoint and session.
-    /// Caller owns disposal. Used by <see cref="TryStart"/> for the singleton case and by
-    /// tests that need an isolated provider (parallel-safe — no static state touched).
-    /// </summary>
-    internal static TracerProvider CreateTracerProvider(
-        Uri endpoint, TestSessionContext context, string sourceName)
-    {
-        return Sdk.CreateTracerProviderBuilder()
+        builder
             .SetResourceBuilder(CreateResourceBuilder(context))
-            .AddSource(sourceName)
             .AddOtlpExporter(options =>
             {
                 options.Endpoint = GetTracesEndpoint(endpoint);
                 options.Protocol = OtlpExportProtocol.HttpProtobuf;
-            })
-            .Build();
+            });
     }
 
-    internal static void Stop()
+    /// <summary>
+    /// Kept for tests that need a standalone provider bound to a captured OTLP endpoint.
+    /// Not used by the production code path — <see cref="AddToBuilder"/> is.
+    /// </summary>
+    internal static TracerProvider CreateTracerProvider(
+        Uri endpoint, TestSessionContext context, string sourceName)
     {
-        TracerProvider? providerToDispose = null;
-
-        lock (SyncLock)
-        {
-            if (_tracerProvider is null)
-            {
-                return;
-            }
-
-            providerToDispose = _tracerProvider;
-            _tracerProvider = null;
-        }
-
-        providerToDispose.Dispose();
+        var builder = Sdk.CreateTracerProviderBuilder().AddSource(sourceName);
+        AddToBuilder(builder, context, endpoint);
+        return builder.Build();
     }
 
     internal static Uri? TryParseDashboardEndpoint(string? value)

--- a/TUnit.Aspire/Telemetry/TestTraceExporter.cs
+++ b/TUnit.Aspire/Telemetry/TestTraceExporter.cs
@@ -31,8 +31,8 @@ internal static class TestTraceExporter
     }
 
     /// <summary>
-    /// Kept for tests that need a standalone provider bound to a captured OTLP endpoint.
-    /// Not used by the production code path — <see cref="AddToBuilder"/> is.
+    /// Builds a standalone <see cref="TracerProvider"/> bound to the captured OTLP endpoint.
+    /// Used by test-only code paths that need an owned provider; production uses <see cref="AddToBuilder"/>.
     /// </summary>
     internal static TracerProvider CreateTracerProvider(
         Uri endpoint, TestSessionContext context, string sourceName)

--- a/TUnit.Aspire/Telemetry/TestTraceExporter.cs
+++ b/TUnit.Aspire/Telemetry/TestTraceExporter.cs
@@ -30,18 +30,6 @@ internal static class TestTraceExporter
             });
     }
 
-    /// <summary>
-    /// Builds a standalone <see cref="TracerProvider"/> bound to the captured OTLP endpoint.
-    /// Used by test-only code paths that need an owned provider; production uses <see cref="AddToBuilder"/>.
-    /// </summary>
-    internal static TracerProvider CreateTracerProvider(
-        Uri endpoint, TestSessionContext context, string sourceName)
-    {
-        var builder = Sdk.CreateTracerProviderBuilder().AddSource(sourceName);
-        AddToBuilder(builder, context, endpoint);
-        return builder.Build();
-    }
-
     internal static Uri? TryParseDashboardEndpoint(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/TUnit.CI.slnx
+++ b/TUnit.CI.slnx
@@ -17,6 +17,7 @@
   <!-- Extension libraries and integrations -->
   <Folder Name="/Libraries/">
     <Project Path="TUnit.Aspire/TUnit.Aspire.csproj" />
+    <Project Path="TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj" />
     <Project Path="TUnit.AspNetCore/TUnit.AspNetCore.csproj" />
     <Project Path="TUnit.AspNetCore.Core/TUnit.AspNetCore.Core.csproj" />
     <Project Path="TUnit.FsCheck/TUnit.FsCheck.csproj" />

--- a/TUnit.CI.slnx
+++ b/TUnit.CI.slnx
@@ -80,6 +80,7 @@
     <Project Path="TUnit.Aspire.Tests/TUnit.Aspire.Tests.csproj" />
     <Project Path="TUnit.Aspire.Tests.AppHost/TUnit.Aspire.Tests.AppHost.csproj" />
     <Project Path="TUnit.Aspire.Tests.ApiService/TUnit.Aspire.Tests.ApiService.csproj" />
+    <Project Path="TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.WebApp/TUnit.AspNetCore.Tests.WebApp.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj" />

--- a/TUnit.Dev.slnx
+++ b/TUnit.Dev.slnx
@@ -17,6 +17,7 @@
   <!-- Extension libraries and integrations -->
   <Folder Name="/Libraries/">
     <Project Path="TUnit.Aspire/TUnit.Aspire.csproj" />
+    <Project Path="TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj" />
     <Project Path="TUnit.AspNetCore/TUnit.AspNetCore.csproj" />
     <Project Path="TUnit.AspNetCore.Core/TUnit.AspNetCore.Core.csproj" />
     <Project Path="TUnit.FsCheck/TUnit.FsCheck.csproj" />

--- a/TUnit.Dev.slnx
+++ b/TUnit.Dev.slnx
@@ -61,6 +61,7 @@
     <Project Path="TUnit.Mocks.Logging.Tests/TUnit.Mocks.Logging.Tests.csproj" />
     <Project Path="TUnit.Mocks.SourceGenerator.Tests/TUnit.Mocks.SourceGenerator.Tests.csproj" />
     <Project Path="TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj" />
+    <Project Path="TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj" />
     <Project Path="TUnit.PublicAPI/TUnit.PublicAPI.csproj" />
     <Project Path="TUnit.RpcTests/TUnit.RpcTests.csproj" />
     <Project Path="TUnit.UnitTests/TUnit.UnitTests.csproj" />

--- a/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
+++ b/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.OpenTelemetry.Tests;
+
+[NotInParallel("TUnitOpenTelemetryGlobalState")] // these tests mutate process-wide AutoStart + env vars + TUnitOpenTelemetry configurators
+public class AutoStartTests
+{
+    [Test]
+    public async Task AutoStart_RegistersListenerForTUnitSource()
+    {
+        // AutoStart.Start fires via [Before(TestDiscovery)] before this test runs.
+        using var source = new ActivitySource("TUnit");
+        await Assert.That(source.HasListeners()).IsTrue();
+    }
+
+    [Test]
+    public async Task AutoStart_SkipsIfUserAlreadyAttachedListener()
+    {
+        AutoStart.Stop();
+
+        using var userListener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "TUnit",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(userListener);
+
+        AutoStart.StartForTesting(resetFirst: true);
+        try
+        {
+            await Assert.That(AutoStart.HasProviderForTesting).IsFalse();
+        }
+        finally
+        {
+            // Leave AutoStart re-armed for subsequent tests (in this class and the runner
+            // at large) since the session-level AutoStart already disposed once.
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
+
+    [Test]
+    public async Task AutoStart_ForceOn_BuildsEvenWhenListenerPresent()
+    {
+        var original = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+        try
+        {
+            using var userListener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == "TUnit",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            };
+            ActivitySource.AddActivityListener(userListener);
+
+            TUnitOpenTelemetry.ResetForTests();
+            TUnitOpenTelemetry.Configure(b => b.AddInMemoryExporter(new List<Activity>()));
+
+            AutoStart.StartForTesting(resetFirst: true);
+            await Assert.That(AutoStart.HasProviderForTesting).IsTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", original);
+            TUnitOpenTelemetry.ResetForTests();
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
+}

--- a/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
+++ b/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
@@ -108,4 +108,32 @@ public class AutoStartTests
             AutoStart.StartForTesting(resetFirst: true);
         }
     }
+
+    [Test]
+    public async Task Start_SetsDefaultServiceName()
+    {
+        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+        TUnitOpenTelemetry.ResetForTests();
+        TUnitOpenTelemetry.Configure(b => b.AddInMemoryExporter(new List<Activity>()));
+        try
+        {
+            AutoStart.StartForTesting(resetFirst: true);
+
+            var resource = AutoStart.GetResourceForTesting();
+            await Assert.That(resource).IsNotNull();
+            var serviceNameAttr = resource!.Attributes.FirstOrDefault(a => a.Key == "service.name");
+            await Assert.That(serviceNameAttr.Key).IsEqualTo("service.name");
+            var serviceName = serviceNameAttr.Value?.ToString();
+            // Not the OTel default placeholder ("unknown_service" or "unknown_service:<process>")
+            await Assert.That(serviceName).IsNotNull();
+            await Assert.That(serviceName!.StartsWith("unknown_service", StringComparison.Ordinal)).IsFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            TUnitOpenTelemetry.ResetForTests();
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
 }

--- a/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
+++ b/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
@@ -71,6 +71,27 @@ public class AutoStartTests
     }
 
     [Test]
+    public async Task Start_NoEndpointNoConfig_DoesNotBuildProvider()
+    {
+        var endpointOriginal = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
+        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", null);
+        TUnitOpenTelemetry.ResetForTests();
+        try
+        {
+            AutoStart.StartForTesting(resetFirst: true);
+            await Assert.That(AutoStart.HasProviderForTesting).IsFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", endpointOriginal);
+            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
+
+    [Test]
     public async Task Start_WithOptOutEnv_DoesNotBuildProvider()
     {
         var original = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");

--- a/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
+++ b/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
@@ -69,4 +69,22 @@ public class AutoStartTests
             AutoStart.StartForTesting(resetFirst: true);
         }
     }
+
+    [Test]
+    public async Task Start_WithOptOutEnv_DoesNotBuildProvider()
+    {
+        var original = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "0");
+        try
+        {
+            AutoStart.StartForTesting(resetFirst: true);
+            await Assert.That(AutoStart.HasProviderForTesting).IsFalse();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", original);
+            // Re-arm for subsequent tests in the runner
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
 }

--- a/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
+++ b/TUnit.OpenTelemetry.Tests/AutoStartTests.cs
@@ -45,8 +45,8 @@ public class AutoStartTests
     [Test]
     public async Task AutoStart_ForceOn_BuildsEvenWhenListenerPresent()
     {
-        var original = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
-        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+        var original = Environment.GetEnvironmentVariable(AutoStart.AutoStartEnvVar);
+        Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, "1");
         try
         {
             using var userListener = new ActivityListener
@@ -64,7 +64,7 @@ public class AutoStartTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", original);
+            Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, original);
             TUnitOpenTelemetry.ResetForTests();
             AutoStart.StartForTesting(resetFirst: true);
         }
@@ -73,10 +73,10 @@ public class AutoStartTests
     [Test]
     public async Task Start_NoEndpointNoConfig_DoesNotBuildProvider()
     {
-        var endpointOriginal = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
-        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
-        Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
-        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", null);
+        var endpointOriginal = Environment.GetEnvironmentVariable(AutoStart.OtlpEndpointEnvVar);
+        var autostartOriginal = Environment.GetEnvironmentVariable(AutoStart.AutoStartEnvVar);
+        Environment.SetEnvironmentVariable(AutoStart.OtlpEndpointEnvVar, null);
+        Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, null);
         TUnitOpenTelemetry.ResetForTests();
         try
         {
@@ -85,8 +85,8 @@ public class AutoStartTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", endpointOriginal);
-            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            Environment.SetEnvironmentVariable(AutoStart.OtlpEndpointEnvVar, endpointOriginal);
+            Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, autostartOriginal);
             AutoStart.StartForTesting(resetFirst: true);
         }
     }
@@ -94,8 +94,8 @@ public class AutoStartTests
     [Test]
     public async Task Start_WithOptOutEnv_DoesNotBuildProvider()
     {
-        var original = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
-        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "0");
+        var original = Environment.GetEnvironmentVariable(AutoStart.AutoStartEnvVar);
+        Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, "0");
         try
         {
             AutoStart.StartForTesting(resetFirst: true);
@@ -103,7 +103,7 @@ public class AutoStartTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", original);
+            Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, original);
             // Re-arm for subsequent tests in the runner
             AutoStart.StartForTesting(resetFirst: true);
         }
@@ -112,8 +112,8 @@ public class AutoStartTests
     [Test]
     public async Task Start_SetsDefaultServiceName()
     {
-        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
-        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+        var autostartOriginal = Environment.GetEnvironmentVariable(AutoStart.AutoStartEnvVar);
+        Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, "1");
         TUnitOpenTelemetry.ResetForTests();
         TUnitOpenTelemetry.Configure(b => b.AddInMemoryExporter(new List<Activity>()));
         try
@@ -131,7 +131,7 @@ public class AutoStartTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, autostartOriginal);
             TUnitOpenTelemetry.ResetForTests();
             AutoStart.StartForTesting(resetFirst: true);
         }

--- a/TUnit.OpenTelemetry.Tests/ConfigureTests.cs
+++ b/TUnit.OpenTelemetry.Tests/ConfigureTests.cs
@@ -1,0 +1,40 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.OpenTelemetry.Tests;
+
+public class ConfigureTests
+{
+    [Test]
+    public async Task Configure_StoresUserCallback()
+    {
+        TUnitOpenTelemetry.ResetForTests();
+        var called = false;
+        TUnitOpenTelemetry.Configure(_ => called = true);
+
+        TUnitOpenTelemetry.ApplyConfiguration(Sdk.CreateTracerProviderBuilder());
+
+        await Assert.That(called).IsTrue();
+    }
+
+    [Test]
+    public async Task Configure_MultipleCalls_AllInvoked()
+    {
+        TUnitOpenTelemetry.ResetForTests();
+        var count = 0;
+        TUnitOpenTelemetry.Configure(_ => count++);
+        TUnitOpenTelemetry.Configure(_ => count++);
+
+        TUnitOpenTelemetry.ApplyConfiguration(Sdk.CreateTracerProviderBuilder());
+
+        await Assert.That(count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Configure_NullCallback_Throws()
+    {
+        await Assert.That(() => TUnitOpenTelemetry.Configure(null!)).Throws<ArgumentNullException>();
+    }
+}

--- a/TUnit.OpenTelemetry.Tests/ConfigureTests.cs
+++ b/TUnit.OpenTelemetry.Tests/ConfigureTests.cs
@@ -5,6 +5,7 @@ using TUnit.Assertions.Extensions;
 
 namespace TUnit.OpenTelemetry.Tests;
 
+[NotInParallel("TUnitOpenTelemetryGlobalState")] // mutates TUnitOpenTelemetry._configurators, which AutoStartTests also touches
 public class ConfigureTests
 {
     [Test]

--- a/TUnit.OpenTelemetry.Tests/CorrelationProcessorTests.cs
+++ b/TUnit.OpenTelemetry.Tests/CorrelationProcessorTests.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.OpenTelemetry.Tests;
+
+public class CorrelationProcessorTests
+{
+    [Test]
+    public async Task Processor_CopiesBaggageToTag()
+    {
+        using var listener = AttachPermissiveListener("CorrelationProcessorTests.Copies");
+        var processor = new TUnitTestCorrelationProcessor();
+
+        using var parent = new Activity("parent").Start();
+        parent.AddBaggage("tunit.test.id", "test-123");
+
+        using var child = new ActivitySource("CorrelationProcessorTests.Copies").StartActivity("child")!;
+        processor.OnStart(child);
+
+        await Assert.That(child.GetTagItem("tunit.test.id")).IsEqualTo("test-123");
+    }
+
+    [Test]
+    public async Task Processor_SkipsWhenAlreadyTagged()
+    {
+        using var listener = AttachPermissiveListener("CorrelationProcessorTests.Skips");
+        var processor = new TUnitTestCorrelationProcessor();
+
+        using var parent = new Activity("parent").Start();
+        parent.AddBaggage("tunit.test.id", "from-baggage");
+
+        using var child = new ActivitySource("CorrelationProcessorTests.Skips").StartActivity("child")!;
+        child.SetTag("tunit.test.id", "already-set");
+        processor.OnStart(child);
+
+        await Assert.That(child.GetTagItem("tunit.test.id")).IsEqualTo("already-set");
+    }
+
+    [Test]
+    public async Task Processor_NoOp_WhenNoBaggage()
+    {
+        using var listener = AttachPermissiveListener("CorrelationProcessorTests.NoBaggage");
+        var processor = new TUnitTestCorrelationProcessor();
+
+        // Suppress the ambient Activity.Current (which the TUnit test runner has set with
+        // tunit.test.id baggage) so we can exercise the "no baggage" code path in isolation.
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            using var child = new ActivitySource("CorrelationProcessorTests.NoBaggage").StartActivity("child")!;
+            processor.OnStart(child);
+
+            await Assert.That(child.GetTagItem("tunit.test.id")).IsNull();
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    private static ActivityListener AttachPermissiveListener(string sourceName)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/TUnit.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/TUnit.OpenTelemetry.Tests/EndToEndTests.cs
@@ -12,10 +12,10 @@ public class EndToEndTests
     [Test]
     public async Task TUnitSource_Spans_AreExported()
     {
-        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        var autostartOriginal = Environment.GetEnvironmentVariable(AutoStart.AutoStartEnvVar);
         // Force-build the provider even if a prior listener is still attached so the
         // InMemory exporter is guaranteed to receive our spans.
-        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+        Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, "1");
 
         var spans = new List<Activity>();
         TUnitOpenTelemetry.ResetForTests();
@@ -43,7 +43,7 @@ public class EndToEndTests
         finally
         {
             Activity.Current = previous;
-            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            Environment.SetEnvironmentVariable(AutoStart.AutoStartEnvVar, autostartOriginal);
             // Re-arm for subsequent tests in this class and the runner at large.
             TUnitOpenTelemetry.ResetForTests();
             AutoStart.StartForTesting(resetFirst: true);

--- a/TUnit.OpenTelemetry.Tests/EndToEndTests.cs
+++ b/TUnit.OpenTelemetry.Tests/EndToEndTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.OpenTelemetry.Tests;
+
+[NotInParallel("TUnitOpenTelemetryGlobalState")] // mutates process-wide AutoStart + TUnitOpenTelemetry configurators
+public class EndToEndTests
+{
+    [Test]
+    public async Task TUnitSource_Spans_AreExported()
+    {
+        var autostartOriginal = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        // Force-build the provider even if a prior listener is still attached so the
+        // InMemory exporter is guaranteed to receive our spans.
+        Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", "1");
+
+        var spans = new List<Activity>();
+        TUnitOpenTelemetry.ResetForTests();
+        TUnitOpenTelemetry.Configure(b => b.AddInMemoryExporter(spans));
+        AutoStart.StartForTesting(resetFirst: true);
+
+        // Suppress the ambient Activity.Current (the TUnit runner sets tunit.test.id baggage
+        // on it) so the child span we create is independent of the outer test context.
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            using (var source = new ActivitySource("TUnit"))
+            using (var activity = source.StartActivity("e2e-probe"))
+            {
+                activity?.SetTag("probe", "value");
+            }
+
+            AutoStart.Stop();
+
+            var probe = spans.Single(s => s.OperationName == "e2e-probe");
+            var probeTag = probe.TagObjects.FirstOrDefault(t => t.Key == "probe").Value?.ToString();
+            await Assert.That(probeTag).IsEqualTo("value");
+        }
+        finally
+        {
+            Activity.Current = previous;
+            Environment.SetEnvironmentVariable("TUNIT_OTEL_AUTOSTART", autostartOriginal);
+            // Re-arm for subsequent tests in this class and the runner at large.
+            TUnitOpenTelemetry.ResetForTests();
+            AutoStart.StartForTesting(resetFirst: true);
+        }
+    }
+}

--- a/TUnit.OpenTelemetry.Tests/GlobalUsings.cs
+++ b/TUnit.OpenTelemetry.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using TUnit.Core;
+global using TUnit.OpenTelemetry;

--- a/TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj
+++ b/TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\TUnit.Engine\TUnit.Engine.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\strongname.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TUnit.OpenTelemetry\TUnit.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\TUnit.Engine\TUnit.Engine.csproj" />
+    <ProjectReference Include="..\TUnit.Assertions\TUnit.Assertions.csproj" />
+    <ProjectReference Include="..\TUnit.Core.SourceGenerator\TUnit.Core.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\TUnit.Analyzers\TUnit.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" />
+  </ItemGroup>
+
+</Project>

--- a/TUnit.OpenTelemetry.Tests/TestSessionSetup.cs
+++ b/TUnit.OpenTelemetry.Tests/TestSessionSetup.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using TUnit.Core;
+
+namespace TUnit.OpenTelemetry.Tests;
+
+public static class TestSessionSetup
+{
+    [Before(HookType.TestDiscovery, Order = int.MinValue)]
+    public static void RegisterDummyConfigurator()
+    {
+        // Without this, AutoStart.Start() returns early because no endpoint + no user config.
+        // A no-op configurator is enough to keep the AutoStart path live for the coexistence tests.
+        TUnitOpenTelemetry.Configure(_ => { });
+    }
+}

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using OpenTelemetry;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using TUnit.Core;
 
@@ -63,6 +64,12 @@ public static class AutoStart
                 builder.AddOtlpExporter();
             }
 
+            builder.SetResourceBuilder(
+                ResourceBuilder.CreateDefault().AddService(
+                    serviceName: Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME")
+                        ?? System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name
+                        ?? "TUnit.Tests"));
+
             TUnitOpenTelemetry.ApplyConfiguration(builder);
             _provider = builder.Build();
         }
@@ -101,6 +108,15 @@ public static class AutoStart
             {
                 return _provider is not null;
             }
+        }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static Resource? GetResourceForTesting()
+    {
+        lock (_lock)
+        {
+            return _provider?.GetResource();
         }
     }
 }

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -18,6 +18,10 @@ public static class AutoStart
     /// <summary>Hook order for <see cref="Start"/>. Runs last so user hooks register first.</summary>
     public const int AutoStartOrder = int.MaxValue;
 
+    internal const string AutoStartEnvVar = "TUNIT_OTEL_AUTOSTART";
+    internal const string OtlpEndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    internal const string ServiceNameEnvVar = "OTEL_SERVICE_NAME";
+
     private static readonly ActivitySource ProbeSource = new("TUnit");
     private static TracerProvider? _provider;
     private static readonly Lock _lock = new();
@@ -25,17 +29,18 @@ public static class AutoStart
     [Before(HookType.TestDiscovery, Order = AutoStartOrder)]
     public static void Start()
     {
-        var autostart = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        var autostart = Environment.GetEnvironmentVariable(AutoStartEnvVar);
         if (autostart == "0")
         {
             return;
         }
 
         var force = autostart == "1";
+        var otlpEndpoint = Environment.GetEnvironmentVariable(OtlpEndpointEnvVar);
+
         if (!force)
         {
-            var hasEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") is not null;
-            if (!hasEndpoint && !TUnitOpenTelemetry.HasConfiguration)
+            if (otlpEndpoint is null && !TUnitOpenTelemetry.HasConfiguration)
             {
                 return;
             }
@@ -52,26 +57,37 @@ public static class AutoStart
             {
                 return;
             }
+        }
 
-            var builder = Sdk.CreateTracerProviderBuilder()
-                .AddSource("TUnit")
-                .AddSource("TUnit.Lifecycle")
-                .AddSource("TUnit.AspNetCore.Http")
-                .AddProcessor(new TUnitTestCorrelationProcessor());
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .AddSource("TUnit")
+            .AddSource("TUnit.Lifecycle")
+            .AddSource("TUnit.AspNetCore.Http")
+            .AddProcessor(new TUnitTestCorrelationProcessor());
 
-            if (Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") is not null)
+        if (otlpEndpoint is not null)
+        {
+            builder.AddOtlpExporter();
+        }
+
+        builder.SetResourceBuilder(
+            ResourceBuilder.CreateDefault().AddService(
+                serviceName: Environment.GetEnvironmentVariable(ServiceNameEnvVar)
+                    ?? System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name
+                    ?? "TUnit.Tests"));
+
+        TUnitOpenTelemetry.ApplyConfiguration(builder);
+        var provider = builder.Build();
+
+        lock (_lock)
+        {
+            if (_provider is not null)
             {
-                builder.AddOtlpExporter();
+                // Lost the race — another Start call built first. Dispose ours.
+                provider?.Dispose();
+                return;
             }
-
-            builder.SetResourceBuilder(
-                ResourceBuilder.CreateDefault().AddService(
-                    serviceName: Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME")
-                        ?? System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name
-                        ?? "TUnit.Tests"));
-
-            TUnitOpenTelemetry.ApplyConfiguration(builder);
-            _provider = builder.Build();
+            _provider = provider;
         }
     }
 

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -38,24 +38,24 @@ public static class AutoStart
         var force = autostart == "1";
         var otlpEndpoint = Environment.GetEnvironmentVariable(OtlpEndpointEnvVar);
 
-        if (!force)
-        {
-            if (otlpEndpoint is null && !TUnitOpenTelemetry.HasConfiguration)
-            {
-                return;
-            }
-
-            if (ProbeSource.HasListeners())
-            {
-                return;
-            }
-        }
-
         lock (_lock)
         {
             if (_provider is not null)
             {
                 return;
+            }
+
+            if (!force)
+            {
+                if (otlpEndpoint is null && !TUnitOpenTelemetry.HasConfiguration)
+                {
+                    return;
+                }
+
+                if (ProbeSource.HasListeners())
+                {
+                    return;
+                }
             }
         }
 
@@ -84,7 +84,7 @@ public static class AutoStart
             if (_provider is not null)
             {
                 // Lost the race — another Start call built first. Dispose ours.
-                provider?.Dispose();
+                provider.Dispose();
                 return;
             }
             _provider = provider;

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using TUnit.Core;
+
+namespace TUnit.OpenTelemetry;
+
+/// <summary>
+/// Lifecycle hooks that build a <see cref="TracerProvider"/> around TUnit's activity
+/// sources at test discovery and dispose it at session end. Users who already register
+/// a listener or TracerProvider in their own <c>[Before(TestDiscovery)]</c> hook keep
+/// full control — this class detects existing listeners and steps aside.
+/// </summary>
+public static class AutoStart
+{
+    /// <summary>Hook order for <see cref="Start"/>. Runs last so user hooks register first.</summary>
+    public const int AutoStartOrder = int.MaxValue;
+
+    private static readonly ActivitySource ProbeSource = new("TUnit");
+    private static TracerProvider? _provider;
+    private static readonly Lock _lock = new();
+
+    [Before(HookType.TestDiscovery, Order = AutoStartOrder)]
+    public static void Start()
+    {
+        var autostart = Environment.GetEnvironmentVariable("TUNIT_OTEL_AUTOSTART");
+        if (autostart == "0")
+        {
+            return;
+        }
+
+        var force = autostart == "1";
+        if (!force && ProbeSource.HasListeners())
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (_provider is not null)
+            {
+                return;
+            }
+
+            var builder = Sdk.CreateTracerProviderBuilder()
+                .AddSource("TUnit")
+                .AddSource("TUnit.Lifecycle")
+                .AddSource("TUnit.AspNetCore.Http")
+                .AddProcessor(new TUnitTestCorrelationProcessor());
+
+            if (Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") is not null)
+            {
+                builder.AddOtlpExporter();
+            }
+
+            TUnitOpenTelemetry.ApplyConfiguration(builder);
+            _provider = builder.Build();
+        }
+    }
+
+    [After(HookType.TestSession, Order = int.MaxValue)]
+    public static void Stop()
+    {
+        TracerProvider? toDispose;
+        lock (_lock)
+        {
+            toDispose = _provider;
+            _provider = null;
+        }
+
+        toDispose?.Dispose();
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static void StartForTesting(bool resetFirst)
+    {
+        if (resetFirst)
+        {
+            Stop();
+        }
+
+        Start();
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static bool HasProviderForTesting
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _provider is not null;
+            }
+        }
+    }
+}

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -31,9 +31,18 @@ public static class AutoStart
         }
 
         var force = autostart == "1";
-        if (!force && ProbeSource.HasListeners())
+        if (!force)
         {
-            return;
+            var hasEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") is not null;
+            if (!hasEndpoint && !TUnitOpenTelemetry.HasConfiguration)
+            {
+                return;
+            }
+
+            if (ProbeSource.HasListeners())
+            {
+                return;
+            }
         }
 
         lock (_lock)

--- a/TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj
+++ b/TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Library.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <Description>Auto-wires an OpenTelemetry TracerProvider for TUnit test processes. Install to get distributed tracing with zero configuration.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="TUnit.OpenTelemetry.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TUnit\TUnit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TUnit.Analyzers\TUnit.Analyzers.csproj" OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\TUnit.Core.SourceGenerator\TUnit.Core.SourceGenerator.csproj"
+      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="..\Library.targets" />
+</Project>

--- a/TUnit.OpenTelemetry/TUnitOpenTelemetry.cs
+++ b/TUnit.OpenTelemetry/TUnitOpenTelemetry.cs
@@ -1,5 +1,63 @@
+using System.ComponentModel;
+using OpenTelemetry.Trace;
+
 namespace TUnit.OpenTelemetry;
 
+/// <summary>
+/// User-facing entry point for customizing the auto-wired <see cref="TracerProvider"/>
+/// built by <see cref="AutoStart"/>. Callbacks are replayed on the shared builder after
+/// TUnit adds its default sources and processors.
+/// </summary>
 public static class TUnitOpenTelemetry
 {
+    private static readonly List<Action<TracerProviderBuilder>> _configurators = [];
+    private static readonly Lock _lock = new();
+
+    /// <summary>
+    /// Registers a callback to customize the auto-wired <see cref="TracerProviderBuilder"/>.
+    /// Call from a static constructor or <c>[Before(HookType.TestDiscovery, Order = int.MinValue)]</c>
+    /// hook so the callback runs before <see cref="AutoStart"/> builds the provider.
+    /// </summary>
+    public static void Configure(Action<TracerProviderBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        lock (_lock)
+        {
+            _configurators.Add(configure);
+        }
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static void ApplyConfiguration(TracerProviderBuilder builder)
+    {
+        Action<TracerProviderBuilder>[] snapshot;
+        lock (_lock)
+        {
+            snapshot = [.. _configurators];
+        }
+
+        foreach (var configure in snapshot)
+        {
+            configure(builder);
+        }
+    }
+
+    internal static bool HasConfiguration
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _configurators.Count > 0;
+            }
+        }
+    }
+
+    internal static void ResetForTests()
+    {
+        lock (_lock)
+        {
+            _configurators.Clear();
+        }
+    }
 }

--- a/TUnit.OpenTelemetry/TUnitOpenTelemetry.cs
+++ b/TUnit.OpenTelemetry/TUnitOpenTelemetry.cs
@@ -1,0 +1,5 @@
+namespace TUnit.OpenTelemetry;
+
+public static class TUnitOpenTelemetry
+{
+}

--- a/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
+++ b/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using OpenTelemetry;
+using TUnit.Core;
 
 namespace TUnit.OpenTelemetry;
 
@@ -10,19 +11,17 @@ namespace TUnit.OpenTelemetry;
 /// </summary>
 public sealed class TUnitTestCorrelationProcessor : BaseProcessor<Activity>
 {
-    private const string TestIdTag = "tunit.test.id";
-
     public override void OnStart(Activity activity)
     {
-        if (activity.GetTagItem(TestIdTag) is not null)
+        if (activity.GetTagItem(TUnitActivitySource.TagTestId) is not null)
         {
             return;
         }
 
-        var testId = Activity.Current?.GetBaggageItem(TestIdTag);
+        var testId = Activity.Current?.GetBaggageItem(TUnitActivitySource.TagTestId);
         if (testId is not null)
         {
-            activity.SetTag(TestIdTag, testId);
+            activity.SetTag(TUnitActivitySource.TagTestId, testId);
         }
     }
 }

--- a/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
+++ b/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace TUnit.OpenTelemetry;
+
+/// <summary>
+/// Copies the <c>tunit.test.id</c> baggage item from the ambient Activity onto
+/// every new span as a tag, so spans produced by libraries with broken parent
+/// chains can still be filtered by test in backends like Jaeger or Seq.
+/// </summary>
+public sealed class TUnitTestCorrelationProcessor : BaseProcessor<Activity>
+{
+    private const string TestIdTag = "tunit.test.id";
+
+    public override void OnStart(Activity activity)
+    {
+        if (activity.GetTagItem(TestIdTag) is not null)
+        {
+            return;
+        }
+
+        var testId = Activity.Current?.GetBaggageItem(TestIdTag);
+        if (testId is not null)
+        {
+            activity.SetTag(TestIdTag, testId);
+        }
+    }
+}

--- a/TUnit.Pipeline/Modules/GetPackageProjectsModule.cs
+++ b/TUnit.Pipeline/Modules/GetPackageProjectsModule.cs
@@ -23,6 +23,7 @@ public class GetPackageProjectsModule : Module<List<File>>
             Sourcy.DotNet.Projects.TUnit_AspNetCore,
             Sourcy.DotNet.Projects.TUnit_AspNetCore_Core,
             Sourcy.DotNet.Projects.TUnit_Aspire,
+            Sourcy.DotNet.Projects.TUnit_OpenTelemetry,
             Sourcy.DotNet.Projects.TUnit_FsCheck,
             Sourcy.DotNet.Projects.TUnit_Mocks,
             Sourcy.DotNet.Projects.TUnit_Mocks_Assertions,

--- a/TUnit.Pipeline/Modules/RunOpenTelemetryTestsModule.cs
+++ b/TUnit.Pipeline/Modules/RunOpenTelemetryTestsModule.cs
@@ -1,0 +1,43 @@
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Extensions;
+using ModularPipelines.Git.Extensions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+namespace TUnit.Pipeline.Modules;
+
+[NotInParallel]
+public class RunOpenTelemetryTestsModule : Module<CommandResult>
+{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {
+        var project = context.Git().RootDirectory.FindFile(x => x.Name == "TUnit.OpenTelemetry.Tests.csproj").AssertExists();
+
+        return await context.DotNet().Run(new DotNetRunOptions
+        {
+            Project = project.Name,
+            NoBuild = true,
+            Configuration = "Release",
+            Framework = "net10.0",
+            Arguments = ["--hangdump", "--hangdump-filename", "hangdump.opentelemetry-tests.dmp", "--hangdump-timeout", "5m"],
+        }, new CommandExecutionOptions
+        {
+            WorkingDirectory = project.Folder!.Path,
+            EnvironmentVariables = new Dictionary<string, string?>
+            {
+                ["DISABLE_GITHUB_REPORTER"] = "true",
+            },
+            LogSettings = new CommandLoggingOptions
+            {
+                ShowCommandArguments = true,
+                ShowStandardError = true,
+                ShowExecutionTime = true,
+                ShowExitCode = true
+            }
+        }, cancellationToken);
+    }
+}

--- a/TUnit.PublicAPI/TUnit.PublicAPI.csproj
+++ b/TUnit.PublicAPI/TUnit.PublicAPI.csproj
@@ -21,6 +21,10 @@
       <ProjectReference Include="..\TUnit.Playwright\TUnit.Playwright.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+      <ProjectReference Include="..\TUnit.OpenTelemetry\TUnit.OpenTelemetry.csproj" />
+    </ItemGroup>
+
     <Import Project="..\TestProject.targets" />
 
 </Project>

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -5,9 +5,9 @@ namespace
     public static class AutoStart
     {
         public const int AutoStartOrder = 2147483647;
-        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1,0 +1,22 @@
+[assembly: .(@".Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100698a70398fa0b2230c5a72e3bd9d56b48f809f6173e49a19fbb942d621be93ad48c5566b47b28faabc359b9ad3ff4e00bbdea88f5bdfa250f391fedd28182b2e37b55d429c0151a42a98ea7a5821818cd15a79fef9903e8607a88304cf3e0317bf86ec96e32e1381535a6582251e5a6eed40b5a3ed82bc444598b1269cce57a7")]
+[assembly: .(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace 
+{
+    public static class AutoStart
+    {
+        public const int AutoStartOrder = 2147483647;
+        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        public static void Start() { }
+        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        public static void Stop() { }
+    }
+    public static class TUnitOpenTelemetry
+    {
+        public static void Configure(<.TracerProviderBuilder> configure) { }
+    }
+    public sealed class TUnitTestCorrelationProcessor : <.Activity>
+    {
+        public TUnitTestCorrelationProcessor() { }
+        public override void OnStart(.Activity activity) { }
+    }
+}

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1,0 +1,22 @@
+[assembly: .(@".Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100698a70398fa0b2230c5a72e3bd9d56b48f809f6173e49a19fbb942d621be93ad48c5566b47b28faabc359b9ad3ff4e00bbdea88f5bdfa250f391fedd28182b2e37b55d429c0151a42a98ea7a5821818cd15a79fef9903e8607a88304cf3e0317bf86ec96e32e1381535a6582251e5a6eed40b5a3ed82bc444598b1269cce57a7")]
+[assembly: .(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace 
+{
+    public static class AutoStart
+    {
+        public const int AutoStartOrder = 2147483647;
+        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        public static void Start() { }
+        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        public static void Stop() { }
+    }
+    public static class TUnitOpenTelemetry
+    {
+        public static void Configure(<.TracerProviderBuilder> configure) { }
+    }
+    public sealed class TUnitTestCorrelationProcessor : <.Activity>
+    {
+        public TUnitTestCorrelationProcessor() { }
+        public override void OnStart(.Activity activity) { }
+    }
+}

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -5,9 +5,9 @@ namespace
     public static class AutoStart
     {
         public const int AutoStartOrder = 2147483647;
-        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -5,9 +5,9 @@ namespace
     public static class AutoStart
     {
         public const int AutoStartOrder = 2147483647;
-        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1,0 +1,22 @@
+[assembly: .(@".Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100698a70398fa0b2230c5a72e3bd9d56b48f809f6173e49a19fbb942d621be93ad48c5566b47b28faabc359b9ad3ff4e00bbdea88f5bdfa250f391fedd28182b2e37b55d429c0151a42a98ea7a5821818cd15a79fef9903e8607a88304cf3e0317bf86ec96e32e1381535a6582251e5a6eed40b5a3ed82bc444598b1269cce57a7")]
+[assembly: .(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
+namespace 
+{
+    public static class AutoStart
+    {
+        public const int AutoStartOrder = 2147483647;
+        [.Before(., "PATH_SCRUBBED", 25, Order=2147483647)]
+        public static void Start() { }
+        [.After(., "PATH_SCRUBBED", 78, Order=2147483647)]
+        public static void Stop() { }
+    }
+    public static class TUnitOpenTelemetry
+    {
+        public static void Configure(<.TracerProviderBuilder> configure) { }
+    }
+    public sealed class TUnitTestCorrelationProcessor : <.Activity>
+    {
+        public TUnitTestCorrelationProcessor() { }
+        public override void OnStart(.Activity activity) { }
+    }
+}

--- a/TUnit.PublicAPI/Tests.cs
+++ b/TUnit.PublicAPI/Tests.cs
@@ -36,6 +36,18 @@ public partial class Tests
         });
 
         await VerifyTUnit.Verify(publicApi)
+            .AddScrubber(sb =>
+            {
+                // Scrub deterministic source paths (e.g. "/_/TUnit.OpenTelemetry/File.cs")
+                // before the URL regex mangles them into bare "/_/".
+                var replaced = System.Text.RegularExpressions.Regex.Replace(
+                    sb.ToString(),
+                    @"/_/[^""\s,)]*",
+                    "PATH_SCRUBBED");
+                sb.Clear();
+                sb.Append(replaced);
+                return sb;
+            })
             .AddScrubber(Scrub)
             .AddScrubber(sb => new StringBuilder(sb.ToString().Replace("\r\n", "\n")))
             .ScrubLinesWithReplace(x => x.Replace("\r\n", "\n"))

--- a/TUnit.PublicAPI/Tests.cs
+++ b/TUnit.PublicAPI/Tests.cs
@@ -19,6 +19,12 @@ public partial class Tests
     public Task Playwright_Library_Has_No_API_Changes()
         => VerifyPublicApi(typeof(Playwright.PageTest).Assembly);
 
+#if NET
+    [Test]
+    public Task OpenTelemetry_Library_Has_No_API_Changes()
+        => VerifyPublicApi(typeof(TUnit.OpenTelemetry.TUnitOpenTelemetry).Assembly);
+#endif
+
     private async Task VerifyPublicApi(Assembly assembly)
     {
         var publicApi = assembly.GeneratePublicApi(new ApiGeneratorOptions

--- a/TUnit.slnx
+++ b/TUnit.slnx
@@ -17,6 +17,7 @@
   <!-- Extension libraries and integrations -->
   <Folder Name="/Libraries/">
     <Project Path="TUnit.Aspire/TUnit.Aspire.csproj" />
+    <Project Path="TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj" />
     <Project Path="TUnit.AspNetCore/TUnit.AspNetCore.csproj" />
     <Project Path="TUnit.AspNetCore.Core/TUnit.AspNetCore.Core.csproj" />
     <Project Path="TUnit.FsCheck/TUnit.FsCheck.csproj" />

--- a/TUnit.slnx
+++ b/TUnit.slnx
@@ -82,6 +82,7 @@
     <Project Path="TUnit.Aspire.Tests/TUnit.Aspire.Tests.csproj" />
     <Project Path="TUnit.Aspire.Tests.ApiService/TUnit.Aspire.Tests.ApiService.csproj" />
     <Project Path="TUnit.Aspire.Tests.AppHost/TUnit.Aspire.Tests.AppHost.csproj" />
+    <Project Path="TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests/TUnit.AspNetCore.Tests.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.WebApp/TUnit.AspNetCore.Tests.WebApp.csproj" />
     <Project Path="TUnit.AspNetCore.Tests.MinimalApi/TUnit.AspNetCore.Tests.MinimalApi.csproj" />

--- a/docs/docs/examples/opentelemetry.md
+++ b/docs/docs/examples/opentelemetry.md
@@ -8,7 +8,58 @@ Activity tracing requires .NET 8 or later. It is not available on .NET Framework
 
 ## Setup
 
-### Option A: OpenTelemetry SDK (recommended)
+### Option A: Zero-config (`TUnit.OpenTelemetry`)
+
+Install the meta-package. OTLP is already bundled — no other OpenTelemetry packages needed for the common case:
+
+```bash
+dotnet add package TUnit.OpenTelemetry
+```
+
+Point it at a backend:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+That's it. The package auto-wires a `TracerProvider` at `[Before(TestDiscovery)]` (subscribed to `TUnit`, `TUnit.Lifecycle`, and `TUnit.AspNetCore.Http`), includes a pre-registered `TUnitTestCorrelationProcessor`, and disposes the provider at `[After(TestSession)]`.
+
+#### Customizing (add exporters, processors, resources)
+
+Call `TUnitOpenTelemetry.Configure` from any `[Before(TestDiscovery)]` hook with `Order` less than `int.MaxValue`:
+
+```csharp
+using OpenTelemetry.Trace;
+using TUnit.OpenTelemetry;
+
+public static class TraceCustomization
+{
+    [Before(TestDiscovery)]
+    public static void Configure()
+    {
+        TUnitOpenTelemetry.Configure(builder => builder
+            .AddConsoleExporter()
+            .AddProcessor(new MyCustomProcessor()));
+    }
+}
+```
+
+Each callback is applied in registration order after the package's defaults, so you can override the resource or add additional exporters.
+
+#### Environment switches
+
+| Variable | Behavior |
+|----------|----------|
+| `TUNIT_OTEL_AUTOSTART=0` | Opt out — package does nothing, user hooks run as normal |
+| `TUNIT_OTEL_AUTOSTART=1` | Force on — build the provider even if another listener is already attached |
+| `OTEL_SERVICE_NAME` | Override `service.name` (defaults to the entry assembly name) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Enables OTLP export when set; when unset, the package stays dormant unless `Configure` is called |
+
+#### Coexistence with hand-rolled setup
+
+If you already register your own `TracerProvider` or `ActivityListener` in a `[Before(TestDiscovery)]` hook, the package detects the attached listener and stays out of the way — no duplicate spans. `Configure(...)` applies only to the package's provider; do not mix it with a separately built `Sdk.CreateTracerProviderBuilder()` in the same project. Pick one.
+
+### Option B: Manual (full control)
 
 Add the OpenTelemetry packages to your test project:
 
@@ -58,7 +109,7 @@ Use one stable service name for the test runner (for example, `MyTests`) rather 
 `service.name` per test. Individual tests are already distinguished by their own trace IDs and
 TUnit tags such as `tunit.test.id`.
 
-### Option B: Raw `ActivityListener` (no SDK dependency)
+### Option C: Raw `ActivityListener` (no SDK dependency)
 
 If you don't want the OpenTelemetry SDK, you can subscribe directly with a `System.Diagnostics.ActivityListener`:
 
@@ -256,7 +307,11 @@ In Seq use `tunit.session.id = '<id>'`. In Jaeger or Tempo use the tag filter bo
 
 Usually a background worker (a hosted service, a message broker like DotPulsar, or a connection pool) started during one test and kept running. Anything it produces inherits whichever test was current when it started.
 
-**Quickest fix**: tag every span with the current test's ID so you can still filter even when the parent is wrong. Add this processor to your OpenTelemetry setup:
+**Quickest fix**: tag every span with the current test's ID so you can still filter even when the parent is wrong.
+
+If you installed `TUnit.OpenTelemetry` (Option A), `TUnitTestCorrelationProcessor` is already registered for you — no additional setup.
+
+For manual setups, add this processor to your tracer builder:
 
 ```csharp
 using System.Diagnostics;
@@ -278,7 +333,7 @@ public sealed class TUnitTagProcessor : BaseProcessor<Activity>
 .AddProcessor(new TUnitTagProcessor())
 ```
 
-Now you can filter by `tunit.test.id` in your backend even when the trace hierarchy is wrong. (Tracking automation: [#5591](https://github.com/thomhurst/TUnit/issues/5591).)
+Now you can filter by `tunit.test.id` in your backend even when the trace hierarchy is wrong.
 
 **Better fix** if you control the worker: stop it from capturing the test's context in the first place.
 

--- a/docs/docs/guides/distributed-tracing.md
+++ b/docs/docs/guides/distributed-tracing.md
@@ -45,6 +45,10 @@ The two sources you usually subscribe to:
 
 The general setup in [OpenTelemetry Tracing](/docs/examples/opentelemetry#setup) works everywhere. Backend-specific notes follow.
 
+:::tip Zero-config setup
+Install [`TUnit.OpenTelemetry`](/docs/examples/opentelemetry#option-a-zero-config-tunitopentelemetry) and set `OTEL_EXPORTER_OTLP_ENDPOINT`. The package auto-wires a `TracerProvider` at test discovery, pre-registers `TUnitTestCorrelationProcessor`, and flushes at session end. Call `TUnitOpenTelemetry.Configure(...)` to add exporters or processors.
+:::
+
 ### Seq
 
 Point the OTLP exporter at Seq's ingestion endpoint:


### PR DESCRIPTION
## Summary

- New `TUnit.OpenTelemetry` NuGet package auto-wires a `TracerProvider` at `[Before(TestDiscovery)]` and disposes at `[After(TestSession)]`. Install the package + set `OTEL_EXPORTER_OTLP_ENDPOINT` — zero boilerplate required.
- Includes `TUnitTestCorrelationProcessor` (resolves #5591's tag-propagation workaround) so spans from broken-parent-chain libraries still carry `tunit.test.id`.
- `TUnit.Aspire` refactored to delegate provider construction via `TUnitOpenTelemetry.Configure`, removing its own `TracerProvider` singleton.
- Coexists cleanly with hand-rolled setups: `[Before(TestDiscovery, Order = int.MaxValue)]` runs last, probes `ActivitySource("TUnit").HasListeners()`, and steps aside if a listener is already attached. `TUNIT_OTEL_AUTOSTART=0` opts out; `=1` force-enables.

Resolves #5593. Bundles fix for #5591.

## Architecture notes

- Public surface: `TUnitOpenTelemetry.Configure(Action<TracerProviderBuilder>)`, `AutoStart` (hooks + `AutoStartOrder` const), `TUnitTestCorrelationProcessor`.
- Gate logic: if `TUNIT_OTEL_AUTOSTART != "1"` and `OTEL_EXPORTER_OTLP_ENDPOINT` is unset and no user `Configure` callbacks are registered, the package stays dormant (no provider built, no listener attached).
- Default `service.name` resource: `OTEL_SERVICE_NAME` > entry assembly name > `"TUnit.Tests"`.
- `builder.Build()` and user callbacks execute outside the `AutoStart` lock to avoid holding a static lock across SDK initialization.
- OTLP exporter is hard-dep'd so the zero-config path doesn't require a second `dotnet add package`.

## Docs

- `docs/docs/examples/opentelemetry.md` gains **Option A: Zero-config**; existing manual setup demoted to Option B / Option C.
- `docs/docs/guides/distributed-tracing.md` gains a zero-config callout pointing to the new option.
- Manual `TUnitTagProcessor` snippet in troubleshooting now points at the pre-registered package processor.

## Test plan

- [x] `dotnet build TUnit.slnx -c Release` — 0 errors
- [x] `TUnit.OpenTelemetry.Tests` — 13/13 pass (Configure, AutoStart coexistence, opt-out env var, correlation processor baggage-to-tag, default service.name, end-to-end InMemory exporter smoke test)
- [x] `TUnit.Aspire.Tests` — 101/101 pass (no regression from the refactor)
- [x] `TUnit.PublicAPI` — new OpenTelemetry snapshot tests pass across net8/net9/net10
- [x] `TUnit.Engine.Tests` hook filter — 17 pass, 16 skip, 0 fail (no regression from the new `Order = int.MaxValue` hook)
- [x] `dotnet pack TUnit.OpenTelemetry` produces a valid nupkg
- [x] `docs && npm run build` — clean build, no broken links
- [ ] Manual: end-to-end trace verification against a local Jaeger/Tempo instance with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`

## Pipeline

- `TUnit.Pipeline/Modules/GetPackageProjectsModule.cs` adds the new package to the pack/publish list.
- New `RunOpenTelemetryTestsModule` mirrors the Aspire test module (no OS gate — nothing platform-specific).
- All three slnx files (`TUnit.slnx`, `TUnit.Dev.slnx`, `TUnit.CI.slnx`) updated.

## Plan

Full implementation plan: `docs/plans/2026-04-17-tunit-opentelemetry-package.md` (14 tasks, each committed separately).