### PR TITLE
feat(aspire): emit client spans for HTTP

### DIFF
--- a/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
+++ b/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
@@ -52,14 +52,25 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
         InjectTraceContext(propagationActivity, request.Headers);
         InjectBaggage(propagationActivity, request.Headers);
 
-        var response = await base.SendAsync(request, cancellationToken);
+        HttpResponseMessage response;
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            RecordException(activity, ex);
+            throw;
+        }
 
         if (activity is not null)
         {
-            activity.SetTag("http.response.status_code", (int)response.StatusCode);
-            if (!response.IsSuccessStatusCode)
+            var statusCode = (int)response.StatusCode;
+            activity.SetTag("http.response.status_code", statusCode);
+            if (statusCode >= 400)
             {
                 activity.SetStatus(ActivityStatusCode.Error);
+                activity.SetTag("error.type", statusCode.ToString());
             }
         }
 
@@ -126,5 +137,24 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
         {
             headers.TryAddWithoutValidation(TUnit.Core.TUnitActivitySource.BaggageHeader, baggage);
         }
+    }
+
+    private static void RecordException(Activity? activity, Exception exception)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        var tags = new ActivityTagsCollection
+        {
+            { "exception.type", exception.GetType().FullName },
+            { "exception.message", exception.Message },
+            { "exception.stacktrace", exception.ToString() }
+        };
+
+        activity.AddEvent(new ActivityEvent("exception", tags: tags));
+        activity.SetTag("error.type", exception.GetType().FullName);
+        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 }

--- a/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
+++ b/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
@@ -59,6 +59,9 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
         }
         catch (Exception ex)
         {
+            // Only the synthesized client span gets exception metadata. When no listener is
+            // attached, propagation falls back to the ambient activity and there is no extra
+            // HTTP client span to annotate.
             TUnit.Core.TUnitActivitySource.RecordException(activity, ex);
             throw;
         }

--- a/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
+++ b/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
@@ -59,7 +59,7 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
         }
         catch (Exception ex)
         {
-            RecordException(activity, ex);
+            TUnit.Core.TUnitActivitySource.RecordException(activity, ex);
             throw;
         }
 
@@ -137,24 +137,5 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
         {
             headers.TryAddWithoutValidation(TUnit.Core.TUnitActivitySource.BaggageHeader, baggage);
         }
-    }
-
-    private static void RecordException(Activity? activity, Exception exception)
-    {
-        if (activity is null)
-        {
-            return;
-        }
-
-        var tags = new ActivityTagsCollection
-        {
-            { "exception.type", exception.GetType().FullName },
-            { "exception.message", exception.Message },
-            { "exception.stacktrace", exception.ToString() }
-        };
-
-        activity.AddEvent(new ActivityEvent("exception", tags: tags));
-        activity.SetTag("error.type", exception.GetType().FullName);
-        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 }

--- a/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
+++ b/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
@@ -119,6 +119,7 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
 
         foreach (var (key, value) in source.Baggage)
         {
+            // Preserve baggage already attached to the synthesized client span itself.
             if (key is null || destination.GetBaggageItem(key) is not null)
             {
                 continue;

--- a/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
+++ b/TUnit.AspNetCore.Core/Http/ActivityPropagationHandler.cs
@@ -82,9 +82,11 @@ internal sealed class ActivityPropagationHandler : DelegatingHandler
 
     private static Activity? StartHttpActivity(HttpRequestMessage request)
     {
-        var path = request.RequestUri?.AbsolutePath ?? request.RequestUri?.ToString() ?? "unknown";
+        var method = string.IsNullOrWhiteSpace(request.Method.Method)
+            ? "HTTP"
+            : request.Method.Method;
         return HttpActivitySource.StartActivity(
-            $"HTTP {request.Method} {path}",
+            method,
             ActivityKind.Client);
     }
 

--- a/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
+++ b/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
@@ -30,10 +30,13 @@ public class ActivityPropagationHandlerTests
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
         var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
 
-        await Assert.That(parts.Length).IsEqualTo(4);
+        await AssertValidW3CTraceparent(traceparent);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
+        await Assert.That(clientSpan.TraceId).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(clientSpan.ParentSpanId).IsEqualTo(activity.SpanId.ToString());
+        await Assert.That(clientSpan.Kind).IsEqualTo(ActivityKind.Client);
         await Assert.That(clientSpan.DisplayName).IsEqualTo("GET");
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
         await Assert.That(baggageHeader).Contains("my-test-context-id");
@@ -57,6 +60,7 @@ public class ActivityPropagationHandlerTests
         var parts = traceparent.Split('-');
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
 
+        await AssertValidW3CTraceparent(traceparent);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(activity.SpanId.ToString());
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
@@ -160,6 +164,19 @@ public class ActivityPropagationHandlerTests
             : new ActivityPropagationHandler(startActivity);
     }
 
+    private static async Task AssertValidW3CTraceparent(string traceparent)
+    {
+        var parts = traceparent.Split('-');
+
+        await Assert.That(parts.Length).IsEqualTo(4);
+        await Assert.That(parts[0]).IsEqualTo("00");
+        await Assert.That(parts[1].Length).IsEqualTo(32);
+        await Assert.That(parts[1].All(static c => Uri.IsHexDigit(c))).IsTrue();
+        await Assert.That(parts[2].Length).IsEqualTo(16);
+        await Assert.That(parts[2].All(static c => Uri.IsHexDigit(c))).IsTrue();
+        await Assert.That(parts[3] is "00" or "01").IsTrue();
+    }
+
     private sealed class ActivityListenerScope : IDisposable
     {
         private readonly ConcurrentQueue<RecordedActivity> _stoppedActivities = new();
@@ -173,8 +190,11 @@ public class ActivityPropagationHandlerTests
                 Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
                     ActivitySamplingResult.AllDataAndRecorded,
                 ActivityStopped = activity => _stoppedActivities.Enqueue(new RecordedActivity(
+                    activity.TraceId.ToString(),
                     activity.SpanId.ToString(),
+                    activity.ParentSpanId == default ? null : activity.ParentSpanId.ToString(),
                     activity.DisplayName,
+                    activity.Kind,
                     activity.Status,
                     activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString()),
                     activity.Events.Select(static e => e.Name).ToArray()))
@@ -192,8 +212,11 @@ public class ActivityPropagationHandlerTests
     }
 
     private sealed record RecordedActivity(
+        string TraceId,
         string SpanId,
+        string? ParentSpanId,
         string DisplayName,
+        ActivityKind Kind,
         ActivityStatusCode Status,
         IReadOnlyDictionary<string, string?> Tags,
         string[] EventNames);

