### PR TITLE
ci: use setup-dotnet built-in NuGet cache

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -71,18 +71,9 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v5
-        continue-on-error: true
         with:
-          path: |
-            ${{ env.NUGET_PACKAGES || '~/.nuget/packages' }}
-            ~/.local/share/NuGet
-            %LocalAppData%\NuGet\v3-cache
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-
+          cache: true
+          cache-dependency-path: Directory.Packages.props
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- Drop the dedicated `actions/cache` step for NuGet packages in `.github/workflows/dotnet.yml` in favour of `actions/setup-dotnet`'s built-in cache.
- Key the cache on `Directory.Packages.props` only — with Central Package Management enabled, it's the sole source of package versions, so hashing csproj files adds nothing.

## Trade-off
`setup-dotnet`'s cache does not expose `restore-keys`, so a version bump now triggers a full cache miss instead of a partial restore. Simpler config in exchange for occasional full re-downloads.

## Test plan
- [ ] CI run on this PR restores/saves the cache via setup-dotnet
- [ ] Subsequent run with no `Directory.Packages.props` change reports a cache hit