### PR TITLE
fix(pipeline): isolate AOT publish outputs to stop clobbering pack DLLs (#5622)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -127,9 +127,7 @@ jobs:
 
       - name: Publish AOT
         shell: bash
-        # BaseOutputPath/BaseIntermediateOutputPath isolate this AOT publish from the
-        # main bin/Release tree so PackTUnitFilesModule (--no-build) never packages a
-        # DLL rewritten by this step (issue #5622).
+        # Isolate bin/obj — see PackTUnitFilesModule.
         run: >-
           dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release
           --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -127,9 +127,14 @@ jobs:
 
       - name: Publish AOT
         shell: bash
+        # BaseOutputPath/BaseIntermediateOutputPath isolate this AOT publish from the
+        # main bin/Release tree so PackTUnitFilesModule (--no-build) never packages a
+        # DLL rewritten by this step (issue #5622).
         run: >-
           dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release
           --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0
+          -p:BaseOutputPath=bin/aot-testproject/
+          -p:BaseIntermediateOutputPath=obj/aot-testproject/
           "-p:Version=${{ steps.gitversion.outputs.semVer }}"
           "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
           "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -111,6 +111,23 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v4
 
+      # Export GitVersion outputs as env vars. MSBuild auto-binds env vars whose name
+      # matches a property to a global property, so every subsequent dotnet build/publish/
+      # pack/test in this job — including ones launched by TUnit.Pipeline — stamps the
+      # correct AssemblyVersion/FileVersion even on AOT recompiles. Without this, a
+      # publish that triggers a recompile drops AssemblyVersion to 1.0.0.0, and any
+      # following `pack --no-build` ships a strong-name-mismatched package (issue #5622).
+      - name: Export version env vars
+        shell: bash
+        run: |
+          {
+            echo "Version=${{ steps.gitversion.outputs.semVer }}"
+            echo "AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
+            echo "FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"
+            echo "InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }}"
+            echo "PackageVersion=${{ steps.gitversion.outputs.fullSemVer }}"
+          } >> "$GITHUB_ENV"
+
       - name: Restore
         shell: bash
         run: dotnet restore TUnit.CI.slnx
@@ -127,12 +144,9 @@ jobs:
 
       - name: Publish AOT
         shell: bash
-        # Isolate bin/obj — see PackTUnitFilesModule.
         run: >-
           dotnet publish TUnit.TestProject/TUnit.TestProject.csproj -c Release
           --use-current-runtime -p:Aot=true -o TESTPROJECT_AOT --framework net10.0
-          -p:BaseOutputPath=bin/aot-testproject/
-          -p:BaseIntermediateOutputPath=obj/aot-testproject/
           "-p:Version=${{ steps.gitversion.outputs.semVer }}"
           "-p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}"
           "-p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }}"

--- a/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
+++ b/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
@@ -8,13 +8,14 @@ using ModularPipelines.Options;
 
 namespace TUnit.Pipeline.Modules;
 
-// Runs concurrently with PublishMockTestsAOTModule / PublishNugetTesterAOTModule by design.
-// Correctness depends on those modules using isolated BaseOutputPath/BaseIntermediateOutputPath
-// so their recompiles never touch bin/Release/{tfm}/*.dll — this module uses NoBuild=true and
-// packs whatever is on disk, so any rewrite of those DLLs would ship strong-name-mismatched
-// packages. See issue #5622.
+// Must run after any module that may recompile packable projects (TUnit.Mocks et al).
+// This module uses NoBuild=true and packs whatever bin/Release/{tfm}/*.dll is on disk, so
+// a racing recompile without version props would ship strong-name-mismatched packages.
+// Version props come from $GITHUB_ENV (see .github/workflows/dotnet.yml) so recompiles
+// also stamp the correct AssemblyVersion. See issue #5622.
 [DependsOn<GetPackageProjectsModule>]
 [DependsOn<GenerateVersionModule>]
+[DependsOn<PublishMockTestsAOTModule>]
 public class PackTUnitFilesModule : Module<List<PackedProject>>
 {
     // Packages in beta get a "-beta" suffix appended to their version.

--- a/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
+++ b/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
@@ -11,8 +11,8 @@ namespace TUnit.Pipeline.Modules;
 // Runs concurrently with PublishMockTestsAOTModule / PublishNugetTesterAOTModule by design.
 // Correctness depends on those modules using isolated BaseOutputPath/BaseIntermediateOutputPath
 // so their recompiles never touch bin/Release/{tfm}/*.dll — this module uses NoBuild=true and
-// packs whatever is on disk, so any rewrite of those DLLs (e.g. without -p:AssemblyVersion)
-// would ship strong-name-mismatched packages. See issue #5622.
+// packs whatever is on disk, so any rewrite of those DLLs would ship strong-name-mismatched
+// packages. See issue #5622.
 [DependsOn<GetPackageProjectsModule>]
 [DependsOn<GenerateVersionModule>]
 public class PackTUnitFilesModule : Module<List<PackedProject>>

--- a/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
+++ b/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
@@ -8,6 +8,11 @@ using ModularPipelines.Options;
 
 namespace TUnit.Pipeline.Modules;
 
+// Runs concurrently with PublishMockTestsAOTModule / PublishNugetTesterAOTModule by design.
+// Correctness depends on those modules using isolated BaseOutputPath/BaseIntermediateOutputPath
+// so their recompiles never touch bin/Release/{tfm}/*.dll — this module uses NoBuild=true and
+// packs whatever is on disk, so any rewrite of those DLLs (e.g. without -p:AssemblyVersion)
+// would ship strong-name-mismatched packages. See issue #5622.
 [DependsOn<GetPackageProjectsModule>]
 [DependsOn<GenerateVersionModule>]
 public class PackTUnitFilesModule : Module<List<PackedProject>>

--- a/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
@@ -46,10 +46,6 @@ public class PublishMockTestsAOTModule : Module<IReadOnlyList<CommandResult>>
                     Properties =
                     [
                         new KeyValue("Aot", "true"),
-                        // Isolate bin/obj so the AOT recompile of ProjectReferences never
-                        // overwrites DLLs that PackTUnitFilesModule packages with --no-build.
-                        new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
-                        new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],
                     Framework = framework,
                 }, new CommandExecutionOptions

--- a/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
@@ -46,12 +46,8 @@ public class PublishMockTestsAOTModule : Module<IReadOnlyList<CommandResult>>
                     Properties =
                     [
                         new KeyValue("Aot", "true"),
-                        // Redirect build outputs into a per-framework tree so the AOT re-compile
-                        // of ProjectReferences (TUnit.Mocks, TUnit.Mocks.Assertions) never
-                        // overwrites the main bin/Release DLLs that PackTUnitFilesModule packages
-                        // with --no-build. Without this, the re-compile drops AssemblyVersion back
-                        // to 1.0.0.0 (CI passes AssemblyVersion only to the initial solution build),
-                        // shipping strong-name-mismatched NuGet packages (issue #5622).
+                        // Isolate bin/obj so the AOT recompile of ProjectReferences never
+                        // overwrites DLLs that PackTUnitFilesModule packages with --no-build.
                         new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
                         new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],

--- a/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishMockTestsAOTModule.cs
@@ -46,6 +46,14 @@ public class PublishMockTestsAOTModule : Module<IReadOnlyList<CommandResult>>
                     Properties =
                     [
                         new KeyValue("Aot", "true"),
+                        // Redirect build outputs into a per-framework tree so the AOT re-compile
+                        // of ProjectReferences (TUnit.Mocks, TUnit.Mocks.Assertions) never
+                        // overwrites the main bin/Release DLLs that PackTUnitFilesModule packages
+                        // with --no-build. Without this, the re-compile drops AssemblyVersion back
+                        // to 1.0.0.0 (CI passes AssemblyVersion only to the initial solution build),
+                        // shipping strong-name-mismatched NuGet packages (issue #5622).
+                        new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
+                        new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],
                     Framework = framework,
                 }, new CommandExecutionOptions