--- a/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
+++ b/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
@@ -34,6 +34,7 @@ public class ActivityPropagationHandlerTests
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
+        await Assert.That(clientSpan.DisplayName).IsEqualTo("GET");
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
         await Assert.That(baggageHeader).Contains("my-test-context-id");
     }
@@ -173,6 +174,7 @@ public class ActivityPropagationHandlerTests
                     ActivitySamplingResult.AllDataAndRecorded,
                 ActivityStopped = activity => _stoppedActivities.Enqueue(new RecordedActivity(
                     activity.SpanId.ToString(),
+                    activity.DisplayName,
                     activity.Status,
                     activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString()),
                     activity.Events.Select(static e => e.Name).ToArray()))
@@ -191,6 +193,7 @@ public class ActivityPropagationHandlerTests
 
     private sealed record RecordedActivity(
         string SpanId,
+        string DisplayName,
         ActivityStatusCode Status,
         IReadOnlyDictionary<string, string?> Tags,
         string[] EventNames);

--- a/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
+++ b/TUnit.AspNetCore.Tests/ActivityPropagationHandlerTests.cs
@@ -1,10 +1,13 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
 
 namespace TUnit.AspNetCore.Tests;
 
+[NotInParallel(nameof(ActivityPropagationHandlerTests))]
 public class ActivityPropagationHandlerTests
 {
     [Test]
@@ -25,8 +28,11 @@ public class ActivityPropagationHandlerTests
         var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
         var parts = traceparent.Split('-');
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
 
+        await Assert.That(parts.Length).IsEqualTo(4);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
         await Assert.That(baggageHeader).Contains("my-test-context-id");
@@ -72,6 +78,80 @@ public class ActivityPropagationHandlerTests
         await Assert.That(captured.LastRequest.Headers.Contains("baggage")).IsFalse();
     }
 
+    [Test]
+    public async Task SendAsync_ClientSpan_3xxStatus_LeavesStatusUnset()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-redirect").Start();
+
+        var captured = new CaptureHandler(HttpStatusCode.Redirect);
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/test");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(302);
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("http.response.status_code")).IsEqualTo("302");
+        await Assert.That(clientSpan.Tags.ContainsKey("error.type")).IsFalse();
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Unset);
+    }
+
+    [Test]
+    public async Task SendAsync_ClientSpan_4xxStatus_SetsErrorStatus()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-not-found").Start();
+
+        var captured = new CaptureHandler(HttpStatusCode.NotFound);
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/test");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(404);
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("http.response.status_code")).IsEqualTo("404");
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("error.type")).IsEqualTo("404");
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Error);
+    }
+
+    [Test]
+    public async Task SendAsync_ClientSpan_RecordsException_WhenInnerHandlerThrows()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-transport-error").Start();
+
+        var handler = CreateHandler();
+        handler.InnerHandler = new ThrowingHandler(new HttpRequestException("boom"));
+        using var client = new HttpClient(handler);
+
+        HttpRequestException? thrown = null;
+        try
+        {
+            await client.GetAsync("http://localhost/test");
+        }
+        catch (HttpRequestException ex)
+        {
+            thrown = ex;
+        }
+
+        await Assert.That(thrown).IsNotNull();
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("error.type")).Contains(nameof(HttpRequestException));
+        await Assert.That(clientSpan.EventNames).Contains("exception");
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Error);
+    }
+
+    // Pass static _ => null to simulate no helper span; null uses the real StartHttpActivity default.
     private static DelegatingHandler CreateHandler(Func<HttpRequestMessage, Activity?>? startActivity = null)
     {
         return startActivity is null
@@ -81,17 +161,27 @@ public class ActivityPropagationHandlerTests
 
     private sealed class ActivityListenerScope : IDisposable
     {
-        private readonly ActivityListener _listener = new()
-        {
-            ShouldListenTo = static source => source.Name == "TUnit.AspNetCore.Http",
-            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
-                ActivitySamplingResult.AllDataAndRecorded
-        };
+        private readonly ConcurrentQueue<RecordedActivity> _stoppedActivities = new();
+        private readonly ActivityListener _listener;
 
         public ActivityListenerScope()
         {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = static source => source.Name == TUnitActivitySource.AspNetCoreHttpSourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => _stoppedActivities.Enqueue(new RecordedActivity(
+                    activity.SpanId.ToString(),
+                    activity.Status,
+                    activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString()),
+                    activity.Events.Select(static e => e.Name).ToArray()))
+            };
+
             ActivitySource.AddActivityListener(_listener);
         }
+
+        public RecordedActivity[] StoppedActivities => _stoppedActivities.ToArray();
 
         public void Dispose()
         {
@@ -99,15 +189,37 @@ public class ActivityPropagationHandlerTests
         }
     }
 
+    private sealed record RecordedActivity(
+        string SpanId,
+        ActivityStatusCode Status,
+        IReadOnlyDictionary<string, string?> Tags,
+        string[] EventNames);
+
     private sealed class CaptureHandler : HttpMessageHandler
     {
+        private readonly HttpStatusCode _statusCode;
+
+        public CaptureHandler(HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _statusCode = statusCode;
+        }
+
         public HttpRequestMessage? LastRequest { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             LastRequest = request;
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            return Task.FromResult(new HttpResponseMessage(_statusCode));
+        }
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromException<HttpResponseMessage>(exception);
         }
     }
 }

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using TUnit.Aspire.Http;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
@@ -6,6 +8,7 @@ using TUnit.Core;
 
 namespace TUnit.Aspire.Tests;
 
