### PR TITLE
fix(assertions): add Task reference forwarders on AsyncDelegateAssertion

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5613Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5613Tests.cs
@@ -1,0 +1,44 @@
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for GitHub issue #5613 findings #1 and #3:
+/// Assert.That(Task task) returns AsyncDelegateAssertion which implements both
+/// IAssertionSource&lt;object?&gt; and IAssertionSource&lt;Task&gt;. This ambiguity breaks
+/// generic inference on IsNotNull / IsNull / IsSameReferenceAs / IsNotSameReferenceAs
+/// (CS0411) and produces a misleading CS1929 pointing at JsonElement.
+///
+/// Fix: instance methods on AsyncDelegateAssertion that forward to the
+/// IAssertionSource&lt;Task&gt; interface.
+/// </summary>
+public class Issue5613Tests
+{
+    [Test]
+    public async Task IsNotNull_On_Task_Reference_Compiles_And_Passes()
+    {
+        Task t = Task.CompletedTask;
+        await Assert.That(t).IsNotNull();
+    }
+
+    [Test]
+    public async Task IsNull_On_Null_Task_Reference_Compiles_And_Passes()
+    {
+        Task? t = null;
+        await Assert.That(t!).IsNull();
+    }
+
+    [Test]
+    public async Task IsSameReferenceAs_On_Task_Compiles_Without_Generic_Annotation()
+    {
+        Task a = Task.CompletedTask;
+        Task b = a;
+        await Assert.That(a).IsSameReferenceAs(b);
+    }
+
+    [Test]
+    public async Task IsNotSameReferenceAs_On_Task_Compiles_Without_Generic_Annotation()
+    {
+        Task a = Task.CompletedTask;
+        Task b = Task.FromResult(true);
+        await Assert.That(a).IsNotSameReferenceAs(b);
+    }
+}

--- a/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using TUnit.Assertions.Conditions;
 using TUnit.Assertions.Core;
@@ -54,6 +55,45 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
 
     // Forwarding methods for Task state assertions
     // These allow calling task assertions directly on AsyncDelegateAssertion without type inference issues
