### PR TITLE
fix(aspire): preserve user-supplied OTLP endpoint (#4818)

### DIFF
--- a/TUnit.Aspire.Tests/OtlpEndpointEnvironmentTests.cs
+++ b/TUnit.Aspire.Tests/OtlpEndpointEnvironmentTests.cs
@@ -1,5 +1,4 @@
 using TUnit.Aspire;
-using TUnit.OpenTelemetry.Receiver;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
@@ -8,64 +7,54 @@ namespace TUnit.Aspire.Tests;
 
 public class OtlpEndpointEnvironmentTests
 {
+    private const string EnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    private const string OverrideEndpoint = "http://127.0.0.1:5000";
+
     [Test]
-    public async Task Capture_PreservesUserEndpoint_AsReceiverUpstream()
+    public async Task Capture_ReturnsUserEndpoint_AndOverridesValue()
     {
         // Regression for #4818: when the user has already set OTEL_EXPORTER_OTLP_ENDPOINT
         // (e.g. pointing at their own Aspire dashboard via WithEnvironment in ConfigureBuilder),
-        // TUnit must capture that endpoint as the receiver's upstream forward target before
-        // overriding the env var with the local OtlpReceiver URL — otherwise spans are
-        // silently dropped from the dashboard.
-        await using var receiver = new OtlpReceiver();
+        // TUnit must surface that endpoint to the caller (which then forwards it to the
+        // receiver) before overriding the env var with the local TUnit receiver URL —
+        // otherwise the user's dashboard silently loses all SUT spans.
         var env = new Dictionary<string, object>
         {
-            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://my-dashboard:18889",
+            [EnvVar] = "http://my-dashboard:18889",
         };
 
-        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
-            env,
-            receiver,
-            overrideEndpoint: "http://127.0.0.1:5000");
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(env, OverrideEndpoint);
 
         await Assert.That(captured).IsEqualTo("http://my-dashboard:18889");
-        await Assert.That(receiver.UpstreamEndpoint).IsEqualTo("http://my-dashboard:18889");
-        await Assert.That(env["OTEL_EXPORTER_OTLP_ENDPOINT"] as string).IsEqualTo("http://127.0.0.1:5000");
+        await Assert.That(env[EnvVar] as string).IsEqualTo(OverrideEndpoint);
     }
 
     [Test]
-    public async Task Capture_NoUserEndpoint_LeavesUpstreamNull()
+    public async Task Capture_NoUserEndpoint_ReturnsNull_AndSetsOverride()
     {
-        await using var receiver = new OtlpReceiver();
         var env = new Dictionary<string, object>();
 
-        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
-            env,
-            receiver,
-            overrideEndpoint: "http://127.0.0.1:5000");
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(env, OverrideEndpoint);
 
         await Assert.That(captured).IsNull();
-        await Assert.That(receiver.UpstreamEndpoint).IsNull();
-        await Assert.That(env["OTEL_EXPORTER_OTLP_ENDPOINT"] as string).IsEqualTo("http://127.0.0.1:5000");
+        await Assert.That(env[EnvVar] as string).IsEqualTo(OverrideEndpoint);
     }
 
     [Test]
-    public async Task Capture_IgnoresNonStringExistingValue()
+    public async Task Capture_IgnoresNonStringExistingValue_ButStillOverrides()
     {
         // Aspire env-var dict values can be EndpointReference, ParameterResource, etc.
-        // Only plain string values should be treated as forward targets — anything else
-        // is opaque and would not have resolved to a usable URL anyway.
-        await using var receiver = new OtlpReceiver();
+        // Only plain string values are forward-target candidates — non-strings are opaque
+        // and cannot be used as a URL. The override still happens so the SUT exports to
+        // the local receiver regardless.
         var env = new Dictionary<string, object>
         {
-            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = new object(),
+            [EnvVar] = new object(),
         };
 
-        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
-            env,
-            receiver,
-            overrideEndpoint: "http://127.0.0.1:5000");
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(env, OverrideEndpoint);
 
         await Assert.That(captured).IsNull();
-        await Assert.That(receiver.UpstreamEndpoint).IsNull();
+        await Assert.That(env[EnvVar] as string).IsEqualTo(OverrideEndpoint);
     }
 }