+[NotInParallel(nameof(BaggagePropagationHandlerTests))]
 public class BaggagePropagationHandlerTests
 {
     [Test]
@@ -15,7 +18,8 @@ public class BaggagePropagationHandlerTests
         using var activity = new Activity("test-traceparent").Start();
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
@@ -24,137 +28,110 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_TraceparentUsesActivityCurrentTraceId()
+    public async Task SendAsync_InjectsTraceContext_FromCreatedClientSpan_WhenHelperSpanIsCreated()
     {
         Activity.Current = null;
-        using var activity = new Activity("test-uses-current").Start();
-        var activityTraceId = activity.TraceId.ToString();
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-root").Start();
+        activity.SetBaggage(TUnitActivitySource.TagTestId, "my-test-context-id");
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test");
-
-        var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        var requestTraceId = traceparent.Split('-')[1];
-
-        // Handler propagates Activity.Current's TraceId — natural OTEL propagation
-        await Assert.That(requestTraceId).IsEqualTo(activityTraceId);
-    }
-
-    [Test]
-    public async Task SendAsync_SameActivity_SharesTraceId()
-    {
-        Activity.Current = null;
-        using var activity = new Activity("test-same-traceid").Start();
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test1");
-        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-
-        await client.GetAsync("http://localhost/test2");
-        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-
-        var traceId1 = traceparent1.Split('-')[1];
-        var traceId2 = traceparent2.Split('-')[1];
-
-        // Same Activity.Current → same TraceId (all requests belong to same trace)
-        await Assert.That(traceId1).IsEqualTo(traceId2);
-    }
-
-    [Test]
-    public async Task SendAsync_TraceparentUsesActivityCurrentSpanId()
-    {
-        Activity.Current = null;
-        using var activity = new Activity("test-current-spanid").Start();
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test");
-
-        var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        var propagatedParentId = traceparent.Split('-')[2];
-
-        // Without an outgoing client span, the current Activity itself is the parent span.
-        await Assert.That(propagatedParentId).IsEqualTo(activity.SpanId.ToString());
-    }
-
-    [Test]
-    public async Task SendAsync_SameActivity_ReusesCurrentSpanId()
-    {
-        Activity.Current = null;
-        using var activity = new Activity("test-reuse-spanid").Start();
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test1");
-        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-
-        await client.GetAsync("http://localhost/test2");
-        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-
-        var spanId1 = traceparent1.Split('-')[2];
-        var spanId2 = traceparent2.Split('-')[2];
-
-        await Assert.That(spanId1).IsEqualTo(activity.SpanId.ToString());
-        await Assert.That(spanId2).IsEqualTo(activity.SpanId.ToString());
-    }
-
-    [Test]
-    public async Task SendAsync_DifferentActivities_UseDifferentTraceIds()
-    {
-        Activity.Current = null;
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        using var activity1 = new Activity("test-trace-1").Start();
-        await client.GetAsync("http://localhost/test1");
-        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        activity1.Stop();
-
-        using var activity2 = new Activity("test-trace-2").Start();
-        await client.GetAsync("http://localhost/test2");
-        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
-        activity2.Stop();
-
-        var traceId1 = traceparent1.Split('-')[1];
-        var traceId2 = traceparent2.Split('-')[1];
-
-        // Different activities → different TraceIds (separate tests = separate traces)
-        await Assert.That(traceId1).IsNotEqualTo(traceId2);
-    }
-
-    [Test]
-    public async Task SendAsync_TraceparentFormat_IsValidW3C()
-    {
-        Activity.Current = null;
-        using var activity = new Activity("test-w3c-format").Start();
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
 
         var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
         var parts = traceparent.Split('-');
+        var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
 
-        await Assert.That(parts.Length).IsEqualTo(4);
-        await Assert.That(parts[0]).IsEqualTo("00");           // version
-        await Assert.That(parts[1].Length).IsEqualTo(32);      // trace-id (16 bytes hex)
-        await Assert.That(parts[2].Length).IsEqualTo(16);      // parent-id (8 bytes hex)
-        // W3C trace-flags: "00" (not sampled) or "01" (sampled)
-        await Assert.That(parts[3]).IsEqualTo("00").Or.IsEqualTo("01");
+        await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
+        await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
+        await Assert.That(clientSpan.ParentSpanId).IsEqualTo(activity.SpanId.ToString());
+        await Assert.That(clientSpan.Kind).IsEqualTo(ActivityKind.Client);
+        await Assert.That(clientSpan.DisplayName).IsEqualTo("HTTP GET /test");
+        await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
+        await Assert.That(baggageHeader).Contains("my-test-context-id");
+    }
+
+    [Test]
+    public async Task SendAsync_CreatesNewClientSpan_PerRequest()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-multiple-requests").Start();
+
+        var captured = new CaptureHandler();
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("http://localhost/test1");
+        var traceparent1 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+
+        await client.GetAsync("http://localhost/test2");
+        var traceparent2 = captured.LastRequest!.Headers.GetValues("traceparent").First();
+
+        var spans = listenerScope.StoppedActivities;
+
+        await Assert.That(spans.Length).IsEqualTo(2);
+        await Assert.That(traceparent1.Split('-')[1]).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(traceparent2.Split('-')[1]).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(traceparent1.Split('-')[2]).IsEqualTo(spans[0].SpanId);
+        await Assert.That(traceparent2.Split('-')[2]).IsEqualTo(spans[1].SpanId);
+        await Assert.That(traceparent1.Split('-')[2]).IsNotEqualTo(traceparent2.Split('-')[2]);
+    }
+
+    [Test]
+    public async Task SendAsync_FallsBackToActivityCurrent_WhenHelperSpanIsNotCreated()
+    {
+        Activity.Current = null;
+        using var activity = new Activity("test-fallback").Start();
+        activity.SetBaggage(TUnitActivitySource.TagTestId, "my-test-context-id");
+
+        var captured = new CaptureHandler();
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("http://localhost/test");
+
+        var traceparent = captured.LastRequest!.Headers.GetValues("traceparent").First();
+        var parts = traceparent.Split('-');
+        var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
+
+        await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
+        await Assert.That(parts[2]).IsEqualTo(activity.SpanId.ToString());
+        await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
+        await Assert.That(baggageHeader).Contains("my-test-context-id");
+    }
+
+    [Test]
+    public async Task SendAsync_ClientSpan_RecordsResponseMetadata()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-response-tags").Start();
+
+        var captured = new CaptureHandler(HttpStatusCode.NotFound);
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/test");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(404);
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("http.request.method")).IsEqualTo("GET");
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("url.full")).IsEqualTo("http://localhost/test");
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("server.address")).IsEqualTo("localhost");
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("http.response.status_code")).IsEqualTo("404");
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Error);
     }
 
     [Test]
