### PR TITLE
perf: engine hot-path allocation wins (#5528 B)

### DIFF
--- a/TUnit.Core/AbstractExecutableTest.cs
+++ b/TUnit.Core/AbstractExecutableTest.cs
@@ -72,14 +72,18 @@ public abstract class AbstractExecutableTest
     {
         State = state;
 
-        // Lazy output building - avoid string allocation when there's no output
-        var output = Context.GetOutput();
-        var errorOutput = Context.GetErrorOutput();
+        // Skip the reader/writer lock + StringBuilder dance entirely when nothing
+        // was ever written — the common passing-test case.
         var combinedOutput = string.Empty;
-
-        if (output.Length > 0 || errorOutput.Length > 0)
+        if (Context.HasCapturedOutput)
         {
-            combinedOutput = string.Concat(output, Environment.NewLine, Environment.NewLine, errorOutput);
+            var output = Context.GetOutput();
+            var errorOutput = Context.GetErrorOutput();
+
+            if (output.Length > 0 || errorOutput.Length > 0)
+            {
+                combinedOutput = string.Concat(output, Environment.NewLine, Environment.NewLine, errorOutput);
+            }
         }
 
         Context.Execution.Result ??= new TestResult

--- a/TUnit.Core/Context.cs
+++ b/TUnit.Core/Context.cs
@@ -110,6 +110,11 @@ public abstract class Context : IContext, IDisposable
 
     public virtual string GetErrorOutput() => _errorOutputWriter?.GetContent() ?? string.Empty;
 
+    // Fast path for callers that need to know whether anything was ever captured —
+    // lets the result-building code skip the reader/writer lock acquisition entirely
+    // for the (very common) case of a passing test with no output.
+    internal virtual bool HasCapturedOutput => _outputWriter != null || _errorOutputWriter != null;
+
     public DefaultLogger GetDefaultLogger()
     {
         return _defaultLogger ??= new DefaultLogger(this);

--- a/TUnit.Core/TestContext.Output.cs
+++ b/TUnit.Core/TestContext.Output.cs
@@ -100,6 +100,9 @@ public partial class TestContext
 
     internal string GetOutputError() => CombineOutputs(_buildTimeErrorOutput, base.GetErrorOutput());
 
+    internal override bool HasCapturedOutput =>
+        base.HasCapturedOutput || _buildTimeOutput != null || _buildTimeErrorOutput != null;
+
     private static string CombineOutputs(string? buildTimeOutput, string runtimeOutput)
     {
         if (string.IsNullOrEmpty(buildTimeOutput))

--- a/TUnit.Core/TestDetails.cs
+++ b/TUnit.Core/TestDetails.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using TUnit.Core.Interfaces;
 
@@ -49,7 +50,39 @@ public partial class TestDetails : ITestIdentity, ITestClass, ITestMethod, ITest
     public string TestFilePath { get; set; } = "";
     public int TestLineNumber { get; set; }
     public required Type ReturnType { get; set; }
-    public IDictionary<string, object?> TestClassInjectedPropertyArguments { get; init; } = new ConcurrentDictionary<string, object?>();
+    // Lazy — the vast majority of tests use zero injected properties, so we skip the
+    // per-test ConcurrentDictionary allocation (~200+ bytes) until there's actually
+    // something to store.
+    private ConcurrentDictionary<string, object?>? _testClassInjectedPropertyArguments;
+
+    public IDictionary<string, object?> TestClassInjectedPropertyArguments
+    {
+        get => _testClassInjectedPropertyArguments ?? EmptyInjectedPropertyArguments.Instance;
+        init => _testClassInjectedPropertyArguments = value switch
+        {
+            null => null,
+            ConcurrentDictionary<string, object?> cd => cd,
+            _ => new ConcurrentDictionary<string, object?>(value)
+        };
+    }
+
+    internal ConcurrentDictionary<string, object?> GetOrCreateInjectedPropertyArguments()
+    {
+        var existing = _testClassInjectedPropertyArguments;
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var created = new ConcurrentDictionary<string, object?>();
+        return Interlocked.CompareExchange(ref _testClassInjectedPropertyArguments, created, null) ?? created;
+    }
+
+    private static class EmptyInjectedPropertyArguments
+    {
+        public static readonly IDictionary<string, object?> Instance =
+            new ReadOnlyDictionary<string, object?>(new Dictionary<string, object?>(0));
+    }
     public List<string> Categories { get; } = [];
     public Dictionary<string, List<string>> CustomProperties { get; } = new();
     public Type[]? TestClassParameterTypes { get; set; }

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -151,11 +151,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
                 }
                 catch
                 {
-                    cleanupExceptions ??= [];
-                    foreach (var e in whenAllTask.Exception!.InnerExceptions)
-                    {
-                        cleanupExceptions.Add(e);
-                    }
+                    (cleanupExceptions ??= []).AddRange(whenAllTask.Exception!.InnerExceptions);
                 }
             }
         }

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -99,23 +99,24 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
         }
     }
 
