### PR TITLE
fix: restore [Obsolete] members removed in v1.27 (#5539)

### DIFF
--- a/TUnit.Assertions/Conditions/Wrappers/CountWrapper.cs
+++ b/TUnit.Assertions/Conditions/Wrappers/CountWrapper.cs
@@ -24,6 +24,13 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
 
     AssertionContext<TCollection> IAssertionSource<TCollection>.Context => _context;
 
+    private static int GetCount(TCollection? value) =>
+        value is null ? 0
+        : value is ICollection collection ? collection.Count
+        : value.Cast<object>().Count();
+
+    private AssertionContext<int> MapToCount() => _context.Map<int>(GetCount);
+
     /// <summary>
     /// Not supported on CountWrapper - use IsTypeOf on the assertion source before calling HasCount().
     /// </summary>
@@ -103,22 +110,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(expected))] string? expression = null)
     {
         _context.ExpressionBuilder.Append($".GreaterThanOrEqualTo({expression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new TValue_IsGreaterThanOrEqualTo_TValue_Assertion<int>(countContext, expected);
+        return new TValue_IsGreaterThanOrEqualTo_TValue_Assertion<int>(MapToCount(), expected);
     }
 
     /// <summary>
@@ -127,22 +119,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
     public TValue_IsGreaterThan_TValue_Assertion<int> Positive()
     {
         _context.ExpressionBuilder.Append(".Positive()");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new TValue_IsGreaterThan_TValue_Assertion<int>(countContext, 0);
+        return new TValue_IsGreaterThan_TValue_Assertion<int>(MapToCount(), 0);
     }
 
     /// <summary>
@@ -153,22 +130,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(expected))] string? expression = null)
     {
         _context.ExpressionBuilder.Append($".GreaterThan({expression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new TValue_IsGreaterThan_TValue_Assertion<int>(countContext, expected);
+        return new TValue_IsGreaterThan_TValue_Assertion<int>(MapToCount(), expected);
     }
 
     /// <summary>
@@ -179,22 +141,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(expected))] string? expression = null)
     {
         _context.ExpressionBuilder.Append($".LessThan({expression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new TValue_IsLessThan_TValue_Assertion<int>(countContext, expected);
+        return new TValue_IsLessThan_TValue_Assertion<int>(MapToCount(), expected);
     }
 
     /// <summary>
@@ -205,22 +152,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(expected))] string? expression = null)
     {
         _context.ExpressionBuilder.Append($".LessThanOrEqualTo({expression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new TValue_IsLessThanOrEqualTo_TValue_Assertion<int>(countContext, expected);
+        return new TValue_IsLessThanOrEqualTo_TValue_Assertion<int>(MapToCount(), expected);
     }
 
     /// <summary>
@@ -233,22 +165,7 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(maximum))] string? maxExpression = null)
     {
         _context.ExpressionBuilder.Append($".Between({minExpression}, {maxExpression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new BetweenAssertion<int>(countContext, minimum, maximum);
+        return new BetweenAssertion<int>(MapToCount(), minimum, maximum);
     }
 
     /// <summary>
@@ -268,21 +185,6 @@ public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
         [CallerArgumentExpression(nameof(expected))] string? expression = null)
     {
         _context.ExpressionBuilder.Append($".NotEqualTo({expression})");
-        // Map context to get the count
-        var countContext = _context.Map<int>(value =>
-        {
-            if (value == null)
-            {
-                return 0;
-            }
-
-            if (value is ICollection collection)
-            {
-                return collection.Count;
-            }
-
-            return value.Cast<object>().Count();
-        });
-        return new NotEqualsAssertion<int>(countContext, expected);
+        return new NotEqualsAssertion<int>(MapToCount(), expected);
     }
 }