@@ -166,7 +143,8 @@ public class BaggagePropagationHandlerTests
         activity.SetBaggage("custom.key", "custom-value");
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
@@ -187,7 +165,8 @@ public class BaggagePropagationHandlerTests
         using var activity = new Activity("test-no-baggage").Start();
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
@@ -196,18 +175,17 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_NoActivity_DoesNotInjectTraceparent()
+    public async Task SendAsync_NoActivity_DoesNotInjectTraceContext()
     {
         Activity.Current = null;
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
 
-        await Assert.That(captured.LastRequest).IsNotNull();
-        // No Activity.Current → no trace context to propagate
         await Assert.That(captured.LastRequest!.Headers.Contains("traceparent")).IsFalse();
         await Assert.That(captured.LastRequest.Headers.Contains("baggage")).IsFalse();
     }
@@ -220,7 +198,8 @@ public class BaggagePropagationHandlerTests
         activity.SetBaggage("key with spaces", "value=with&special");
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         await client.GetAsync("http://localhost/test");
@@ -231,24 +210,6 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_MultipleBaggageItems_CommaSeparated()
-    {
-        Activity.Current = null;
-        using var activity = new Activity("test-multi-baggage").Start();
-        activity.SetBaggage("key1", "val1");
-        activity.SetBaggage("key2", "val2");
-
-        var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        await client.GetAsync("http://localhost/test");
-
-        var baggageHeader = captured.LastRequest!.Headers.GetValues("baggage").First();
-        await Assert.That(baggageHeader).Contains(",");
-    }
-
-    [Test]
     public async Task SendAsync_ExistingBaggageHeader_IsPreserved()
     {
         Activity.Current = null;
@@ -256,7 +217,8 @@ public class BaggagePropagationHandlerTests
         activity.SetBaggage("should.not.appear", "true");
 
         var captured = new CaptureHandler();
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
+        var handler = CreateHandler(static _ => null);
+        handler.InnerHandler = captured;
         using var client = new HttpClient(handler);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/test");
@@ -267,25 +229,64 @@ public class BaggagePropagationHandlerTests
         var allBaggageValues = string.Join(",",
             captured.LastRequest!.Headers.GetValues("baggage"));
         await Assert.That(allBaggageValues).Contains("existing=value");
+        await Assert.That(allBaggageValues).DoesNotContain("should.not.appear");
     }
 
-    [Test]
-    public async Task SendAsync_InnerHandlerResponse_IsPassedThrough()
+    private static TUnitBaggagePropagationHandler CreateHandler(
+        Func<HttpRequestMessage, Activity?>? startActivity = null)
     {
-        var captured = new CaptureHandler(System.Net.HttpStatusCode.NotFound);
-        var handler = new TUnitBaggagePropagationHandler { InnerHandler = captured };
-        using var client = new HttpClient(handler);
-
-        using var response = await client.GetAsync("http://localhost/test");
-
-        await Assert.That((int)response.StatusCode).IsEqualTo(404);
+        return startActivity is null
+            ? new TUnitBaggagePropagationHandler()
+            : new TUnitBaggagePropagationHandler(startActivity);
     }
+
+    private sealed class ActivityListenerScope : IDisposable
+    {
+        private readonly ConcurrentQueue<RecordedActivity> _stoppedActivities = new();
+        private readonly ActivityListener _listener;
+
+        public ActivityListenerScope()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = static source => source.Name == TUnitActivitySource.AspireHttpSourceName,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => _stoppedActivities.Enqueue(new RecordedActivity(
+                    activity.TraceId.ToString(),
+                    activity.SpanId.ToString(),
+                    activity.ParentSpanId == default ? null : activity.ParentSpanId.ToString(),
+                    activity.DisplayName,
+                    activity.Kind,
+                    activity.Status,
+                    activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString())))
+            };
+
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public RecordedActivity[] StoppedActivities => _stoppedActivities.ToArray();
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+
+    private sealed record RecordedActivity(
+        string TraceId,
+        string SpanId,
+        string? ParentSpanId,
+        string DisplayName,
+        ActivityKind Kind,
+        ActivityStatusCode Status,
+        IReadOnlyDictionary<string, string?> Tags);
 
     /// <summary>
     /// A handler that captures the outgoing request instead of sending it over the network.
     /// </summary>
     private sealed class CaptureHandler(
-        System.Net.HttpStatusCode statusCode = System.Net.HttpStatusCode.OK) : HttpMessageHandler
+        HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
     {
         public HttpRequestMessage? LastRequest { get; private set; }
 

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -53,7 +53,7 @@ public class BaggagePropagationHandlerTests
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
         await Assert.That(clientSpan.ParentSpanId).IsEqualTo(activity.SpanId.ToString());
         await Assert.That(clientSpan.Kind).IsEqualTo(ActivityKind.Client);
-        await Assert.That(clientSpan.DisplayName).IsEqualTo("HTTP GET /test");
+        await Assert.That(clientSpan.DisplayName).IsEqualTo("GET");
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
         await Assert.That(baggageHeader).Contains("my-test-context-id");
     }

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -230,6 +230,7 @@ public class BaggagePropagationHandlerTests
         await client.GetAsync("http://localhost/test");
 
         var baggageHeader = captured.LastRequest!.Headers.GetValues("baggage").First();