--- a/TUnit.Aspire.Tests/OtlpEndpointEnvironmentTests.cs
+++ b/TUnit.Aspire.Tests/OtlpEndpointEnvironmentTests.cs
@@ -1,0 +1,71 @@
+using TUnit.Aspire;
+using TUnit.OpenTelemetry.Receiver;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using TUnit.Core;
+
+namespace TUnit.Aspire.Tests;
+
+public class OtlpEndpointEnvironmentTests
+{
+    [Test]
+    public async Task Capture_PreservesUserEndpoint_AsReceiverUpstream()
+    {
+        // Regression for #4818: when the user has already set OTEL_EXPORTER_OTLP_ENDPOINT
+        // (e.g. pointing at their own Aspire dashboard via WithEnvironment in ConfigureBuilder),
+        // TUnit must capture that endpoint as the receiver's upstream forward target before
+        // overriding the env var with the local OtlpReceiver URL — otherwise spans are
+        // silently dropped from the dashboard.
+        await using var receiver = new OtlpReceiver();
+        var env = new Dictionary<string, object>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://my-dashboard:18889",
+        };
+
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
+            env,
+            receiver,
+            overrideEndpoint: "http://127.0.0.1:5000");
+
+        await Assert.That(captured).IsEqualTo("http://my-dashboard:18889");
+        await Assert.That(receiver.UpstreamEndpoint).IsEqualTo("http://my-dashboard:18889");
+        await Assert.That(env["OTEL_EXPORTER_OTLP_ENDPOINT"] as string).IsEqualTo("http://127.0.0.1:5000");
+    }
+
+    [Test]
+    public async Task Capture_NoUserEndpoint_LeavesUpstreamNull()
+    {
+        await using var receiver = new OtlpReceiver();
+        var env = new Dictionary<string, object>();
+
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
+            env,
+            receiver,
+            overrideEndpoint: "http://127.0.0.1:5000");
+
+        await Assert.That(captured).IsNull();
+        await Assert.That(receiver.UpstreamEndpoint).IsNull();
+        await Assert.That(env["OTEL_EXPORTER_OTLP_ENDPOINT"] as string).IsEqualTo("http://127.0.0.1:5000");
+    }
+
+    [Test]
+    public async Task Capture_IgnoresNonStringExistingValue()
+    {
+        // Aspire env-var dict values can be EndpointReference, ParameterResource, etc.
+        // Only plain string values should be treated as forward targets — anything else
+        // is opaque and would not have resolved to a usable URL anyway.
+        await using var receiver = new OtlpReceiver();
+        var env = new Dictionary<string, object>
+        {
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = new object(),
+        };
+
+        var captured = OtlpEndpointEnvironment.CaptureAndOverride(
+            env,
+            receiver,
+            overrideEndpoint: "http://127.0.0.1:5000");
+
+        await Assert.That(captured).IsNull();
+        await Assert.That(receiver.UpstreamEndpoint).IsNull();
+    }
+}

--- a/TUnit.Aspire.Tests/OtlpReceiverTests.cs
+++ b/TUnit.Aspire.Tests/OtlpReceiverTests.cs
@@ -288,6 +288,46 @@ public class OtlpReceiverTests
     }
 
     [Test]