-    public ValueTask UntrackObjects(TestContext testContext, List<Exception> cleanupExceptions)
+    public ValueTask<List<Exception>?> UntrackObjects(TestContext testContext)
     {
         var trackedObjects = testContext.TrackedObjects;
 
         if (CountTrackedObjects(trackedObjects) == 0)
         {
-            return ValueTask.CompletedTask;
+            return new ValueTask<List<Exception>?>((List<Exception>?)null);
         }
 
-        return UntrackObjectsAsync(cleanupExceptions, trackedObjects);
+        return UntrackObjectsAsync(trackedObjects);
     }
 
-    private async ValueTask UntrackObjectsAsync(List<Exception> cleanupExceptions, SortedList<int, HashSet<object>> trackedObjects)
+    private async ValueTask<List<Exception>?> UntrackObjectsAsync(SortedList<int, HashSet<object>> trackedObjects)
     {
         // SortedList keeps keys in ascending order; iterate in ascending order (shallowest depth first).
         // This ensures disposal happens in reverse order of initialization (which goes deepest first).
         // Dependents (shallow) are disposed before their dependencies (deep).
+        List<Exception>? cleanupExceptions = null;
         var values = trackedObjects.Values;
 
         for (var i = 0; i < values.Count; i++)
@@ -137,7 +138,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
                 }
                 catch (Exception e)
                 {
-                    cleanupExceptions.Add(e);
+                    (cleanupExceptions ??= []).Add(e);
                 }
             }
 
@@ -150,6 +151,7 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
                 }
                 catch
                 {
+                    cleanupExceptions ??= [];
                     foreach (var e in whenAllTask.Exception!.InnerExceptions)
                     {
                         cleanupExceptions.Add(e);
@@ -157,6 +159,8 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
                 }
             }
         }
+
+        return cleanupExceptions;
     }
 
     /// <summary>

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -552,9 +552,9 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
     /// Cleans up after test execution.
     /// Decrements reference counts and disposes objects when count reaches zero.
     /// </summary>
-    public Task CleanupTestAsync(TestContext testContext, List<Exception> cleanupExceptions)
+    public Task<List<Exception>?> CleanupTestAsync(TestContext testContext)
     {
-        return _objectTracker.UntrackObjects(testContext, cleanupExceptions).AsTask();
+        return _objectTracker.UntrackObjects(testContext).AsTask();
     }
 
     #endregion

--- a/TUnit.Engine/Services/PropertyInjector.cs
+++ b/TUnit.Engine/Services/PropertyInjector.cs
@@ -299,8 +299,7 @@ internal sealed class PropertyInjector
         // SetCachedPropertiesOnInstance can use the value directly without re-converting.
         if (testContext != null)
         {
-            ((ConcurrentDictionary<string, object?>)testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments)
-                [cacheKey] = resolvedValue;
+            testContext.Metadata.TestDetails.GetOrCreateInjectedPropertyArguments()[cacheKey] = resolvedValue;
         }
     }
 
@@ -459,9 +458,7 @@ internal sealed class PropertyInjector
 
         if (resolvedValue != null)
         {
-            // Cache the resolved value
-            ((ConcurrentDictionary<string, object?>)testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments)
-                .TryAdd(cacheKey, resolvedValue);
+            testContext.Metadata.TestDetails.GetOrCreateInjectedPropertyArguments().TryAdd(cacheKey, resolvedValue);
         }
     }
 
@@ -504,9 +501,7 @@ internal sealed class PropertyInjector
 
         if (resolvedValue != null)
         {
-            // Cache the resolved value
-            ((ConcurrentDictionary<string, object?>)testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments)
-                .TryAdd(cacheKey, resolvedValue);
+            testContext.Metadata.TestDetails.GetOrCreateInjectedPropertyArguments().TryAdd(cacheKey, resolvedValue);
         }
     }
 

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -134,8 +134,6 @@ internal sealed class TestCoordinator : ITestCoordinator
         }
         finally
         {
-            List<Exception>? cleanupExceptions = null;
-
             // Flush console interceptors to ensure all buffered output is captured
             // This is critical for output from Console.Write() without newline
             try
@@ -148,7 +146,9 @@ internal sealed class TestCoordinator : ITestCoordinator
                 await _logger.LogErrorAsync($"Error flushing console output for {test.TestId}: {flushEx}").ConfigureAwait(false);
             }
 