+        await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
         await Assert.That(baggageHeader).Contains(",");
     }
 

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -47,7 +47,7 @@ public class BaggagePropagationHandlerTests
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
         var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
 
-        await Assert.That(parts.Length).IsEqualTo(4);
+        await AssertValidW3CTraceparent(traceparent);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
@@ -105,6 +105,7 @@ public class BaggagePropagationHandlerTests
         var parts = traceparent.Split('-');
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
 
+        await AssertValidW3CTraceparent(traceparent);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(activity.SpanId.ToString());
         await Assert.That(baggageHeader).Contains(TUnitActivitySource.TagTestId);
@@ -315,6 +316,19 @@ public class BaggagePropagationHandlerTests
         return startActivity is null
             ? new TUnitBaggagePropagationHandler()
             : new TUnitBaggagePropagationHandler(startActivity);
+    }
+
+    private static async Task AssertValidW3CTraceparent(string traceparent)
+    {
+        var parts = traceparent.Split('-');
+
+        await Assert.That(parts.Length).IsEqualTo(4);
+        await Assert.That(parts[0]).IsEqualTo("00");
+        await Assert.That(parts[1].Length).IsEqualTo(32);
+        await Assert.That(parts[1].All(static c => Uri.IsHexDigit(c))).IsTrue();
+        await Assert.That(parts[2].Length).IsEqualTo(16);
+        await Assert.That(parts[2].All(static c => Uri.IsHexDigit(c))).IsTrue();
+        await Assert.That(parts[3] is "00" or "01").IsTrue();
     }
 
     private sealed class ActivityListenerScope : IDisposable

--- a/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
+++ b/TUnit.Aspire.Tests/BaggagePropagationHandlerTests.cs
@@ -47,6 +47,7 @@ public class BaggagePropagationHandlerTests
         var baggageHeader = captured.LastRequest.Headers.GetValues("baggage").First();
         var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
 
+        await Assert.That(parts.Length).IsEqualTo(4);
         await Assert.That(parts[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(parts[2]).IsEqualTo(clientSpan.SpanId);
         await Assert.That(parts[2]).IsNotEqualTo(activity.SpanId.ToString());
@@ -80,6 +81,7 @@ public class BaggagePropagationHandlerTests
         await Assert.That(spans.Length).IsEqualTo(2);
         await Assert.That(traceparent1.Split('-')[1]).IsEqualTo(activity.TraceId.ToString());
         await Assert.That(traceparent2.Split('-')[1]).IsEqualTo(activity.TraceId.ToString());
+        // Requests are awaited sequentially, so ActivityStopped fires in request order.
         await Assert.That(traceparent1.Split('-')[2]).IsEqualTo(spans[0].SpanId);
         await Assert.That(traceparent2.Split('-')[2]).IsEqualTo(spans[1].SpanId);
         await Assert.That(traceparent1.Split('-')[2]).IsNotEqualTo(traceparent2.Split('-')[2]);
@@ -110,7 +112,7 @@ public class BaggagePropagationHandlerTests
     }
 
     [Test]
-    public async Task SendAsync_ClientSpan_RecordsResponseMetadata()
+    public async Task SendAsync_ClientSpan_4xxStatus_SetsErrorStatus()
     {
         Activity.Current = null;
         using var listenerScope = new ActivityListenerScope();
@@ -131,6 +133,59 @@ public class BaggagePropagationHandlerTests
         await Assert.That(clientSpan.Tags.GetValueOrDefault("url.full")).IsEqualTo("http://localhost/test");
         await Assert.That(clientSpan.Tags.GetValueOrDefault("server.address")).IsEqualTo("localhost");
         await Assert.That(clientSpan.Tags.GetValueOrDefault("http.response.status_code")).IsEqualTo("404");
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("error.type")).IsEqualTo("404");
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Error);
+    }
+
+    [Test]
+    public async Task SendAsync_ClientSpan_3xxStatus_LeavesStatusUnset()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-redirect-tags").Start();
+
+        var captured = new CaptureHandler(HttpStatusCode.Redirect);
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync("http://localhost/test");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(302);
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("http.response.status_code")).IsEqualTo("302");
+        await Assert.That(clientSpan.Tags.ContainsKey("error.type")).IsFalse();
+        await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Unset);
+    }
+
+    [Test]
+    public async Task SendAsync_ClientSpan_RecordsException_WhenInnerHandlerThrows()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-transport-error").Start();
+
+        var handler = CreateHandler();
+        handler.InnerHandler = new ThrowingHandler(new HttpRequestException("boom"));
+        using var client = new HttpClient(handler);
+
+        HttpRequestException? thrown = null;
+        try
+        {
+            await client.GetAsync("http://localhost/test");
+        }
+        catch (HttpRequestException ex)
+        {
+            thrown = ex;
+        }
+
+        await Assert.That(thrown).IsNotNull();
+
+        var clientSpan = await Assert.That(listenerScope.StoppedActivities).HasSingleItem();
+        await Assert.That(clientSpan.Tags.GetValueOrDefault("error.type")).Contains(nameof(HttpRequestException));
+        await Assert.That(clientSpan.EventNames).Contains("exception");
         await Assert.That(clientSpan.Status).IsEqualTo(ActivityStatusCode.Error);
     }
 
@@ -156,6 +211,26 @@ public class BaggagePropagationHandlerTests
         await Assert.That(baggageHeader).Contains("my-test-context-id");
         await Assert.That(baggageHeader).Contains("custom.key");
         await Assert.That(baggageHeader).Contains("custom-value");
