### PR TITLE
Revert "chore(deps): update dependency docusaurus-plugin-llms to ^0.4.0 (#5637)"

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "@docusaurus/module-type-aliases": "3.10.0",
     "@docusaurus/tsconfig": "3.10.0",
     "@docusaurus/types": "3.10.0",
-    "docusaurus-plugin-llms": "^0.4.0",
+    "docusaurus-plugin-llms": "^0.3.1",
     "typescript": "~6.0.3"
   },
   "browserslist": {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4539,10 +4539,10 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-plugin-llms@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz#020f00d83459c7feb71c7b6e61774d864336d8ae"
-  integrity sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==
+docusaurus-plugin-llms@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.3.1.tgz#086e7f1f3ecbfb85345ffed01218746145d032a7"
+  integrity sha512-2RsDC4czy1pt2kauIACOcLvSaGmjF3X0pgcVtL6fblzzZMgkasQJrOLN0pRur11j7rQkiaiCGR9NsU3mp4M8fg==
   dependencies:
     gray-matter "^4.0.3"
     minimatch "^9.0.3"


### PR DESCRIPTION
Reverts #5637.

## Summary
- Reverts the bump of `docusaurus-plugin-llms` from the prior version to `^0.4.0` in `docs/package.json` and `docs/yarn.lock`.

## Test plan
- [ ] `docs` build succeeds on the reverted version