### PR TITLE
fix(assertions): render collection contents in IsEqualTo failure messages (#5613 B)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
@@ -1,0 +1,81 @@
+using TUnit.Assertions.Exceptions;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for GitHub issue #5613 finding #2: array IsEqualTo uses reference
+/// equality, and failure messages rendered both sides as "System.UInt32[]" because
+/// arrays don't override ToString. The message must:
+///  - show element contents when references (and contents) differ, and
+///  - disclose reference-equality semantics (especially when contents match), so users
+///    see why a "visually-equal" assertion failed and are pointed at IsEquivalentTo.
+/// </summary>
+public class Issue5613ArrayFormatTests
+{
+    [Test]
+    public async Task Array_IsEqualTo_With_Different_Contents_Renders_Both_Sides()
+    {
+        uint[] actual = [2u, 5u, 7u];
+        uint[] expected = [2u, 5u, 8u];
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).DoesNotContain("System.UInt32[]");
+        await Assert.That(exception.Message).Contains("[2, 5, 8]");
+        await Assert.That(exception.Message).Contains("[2, 5, 7]");
+    }
+
+    [Test]
+    public async Task Array_IsEqualTo_With_Equal_Contents_Different_References_Explains_Reference_Semantics()
+    {
+        uint[] actual = [2u, 5u, 7u];
+        uint[] expected = [2u, 5u, 7u];
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).DoesNotContain("System.UInt32[]");
+        await Assert.That(exception.Message).Contains("IsEquivalentTo");
+    }
+
+    [Test]
+    public async Task IntArray_IsEqualTo_Failure_Renders_Contents()
+    {
+        int[] actual = [1, 2, 3];
+        int[] expected = [4, 5, 6];
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).DoesNotContain("System.Int32[]");
+        await Assert.That(exception.Message).Contains("[1, 2, 3]");
+        await Assert.That(exception.Message).Contains("[4, 5, 6]");
+    }
+
+    [Test]
+    public async Task List_IsEqualTo_Failure_Renders_Contents()
+    {
+        var actual = new List<int> { 1, 2, 3 };
+        var expected = new List<int> { 4, 5, 6 };
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).Contains("[1, 2, 3]");
+        await Assert.That(exception.Message).Contains("[4, 5, 6]");
+    }
+
+    [Test]
+    public async Task LargeArray_IsEqualTo_Failure_Truncates_Contents()
+    {
+        var actual = Enumerable.Range(1, 15).ToArray();
+        var expected = Enumerable.Range(100, 15).ToArray();
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).DoesNotContain("System.Int32[]");
+        await Assert.That(exception.Message).Contains("more...");
+    }
+}

--- a/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
@@ -100,4 +100,32 @@ public class Issue5613ArrayFormatTests
         await Assert.That(exception.Message).DoesNotContain("System.Int32[]");
         await Assert.That(exception.Message).Contains("more...");
     }
+
+    [Test]
+    public async Task StringArray_IsEqualTo_Failure_Quotes_Items()
+    {
+        // Prevents ambiguity between null and the literal "null", and keeps whitespace visible.
+        string[] actual = ["hello", "world"];
+        string[] expected = ["foo", "bar"];
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).Contains("[\"hello\", \"world\"]");
+        await Assert.That(exception.Message).Contains("[\"foo\", \"bar\"]");
+    }
+
+    [Test]
+    public async Task NestedCollection_IsEqualTo_Failure_Recurses_Into_Items()
+    {
+        int[][] actual = [[1, 2], [3, 4]];
+        int[][] expected = [[5, 6], [7, 8]];
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).DoesNotContain("System.Int32[]");
+        await Assert.That(exception.Message).Contains("[[1, 2], [3, 4]]");
+        await Assert.That(exception.Message).Contains("[[5, 6], [7, 8]]");
+    }
 }

--- a/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5613ArrayFormatTests.cs
@@ -67,6 +67,28 @@ public class Issue5613ArrayFormatTests
     }
 
     [Test]
