### PR TITLE
feat(analyzers): code-fix for TUnit0049 to insert [MatrixDataSource] (#5613 C)

### DIFF
--- a/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
@@ -57,7 +57,7 @@ public class MatrixDataSourceCodeFixProvider : CodeFixProvider
         {
             MethodDeclarationSyntax method => method.AddAttributeLists(attributeList),
             TypeDeclarationSyntax type => type.AddAttributeLists(attributeList),
-            _ => target,
+            _ => throw new InvalidOperationException($"Unexpected node kind: {target.Kind()}"),
         };
 
         editor.ReplaceNode(target, updated);

--- a/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace TUnit.Analyzers.CodeFixers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatrixDataSourceCodeFixProvider)), Shared]
+public class MatrixDataSourceCodeFixProvider : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ImmutableArray.Create(Rules.MatrixDataSourceAttributeRequired.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan);
+            var target = node.FirstAncestorOrSelf<SyntaxNode>(n => n is MethodDeclarationSyntax or TypeDeclarationSyntax);
+
+            if (target is null)
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Add [MatrixDataSource]",
+                    createChangedDocument: c => AddMatrixDataSourceAsync(context.Document, target, c),
+                    equivalenceKey: "AddMatrixDataSource"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> AddMatrixDataSourceAsync(Document document, SyntaxNode target, CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var attributeList = SyntaxFactory.AttributeList(
+            SyntaxFactory.SingletonSeparatedList(
+                SyntaxFactory.Attribute(SyntaxFactory.ParseName("MatrixDataSource"))));
+
+        SyntaxNode updated = target switch
+        {
+            MethodDeclarationSyntax method => method.AddAttributeLists(attributeList),
+            TypeDeclarationSyntax type => type.AddAttributeLists(attributeList),
+            _ => target,
+        };
+
+        editor.ReplaceNode(target, updated);
+        return editor.GetChangedDocument();
+    }
+}

--- a/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
@@ -12,6 +12,8 @@ namespace TUnit.Analyzers.CodeFixers;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatrixDataSourceCodeFixProvider)), Shared]
 public class MatrixDataSourceCodeFixProvider : CodeFixProvider
 {
+    private const string Title = "Add [MatrixDataSource]";
+
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
         ImmutableArray.Create(Rules.MatrixDataSourceAttributeRequired.Id);
 
@@ -37,9 +39,9 @@ public class MatrixDataSourceCodeFixProvider : CodeFixProvider
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: "Add [MatrixDataSource]",
+                    title: Title,
                     createChangedDocument: c => AddMatrixDataSourceAsync(context.Document, target, c),
-                    equivalenceKey: "AddMatrixDataSource"),
+                    equivalenceKey: Title),
                 diagnostic);
         }
     }
@@ -49,7 +51,7 @@ public class MatrixDataSourceCodeFixProvider : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var attributeList = SyntaxFactory.AttributeList(
             SyntaxFactory.SingletonSeparatedList(
-                SyntaxFactory.Attribute(SyntaxFactory.ParseName("MatrixDataSource"))));
+                SyntaxFactory.Attribute(SyntaxFactory.IdentifierName("MatrixDataSource"))));
 
         SyntaxNode updated = target switch
         {

--- a/TUnit.Analyzers.Tests/MatrixDataSourceCodeFixProviderTests.cs
+++ b/TUnit.Analyzers.Tests/MatrixDataSourceCodeFixProviderTests.cs
@@ -1,0 +1,86 @@
+using Verifier = TUnit.Analyzers.Tests.Verifiers.CSharpCodeFixVerifier<
+    TUnit.Analyzers.MatrixAnalyzer,
+    TUnit.Analyzers.CodeFixers.MatrixDataSourceCodeFixProvider>;
+
+namespace TUnit.Analyzers.Tests;
+
+public class MatrixDataSourceCodeFixProviderTests
+{
+    [Test]
+    public async Task Adds_MatrixDataSource_On_Method()
+    {
+        await Verifier.VerifyCodeFixAsync(
+            """
+            using TUnit.Core;
+
+            public class MyClass
+            {
+                [Test]
+                public void {|#0:MyTest|}(
+                    [Matrix(1, 2, 3)] int value,
+                    [Matrix(true, false)] bool flag)
+                {
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.MatrixDataSourceAttributeRequired).WithLocation(0),
+            """
+            using TUnit.Core;
+
+            public class MyClass
+            {
+                [Test]
+                [MatrixDataSource]
+                public void MyTest(
+                    [Matrix(1, 2, 3)] int value,
+                    [Matrix(true, false)] bool flag)
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Adds_MatrixDataSource_On_Class()
+    {
+        await Verifier.VerifyCodeFixAsync(
+            """
+            using TUnit.Core;
+
+            public class {|#0:MyClass|}
+            {
+                public MyClass(
+                    [Matrix(1, 2)] int value,
+                    [Matrix(true, false)] bool flag)
+                {
+                }
+
+                [Test]
+                public void MyTest()
+                {
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.MatrixDataSourceAttributeRequired).WithLocation(0),
+            """
+            using TUnit.Core;
+
+            [MatrixDataSource]
+            public class MyClass
+            {
+                public MyClass(
+                    [Matrix(1, 2)] int value,
+                    [Matrix(true, false)] bool flag)
+                {
+                }
+
+                [Test]
+                public void MyTest()
+                {
+                }
+            }
+            """
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Part C of #5613. Adds a Roslyn code-fix for **TUnit0049 (`MatrixDataSourceAttributeRequired`)** so the error is auto-repairable.

When a method has `[Matrix]` parameters (or a class has `[Matrix]` constructor parameters) but is missing `[MatrixDataSource]`, TUnit0049 fires as an error. Previously the user had to hand-edit. Now the IDE offers **Add [MatrixDataSource]** which inserts the attribute on the diagnosed method or type.

### Note on scope
An earlier exploration tried making `[MatrixDataSource]` implicit whenever `[Matrix]` params were present, but that touched source-gen + reflection engine + analyzer deletion and risked changing established semantics. A code-fix is a smaller, more discoverable change that leaves the explicit-attribute model intact.

## Test plan
- [x] `Adds_MatrixDataSource_On_Method` — method gains `[MatrixDataSource]`
- [x] `Adds_MatrixDataSource_On_Class` — class gains `[MatrixDataSource]`
- [ ] Manual: trigger TUnit0049 in an IDE and apply the code-fix