+    }
+
+    [Test]
+    public async Task SendAsync_MultipleBaggageItems_CommaSeparated()
+    {
+        Activity.Current = null;
+        using var listenerScope = new ActivityListenerScope();
+        using var activity = new Activity("test-multi-baggage").Start();
+        activity.SetBaggage("key1", "val1");
+        activity.SetBaggage("key2", "val2");
+
+        var captured = new CaptureHandler();
+        var handler = CreateHandler();
+        handler.InnerHandler = captured;
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("http://localhost/test");
+
+        var baggageHeader = captured.LastRequest!.Headers.GetValues("baggage").First();
+        await Assert.That(baggageHeader).Contains(",");
     }
 
     [Test]
@@ -232,6 +307,7 @@ public class BaggagePropagationHandlerTests
         await Assert.That(allBaggageValues).DoesNotContain("should.not.appear");
     }
 
+    // Pass static _ => null to simulate no helper span; null uses the real StartHttpActivity default.
     private static TUnitBaggagePropagationHandler CreateHandler(
         Func<HttpRequestMessage, Activity?>? startActivity = null)
     {
@@ -259,7 +335,8 @@ public class BaggagePropagationHandlerTests
                     activity.DisplayName,
                     activity.Kind,
                     activity.Status,
-                    activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString())))
+                    activity.TagObjects.ToDictionary(static t => t.Key, static t => t.Value?.ToString()),
+                    activity.Events.Select(static e => e.Name).ToArray()))
             };
 
             ActivitySource.AddActivityListener(_listener);
@@ -280,7 +357,8 @@ public class BaggagePropagationHandlerTests
         string DisplayName,
         ActivityKind Kind,
         ActivityStatusCode Status,
-        IReadOnlyDictionary<string, string?> Tags);
+        IReadOnlyDictionary<string, string?> Tags,
+        string[] EventNames);
 
     /// <summary>
     /// A handler that captures the outgoing request instead of sending it over the network.
@@ -295,6 +373,15 @@ public class BaggagePropagationHandlerTests
         {
             LastRequest = request;
             return Task.FromResult(new HttpResponseMessage(statusCode));
+        }
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromException<HttpResponseMessage>(exception);
         }
     }
 }

--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -55,9 +55,10 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             return App.CreateHttpClient(resourceName, endpointName);
         }
 
