### PR TITLE
test(asp-net): fix race in FactoryMethodOrderTests

### DIFF
--- a/TUnit.Example.Asp.Net.TestProject/FactoryMethodOrderTests.cs
+++ b/TUnit.Example.Asp.Net.TestProject/FactoryMethodOrderTests.cs
@@ -56,13 +56,12 @@ public class FactoryMethodOrderTests : TestsBase
     {
         _ = Factory.CreateClient();
 
-        // Only verify relative order if factory methods were tracked by this test's counter
-        if (FactoryConfigureWebHostCalledOrder > 0 && FactoryConfigureStartupConfigurationCalledOrder > 0)
-        {
-            await Assert.That(FactoryConfigureStartupConfigurationCalledOrder)
-                .IsGreaterThan(FactoryConfigureWebHostCalledOrder)
-                .Because("ConfigureStartupConfiguration should run after ConfigureWebHost");
-        }
+        // Compare against the factory-owned counter rather than per-test counters — parallel tests
+        // racing on GlobalFactory.GetNextOrderCallback could otherwise interleave captures across
+        // different counters, making Startup appear to precede WebHost.
+        await Assert.That(GlobalFactory.ConfigureStartupConfigurationFactoryOrder)
+            .IsGreaterThan(GlobalFactory.ConfigureWebHostFactoryOrder)
+            .Because("ConfigureStartupConfiguration should run after ConfigureWebHost");
     }
 
     [Test]

--- a/TUnit.Example.Asp.Net.TestProject/WebApplicationFactory.cs
+++ b/TUnit.Example.Asp.Net.TestProject/WebApplicationFactory.cs
@@ -17,6 +17,12 @@ public class WebApplicationFactory : TestWebApplicationFactory<Program>
     private int _configureWebHostCallCount;
     private int _configureStartupConfigurationCallCount;
 
+    // Factory-owned monotonic counter used for inter-factory-method ordering assertions.
+    // Isolated from per-test callbacks so parallel tests can't produce interleaved orderings
+    // (e.g. ConfigureWebHost captured under test A's counter, ConfigureStartupConfiguration
+    // under test B's newly-initialised counter -> Startup < WebHost and the assertion fails).
+    private int _factoryMethodOrderCounter;
+
     /// <summary>
     /// Number of times ConfigureWebHost has been called.
     /// </summary>
@@ -33,14 +39,28 @@ public class WebApplicationFactory : TestWebApplicationFactory<Program>
     public Func<int>? GetNextOrderCallback { get; set; }
 
     /// <summary>
-    /// Order when ConfigureWebHost was called.
+    /// Order when ConfigureWebHost was called, relative to the active test's counter.
+    /// Useful for comparing against per-test hook orders.
     /// </summary>
     public int ConfigureWebHostCalledOrder { get; private set; }
 
     /// <summary>
-    /// Order when ConfigureStartupConfiguration was called.
+    /// Order when ConfigureStartupConfiguration was called, relative to the active test's counter.
+    /// Useful for comparing against per-test hook orders.
     /// </summary>
     public int ConfigureStartupConfigurationCalledOrder { get; private set; }
+
+    /// <summary>
+    /// Order when ConfigureWebHost was called, relative to a factory-owned counter.
+    /// Safe to compare against other factory-relative orders regardless of parallel-test races.
+    /// </summary>
+    public int ConfigureWebHostFactoryOrder { get; private set; }
+
+    /// <summary>
+    /// Order when ConfigureStartupConfiguration was called, relative to a factory-owned counter.
+    /// Safe to compare against other factory-relative orders regardless of parallel-test races.
+    /// </summary>
+    public int ConfigureStartupConfigurationFactoryOrder { get; private set; }
 
     /// <summary>
     /// PostgreSQL container - shared across all tests in the session.
@@ -63,6 +83,10 @@ public class WebApplicationFactory : TestWebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         Interlocked.Increment(ref _configureWebHostCallCount);
+        if (ConfigureWebHostFactoryOrder == 0)
+        {
+            ConfigureWebHostFactoryOrder = Interlocked.Increment(ref _factoryMethodOrderCounter);
+        }
         if (GetNextOrderCallback != null && ConfigureWebHostCalledOrder == 0)
         {
             ConfigureWebHostCalledOrder = GetNextOrderCallback();
@@ -85,6 +109,10 @@ public class WebApplicationFactory : TestWebApplicationFactory<Program>
     protected override void ConfigureStartupConfiguration(IConfigurationBuilder configurationBuilder)
     {
         Interlocked.Increment(ref _configureStartupConfigurationCallCount);
+        if (ConfigureStartupConfigurationFactoryOrder == 0)
+        {
+            ConfigureStartupConfigurationFactoryOrder = Interlocked.Increment(ref _factoryMethodOrderCounter);
+        }
         if (GetNextOrderCallback != null && ConfigureStartupConfigurationCalledOrder == 0)
         {
             ConfigureStartupConfigurationCalledOrder = GetNextOrderCallback();


### PR DESCRIPTION
## Summary

- `Factory_ConfigureStartupConfiguration_Runs_After_ConfigureWebHost` is flaky: the shared `GlobalFactory` captures the two factory-method orders through a mutable `GetNextOrderCallback` that parallel tests overwrite, so the two values can come from different counters (WebHost=3 from test A, Startup=1 from test B's fresh counter) and the assertion fails with "Expected to be greater than 3".
- Adds factory-owned `ConfigureWebHostFactoryOrder` / `ConfigureStartupConfigurationFactoryOrder` backed by an internal `Interlocked` counter. Both values always come from the same source so inter-factory-method ordering is race-free.
- Updates the failing test to compare against the factory-owned counter (no longer needs the "if this test initialised the factory" guard).
- Keeps the existing test-counter-relative properties intact for cross-hook comparisons in the other order tests.

Caught while investigating a failing CI run on unrelated PR #5620.

## Test plan

- [x] `dotnet run -c Release --framework net10.0 -- --treenode-filter "/*/*/FactoryMethodOrderTests/*"` — 7/7 passing locally
- [ ] Green CI on this PR