+    public async Task NonReplayable_IEnumerable_IsEqualTo_Failure_Renders_Contents_Once()
+    {
+        // Regression: iterator-generated sequences (yield) are single-shot. Earlier revision
+        // enumerated value+expected twice (FormatValue then SequenceEquals) — the second
+        // pass saw an empty sequence and silently misreported "same contents, different ref".
+        static IEnumerable<int> Yield(params int[] values)
+        {
+            foreach (var v in values) yield return v;
+        }
+
+        IEnumerable<int> actual = Yield(1, 2, 3);
+        IEnumerable<int> expected = Yield(4, 5, 6);
+        var action = async () => await Assert.That(actual).IsEqualTo(expected);
+
+        var exception = await Assert.That(action).Throws<AssertionException>();
+
+        await Assert.That(exception.Message).Contains("[1, 2, 3]");
+        await Assert.That(exception.Message).Contains("[4, 5, 6]");
+        await Assert.That(exception.Message).DoesNotContain("IsEquivalentTo");
+    }
+
+    [Test]
     public async Task LargeArray_IsEqualTo_Failure_Truncates_Contents()
     {
         var actual = Enumerable.Range(1, 15).ToArray();

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -19,6 +19,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
     private readonly TValue? _expected;
     private readonly IEqualityComparer<TValue>? _comparer;
     private readonly HashSet<Type> _ignoredTypes = new();
+    private string? _cachedExpectedFormat;
 
     // Cache reflection results for better performance in deep comparison
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
@@ -109,8 +110,14 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
         // when references differ but contents match, surface IsEquivalentTo to the user.
         if (_comparer is null && IsFormattableCollection(value) && IsFormattableCollection(_expected))
         {
-            var actualPreview = FormatValue(value);
-            if (SequenceEqualsNonGeneric(value!, _expected!))
+            // Materialize both once — non-replayable sequences (yield, LINQ, File.ReadLines)
+            // would otherwise be exhausted by the first enumeration.
+            var actualItems = Materialize((IEnumerable)value!);
+            var expectedItems = Materialize((IEnumerable)_expected!);
+            var actualPreview = FormatItems(actualItems);
+            _cachedExpectedFormat = FormatItems(expectedItems);
+
+            if (SequenceEqualsLists(actualItems, expectedItems))
             {
                 return Task.FromResult(AssertionResult.Failed(
                     $"received {actualPreview} (same contents, different reference — use IsEquivalentTo to compare by contents)"));
@@ -141,60 +148,56 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
 
         if (value is IEnumerable enumerable)
         {
-            var items = new List<string>(CollectionPreviewMax);
-            var total = 0;
-            foreach (var item in enumerable)
-            {
-                if (total < CollectionPreviewMax)
-                {
-                    items.Add(item?.ToString() ?? "null");
-                }
-                total++;
-            }
-
-            var preview = string.Join(", ", items);
-            if (total > CollectionPreviewMax)
-            {
-                preview += $", and {total - CollectionPreviewMax} more...";
-            }
-
-            return $"[{preview}]";
+            return FormatItems(Materialize(enumerable));
         }
 
         return value.ToString() ?? "null";
     }
 
-    private static bool SequenceEqualsNonGeneric(object actual, object expected)
+    private static List<object?> Materialize(IEnumerable source)
     {
-        var enumActual = ((IEnumerable)actual).GetEnumerator();
-        var enumExpected = ((IEnumerable)expected).GetEnumerator();
-        try
+        var list = new List<object?>();
+        foreach (var item in source)
         {
-            while (true)
+            list.Add(item);
+        }
+        return list;
+    }
+
+    private static string FormatItems(List<object?> items)
+    {
+        var take = Math.Min(items.Count, CollectionPreviewMax);
+        var parts = new string[take];
+        for (var i = 0; i < take; i++)
+        {
+            parts[i] = items[i]?.ToString() ?? "null";
+        }
+
+        var preview = string.Join(", ", parts);
+        if (items.Count > CollectionPreviewMax)
+        {
+            preview += $", and {items.Count - CollectionPreviewMax} more...";
+        }
+
+        return $"[{preview}]";
+    }
+
+    private static bool SequenceEqualsLists(List<object?> actual, List<object?> expected)
+    {
+        if (actual.Count != expected.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < actual.Count; i++)
+        {
+            if (!Equals(actual[i], expected[i]))
             {
-                var hasActual = enumActual.MoveNext();
-                var hasExpected = enumExpected.MoveNext();
-                if (hasActual != hasExpected)
-                {
-                    return false;
-                }
-
-                if (!hasActual)
-                {
-                    return true;
-                }
-
-                if (!Equals(enumActual.Current, enumExpected.Current))
-                {
-                    return false;
-                }
+                return false;
             }
         }
-        finally
-        {
-            (enumActual as IDisposable)?.Dispose();
-            (enumExpected as IDisposable)?.Dispose();
-        }
+
+        return true;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Deep comparison requires reflection access to all public properties and fields of runtime types")]
@@ -304,5 +307,5 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
         return (true, null);
     }
 
-    protected override string GetExpectation() => $"to be equal to {FormatValue(_expected)}";
+    protected override string GetExpectation() => $"to be equal to {_cachedExpectedFormat ?? FormatValue(_expected)}";
 }

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -103,7 +104,97 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
             return AssertionResult._passedTask;
         }
 