+    public async Task Receiver_ForwardsToUpstream_WhenSetAfterConstruction()
+    {
+        // Regression: AspireFixture must be able to discover the user's OTLP endpoint
+        // (e.g. an Aspire dashboard configured via WithEnvironment in ConfigureBuilder)
+        // AFTER the receiver is constructed, because environment callbacks resolve at
+        // resource startup — not when StartOtlpReceiver runs.
+        await using var upstream = new OtlpReceiver();
+        upstream.Start();
+
+        await using var receiver = new OtlpReceiver();
+        receiver.Start();
+
+        // Set forwarding target after construction (simulates the AspireFixture
+        // capturing the user-supplied OTEL_EXPORTER_OTLP_ENDPOINT inside its callback).
+        receiver.UpstreamEndpoint = $"http://127.0.0.1:{upstream.Port}";
+
+        var body = OtlpProtobufBuilder.BuildExportLogsServiceRequest(
+            "late-bound-svc",
+            new LogRecordSpec
+            {
+                TraceId = Guid.NewGuid().ToString("N"),
+                SeverityNumber = 9,
+                Body = "Forwarded after upstream was set",
+            });
+
+        using var client = new HttpClient();
+        var content = new ByteArrayContent(body);
+        content.Headers.ContentType = new("application/x-protobuf");
+
+        var response = await client.PostAsync($"http://127.0.0.1:{receiver.Port}/v1/logs", content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        await receiver.WhenIdle();
+        await upstream.WhenIdle();
+
+        await Assert.That(upstream.RequestCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Receiver_HandlesMultipleSequentialRequests()
     {
         var testContext = TestContext.Current!;

--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -367,7 +367,6 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     // --- OTLP Telemetry ---
 
     private const string DashboardOtlpEndpointEnvVar = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
-    private const string OtelExporterEndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
     private const string OtelExporterProtocolEnvVar = "OTEL_EXPORTER_OTLP_PROTOCOL";
     private const string OtelServiceNameEnvVar = "OTEL_SERVICE_NAME";
     private const string OtelBlrpScheduleDelayEnvVar = "OTEL_BLRP_SCHEDULE_DELAY";
@@ -385,6 +384,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     private void ConfigureOtlpEndpoints(IDistributedApplicationTestingBuilder builder)
     {
         var otlpEndpoint = $"http://127.0.0.1:{_otlpReceiver!.Port}";
+        var receiver = _otlpReceiver;
 
         foreach (var resource in builder.Resources)
         {
@@ -395,7 +395,13 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
                 projectResource.Annotations.Add(
                     new EnvironmentCallbackAnnotation(context =>
                     {
-                        context.EnvironmentVariables[OtelExporterEndpointEnvVar] = otlpEndpoint;
+                        // Forward to user's dashboard if they set OTEL_EXPORTER_OTLP_ENDPOINT
+                        // themselves (#4818), otherwise their spans get dropped by the override.
+                        OtlpEndpointEnvironment.CaptureAndOverride(
+                            context.EnvironmentVariables,
+                            receiver,
+                            otlpEndpoint);
+
                         context.EnvironmentVariables[OtelExporterProtocolEnvVar] = "http/protobuf";
 
                         // Set the service name from the Aspire resource name so

--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -397,10 +397,13 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
                     {
                         // Forward to user's dashboard if they set OTEL_EXPORTER_OTLP_ENDPOINT
                         // themselves (#4818), otherwise their spans get dropped by the override.
-                        OtlpEndpointEnvironment.CaptureAndOverride(
+                        var userEndpoint = OtlpEndpointEnvironment.CaptureAndOverride(
                             context.EnvironmentVariables,
-                            receiver,
                             otlpEndpoint);
+                        if (userEndpoint is not null)
+                        {
+                            receiver.UpstreamEndpoint = userEndpoint;
+                        }
 
                         context.EnvironmentVariables[OtelExporterProtocolEnvVar] = "http/protobuf";
 

--- a/TUnit.Aspire/OtlpEndpointEnvironment.cs
+++ b/TUnit.Aspire/OtlpEndpointEnvironment.cs
@@ -1,0 +1,34 @@
+using TUnit.OpenTelemetry.Receiver;
+
+namespace TUnit.Aspire;
+
+internal static class OtlpEndpointEnvironment
+{
+    internal const string OtelExporterEndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+    /// <summary>
+    /// Captures any user-supplied <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> as the receiver's
+    /// upstream forward target, then overrides the env var with <paramref name="overrideEndpoint"/>
+    /// so the SUT exports to the local TUnit receiver. Without this, the user's own
+    /// dashboard silently loses all SUT spans (#4818).
+    /// </summary>
+    /// <returns>The captured user endpoint, or <c>null</c> if none was set.</returns>
+    public static string? CaptureAndOverride(
+        IDictionary<string, object> environmentVariables,
+        OtlpReceiver receiver,
+        string overrideEndpoint)
+    {
+        string? userEndpoint = null;
+
+        if (environmentVariables.TryGetValue(OtelExporterEndpointEnvVar, out var existing)
+            && existing is string s
+            && !string.IsNullOrWhiteSpace(s))
+        {
+            userEndpoint = s;
+            receiver.UpstreamEndpoint = s;
+        }
+
+        environmentVariables[OtelExporterEndpointEnvVar] = overrideEndpoint;
+        return userEndpoint;
+    }
+}

--- a/TUnit.Aspire/OtlpEndpointEnvironment.cs
+++ b/TUnit.Aspire/OtlpEndpointEnvironment.cs
@@ -1,5 +1,3 @@
-using TUnit.OpenTelemetry.Receiver;
-
 namespace TUnit.Aspire;
 
 internal static class OtlpEndpointEnvironment
@@ -7,15 +5,21 @@ internal static class OtlpEndpointEnvironment
     internal const string OtelExporterEndpointEnvVar = "OTEL_EXPORTER_OTLP_ENDPOINT";
 
     /// <summary>
-    /// Captures any user-supplied <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> as the receiver's
-    /// upstream forward target, then overrides the env var with <paramref name="overrideEndpoint"/>
-    /// so the SUT exports to the local TUnit receiver. Without this, the user's own
-    /// dashboard silently loses all SUT spans (#4818).
+    /// Captures any user-supplied <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>, then overrides the
+    /// env var with <paramref name="overrideEndpoint"/> so the SUT exports to the local
+    /// TUnit receiver. The caller is responsible for forwarding the captured value to the
+    /// receiver's upstream — without it, the user's own dashboard silently loses all SUT
+    /// spans (#4818).
     /// </summary>
-    /// <returns>The captured user endpoint, or <c>null</c> if none was set.</returns>
-    public static string? CaptureAndOverride(
+    /// <returns>The captured user endpoint, or <c>null</c> if none was set as a string.</returns>
+    /// <remarks>
+    /// Non-string entries (e.g. <c>EndpointReference</c>, <c>ParameterResource</c>) are not
+    /// captured. Aspire would normally resolve those to URLs at process launch, but once
+    /// we overwrite the entry that resolution path is lost. Documenting as a known
+    /// limitation; revisit if a user reports it.
+    /// </remarks>
+    internal static string? CaptureAndOverride(
         IDictionary<string, object> environmentVariables,
-        OtlpReceiver receiver,
         string overrideEndpoint)
     {
         string? userEndpoint = null;
@@ -25,7 +29,6 @@ internal static class OtlpEndpointEnvironment
             && !string.IsNullOrWhiteSpace(s))
         {
             userEndpoint = s;
-            receiver.UpstreamEndpoint = s;
         }
 
         environmentVariables[OtelExporterEndpointEnvVar] = overrideEndpoint;

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -69,15 +69,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     public string? UpstreamEndpoint
     {
         get => Volatile.Read(ref _upstreamEndpoint);
-        set
-        {
-            var normalized = value?.TrimEnd('/');
-            if (normalized == Volatile.Read(ref _upstreamEndpoint))
-            {
-                return;
-            }
-            Volatile.Write(ref _upstreamEndpoint, normalized);
-        }
+        set => Volatile.Write(ref _upstreamEndpoint, value?.TrimEnd('/'));
     }
 
     /// <summary>

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -28,11 +28,12 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 {
     private const long MaxBodyBytes = 16 * 1024 * 1024; // 16 MB
 
+    private static readonly HttpClient s_forwardingClient = new();
+
     private readonly HttpListener _listener;
     private readonly CancellationTokenSource _cts = new();
     private readonly ConcurrentDictionary<int, Task> _inflightTasks = new();
-    private readonly HttpClient? _forwardingClient;
-    private readonly string? _upstreamEndpoint;
+    private string? _upstreamEndpoint;
     private Task? _listenTask;
     private int _taskIdCounter;
     private int _requestCount;
@@ -56,12 +57,26 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     /// </param>
     public OtlpReceiver(string? upstreamEndpoint = null)
     {
-        _upstreamEndpoint = upstreamEndpoint?.TrimEnd('/');
         (_listener, Port) = CreateListener();
+        UpstreamEndpoint = upstreamEndpoint;
+    }
 
-        if (_upstreamEndpoint is not null)
+    /// <summary>
+    /// Optional upstream OTLP endpoint to forward telemetry to. May be assigned after
+    /// construction — Aspire env-var callbacks resolve at resource startup, not at
+    /// receiver-build time. Set to <c>null</c> to stop forwarding.
+    /// </summary>
+    public string? UpstreamEndpoint
+    {
+        get => Volatile.Read(ref _upstreamEndpoint);
+        set
         {
-            _forwardingClient = new HttpClient();
+            var normalized = value?.TrimEnd('/');
+            if (normalized == Volatile.Read(ref _upstreamEndpoint))
+            {
+                return;
+            }
+            Volatile.Write(ref _upstreamEndpoint, normalized);
         }
     }
 
@@ -175,9 +190,10 @@ internal sealed class OtlpReceiver : IAsyncDisposable
                 ProcessTraces(body);
             }
 
-            if (_upstreamEndpoint is not null && _forwardingClient is not null)
+            var upstream = Volatile.Read(ref _upstreamEndpoint);
+            if (upstream is not null)
             {
-                TrackTask(ForwardAsync(path, body, request.ContentType));
+                TrackTask(ForwardAsync(upstream, path, body, request.ContentType));
             }
 
             Interlocked.Increment(ref _requestCount);
@@ -369,7 +385,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
         }
     }
 
-    private async Task ForwardAsync(string path, byte[] body, string? contentType)
+    private static async Task ForwardAsync(string upstream, string path, byte[] body, string? contentType)
     {
         try
         {
@@ -379,8 +395,8 @@ internal sealed class OtlpReceiver : IAsyncDisposable
                 content.Headers.TryAddWithoutValidation("Content-Type", contentType);
             }
 
-            await _forwardingClient!.PostAsync(
-                $"{_upstreamEndpoint}{path}",
+            await s_forwardingClient.PostAsync(
+                $"{upstream}{path}",
                 content).ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -426,7 +442,6 @@ internal sealed class OtlpReceiver : IAsyncDisposable
             // Best effort — individual failures already logged via Trace.WriteLine
         }
 
-        _forwardingClient?.Dispose();
         _cts.Dispose();
     }
 


### PR DESCRIPTION
## Summary

Fixes #4818 — TUnit.Aspire was silently dropping SUT traces from a user-hosted Aspire dashboard whenever `OTEL_EXPORTER_OTLP_ENDPOINT` was set via `WithEnvironment` in `ConfigureBuilder`.

- `AspireFixture.ConfigureOtlpEndpoints` now captures any pre-existing user `OTEL_EXPORTER_OTLP_ENDPOINT` value as the receiver's upstream forwarding target before overriding it with the local TUnit receiver URL. Project resources still export to TUnit (for log/test correlation), and the receiver now forwards everything to the user's dashboard.
- `OtlpReceiver.UpstreamEndpoint` made settable post-construction (via lock-free `Volatile.Read/Write`); a single `static readonly HttpClient` handles forwarding so there's no instance lock on the per-export hot path.
- New `OtlpEndpointEnvironment.CaptureAndOverride` helper isolates the capture-then-override logic so it's unit-testable without spinning up a full Aspire host.

## Why it broke

Environment callbacks resolve at resource startup, not at `StartOtlpReceiver` time. Before this fix, the receiver only knew about `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` (set when Aspire's built-in dashboard is enabled). Users disabling the built-in dashboard (`options.DisableDashboard = true`) and pointing project resources at their own dashboard had no way to inform the receiver — so spans went into the receiver and never came out the other side.

`ContainerResource`-typed resources (e.g. WireMock) kept working because TUnit only annotates `ProjectResource`s, leaving container env vars untouched. That asymmetry is what made the regression so confusing in the issue report.

## Test plan

- [x] New unit tests for `OtlpEndpointEnvironment.CaptureAndOverride` (capture / no-key / non-string-value cases) — `TUnit.Aspire.Tests/OtlpEndpointEnvironmentTests.cs`
- [x] New `OtlpReceiver` test that sets `UpstreamEndpoint` post-construction and verifies forwarding still works — `TUnit.Aspire.Tests/OtlpReceiverTests.cs`
- [x] All existing `OtlpReceiverTests` still pass (14/14)
- [ ] End-to-end verification with redoz's repro repo (https://github.com/redoz/tunit-aspire-wiremock-example) — recommend running before release