--- a/TUnit.Assertions/Conditions/Wrappers/CountWrapper.cs
+++ b/TUnit.Assertions/Conditions/Wrappers/CountWrapper.cs
@@ -1,0 +1,288 @@
+using System.Collections;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Core;
+using TUnit.Assertions.Extensions;
+
+namespace TUnit.Assertions.Conditions.Wrappers;
+
+/// <summary>
+/// Wrapper for collection count assertions that provides .EqualTo() method.
+/// Example: await Assert.That(list).Count().EqualTo(5);
+/// </summary>
+public class CountWrapper<TCollection, TItem> : IAssertionSource<TCollection>
+    where TCollection : IEnumerable<TItem>
+{
+    private readonly AssertionContext<TCollection> _context;
+
+    public CountWrapper(AssertionContext<TCollection> context)
+    {
+        _context = context;
+    }
+
+    AssertionContext<TCollection> IAssertionSource<TCollection>.Context => _context;
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsTypeOf on the assertion source before calling HasCount().
+    /// </summary>
+    TypeOfAssertion<TCollection, TExpected> IAssertionSource<TCollection>.IsTypeOf<TExpected>()
+    {
+        throw new NotSupportedException(
+            "IsTypeOf is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsTypeOf<List<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsAssignableTo on the assertion source before calling HasCount().
+    /// </summary>
+    IsAssignableToAssertion<TTarget, TCollection> IAssertionSource<TCollection>.IsAssignableTo<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsAssignableTo is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsAssignableTo<IList<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsNotAssignableTo on the assertion source before calling HasCount().
+    /// </summary>
+    IsNotAssignableToAssertion<TTarget, TCollection> IAssertionSource<TCollection>.IsNotAssignableTo<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsNotAssignableTo is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsNotAssignableTo<IList<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsAssignableFrom on the assertion source before calling HasCount().
+    /// </summary>
+    IsAssignableFromAssertion<TTarget, TCollection> IAssertionSource<TCollection>.IsAssignableFrom<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsAssignableFrom is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsAssignableFrom<IList<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsNotAssignableFrom on the assertion source before calling HasCount().
+    /// </summary>
+    IsNotAssignableFromAssertion<TTarget, TCollection> IAssertionSource<TCollection>.IsNotAssignableFrom<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsNotAssignableFrom is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsNotAssignableFrom<IList<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on CountWrapper - use IsNotTypeOf on the assertion source before calling HasCount().
+    /// </summary>
+    IsNotTypeOfAssertion<TCollection, TExpected> IAssertionSource<TCollection>.IsNotTypeOf<TExpected>()
+    {
+        throw new NotSupportedException(
+            "IsNotTypeOf is not supported after HasCount(). " +
+            "Use: Assert.That(value).IsNotTypeOf<List<int>>().HasCount().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is equal to the expected count.
+    /// </summary>
+    public CollectionCountAssertion<TCollection, TItem> EqualTo(
+        int expectedCount,
+        [CallerArgumentExpression(nameof(expectedCount))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".EqualTo({expression})");
+        return new CollectionCountAssertion<TCollection, TItem>(_context, expectedCount);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is greater than or equal to the expected count.
+    /// </summary>
+    public TValue_IsGreaterThanOrEqualTo_TValue_Assertion<int> GreaterThanOrEqualTo(
+        int expected,
+        [CallerArgumentExpression(nameof(expected))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".GreaterThanOrEqualTo({expression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new TValue_IsGreaterThanOrEqualTo_TValue_Assertion<int>(countContext, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is positive (greater than 0).
+    /// </summary>
+    public TValue_IsGreaterThan_TValue_Assertion<int> Positive()
+    {
+        _context.ExpressionBuilder.Append(".Positive()");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new TValue_IsGreaterThan_TValue_Assertion<int>(countContext, 0);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is greater than the expected count.
+    /// </summary>
+    public TValue_IsGreaterThan_TValue_Assertion<int> GreaterThan(
+        int expected,
+        [CallerArgumentExpression(nameof(expected))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".GreaterThan({expression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new TValue_IsGreaterThan_TValue_Assertion<int>(countContext, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is less than the expected count.
+    /// </summary>
+    public TValue_IsLessThan_TValue_Assertion<int> LessThan(
+        int expected,
+        [CallerArgumentExpression(nameof(expected))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".LessThan({expression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new TValue_IsLessThan_TValue_Assertion<int>(countContext, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is less than or equal to the expected count.
+    /// </summary>
+    public TValue_IsLessThanOrEqualTo_TValue_Assertion<int> LessThanOrEqualTo(
+        int expected,
+        [CallerArgumentExpression(nameof(expected))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".LessThanOrEqualTo({expression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new TValue_IsLessThanOrEqualTo_TValue_Assertion<int>(countContext, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is between the minimum and maximum values.
+    /// </summary>
+    public BetweenAssertion<int> Between(
+        int minimum,
+        int maximum,
+        [CallerArgumentExpression(nameof(minimum))] string? minExpression = null,
+        [CallerArgumentExpression(nameof(maximum))] string? maxExpression = null)
+    {
+        _context.ExpressionBuilder.Append($".Between({minExpression}, {maxExpression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new BetweenAssertion<int>(countContext, minimum, maximum);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is zero (empty collection).
+    /// </summary>
+    public CollectionCountAssertion<TCollection, TItem> Zero()
+    {
+        _context.ExpressionBuilder.Append(".Zero()");
+        return new CollectionCountAssertion<TCollection, TItem>(_context, 0);
+    }
+
+    /// <summary>
+    /// Asserts that the collection count is not equal to the expected count.
+    /// </summary>
+    public NotEqualsAssertion<int> NotEqualTo(
+        int expected,
+        [CallerArgumentExpression(nameof(expected))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".NotEqualTo({expression})");
+        // Map context to get the count
+        var countContext = _context.Map<int>(value =>
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            if (value is ICollection collection)
+            {
+                return collection.Count;
+            }
+
+            return value.Cast<object>().Count();
+        });
+        return new NotEqualsAssertion<int>(countContext, expected);
+    }
+}

--- a/TUnit.Assertions/Conditions/Wrappers/LengthWrapper.cs
+++ b/TUnit.Assertions/Conditions/Wrappers/LengthWrapper.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Core;
+
+namespace TUnit.Assertions.Conditions.Wrappers;
+
+/// <summary>
+/// Wrapper for string length assertions that provides .EqualTo() method.
+/// Example: await Assert.That(str).HasLength().EqualTo(5);
+/// </summary>
+public class LengthWrapper : IAssertionSource<string>
+{
+    private readonly AssertionContext<string> _context;
+
+    public LengthWrapper(AssertionContext<string> context)
+    {
+        _context = context;
+    }
+
+    AssertionContext<string> IAssertionSource<string>.Context => _context;
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsTypeOf on the assertion source before calling HasLength().
+    /// </summary>
+    TypeOfAssertion<string, TExpected> IAssertionSource<string>.IsTypeOf<TExpected>()
+    {
+        throw new NotSupportedException(
+            "IsTypeOf is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsTypeOf<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsAssignableTo on the assertion source before calling HasLength().
+    /// </summary>
+    IsAssignableToAssertion<TTarget, string> IAssertionSource<string>.IsAssignableTo<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsAssignableTo is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsAssignableTo<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsNotAssignableTo on the assertion source before calling HasLength().
+    /// </summary>
+    IsNotAssignableToAssertion<TTarget, string> IAssertionSource<string>.IsNotAssignableTo<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsNotAssignableTo is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsNotAssignableTo<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsAssignableFrom on the assertion source before calling HasLength().
+    /// </summary>
+    IsAssignableFromAssertion<TTarget, string> IAssertionSource<string>.IsAssignableFrom<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsAssignableFrom is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsAssignableFrom<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsNotAssignableFrom on the assertion source before calling HasLength().
+    /// </summary>
+    IsNotAssignableFromAssertion<TTarget, string> IAssertionSource<string>.IsNotAssignableFrom<TTarget>()
+    {
+        throw new NotSupportedException(
+            "IsNotAssignableFrom is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsNotAssignableFrom<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Not supported on LengthWrapper - use IsNotTypeOf on the assertion source before calling HasLength().
+    /// </summary>
+    IsNotTypeOfAssertion<string, TExpected> IAssertionSource<string>.IsNotTypeOf<TExpected>()
+    {
+        throw new NotSupportedException(
+            "IsNotTypeOf is not supported after HasLength(). " +
+            "Use: Assert.That(value).IsNotTypeOf<string>().HasLength().EqualTo(5)");
+    }
+
+    /// <summary>
+    /// Asserts that the string length is equal to the expected length.
+    /// </summary>
+    public StringLengthAssertion EqualTo(
+        int expectedLength,
+        [CallerArgumentExpression(nameof(expectedLength))] string? expression = null)
+    {
+        _context.ExpressionBuilder.Append($".EqualTo({expression})");
+        return new StringLengthAssertion(_context, expectedLength);
+    }
+}

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using TUnit.Assertions.Chaining;
 using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Conditions.Wrappers;
 using TUnit.Assertions.Core;
 using TUnit.Assertions.Sources;
 
@@ -879,6 +880,32 @@ public static class AssertionExtensions
     {
         source.Context.ExpressionBuilder.Append($".Length({expression})");
         return new StringLengthWithInlineAssertionAssertion(source.Context, lengthAssertion);
+    }
+
+    /// <summary>
+    /// Returns a wrapper for string length assertions.
+    /// Example: await Assert.That(str).HasLength().EqualTo(5);
+    /// </summary>
+    [Obsolete("Use Length() instead, which provides all numeric assertion methods. Example: Assert.That(str).Length().IsGreaterThan(5)")]
+    public static LengthWrapper HasLength(
+        this IAssertionSource<string> source)
+    {
+        source.Context.ExpressionBuilder.Append(".HasLength()");
+        return new LengthWrapper(source.Context);
+    }
+
+    /// <summary>
+    /// Asserts that the string has the expected length.
+    /// Example: await Assert.That(str).HasLength(5);
+    /// </summary>
+    [Obsolete("Use Length().IsEqualTo(expectedLength) instead.")]
+    public static StringLengthAssertion HasLength(
+        this IAssertionSource<string> source,
+        int expectedLength,
+        [CallerArgumentExpression(nameof(expectedLength))] string? expression = null)
+    {
+        source.Context.ExpressionBuilder.Append($".HasLength({expression})");
+        return new StringLengthAssertion(source.Context, expectedLength);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/CollectionAssertionBase.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertionBase.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
 using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Conditions.Wrappers;
 using TUnit.Assertions.Core;
 
 namespace TUnit.Assertions.Sources;
@@ -297,6 +298,32 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     {
         Context.ExpressionBuilder.Append($".HasAtMost({expression})");
         return new CollectionHasAtMostAssertion<TCollection, TItem>(Context, maxCount);
+    }
+
+    /// <summary>
+    /// Asserts that the collection has the specified number of items.
+    /// This instance method enables calling HasCount with proper type inference.
+    /// Example: await Assert.That(list).HasCount(5);
+    /// </summary>
+    [Obsolete("Use Count().IsEqualTo(expectedCount) instead.")]
+    public CollectionCountAssertion<TCollection, TItem> HasCount(
+        int expectedCount,
+        [CallerArgumentExpression(nameof(expectedCount))] string? expression = null)
+    {
+        Context.ExpressionBuilder.Append($".HasCount({expression})");
+        return new CollectionCountAssertion<TCollection, TItem>(Context, expectedCount);
+    }
+
+    /// <summary>
+    /// Returns a wrapper for fluent count assertions.
+    /// This enables the pattern: .HasCount().GreaterThan(5)
+    /// Example: await Assert.That(list).HasCount().EqualTo(5);
+    /// </summary>
+    [Obsolete("Use Count() instead, which provides all numeric assertion methods. Example: Assert.That(list).Count().IsGreaterThan(5)")]
+    public CountWrapper<TCollection, TItem> HasCount()
+    {
+        Context.ExpressionBuilder.Append(".HasCount()");
+        return new CountWrapper<TCollection, TItem>(Context);
     }
 
     /// <summary>

--- a/TUnit.Core/Contexts/TestRegisteredContext.cs
+++ b/TUnit.Core/Contexts/TestRegisteredContext.cs
@@ -26,6 +26,12 @@ public class TestRegisteredContext
     public ConcurrentDictionary<string, object?> StateBag => TestContext.StateBag.Items;
 
     /// <summary>
+    /// Gets the object bag from the underlying TestContext
+    /// </summary>
+    [Obsolete("Use StateBag property instead.")]
+    public ConcurrentDictionary<string, object?> ObjectBag => StateBag;
+
+    /// <summary>
     /// Gets the test details from the underlying TestContext
     /// </summary>
     public TestDetails TestDetails => TestContext.Metadata.TestDetails;

--- a/TUnit.Core/Contexts/TestRegisteredContext.cs
+++ b/TUnit.Core/Contexts/TestRegisteredContext.cs
@@ -25,9 +25,7 @@ public class TestRegisteredContext
     /// </summary>
     public ConcurrentDictionary<string, object?> StateBag => TestContext.StateBag.Items;
 
-    /// <summary>
-    /// Gets the object bag from the underlying TestContext
-    /// </summary>
+    /// <inheritdoc cref="StateBag"/>
     [Obsolete("Use StateBag property instead.")]
     public ConcurrentDictionary<string, object?> ObjectBag => StateBag;
 

--- a/TUnit.Core/Interfaces/ITestOutput.cs
+++ b/TUnit.Core/Interfaces/ITestOutput.cs
@@ -21,10 +21,25 @@ public interface ITestOutput
     TextWriter ErrorOutput { get; }
 
     /// <summary>
+    /// Gets the collection of timing measurements recorded during test execution.
+    /// Useful for performance profiling and identifying bottlenecks.
+    /// </summary>
+    [Obsolete("Use OpenTelemetry activity spans instead. Hook timings are now automatically recorded as OTel child spans of the test activity.")]
+    IReadOnlyCollection<Timing> Timings { get; }
+
+    /// <summary>
     /// Gets the collection of artifacts (files, screenshots, logs) attached to this test.
     /// Artifacts are preserved after test execution for review and debugging.
     /// </summary>
     IReadOnlyCollection<Artifact> Artifacts { get; }
+
+    /// <summary>
+    /// Records a timing measurement for a specific operation or phase.
+    /// Thread-safe for concurrent calls.
+    /// </summary>
+    /// <param name="timing">The timing information to record</param>
+    [Obsolete("Use OpenTelemetry activity spans instead. Hook timings are now automatically recorded as OTel child spans of the test activity.")]
+    void RecordTiming(Timing timing);
 
     /// <summary>
     /// Attaches an artifact (file, screenshot, log, etc.) to this test.

--- a/TUnit.Core/TestBuilderContext.cs
+++ b/TUnit.Core/TestBuilderContext.cs
@@ -37,9 +37,7 @@ public record TestBuilderContext
         set => _stateBag = value;
     }
 
-    /// <summary>
-    /// Gets the state bag for storing arbitrary data during test building.
-    /// </summary>
+    /// <inheritdoc cref="StateBag"/>
     [Obsolete("Use StateBag property instead.")]
     public ConcurrentDictionary<string, object?> ObjectBag => StateBag;
 

--- a/TUnit.Core/TestBuilderContext.cs
+++ b/TUnit.Core/TestBuilderContext.cs
@@ -37,6 +37,12 @@ public record TestBuilderContext
         set => _stateBag = value;
     }
 
+    /// <summary>
+    /// Gets the state bag for storing arbitrary data during test building.
+    /// </summary>
+    [Obsolete("Use StateBag property instead.")]
+    public ConcurrentDictionary<string, object?> ObjectBag => StateBag;
+
     internal void CopyStateBagTo(TestBuilderContext target)
     {
         if (_stateBag is { IsEmpty: false } bag)

--- a/TUnit.Core/TestContext.Output.cs
+++ b/TUnit.Core/TestContext.Output.cs
@@ -17,6 +17,7 @@ public partial class TestContext
     // Internal backing fields and properties
     // Timings are written sequentially by the framework during test execution, never by user code.
     internal List<TimingEntry> Timings { get; } = [];
+    private readonly Lock _timingsLock = new();
     // Artifacts use a lock because AttachArtifact is user-facing and can be called
     // from parallel Task.WhenAll branches within a single test.
     private readonly Lock _artifactsLock = new();
@@ -28,6 +29,24 @@ public partial class TestContext
     TextWriter ITestOutput.StandardOutput => OutputWriter;
     TextWriter ITestOutput.ErrorOutput => ErrorOutputWriter;
     IReadOnlyCollection<Artifact> ITestOutput.Artifacts => Artifacts;
+
+#pragma warning disable CS0618 // Obsolete Timing API — bridge to internal TimingEntry storage
+    IReadOnlyCollection<Timing> ITestOutput.Timings
+    {
+        get
+        {
+            lock (_timingsLock)
+            {
+                return Timings.ConvertAll(t => new Timing(t.StepName, t.Start, t.End));
+            }
+        }
+    }
+
+    void ITestOutput.RecordTiming(Timing timing)
+    {
+        lock (_timingsLock) Timings.Add(new TimingEntry(timing.StepName, timing.Start, timing.End));
+    }
+#pragma warning restore CS0618
 
     void ITestOutput.AttachArtifact(Artifact artifact)
     {

--- a/TUnit.Core/TestContext.Output.cs
+++ b/TUnit.Core/TestContext.Output.cs
@@ -14,8 +14,10 @@ internal record TimingEntry(string StepName, DateTimeOffset Start, DateTimeOffse
 /// </summary>
 public partial class TestContext
 {
-    // Internal backing fields and properties
-    // Timings are written sequentially by the framework during test execution, never by user code.
+    // Internal backing fields and properties.
+    // Engine writes are sequential per-test (lifecycle-ordered).
+    // User-facing writes via the obsolete ITestOutput.RecordTiming API may be concurrent,
+    // so all access through the obsolete bridge takes _timingsLock.
     internal List<TimingEntry> Timings { get; } = [];
     private readonly Lock _timingsLock = new();
     // Artifacts use a lock because AttachArtifact is user-facing and can be called

--- a/TUnit.Core/Timing.cs
+++ b/TUnit.Core/Timing.cs
@@ -1,0 +1,7 @@
+﻿namespace TUnit.Core;
+
+[Obsolete("Use OpenTelemetry activity spans instead. Hook timings are now automatically recorded as OTel child spans of the test activity.")]
+public record Timing(string StepName, DateTimeOffset Start, DateTimeOffset End)
+{
+    public TimeSpan Duration => End - Start;
+}

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2363,6 +2363,28 @@ namespace .
         public static . IsValidJsonObject(this string value) { }
     }
 }
+namespace .
+{
+    public class CountWrapper<TCollection, TItem> : ., .<TCollection>
+        where TCollection : .<TItem>
+    {
+        public CountWrapper(.<TCollection> context) { }
+        public .<int> Between(int minimum, int maximum, [.("minimum")] string? minExpression = null, [.("maximum")] string? maxExpression = null) { }
+        public .<TCollection, TItem> EqualTo(int expectedCount, [.("expectedCount")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> GreaterThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThanOrEqualTo_TValue_Assertion<int> GreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThan_TValue_Assertion<int> LessThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThanOrEqualTo_TValue_Assertion<int> LessThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public .<int> NotEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> Positive() { }
+        public .<TCollection, TItem> Zero() { }
+    }
+    public class LengthWrapper : ., .<string>
+    {
+        public LengthWrapper(.<string> context) { }
+        public . EqualTo(int expectedLength, [.("expectedLength")] string? expression = null) { }
+    }
+}
 namespace .Core
 {
     public class AndContinuation<TValue> : .<TValue> { }
@@ -2606,6 +2628,11 @@ namespace .Extensions
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
+            "(str).Length().IsGreaterThan(5)")]
+        public static ..LengthWrapper HasLength(this .<string> source) { }
+        [("Use Length().IsEqualTo(expectedLength) instead.")]
+        public static . HasLength(this .<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
             where TException :  { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage,  comparison, [.("expectedMessage")] string? expression = null)
@@ -6120,6 +6147,11 @@ namespace .Sources
         protected override string GetExpectation() { }
         public .<TCollection, TItem> HasAtLeast(int minCount, [.("minCount")] string? expression = null) { }
         public .<TCollection, TItem> HasAtMost(int maxCount, [.("maxCount")] string? expression = null) { }
+        [("Use Count() instead, which provides all numeric assertion methods. Example: Asser" +
+            "(list).Count().IsGreaterThan(5)")]
+        public ..CountWrapper<TCollection, TItem> HasCount() { }
+        [("Use Count().IsEqualTo(expectedCount) instead.")]
+        public .<TCollection, TItem> HasCount(int expectedCount, [.("expectedCount")] string? expression = null) { }
         public .<TCollection, TItem> HasCountBetween(int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
         public .<TCollection, TItem> HasDistinctItems() { }
         public .<TCollection, TItem> HasDistinctItems(.<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2342,6 +2342,28 @@ namespace .
         public static . IsValidJsonObject(this string value) { }
     }
 }
+namespace .
+{
+    public class CountWrapper<TCollection, TItem> : ., .<TCollection>
+        where TCollection : .<TItem>
+    {
+        public CountWrapper(.<TCollection> context) { }
+        public .<int> Between(int minimum, int maximum, [.("minimum")] string? minExpression = null, [.("maximum")] string? maxExpression = null) { }
+        public .<TCollection, TItem> EqualTo(int expectedCount, [.("expectedCount")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> GreaterThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThanOrEqualTo_TValue_Assertion<int> GreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThan_TValue_Assertion<int> LessThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThanOrEqualTo_TValue_Assertion<int> LessThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public .<int> NotEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> Positive() { }
+        public .<TCollection, TItem> Zero() { }
+    }
+    public class LengthWrapper : ., .<string>
+    {
+        public LengthWrapper(.<string> context) { }
+        public . EqualTo(int expectedLength, [.("expectedLength")] string? expression = null) { }
+    }
+}
 namespace .Core
 {
     public class AndContinuation<TValue> : .<TValue> { }
@@ -2585,6 +2607,11 @@ namespace .Extensions
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
+            "(str).Length().IsGreaterThan(5)")]
+        public static ..LengthWrapper HasLength(this .<string> source) { }
+        [("Use Length().IsEqualTo(expectedLength) instead.")]
+        public static . HasLength(this .<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
             where TException :  { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage,  comparison, [.("expectedMessage")] string? expression = null)
@@ -6053,6 +6080,11 @@ namespace .Sources
         protected override string GetExpectation() { }
         public .<TCollection, TItem> HasAtLeast(int minCount, [.("minCount")] string? expression = null) { }
         public .<TCollection, TItem> HasAtMost(int maxCount, [.("maxCount")] string? expression = null) { }
+        [("Use Count() instead, which provides all numeric assertion methods. Example: Asser" +
+            "(list).Count().IsGreaterThan(5)")]
+        public ..CountWrapper<TCollection, TItem> HasCount() { }
+        [("Use Count().IsEqualTo(expectedCount) instead.")]
+        public .<TCollection, TItem> HasCount(int expectedCount, [.("expectedCount")] string? expression = null) { }
         public .<TCollection, TItem> HasCountBetween(int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
         public .<TCollection, TItem> HasDistinctItems() { }
         public .<TCollection, TItem> HasDistinctItems(.<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2363,6 +2363,28 @@ namespace .
         public static . IsValidJsonObject(this string value) { }
     }
 }
+namespace .
+{
+    public class CountWrapper<TCollection, TItem> : ., .<TCollection>
+        where TCollection : .<TItem>
+    {
+        public CountWrapper(.<TCollection> context) { }
+        public .<int> Between(int minimum, int maximum, [.("minimum")] string? minExpression = null, [.("maximum")] string? maxExpression = null) { }
+        public .<TCollection, TItem> EqualTo(int expectedCount, [.("expectedCount")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> GreaterThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThanOrEqualTo_TValue_Assertion<int> GreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThan_TValue_Assertion<int> LessThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThanOrEqualTo_TValue_Assertion<int> LessThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public .<int> NotEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> Positive() { }
+        public .<TCollection, TItem> Zero() { }
+    }
+    public class LengthWrapper : ., .<string>
+    {
+        public LengthWrapper(.<string> context) { }
+        public . EqualTo(int expectedLength, [.("expectedLength")] string? expression = null) { }
+    }
+}
 namespace .Core
 {
     public class AndContinuation<TValue> : .<TValue> { }
@@ -2606,6 +2628,11 @@ namespace .Extensions
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
+            "(str).Length().IsGreaterThan(5)")]
+        public static ..LengthWrapper HasLength(this .<string> source) { }
+        [("Use Length().IsEqualTo(expectedLength) instead.")]
+        public static . HasLength(this .<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
             where TException :  { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage,  comparison, [.("expectedMessage")] string? expression = null)
@@ -6120,6 +6147,11 @@ namespace .Sources
         protected override string GetExpectation() { }
         public .<TCollection, TItem> HasAtLeast(int minCount, [.("minCount")] string? expression = null) { }
         public .<TCollection, TItem> HasAtMost(int maxCount, [.("maxCount")] string? expression = null) { }
+        [("Use Count() instead, which provides all numeric assertion methods. Example: Asser" +
+            "(list).Count().IsGreaterThan(5)")]
+        public ..CountWrapper<TCollection, TItem> HasCount() { }
+        [("Use Count().IsEqualTo(expectedCount) instead.")]
+        public .<TCollection, TItem> HasCount(int expectedCount, [.("expectedCount")] string? expression = null) { }
         public .<TCollection, TItem> HasCountBetween(int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
         public .<TCollection, TItem> HasDistinctItems() { }
         public .<TCollection, TItem> HasDistinctItems(.<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2114,6 +2114,28 @@ namespace .
         public static . IsValidJsonObject(this string value) { }
     }
 }
+namespace .
+{
+    public class CountWrapper<TCollection, TItem> : ., .<TCollection>
+        where TCollection : .<TItem>
+    {
+        public CountWrapper(.<TCollection> context) { }
+        public .<int> Between(int minimum, int maximum, [.("minimum")] string? minExpression = null, [.("maximum")] string? maxExpression = null) { }
+        public .<TCollection, TItem> EqualTo(int expectedCount, [.("expectedCount")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> GreaterThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThanOrEqualTo_TValue_Assertion<int> GreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThan_TValue_Assertion<int> LessThan(int expected, [.("expected")] string? expression = null) { }
+        public ._IsLessThanOrEqualTo_TValue_Assertion<int> LessThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public .<int> NotEqualTo(int expected, [.("expected")] string? expression = null) { }
+        public ._IsGreaterThan_TValue_Assertion<int> Positive() { }
+        public .<TCollection, TItem> Zero() { }
+    }
+    public class LengthWrapper : ., .<string>
+    {
+        public LengthWrapper(.<string> context) { }
+        public . EqualTo(int expectedLength, [.("expectedLength")] string? expression = null) { }
+    }
+}
 namespace .Core
 {
     public class AndContinuation<TValue> : .<TValue> { }
@@ -2341,6 +2363,11 @@ namespace .Extensions
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
+            "(str).Length().IsGreaterThan(5)")]
+        public static ..LengthWrapper HasLength(this .<string> source) { }
+        [("Use Length().IsEqualTo(expectedLength) instead.")]
+        public static . HasLength(this .<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
             where TException :  { }
         public static .<TException> HasMessage<TException>(this .<TException> source, string expectedMessage,  comparison, [.("expectedMessage")] string? expression = null)
@@ -5296,6 +5323,11 @@ namespace .Sources
         protected override string GetExpectation() { }
         public .<TCollection, TItem> HasAtLeast(int minCount, [.("minCount")] string? expression = null) { }
         public .<TCollection, TItem> HasAtMost(int maxCount, [.("maxCount")] string? expression = null) { }
+        [("Use Count() instead, which provides all numeric assertion methods. Example: Asser" +
+            "(list).Count().IsGreaterThan(5)")]
+        public ..CountWrapper<TCollection, TItem> HasCount() { }
+        [("Use Count().IsEqualTo(expectedCount) instead.")]
+        public .<TCollection, TItem> HasCount(int expectedCount, [.("expectedCount")] string? expression = null) { }
         public .<TCollection, TItem> HasCountBetween(int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
         public .<TCollection, TItem> HasDistinctItems() { }
         public .<TCollection, TItem> HasDistinctItems(.<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1352,6 +1352,8 @@ namespace
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; set; }
         public required .MethodMetadata TestMetadata { get; init; }
         public static .TestBuilderContext? Current { get; }
@@ -1647,6 +1649,8 @@ namespace
         public TestRegisteredContext(.TestContext testContext) { }
         public string? CustomDisplayName { get; }
         public .DiscoveredTest DiscoveredTest { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; }
         public .TestContext TestContext { get; }
         public .TestDetails TestDetails { get; }
@@ -1716,6 +1720,16 @@ namespace
         public  Timeout { get; }
         public . OnHookRegistered(.HookRegisteredContext context) { }
         public . OnTestDiscovered(.DiscoveredTestContext context) { }
+    }
+    [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+        "rded as OTel child spans of the test activity.")]
+    public class Timing : <.Timing>
+    {
+        public Timing(string StepName,  Start,  End) { }
+        public  Duration { get; }
+        public  End { get; init; }
+        public  Start { get; init; }
+        public string StepName { get; init; }
     }
     public sealed class TypeArrayComparer : .<[]>
     {
@@ -2644,10 +2658,16 @@ namespace .Interfaces
         .<.Artifact> Artifacts { get; }
         .TextWriter ErrorOutput { get; }
         .TextWriter StandardOutput { get; }
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        .<.Timing> Timings { get; }
         void AttachArtifact(.Artifact artifact);
         void AttachArtifact(string filePath, string? displayName = null, string? description = null);
         string GetErrorOutput();
         string GetStandardOutput();
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        void RecordTiming(.Timing timing);
         void WriteError(string message);
         void WriteLine(string message);
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1352,6 +1352,8 @@ namespace
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; set; }
         public required .MethodMetadata TestMetadata { get; init; }
         public static .TestBuilderContext? Current { get; }
@@ -1647,6 +1649,8 @@ namespace
         public TestRegisteredContext(.TestContext testContext) { }
         public string? CustomDisplayName { get; }
         public .DiscoveredTest DiscoveredTest { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; }
         public .TestContext TestContext { get; }
         public .TestDetails TestDetails { get; }
@@ -1716,6 +1720,16 @@ namespace
         public  Timeout { get; }
         public . OnHookRegistered(.HookRegisteredContext context) { }
         public . OnTestDiscovered(.DiscoveredTestContext context) { }
+    }
+    [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+        "rded as OTel child spans of the test activity.")]
+    public class Timing : <.Timing>
+    {
+        public Timing(string StepName,  Start,  End) { }
+        public  Duration { get; }
+        public  End { get; init; }
+        public  Start { get; init; }
+        public string StepName { get; init; }
     }
     public sealed class TypeArrayComparer : .<[]>
     {
@@ -2644,10 +2658,16 @@ namespace .Interfaces
         .<.Artifact> Artifacts { get; }
         .TextWriter ErrorOutput { get; }
         .TextWriter StandardOutput { get; }
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        .<.Timing> Timings { get; }
         void AttachArtifact(.Artifact artifact);
         void AttachArtifact(string filePath, string? displayName = null, string? description = null);
         string GetErrorOutput();
         string GetStandardOutput();
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        void RecordTiming(.Timing timing);
         void WriteError(string message);
         void WriteLine(string message);
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1352,6 +1352,8 @@ namespace
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; set; }
         public required .MethodMetadata TestMetadata { get; init; }
         public static .TestBuilderContext? Current { get; }
@@ -1647,6 +1649,8 @@ namespace
         public TestRegisteredContext(.TestContext testContext) { }
         public string? CustomDisplayName { get; }
         public .DiscoveredTest DiscoveredTest { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; }
         public .TestContext TestContext { get; }
         public .TestDetails TestDetails { get; }
@@ -1716,6 +1720,16 @@ namespace
         public  Timeout { get; }
         public . OnHookRegistered(.HookRegisteredContext context) { }
         public . OnTestDiscovered(.DiscoveredTestContext context) { }
+    }
+    [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+        "rded as OTel child spans of the test activity.")]
+    public class Timing : <.Timing>
+    {
+        public Timing(string StepName,  Start,  End) { }
+        public  Duration { get; }
+        public  End { get; init; }
+        public  Start { get; init; }
+        public string StepName { get; init; }
     }
     public sealed class TypeArrayComparer : .<[]>
     {
@@ -2644,10 +2658,16 @@ namespace .Interfaces
         .<.Artifact> Artifacts { get; }
         .TextWriter ErrorOutput { get; }
         .TextWriter StandardOutput { get; }
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        .<.Timing> Timings { get; }
         void AttachArtifact(.Artifact artifact);
         void AttachArtifact(string filePath, string? displayName = null, string? description = null);
         string GetErrorOutput();
         string GetStandardOutput();
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        void RecordTiming(.Timing timing);
         void WriteError(string message);
         void WriteLine(string message);
     }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1300,6 +1300,8 @@ namespace
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; set; }
         public required .MethodMetadata TestMetadata { get; init; }
         public static .TestBuilderContext? Current { get; }
@@ -1589,6 +1591,8 @@ namespace
         public TestRegisteredContext(.TestContext testContext) { }
         public string? CustomDisplayName { get; }
         public .DiscoveredTest DiscoveredTest { get; set; }
+        [("Use StateBag property instead.")]
+        public .<string, object?> ObjectBag { get; }
         public .<string, object?> StateBag { get; }
         public .TestContext TestContext { get; }
         public .TestDetails TestDetails { get; }
@@ -1658,6 +1662,16 @@ namespace
         public  Timeout { get; }
         public . OnHookRegistered(.HookRegisteredContext context) { }
         public . OnTestDiscovered(.DiscoveredTestContext context) { }
+    }
+    [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+        "rded as OTel child spans of the test activity.")]
+    public class Timing : <.Timing>
+    {
+        public Timing(string StepName,  Start,  End) { }
+        public  Duration { get; }
+        public  End { get; init; }
+        public  Start { get; init; }
+        public string StepName { get; init; }
     }
     public sealed class TypeArrayComparer : .<[]>
     {
@@ -2578,10 +2592,16 @@ namespace .Interfaces
         .<.Artifact> Artifacts { get; }
         .TextWriter ErrorOutput { get; }
         .TextWriter StandardOutput { get; }
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        .<.Timing> Timings { get; }
         void AttachArtifact(.Artifact artifact);
         void AttachArtifact(string filePath, string? displayName = null, string? description = null);
         string GetErrorOutput();
         string GetStandardOutput();
+        [("Use OpenTelemetry activity spans instead. Hook timings are now automatically reco" +
+            "rded as OTel child spans of the test activity.")]
+        void RecordTiming(.Timing timing);
         void WriteError(string message);
         void WriteLine(string message);
     }


### PR DESCRIPTION
## Summary

- Restores public members that were deleted in #5384 (v1.27.0), reapplying their original `[Obsolete]` attributes so v1.x users can upgrade without compile errors.
- Actual deletion is deferred to the v2 major bump — tracked in #5604.

Fixes #5539.

## Restored members

**TUnit.Assertions**
- `CountWrapper<TCollection, TItem>` and `LengthWrapper` (recreated verbatim under `TUnit.Assertions.Conditions.Wrappers`)
- `CollectionAssertionBase<TCollection, TItem>.HasCount()` / `.HasCount(int)`
- `AssertionExtensions.HasLength(IAssertionSource<string>)` / `.HasLength(IAssertionSource<string>, int)`

**TUnit.Core**
- `TestBuilderContext.ObjectBag` and `TestRegisteredContext.ObjectBag` (alias `=> StateBag`)
- `Timing` record
- `ITestOutput.Timings` property + `ITestOutput.RecordTiming(Timing)` method, bridged in `TestContext.Output.cs` to the internal `TimingEntry` storage. Adds `_timingsLock` to make user-facing concurrent `RecordTiming` calls safe (engine no longer writes to this list — OTel handles timing internally).

PublicAPI snapshots regenerated for net8.0 / net9.0 / net10.0 / net472.

## Test plan
- [x] `dotnet build TUnit.Core` — clean
- [x] `dotnet build TUnit.Assertions` — clean
- [x] `dotnet build TUnit.Engine` — clean
- [x] `TUnit.PublicAPI` tests pass on net8.0, net9.0, net10.0, net472
- [ ] CI green