### PR TITLE
docs(test-filters): add migration callout for --filter → --treenode-filter

### DIFF
--- a/docs/docs/execution/test-filters.md
+++ b/docs/docs/execution/test-filters.md
@@ -2,6 +2,27 @@
 
 Running TUnit via `dotnet run` supports test filters.
 
+:::tip Coming from xUnit, NUnit, or MSTest?
+
+TUnit runs on Microsoft.Testing.Platform, not VSTest. The familiar
+`dotnet test --filter "Category=X"` is **not supported** — the flag is
+silently rejected, the MTP help is printed, and the run exits with
+`Zero tests ran`. This can look like a test failure when it's actually
+just an unrecognised flag.
+
+Use `--treenode-filter` instead:
+
+| VSTest (xUnit / NUnit / MSTest)            | TUnit                                                  |
+|--------------------------------------------|--------------------------------------------------------|
+| `--filter "Category=Integration"`          | `--treenode-filter "/*/*/*/*[Category=Integration]"`   |
+| `--filter "FullyQualifiedName~LoginTests"` | `--treenode-filter "/*/*/LoginTests/*"`                |
+| `--filter "Name=AcceptCookiesTest"`        | `--treenode-filter "/*/*/*/AcceptCookiesTest"`         |
+
+When using `dotnet test`, pass the flag as an application argument:
+`dotnet test -- --treenode-filter "..."`.
+
+:::
+
 TUnit can select tests by:
 
 - Assembly


### PR DESCRIPTION
Small docs-only change. Adds a tip callout to the top of the existing test filters page so users coming from xUnit / NUnit / MSTest find the `--filter` → `--treenode-filter` mapping before they go looking for it.

## Why

VSTest's `dotnet test --filter "Category=X"` is familiar to anyone migrating. On Microsoft.Testing.Platform the flag is silently rejected, the MTP help is printed, and the run exits with `Zero tests ran`. It looks like a test failure when it's actually just an unrecognised flag — I hit this myself running an AI dev agent against a TUnit project (the agent spent ~11 minutes trying filter variations before giving up). Easy signposting seemed like the lightest-weight fix.

## Scope

Single file: `docs/docs/execution/test-filters.md`. One callout block plus a three-row mapping table, links back into the existing filter examples that already cover the destination syntax comprehensively. Nothing else touched.

## Alternatives considered

- Adding to each of the three migration pages (`xunit.md`, `nunit.md`, `mstest.md`). They currently focus on code syntax rather than CLI, so one central callout felt lighter than three duplicate ones.
- A brand-new "Running tests from xUnit/NUnit" page. Felt like overkill for a small signpost.

Love TUnit — using it heavily on a new project. Thanks for building it.