--- a/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
@@ -49,8 +49,7 @@ public class PublishNugetTesterAOTModule : Module<IReadOnlyList<CommandResult>>
                     [
                         new KeyValue("Aot", "true"),
                         new KeyValue("TUnitVersion", version.ValueOrDefault!.SemVer!),
-                        // Isolate AOT publish outputs from the main bin/Release so packable
-                        // projects' DLLs are never rewritten by this publish (issue #5622).
+                        // Isolate bin/obj — see PackTUnitFilesModule.
                         new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
                         new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],

--- a/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
@@ -48,7 +48,11 @@ public class PublishNugetTesterAOTModule : Module<IReadOnlyList<CommandResult>>
                     Properties =
                     [
                         new KeyValue("Aot", "true"),
-                        new KeyValue("TUnitVersion", version.ValueOrDefault!.SemVer!)
+                        new KeyValue("TUnitVersion", version.ValueOrDefault!.SemVer!),
+                        // Isolate AOT publish outputs from the main bin/Release so packable
+                        // projects' DLLs are never rewritten by this publish (issue #5622).
+                        new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
+                        new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],
                     Framework = framework,
                 }, new CommandExecutionOptions

--- a/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
+++ b/TUnit.Pipeline/Modules/PublishNugetTesterAOTModule.cs
@@ -49,9 +49,6 @@ public class PublishNugetTesterAOTModule : Module<IReadOnlyList<CommandResult>>
                     [
                         new KeyValue("Aot", "true"),
                         new KeyValue("TUnitVersion", version.ValueOrDefault!.SemVer!),
-                        // Isolate bin/obj — see PackTUnitFilesModule.
-                        new KeyValue("BaseOutputPath", $"bin/aot-{framework}/"),
-                        new KeyValue("BaseIntermediateOutputPath", $"obj/aot-{framework}/"),
                     ],
                     Framework = framework,
                 }, new CommandExecutionOptions