+        // Render collections with element contents so failure messages aren't "System.Int32[]".
+        // Arrays and most collections use reference equality via EqualityComparer<T>.Default —
+        // when references differ but contents match, surface IsEquivalentTo to the user.
+        if (_comparer is null && IsFormattableCollection(value) && IsFormattableCollection(_expected))
+        {
+            var actualPreview = FormatValue(value);
+            if (SequenceEqualsNonGeneric(value!, _expected!))
+            {
+                return Task.FromResult(AssertionResult.Failed(
+                    $"received {actualPreview} (same contents, different reference — use IsEquivalentTo to compare by contents)"));
+            }
+
+            return Task.FromResult(AssertionResult.Failed($"received {actualPreview}"));
+        }
+
         return Task.FromResult(AssertionResult.Failed($"received {value}"));
+    }
+
+    private const int CollectionPreviewMax = 10;
+
+    private static bool IsFormattableCollection(object? value)
+        => value is IEnumerable && value is not string;
+
+    private static string FormatValue(object? value)
+    {
+        if (value is null)
+        {
+            return "null";
+        }
+
+        if (value is string s)
+        {
+            return $"\"{s}\"";
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            var items = new List<string>(CollectionPreviewMax);
+            var total = 0;
+            foreach (var item in enumerable)
+            {
+                if (total < CollectionPreviewMax)
+                {
+                    items.Add(item?.ToString() ?? "null");
+                }
+                total++;
+            }
+
+            var preview = string.Join(", ", items);
+            if (total > CollectionPreviewMax)
+            {
+                preview += $", and {total - CollectionPreviewMax} more...";
+            }
+
+            return $"[{preview}]";
+        }
+
+        return value.ToString() ?? "null";
+    }
+
+    private static bool SequenceEqualsNonGeneric(object actual, object expected)
+    {
+        var enumActual = ((IEnumerable)actual).GetEnumerator();
+        var enumExpected = ((IEnumerable)expected).GetEnumerator();
+        try
+        {
+            while (true)
+            {
+                var hasActual = enumActual.MoveNext();
+                var hasExpected = enumExpected.MoveNext();
+                if (hasActual != hasExpected)
+                {
+                    return false;
+                }
+
+                if (!hasActual)
+                {
+                    return true;
+                }
+
+                if (!Equals(enumActual.Current, enumExpected.Current))
+                {
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            (enumActual as IDisposable)?.Dispose();
+            (enumExpected as IDisposable)?.Dispose();
+        }
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Deep comparison requires reflection access to all public properties and fields of runtime types")]
@@ -213,5 +304,5 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
         return (true, null);
     }
 
-    protected override string GetExpectation() => $"to be equal to {(_expected is string s ? $"\"{s}\"" : _expected)}";
+    protected override string GetExpectation() => $"to be equal to {FormatValue(_expected)}";
 }

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -134,7 +134,12 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
     private static bool IsFormattableCollection(object? value)
         => value is IEnumerable && value is not string;
 
-    private static string FormatValue(object? value)
+    // Fallback formatter used by GetExpectation when the failure path did not run
+    // (e.g. when a custom comparer was supplied, or the receiver is not a collection).
+    // The hot collection path in CheckAsync materializes once and calls FormatItems directly.
+    private static string FormatValue(object? value) => FormatItem(value);
+
+    private static string FormatItem(object? value)
     {
         if (value is null)
         {
@@ -170,7 +175,7 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
         var parts = new string[take];
         for (var i = 0; i < take; i++)
         {
-            parts[i] = items[i]?.ToString() ?? "null";
+            parts[i] = FormatItem(items[i]);
         }
 
         var preview = string.Join(", ", parts);


### PR DESCRIPTION
## Summary

- Addresses finding #2 from #5613: `IsEqualTo` on arrays produced failure messages like `Expected to be equal to System.Int32[] but received System.Int32[]` because arrays don't override `ToString()` and `EqualityComparer<T>.Default` uses reference equality.
- `EqualsAssertion` now formats both sides as `[a, b, c]` (capped at 10 items, truncated as `, and N more...`) when the value is a non-string `IEnumerable` and no explicit comparer was supplied.
- When contents sequence-equal but references differ, the message surfaces `IsEquivalentTo` so users see why a "visually-equal" assertion failed and are pointed at the right API.
- Complements the new `TUnitAssertions0016` analyzer (#5615) which catches the same mistake at compile time; this fix improves the runtime failure message for cases that slip through.

## Test plan

- [x] `Issue5613ArrayFormatTests`: 5 regression tests (array contents differ, array contents match + reference differ → hints `IsEquivalentTo`, int array, `List<int>`, large array truncation)
- [x] Full `TUnit.Assertions.Tests` suite passes across net472, net8.0, net9.0, net10.0
- [x] `TUnit.PublicAPI` snapshot tests pass (no public API changes)