+
+    /// <summary>
+    /// Asserts that the task reference is not null.
+    /// Without this instance method, <c>Assert.That(task).IsNotNull()</c> would fail generic inference
+    /// because <see cref="AsyncDelegateAssertion"/> implements both <c>IAssertionSource&lt;object?&gt;</c>
+    /// and <c>IAssertionSource&lt;Task&gt;</c>.
+    /// </summary>
+    public NotNullAssertion<Task> IsNotNull()
+    {
+        return ((IAssertionSource<Task>)this).IsNotNull();
+    }
+
+    /// <summary>
+    /// Asserts that the task reference is null.
+    /// </summary>
+    public TValue_IsNull_Assertion<Task> IsNull()
+    {
+        return ((IAssertionSource<Task>)this).IsNull();
+    }
+
+    /// <summary>
+    /// Asserts that the task is the same reference as <paramref name="expected"/>.
+    /// </summary>
+    public TValue_IsSameReferenceAs_Object_Assertion<Task> IsSameReferenceAs(
+        object? expected,
+        [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        return ((IAssertionSource<Task>)this).IsSameReferenceAs(expected, expectedExpression);
+    }
+
+    /// <summary>
+    /// Asserts that the task is not the same reference as <paramref name="expected"/>.
+    /// </summary>
+    public TValue_IsNotSameReferenceAs_Object_Assertion<Task> IsNotSameReferenceAs(
+        object? expected,
+        [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        return ((IAssertionSource<Task>)this).IsNotSameReferenceAs(expected, expectedExpression);
+    }
 
     /// <summary>
     /// Asserts that the task is completed.

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -6063,7 +6063,11 @@ namespace .Sources
         public .<.> IsNotCompleted() { }
         public .<.> IsNotCompletedSuccessfully() { }
         public .<.> IsNotFaulted() { }
+        public .<.> IsNotNull() { }
+        public ._IsNotSameReferenceAs_Object_Assertion<.> IsNotSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsNotTypeOf<TExpected>() { }
+        public ._IsNull_Assertion<.> IsNull() { }
+        public ._IsSameReferenceAs_Object_Assertion<.> IsSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsTypeOf<TExpected>() { }
         public .<?> Throws( exceptionType) { }
         public .<TException> Throws<TException>()

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -5997,7 +5997,11 @@ namespace .Sources
         public .<.> IsNotCompleted() { }
         public .<.> IsNotCompletedSuccessfully() { }
         public .<.> IsNotFaulted() { }
+        public .<.> IsNotNull() { }
+        public ._IsNotSameReferenceAs_Object_Assertion<.> IsNotSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsNotTypeOf<TExpected>() { }
+        public ._IsNull_Assertion<.> IsNull() { }
+        public ._IsSameReferenceAs_Object_Assertion<.> IsSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsTypeOf<TExpected>() { }
         public .<?> Throws( exceptionType) { }
         public .<TException> Throws<TException>()

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -6063,7 +6063,11 @@ namespace .Sources
         public .<.> IsNotCompleted() { }
         public .<.> IsNotCompletedSuccessfully() { }
         public .<.> IsNotFaulted() { }
+        public .<.> IsNotNull() { }
+        public ._IsNotSameReferenceAs_Object_Assertion<.> IsNotSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsNotTypeOf<TExpected>() { }
+        public ._IsNull_Assertion<.> IsNull() { }
+        public ._IsSameReferenceAs_Object_Assertion<.> IsSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsTypeOf<TExpected>() { }
         public .<?> Throws( exceptionType) { }
         public .<TException> Throws<TException>()

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -5240,7 +5240,11 @@ namespace .Sources
         public .<.> IsNotCanceled() { }
         public .<.> IsNotCompleted() { }
         public .<.> IsNotFaulted() { }
+        public .<.> IsNotNull() { }
+        public ._IsNotSameReferenceAs_Object_Assertion<.> IsNotSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsNotTypeOf<TExpected>() { }
+        public ._IsNull_Assertion<.> IsNull() { }
+        public ._IsSameReferenceAs_Object_Assertion<.> IsSameReferenceAs(object? expected, [.("expected")] string? expectedExpression = null) { }
         public .<object?, TExpected> IsTypeOf<TExpected>() { }
         public .<?> Throws( exceptionType) { }
         public .<TException> Throws<TException>()


### PR DESCRIPTION
## Summary

Addresses findings #1 and #3 of issue #5613.

`Assert.That(Task task)` returns `AsyncDelegateAssertion`, which implements both `IAssertionSource<object?>` and `IAssertionSource<Task>`. The ambiguity breaks C# generic inference on a handful of otherwise-natural assertions:

- `Assert.That(task).IsNotNull()` / `IsNull()` → `CS1929` with a misleading diagnostic pointing at `JsonElementAssertionExtensions.IsNotNull(IAssertionSource<JsonElement>)` (compiler's fallback "best candidate").
- `Assert.That(task).IsSameReferenceAs(other)` / `IsNotSameReferenceAs(other)` → `CS0411` ("type arguments cannot be inferred").

Fix: add four instance methods on `AsyncDelegateAssertion` that forward to the `IAssertionSource<Task>` interface. This matches the pattern already used on the same class for `IsCompleted` / `IsFaulted` / `IsCanceled` / `IsTypeOf` / etc., which exist for the same reason.

No behavior change for existing callers — the forwarders resolve an inference ambiguity that previously required `((object)task)` or `<Task>` annotations.

Remaining findings (#2, #4, #5) will be addressed in follow-up PRs.

## Test plan

- [x] New regression tests in `TUnit.Assertions.Tests/Bugs/Issue5613Tests.cs` (4 tests, one per method). Confirmed failing-to-compile before the fix, passing after.
- [x] Full `TUnit.Assertions.Tests` suite passes on net10 (1978), net9 (1978), net8 (1926), net472 (1778).
- [x] `TUnit.PublicAPI` snapshots updated for all four TFMs (only change: the 4 new public methods on `AsyncDelegateAssertion`).