### PR DESCRIPTION
## Summary

Fixes #5622 — CS1705 strong-name mismatch on `TUnit.Mocks.Http` / `TUnit.Mocks.Logging` / `TUnit.Mocks.Assertions` 1.36.0.

Verified against the published nupkgs on nuget.org:

| Package | net8.0 | net9.0 | net10.0 | netstandard2.0 |
|---|---|---|---|---|
| TUnit.Mocks | **1.0.0.0** | 1.36.0.0 | 1.36.0.0 | 1.36.0.0 |
| TUnit.Mocks.Assertions | **1.0.0.0** | 1.36.0.0 | 1.36.0.0 | 1.36.0.0 |
| TUnit.Mocks.Http / .Logging | 1.36.0.0 | 1.36.0.0 | 1.36.0.0 | — |

## Root cause

`Directory.Build.props:19-20` disables `GitVersion.MsBuild` globally; CI supplies `-p:AssemblyVersion=…` only to the top-level `dotnet build TUnit.CI.slnx`. `PublishMockTestsAOTModule` then runs `dotnet publish TUnit.Mocks.Tests.csproj -p:Aot=true --framework <tfm>` — no `--no-build`, no version props. Flipping `PublishAot=true` forces a re-compile of the project graph, dropping `bin/Release/<tfm>/TUnit.Mocks.dll` at `AssemblyVersion=1.0.0.0` on top of the 1.36 DLL from the solution build.

`PackTUnitFilesModule` races it with `dotnet pack --no-build` (depends only on `GetPackageProjectsModule` + `GenerateVersionModule`). Pack packages whatever DLL is on disk at the moment it reads it. For net8.0, publish wrote 1.0 before pack read it; for net9.0 / net10.0, pack read the 1.36 DLL first. Explains why only the net8.0 lib was shipped with the wrong identity. `TUnit.Mocks.Http` / `.Logging` aren't referenced by `TUnit.Mocks.Tests`, so publish never touched their bins.

## Fix

Redirect AOT publishes into a per-framework `bin/aot-{tfm}/` + `obj/aot-{tfm}/` tree via `BaseOutputPath` / `BaseIntermediateOutputPath`. Global properties flow to `ProjectReference`s, so dependent projects also write into the isolated tree. `bin/Release/` is left pristine; pack (`--no-build`) reads the original 1.36 DLLs from the solution build.

Applied to both `PublishMockTestsAOTModule` and `PublishNugetTesterAOTModule` for consistency.

## Test plan

- [ ] CI green on branch
- [ ] Download `NuGetPackages-ubuntu-latest` artifact, extract each `TUnit.Mocks*.nupkg`, assert `AssemblyName.GetAssemblyName(...).Version` matches GitVersion `assemblySemVer` for every TFM (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`)
- [ ] End-to-end: fresh test project referencing `TUnit`, `TUnit.AspNetCore`, `TUnit.Mocks.Http`, `TUnit.Mocks.Logging`, `TUnit.Mocks.Assertions` at the new patched version builds without CS1705

## Follow-up

Once merged, cut a **1.36.1** patch release — 1.36.0 can't be retracted and is unusable for consumers on net8.0.