-        // Share a single handler across all HttpClient instances. The handler is stateless
-        // (reads Activity.Current which is async-local/per-test), so sharing is safe for
-        // correctness while reusing the SocketsHttpHandler connection pool across tests.
+        // Share a single handler across all HttpClient instances. The handler is stateless:
+        // Activity.Current is async-local/per-test, and each SendAsync call creates and
+        // disposes its own client Activity span, so sharing stays safe while reusing the
+        // SocketsHttpHandler connection pool across tests.
         _httpHandler ??= new Http.TUnitBaggagePropagationHandler
         {
             InnerHandler = new SocketsHttpHandler

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -87,9 +87,11 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
 
     private static Activity? StartHttpActivity(HttpRequestMessage request)
     {
-        var path = request.RequestUri?.AbsolutePath ?? request.RequestUri?.ToString() ?? "unknown";
+        var method = string.IsNullOrWhiteSpace(request.Method.Method)
+            ? "HTTP"
+            : request.Method.Method;
         return HttpActivitySource.StartActivity(
-            $"HTTP {request.Method} {path}",
+            method,
             ActivityKind.Client);
     }
 

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -4,10 +4,10 @@ using TUnit.Core;
 namespace TUnit.Aspire.Http;
 
 /// <summary>
-/// DelegatingHandler that propagates W3C <c>traceparent</c> and <c>baggage</c> headers
-/// from <see cref="Activity.Current"/> into outgoing HTTP requests. This enables natural
-/// OpenTelemetry distributed tracing: the SUT receives the test's TraceId and all its
-/// spans and logs can be correlated back to the originating test.
+/// DelegatingHandler that creates Aspire HTTP client spans and propagates W3C
+/// <c>traceparent</c> and <c>baggage</c> headers into outgoing HTTP requests.
+/// This restores normal OpenTelemetry client/server span topology for
+/// <c>AspireFixture.CreateHttpClient</c> requests.
 /// </summary>
 /// <remarks>
 /// Each test case starts its own W3C trace (unique TraceId) via a root activity in the
@@ -22,32 +22,109 @@ namespace TUnit.Aspire.Http;
 /// </remarks>
 internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
 {
-    protected override Task<HttpResponseMessage> SendAsync(
+    private static readonly ActivitySource HttpActivitySource = new(TUnitActivitySource.AspireHttpSourceName);
+    private readonly Func<HttpRequestMessage, Activity?> _startActivity;
+
+    public TUnitBaggagePropagationHandler()
+    {
+        _startActivity = StartHttpActivity;
+    }
+
+    internal TUnitBaggagePropagationHandler(Func<HttpRequestMessage, Activity?> startActivity)
+    {
+        _startActivity = startActivity;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (Activity.Current is { } activity)
-        {
-            // Aspire's CreateHttpClient doesn't create an outgoing client span. Propagate the
-            // current test span itself so downstream server spans parent to a real exported span
-            // instead of a synthetic parent ID that backends can't render.
-            DistributedContextPropagator.Current.Inject(activity, request, static (carrier, key, value) =>
-            {
-                if (carrier is HttpRequestMessage httpRequest && key is not null && !httpRequest.Headers.Contains(key))
-                {
-                    httpRequest.Headers.TryAddWithoutValidation(key, value);
-                }
-            });
+        var ambientActivity = Activity.Current;
+        using var activity = _startActivity(request);
 
-            if (!request.Headers.Contains(TUnitActivitySource.BaggageHeader)
-                && TUnitActivitySource.TryBuildBaggageHeader(activity) is { } baggage)
+        if (activity is not null)
+        {
+            activity.SetTag("http.request.method", request.Method.Method);
+            activity.SetTag("url.full", request.RequestUri?.ToString());
+            activity.SetTag("server.address", request.RequestUri?.Host);
+
+            // Aspire's CreateHttpClient bypasses DiagnosticsHandler, so when we synthesize
+            // a client span we also need to flow the ambient baggage onto it explicitly.
+            CopyBaggage(ambientActivity, activity);
+        }
+
+        var propagationActivity = activity ?? ambientActivity;
+        InjectTraceContext(propagationActivity, request);
+        InjectBaggage(propagationActivity, request);
+
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (activity is not null)
+        {
+            activity.SetTag("http.response.status_code", (int)response.StatusCode);
+            if (!response.IsSuccessStatusCode)
             {
-                // Belt-and-braces for users who opt out of TUnit's W3C propagator alignment
-                // via TUNIT_KEEP_LEGACY_PROPAGATOR=1: LegacyPropagator emits Correlation-Context
-                // only, so still emit W3C baggage explicitly for backend correlation.
-                request.Headers.TryAddWithoutValidation(TUnitActivitySource.BaggageHeader, baggage);
+                activity.SetStatus(ActivityStatusCode.Error);
             }
         }
 
-        return base.SendAsync(request, cancellationToken);
+        return response;
+    }
+
+    private static Activity? StartHttpActivity(HttpRequestMessage request)
+    {
+        var path = request.RequestUri?.AbsolutePath ?? request.RequestUri?.ToString() ?? "unknown";
+        return HttpActivitySource.StartActivity(
+            $"HTTP {request.Method} {path}",
+            ActivityKind.Client);
+    }
+
+    private static void InjectTraceContext(Activity? activity, HttpRequestMessage request)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        DistributedContextPropagator.Current.Inject(activity, request, static (carrier, key, value) =>
+        {
+            if (carrier is HttpRequestMessage httpRequest && key is not null && !httpRequest.Headers.Contains(key))
+            {
+                httpRequest.Headers.TryAddWithoutValidation(key, value);
+            }
+        });
+    }
+
+    private static void CopyBaggage(Activity? source, Activity destination)
+    {
+        if (source is null || ReferenceEquals(source, destination))
+        {
+            return;
+        }
+
+        foreach (var (key, value) in source.Baggage)
+        {
+            if (key is null || destination.GetBaggageItem(key) is not null)
+            {
+                continue;
+            }
+
+            destination.SetBaggage(key, value);
+        }
+    }
+
+    private static void InjectBaggage(Activity? activity, HttpRequestMessage request)
+    {
+        if (activity is null || request.Headers.Contains(TUnitActivitySource.BaggageHeader))
+        {
+            return;
+        }
+
+        if (TUnitActivitySource.TryBuildBaggageHeader(activity) is { } baggage)
+        {
+            // Belt-and-braces for users who opt out of TUnit's W3C propagator alignment
+            // via TUNIT_KEEP_LEGACY_PROPAGATOR=1: LegacyPropagator emits Correlation-Context
+            // only, so still emit W3C baggage explicitly for backend correlation.
+            request.Headers.TryAddWithoutValidation(TUnitActivitySource.BaggageHeader, baggage);
+        }
     }
 }

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -63,6 +63,9 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
         }
         catch (Exception ex)
         {
+            // Only the synthesized client span gets exception metadata. When no listener is
+            // attached, propagation falls back to the ambient activity and there is no extra
+            // HTTP client span to annotate.
             TUnitActivitySource.RecordException(activity, ex);
             throw;
         }

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -56,14 +56,26 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
         InjectTraceContext(propagationActivity, request);
         InjectBaggage(propagationActivity, request);
 
-        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage response;
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            RecordException(activity, ex);
+            throw;
+        }
 
         if (activity is not null)
         {
-            activity.SetTag("http.response.status_code", (int)response.StatusCode);
-            if (!response.IsSuccessStatusCode)
+            var statusCode = (int)response.StatusCode;
+            activity.SetTag("http.response.status_code", statusCode);
+
+            if (statusCode >= 400)
             {
                 activity.SetStatus(ActivityStatusCode.Error);
+                activity.SetTag("error.type", statusCode.ToString());
             }
         }
 
@@ -126,5 +138,24 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
             // only, so still emit W3C baggage explicitly for backend correlation.
             request.Headers.TryAddWithoutValidation(TUnitActivitySource.BaggageHeader, baggage);
         }
+    }
+
+    private static void RecordException(Activity? activity, Exception exception)
+    {
+        if (activity is null)
+        {
+            return;
+        }
+
+        var tags = new ActivityTagsCollection
+        {
+            { "exception.type", exception.GetType().FullName },
+            { "exception.message", exception.Message },
+            { "exception.stacktrace", exception.ToString() }
+        };
+
+        activity.AddEvent(new ActivityEvent("exception", tags: tags));
+        activity.SetTag("error.type", exception.GetType().FullName);
+        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 }

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -63,7 +63,7 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
         }
         catch (Exception ex)
         {
-            RecordException(activity, ex);
+            TUnitActivitySource.RecordException(activity, ex);
             throw;
         }
 
@@ -138,24 +138,5 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
             // only, so still emit W3C baggage explicitly for backend correlation.
             request.Headers.TryAddWithoutValidation(TUnitActivitySource.BaggageHeader, baggage);
         }
-    }
-
-    private static void RecordException(Activity? activity, Exception exception)
-    {
-        if (activity is null)
-        {
-            return;
-        }
-
-        var tags = new ActivityTagsCollection
-        {
-            { "exception.type", exception.GetType().FullName },
-            { "exception.message", exception.Message },
-            { "exception.stacktrace", exception.ToString() }
-        };
-
-        activity.AddEvent(new ActivityEvent("exception", tags: tags));
-        activity.SetTag("error.type", exception.GetType().FullName);
-        activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 }