-            await _objectTracker.UntrackObjects(test.Context, cleanupExceptions ??= []).ConfigureAwait(false);
+            // Stay null on the success path — materializing the list only when something actually fails
+            // saves ~56 bytes per passing test (and passing is the overwhelming majority).
+            var cleanupExceptions = await _objectTracker.UntrackObjects(test.Context).ConfigureAwait(false);
 
 #if NET
             // Per-test cleanup has completed. Keep the test activity open for final status
@@ -161,13 +161,21 @@ internal sealed class TestCoordinator : ITestCoordinator
             var testAssembly = testClass.Assembly;
             var hookExceptions = await _testExecutor.ExecuteAfterClassAssemblyHooks(test, testClass, testAssembly, CancellationToken.None).ConfigureAwait(false);
 
-            if (hookExceptions.Count > 0)
+            if (hookExceptions is { Count: > 0 })
             {
                 foreach (var ex in hookExceptions)
                 {
                     await _logger.LogErrorAsync($"Error executing After hooks for {test.TestId}: {ex}").ConfigureAwait(false);
                 }
-                (cleanupExceptions ??= []).AddRange(hookExceptions);
+
+                if (cleanupExceptions is null)
+                {
+                    cleanupExceptions = hookExceptions;
+                }
+                else
+                {
+                    cleanupExceptions.AddRange(hookExceptions);
+                }
             }
 
             // Invoke Last event receivers for class and assembly

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -393,19 +393,28 @@ internal class TestExecutor
         }
     }
 
-    internal async Task<List<Exception>> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,
+    internal async Task<List<Exception>?> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties
             | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass, Assembly testAssembly, CancellationToken cancellationToken)
     {
-        var exceptions = new List<Exception>();
         var flags = _lifecycleCoordinator.DecrementAndCheckAfterHooks(testClass, testAssembly);
+
+        if (!flags.ShouldExecuteAfterClass && !flags.ShouldExecuteAfterAssembly)
+        {
+            return null;
+        }
+
+        List<Exception>? exceptions = null;
 
         if (flags.ShouldExecuteAfterClass)
         {
             // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
             var classExceptions = await _afterHookPairTracker.GetOrCreateAfterClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
-            exceptions.AddRange(classExceptions);
+            if (classExceptions.Count > 0)
+            {
+                (exceptions ??= []).AddRange(classExceptions);
+            }
         }
 
         if (flags.ShouldExecuteAfterAssembly)
@@ -414,7 +423,10 @@ internal class TestExecutor
             var assemblyExceptions = await _afterHookPairTracker.GetOrCreateAfterAssemblyTask(
                 testAssembly,
                 (assembly) => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, cancellationToken)).ConfigureAwait(false);
-            exceptions.AddRange(assemblyExceptions);
+            if (assemblyExceptions.Count > 0)
+            {
+                (exceptions ??= []).AddRange(assemblyExceptions);
+            }
         }
 
         return exceptions;


### PR DESCRIPTION
Part B of the perf work catalogued in #5528. Tackles per-test allocation wins on the execution hot path.

## Items

### 3. \`TestDetails.TestClassInjectedPropertyArguments\` → lazy
Most tests inject zero properties, so the per-test \`ConcurrentDictionary\` allocation (~200+ bytes) is pure waste. The property now returns a shared read-only empty singleton until \`GetOrCreateInjectedPropertyArguments()\` is called from \`PropertyInjector\` on first write.

### 5. Nullable \`cleanupExceptions\`
- \`ObjectTracker.UntrackObjects\` returns \`List<Exception>?\` — null on the success path
- \`TestExecutor.ExecuteAfterClassAssemblyHooks\` returns \`List<Exception>?\` instead of always allocating a fresh list
- \`TestCoordinator\`'s \`finally\` block now holds a nullable and materializes only when something fails

Saves ~56 bytes per passing test (the common case).

### 6. \`Context.HasCapturedOutput\` short-circuit
Passing tests with no output skip the \`GetOutput\` / \`GetErrorOutput\` calls — and their \`ReaderWriterLockSlim\` acquisition — entirely when neither writer nor build-time output was ever populated.

## Item 4 — skipped deliberately
The audit in #5528 proposed dropping the unconditional \`Console.Out.FlushAsync() / Console.Error.FlushAsync()\` calls in \`TestCoordinator\`'s finally block on the claim that \`ConcurrentStringWriter.Flush\` is a no-op. In practice \`Console.Out\` is the \`OptimizedConsoleInterceptor\`, whose \`FlushAsync\` flushes partial-line buffers to the output sinks — skipping it loses any \`Console.Write(\"…\")\` output that didn't end in a newline. Left as-is.

## Test plan
- [x] \`TUnit.Engine.Tests\` — 148/148 pass
- [x] \`TUnit.UnitTests\` — 180/180 pass
- [x] \`TUnit.PublicAPI\` — 4/4 pass (no public surface changes)