### PR TITLE
docs: add Tluma Ask AI widget to Docusaurus site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -34,6 +34,30 @@ const config: Config = {
     'docusaurus-plugin-llms',
   ],
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `window.tlumaConfig = {
+  source: "thomhurst/tunit",
+  theme: "auto",
+  brandColor: "blue",
+  button: "bottom-right",
+  welcomePulse: true,
+  edgePadding: "1rem",
+  autoOpen: false,
+  desktopFullscreenByDefault: false
+};`,
+    },
+  ],
+
+  scripts: [
+    {
+      src: 'https://tluma.ai/widget.js',
+      async: true,
+    },
+  ],
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
## Summary
- Add Tluma Ask AI widget to the Docusaurus docs site
- Inject `window.tlumaConfig` via `headTags` with the provided source/theme/brand settings
- Load `https://tluma.ai/widget.js` asynchronously via the `scripts` option
- No existing Docusaurus configuration was removed; TypeScript `Config` types remain valid

## Test plan
- [ ] `cd docs && npm run build` succeeds with no TypeScript errors
- [ ] `cd docs && npm start` serves the site locally with the Tluma launcher button visible in the bottom-right corner
- [ ] Clicking the launcher opens the Ask AI widget and it responds to queries against `thomhurst/tunit`