--- a/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
+++ b/TUnit.Aspire/Http/TUnitBaggagePropagationHandler.cs
@@ -49,6 +49,8 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
 
             // Aspire's CreateHttpClient bypasses DiagnosticsHandler, so when we synthesize
             // a client span we also need to flow the ambient baggage onto it explicitly.
+            // Child Activities do not reliably surface parent baggage across all target
+            // frameworks, but correlation relies on the test's baggage being propagated.
             CopyBaggage(ambientActivity, activity);
         }
 
@@ -120,6 +122,7 @@ internal sealed class TUnitBaggagePropagationHandler : DelegatingHandler
 
         foreach (var (key, value) in source.Baggage)
         {
+            // Preserve baggage already attached to the synthesized client span itself.
             if (key is null || destination.GetBaggageItem(key) is not null)
             {
                 continue;

--- a/TUnit.Core/TUnitActivitySource.cs
+++ b/TUnit.Core/TUnitActivitySource.cs
@@ -179,15 +179,16 @@ public static class TUnitActivitySource
             return;
         }
 
+        var exceptionType = exception.GetType().FullName ?? exception.GetType().Name;
         var tagsCollection = new ActivityTagsCollection
         {
-            { "exception.type", exception.GetType().FullName },
+            { "exception.type", exceptionType },
             { "exception.message", exception.Message },
             { "exception.stacktrace", exception.ToString() }
         };
 
         activity.AddEvent(new ActivityEvent("exception", tags: tagsCollection));
-        activity.SetTag("error.type", exception.GetType().FullName);
+        activity.SetTag("error.type", exceptionType);
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
 

--- a/TUnit.Core/TUnitActivitySource.cs
+++ b/TUnit.Core/TUnitActivitySource.cs
@@ -19,6 +19,13 @@ public static class TUnitActivitySource
     /// </summary>
     public const string AspNetCoreHttpSourceName = "TUnit.AspNetCore.Http";
 
+    /// <summary>
+    /// Activity source emitted by TUnit's Aspire HTTP propagation handler.
+    /// Registered automatically by <c>TUnit.OpenTelemetry.AutoStart</c> so outbound
+    /// requests made through <c>AspireFixture.CreateHttpClient</c> appear as client spans.
+    /// </summary>
+    public const string AspireHttpSourceName = "TUnit.Aspire.Http";
+
     /// <summary>W3C baggage HTTP header name.</summary>
     internal const string BaggageHeader = "baggage";
 

--- a/TUnit.OpenTelemetry/AutoStart.cs
+++ b/TUnit.OpenTelemetry/AutoStart.cs
@@ -63,6 +63,7 @@ public static class AutoStart
             .AddSource("TUnit")
             .AddSource("TUnit.Lifecycle")
             .AddSource("TUnit.AspNetCore.Http")
+            .AddSource(TUnitActivitySource.AspireHttpSourceName)
             .AddProcessor(new TUnitTestCorrelationProcessor());
 
         if (otlpEndpoint is not null)

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1334,6 +1334,7 @@ namespace
     public static class TUnitActivitySource
     {
         public const string AspNetCoreHttpSourceName = ".Http";
+        public const string AspireHttpSourceName = ".Http";
         public const string TagTestId = ".id";
     }
     public class TUnitAttribute :  { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1334,6 +1334,7 @@ namespace
     public static class TUnitActivitySource
     {
         public const string AspNetCoreHttpSourceName = ".Http";
+        public const string AspireHttpSourceName = ".Http";
         public const string TagTestId = ".id";
     }
     public class TUnitAttribute :  { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1334,6 +1334,7 @@ namespace
     public static class TUnitActivitySource
     {
         public const string AspNetCoreHttpSourceName = ".Http";
+        public const string AspireHttpSourceName = ".Http";
         public const string TagTestId = ".id";
     }
     public class TUnitAttribute :  { }

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -18,7 +18,7 @@ namespace
         public const int AutoStartOrder = 2147483647;
         [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 95, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -18,7 +18,7 @@ namespace
         public const int AutoStartOrder = 2147483647;
         [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 95, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -18,7 +18,7 @@ namespace
         public const int AutoStartOrder = 2147483647;
         [.Before(., "PATH_SCRUBBED", 29, Order=2147483647)]
         public static void Start() { }
-        [.After(., "PATH_SCRUBBED", 94, Order=2147483647)]
+        [.After(., "PATH_SCRUBBED", 95, Order=2147483647)]
         public static void Stop() { }
     }
     public static class TUnitOpenTelemetry


### PR DESCRIPTION
## Summary

Follow-up to #5665 focused on trace topology rather than OTLP forwarding.

- create a real `TUnit.Aspire.Http` client span around `AspireFixture.CreateHttpClient` requests
- propagate `traceparent` and `baggage` from that client span, with fallback to the ambient activity when no listener is attached
- export the new source from `TUnit.OpenTelemetry.AutoStart`
- update `BaggagePropagationHandlerTests` to assert client span creation, parent-child shape, response tagging, and fallback behavior

## Why

#5665 fixes forwarding to user dashboards, but the Aspire handler still propagated the ambient test span directly. That kept correlation working while flattening the distributed trace tree in backends like the Aspire dashboard.

This change restores the normal OTel client/server shape:
`test case` -> `test body` -> `TUnit.Aspire.Http` client span -> SUT server span

Refs #4818

## Test plan

- [x] `dotnet test TUnit.Aspire.Tests/TUnit.Aspire.Tests.csproj -c Release -- --treenode-filter "/*/*/BaggagePropagationHandlerTests/*"`
- [x] `dotnet test TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj -c Release -- --treenode-filter "/*/*/AutoStartTests/*"`
- [x] `dotnet build TUnit.Aspire.Tests/TUnit.Aspire.Tests.csproj -c Release --no-restore`
- [x] `dotnet build TUnit.OpenTelemetry.Tests/TUnit.OpenTelemetry.Tests.csproj -c Release --no-restore`