### PR TITLE
perf(mocks): shrink MethodSetup + cache stateless matchers

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
@@ -123,8 +123,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<T>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IRepository_T__GetById_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -134,13 +132,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<T> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<T>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<T> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<T> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<T>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IRepository_T__GetById_M0_MockCall<T> Returns(T value) { EnsureSetup().Returns(value); return this; }
@@ -203,8 +213,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IRepository_T__Save_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -215,13 +223,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IRepository_T__Save_M1_MockCall<T> Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
@@ -116,8 +116,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal Sandbox_IFoo_T__Process_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -128,13 +126,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public Sandbox_IFoo_T__Process_M1_MockCall<T> Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
@@ -100,8 +100,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal Sandbox_IMapper_TIn_TOut__Map_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -111,13 +109,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<TOut>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public Sandbox_IMapper_TIn_TOut__Map_M0_MockCall<TIn, TOut> Returns(TOut value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
@@ -116,8 +116,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal Sandbox_IService_T__Apply_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -128,13 +126,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public Sandbox_IService_T__Apply_M1_MockCall<T> Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
@@ -139,8 +139,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ICustomCollection_Add_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -151,13 +149,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ICustomCollection_Add_M1_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
@@ -138,8 +138,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -150,13 +148,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IReadWriter_Write_M2_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -211,8 +211,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IAsyncService_GetValueAsync_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -222,13 +220,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IAsyncService_GetValueAsync_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }
@@ -303,8 +313,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IAsyncService_DoWorkAsync_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -315,13 +323,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IAsyncService_DoWorkAsync_M1_MockCall Returns() { EnsureSetup().Returns(); return this; }
@@ -364,8 +384,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<int>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IAsyncService_ComputeAsync_M2_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -375,13 +393,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IAsyncService_ComputeAsync_M2_MockCall Returns(int value) { EnsureSetup().Returns(value); return this; }
@@ -458,8 +488,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -470,13 +498,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IAsyncService_InitializeAsync_M3_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
@@ -170,8 +170,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal INotifier_Notify_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -182,13 +180,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public INotifier_Notify_M0_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -144,8 +144,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ITest_Test_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -156,13 +154,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ITest_Test_M0_MockCall Returns() { EnsureSetup().Returns(); return this; }
@@ -214,8 +224,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ITest_Get_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -225,13 +233,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ITest_Get_M1_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -227,8 +227,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IService_GetAsync_M3_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -238,13 +236,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IService_GetAsync_M3_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }
@@ -322,8 +332,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IService_Process_M4_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -334,13 +342,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IService_Process_M4_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -261,8 +261,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFoo_Bar_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -273,13 +271,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFoo_Bar_M0_MockCall Returns() { EnsureSetup().Returns(); return this; }
@@ -331,8 +341,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -342,13 +350,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFoo_GetValue_M1_MockCall Returns(string? value) { EnsureSetup().Returns(value); return this; }
@@ -411,8 +431,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFoo_Process_M2_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -423,13 +441,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFoo_Process_M2_MockCall Returns() { EnsureSetup().Returns(); return this; }
@@ -481,8 +511,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFoo_GetAsync_M3_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -492,13 +520,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFoo_GetAsync_M3_MockCall Returns(string? value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -83,8 +83,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal BaseDialog_Compute_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -94,13 +92,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public BaseDialog_Compute_M0_MockCall Returns(string? value) { EnsureSetup().Returns(value); return this; }
@@ -457,8 +467,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IDialogService_Show_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -468,13 +476,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IDialogService_Show_M0_MockCall Returns(string? value) { EnsureSetup().Returns(value); return this; }
@@ -540,8 +560,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IDialogService_WithTrickyChars_M8_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -551,13 +569,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string?> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string?>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IDialogService_WithTrickyChars_M8_MockCall Returns(string? value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
@@ -135,8 +135,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<bool>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IDictionary_TryGetValue_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -146,13 +144,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<bool> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<bool>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<bool> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<bool> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<bool>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IDictionary_TryGetValue_M0_MockCall Returns(bool value) { EnsureSetup().Returns(value); return this; }
@@ -218,8 +228,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IDictionary_Swap_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -230,13 +238,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IDictionary_Swap_M1_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
@@ -228,8 +228,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFormatter_Format_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -239,13 +237,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFormatter_Format_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }
@@ -308,8 +318,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFormatter_Format_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -319,13 +327,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFormatter_Format_M1_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }
@@ -388,8 +408,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFormatter_Format_M2_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -399,13 +417,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFormatter_Format_M2_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }
@@ -468,8 +498,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IFormatter_Format_M3_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -479,13 +507,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IFormatter_Format_M3_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
@@ -125,8 +125,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IMyService_GetValue_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -136,13 +134,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IMyService_GetValue_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -172,8 +172,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<int>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ICalculator_Add_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -183,13 +181,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ICalculator_Add_M0_MockCall Returns(int value) { EnsureSetup().Returns(value); return this; }
@@ -252,8 +262,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<int>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -263,13 +271,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<int> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<int>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ICalculator_Subtract_M1_MockCall Returns(int value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -122,8 +122,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ExternalLib_ExternalClient_PublicMethod_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -133,13 +131,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ExternalLib_ExternalClient_PublicMethod_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
@@ -82,8 +82,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -93,13 +91,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public ExternalLib_ServiceClient_GetValue_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
@@ -106,8 +106,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.MethodSetupBuilder<string>? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -117,13 +115,25 @@ namespace TUnit.Mocks.Generated
             _matchers = matchers;
         }
 
-        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.MethodSetupBuilder<string> EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.MethodSetupBuilder<string>(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public IGreeter_Greet_M0_MockCall Returns(string value) { EnsureSetup().Returns(value); return this; }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
@@ -122,8 +122,6 @@ namespace TUnit.Mocks.Generated
         private readonly string _memberName;
         private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;
         private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder? _builder;
-        private bool _builderInitialized;
-        private object? _builderLock;
 
         internal INotifier_Notify_M0_MockCall(global::TUnit.Mocks.IMockEngineAccess engine, int memberId, string memberName, global::TUnit.Mocks.Arguments.IArgumentMatcher[] matchers)
         {
@@ -134,13 +132,25 @@ namespace TUnit.Mocks.Generated
             _ = EnsureSetup();
         }
 
-        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup() =>
-            global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
-            {
-                var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
-                _engine.AddSetup(setup);
-                return new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
-            })!;
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetup()
+        {
+            var existing = global::System.Threading.Volatile.Read(ref _builder);
+            if (existing is not null) return existing;
+            return EnsureSetupSlow();
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private global::TUnit.Mocks.Setup.VoidMethodSetupBuilder EnsureSetupSlow()
+        {
+            var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);
+            var fresh = new global::TUnit.Mocks.Setup.VoidMethodSetupBuilder(setup);
+            var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);
+            if (prev is not null) return prev;
+            // AddSetup runs only on the CAS winner. Setup is sequential in practice,
+            // so a concurrent loser observing the builder before registration is benign.
+            _engine.AddSetup(setup);
+            return fresh;
+        }
 
         /// <inheritdoc />
         public INotifier_Notify_M0_MockCall Returns() { EnsureSetup().Returns(); return this; }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -212,8 +212,6 @@ internal static class MockMembersBuilder
             writer.AppendLine("private readonly string _memberName;");
             writer.AppendLine("private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;");
             writer.AppendLine($"private {builderType}? _builder;");
-            writer.AppendLine("private bool _builderInitialized;");
-            writer.AppendLine("private object? _builderLock;");
             writer.AppendLine();
 
             // Constructor
@@ -324,8 +322,6 @@ internal static class MockMembersBuilder
             writer.AppendLine("private readonly string _memberName;");
             writer.AppendLine("private readonly global::TUnit.Mocks.Arguments.IArgumentMatcher[] _matchers;");
             writer.AppendLine($"private {builderType}? _builder;");
-            writer.AppendLine("private bool _builderInitialized;");
-            writer.AppendLine("private object? _builderLock;");
             writer.AppendLine();
 
             // Constructor — eagerly registers because void methods
@@ -1136,15 +1132,27 @@ internal static class MockMembersBuilder
 
     private static void EmitEnsureSetup(CodeWriter writer, string builderType)
     {
-        writer.AppendLine($"private {builderType} EnsureSetup() =>");
-        writer.IncreaseIndent();
-        writer.AppendLine($"global::System.Threading.LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>");
-        writer.OpenBrace();
-        writer.AppendLine("var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);");
-        writer.AppendLine("_engine.AddSetup(setup);");
-        writer.AppendLine($"return new {builderType}(setup);");
-        writer.CloseBrace(")!;");
-        writer.DecreaseIndent();
+        // CAS-based lazy init avoids the LazyInitializer Func closure and its two scratch fields.
+        writer.AppendLine($"private {builderType} EnsureSetup()");
+        using (writer.Block())
+        {
+            writer.AppendLine($"var existing = global::System.Threading.Volatile.Read(ref _builder);");
+            writer.AppendLine("if (existing is not null) return existing;");
+            writer.AppendLine("return EnsureSetupSlow();");
+        }
+
+        writer.AppendLine();
+        writer.AppendLine("[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]");
+        writer.AppendLine($"private {builderType} EnsureSetupSlow()");
+        using (writer.Block())
+        {
+            writer.AppendLine("var setup = new global::TUnit.Mocks.Setup.MethodSetup(_memberId, _matchers, _memberName);");
+            writer.AppendLine($"var fresh = new {builderType}(setup);");
+            writer.AppendLine($"var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);");
+            writer.AppendLine("if (prev is not null) return prev;");
+            writer.AppendLine("_engine.AddSetup(setup);");
+            writer.AppendLine("return fresh;");
+        }
     }
 
 }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -226,7 +226,7 @@ internal static class MockMembersBuilder
 
             writer.AppendLine();
 
-            // EnsureSetup method — uses LazyInitializer to guarantee exactly-once AddSetup
+            // EnsureSetup — CAS-based lazy init (see EmitEnsureSetup)
             EmitEnsureSetup(writer, builderType);
 
             writer.AppendLine();
@@ -338,7 +338,7 @@ internal static class MockMembersBuilder
 
             writer.AppendLine();
 
-            // EnsureSetup method — uses LazyInitializer to guarantee exactly-once AddSetup
+            // EnsureSetup — CAS-based lazy init (see EmitEnsureSetup)
             EmitEnsureSetup(writer, builderType);
 
             writer.AppendLine();
@@ -1142,6 +1142,10 @@ internal static class MockMembersBuilder
         }
 
         writer.AppendLine();
+        // Race note: if two threads lose/win the CAS, the loser returns before the winner
+        // calls AddSetup. Mock setup is sequential in normal usage (test setup phase completes
+        // before invocations), so this window is not observable. If you ever need concurrent
+        // setup + invocation of the same method-wrapper, reintroduce synchronization here.
         writer.AppendLine("[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]");
         writer.AppendLine($"private {builderType} EnsureSetupSlow()");
         using (writer.Block())
@@ -1150,6 +1154,8 @@ internal static class MockMembersBuilder
             writer.AppendLine($"var fresh = new {builderType}(setup);");
             writer.AppendLine($"var prev = global::System.Threading.Interlocked.CompareExchange(ref _builder, fresh, null);");
             writer.AppendLine("if (prev is not null) return prev;");
+            writer.AppendLine("// AddSetup runs only on the CAS winner. Setup is sequential in practice,");
+            writer.AppendLine("// so a concurrent loser observing the builder before registration is benign.");
             writer.AppendLine("_engine.AddSetup(setup);");
             writer.AppendLine("return fresh;");
         }

--- a/TUnit.Mocks/Arguments/Arg.cs
+++ b/TUnit.Mocks/Arguments/Arg.cs
@@ -10,7 +10,7 @@ namespace TUnit.Mocks.Arguments;
 public static class Arg
 {
     /// <summary>Matches any value of the specified type, including null.</summary>
-    public static Arg<T> Any<T>() => new(new AnyMatcher<T>());
+    public static Arg<T> Any<T>() => new(AnyMatcher<T>.Instance);
 
     /// <summary>Matches any value — type is inferred from the parameter position.</summary>
     public static AnyArg Any() => AnyArg.Instance;
@@ -22,10 +22,10 @@ public static class Arg
     public static Arg<T> Is<T>(Func<T?, bool> predicate) => new(new PredicateMatcher<T>(predicate));
 
     /// <summary>Matches only when the argument is null. Supports reference types and nullable value types.</summary>
-    public static Arg<T> IsNull<T>() => new(new NullMatcher<T>());
+    public static Arg<T> IsNull<T>() => new(NullMatcher<T>.Instance);
 
     /// <summary>Matches only when the argument is not null. Supports reference types and nullable value types.</summary>
-    public static Arg<T> IsNotNull<T>() => new(new NotNullMatcher<T>());
+    public static Arg<T> IsNotNull<T>() => new(NotNullMatcher<T>.Instance);
 
     /// <summary>Matches a string against a regular expression pattern.</summary>
     public static Arg<string> Matches(string pattern) => new(new RegexMatcher(pattern));
@@ -45,7 +45,7 @@ public static class Arg
     public static Arg<T> HasCount<T>(int count) => new(new CountMatcher(count));
 
     /// <summary>Matches an empty collection.</summary>
-    public static Arg<T> IsEmpty<T>() => new(new EmptyMatcher());
+    public static Arg<T> IsEmpty<T>() => new(EmptyMatcher.Instance);
 
     /// <summary>Matches a collection with element-by-element equality.</summary>
     public static Arg<TCollection> SequenceEquals<TCollection, TElement>(IEnumerable<TElement> expected)

--- a/TUnit.Mocks/Arguments/ArgOfT.cs
+++ b/TUnit.Mocks/Arguments/ArgOfT.cs
@@ -38,5 +38,5 @@ public readonly struct Arg<T>
     /// <param name="predicate">The predicate that determines whether an argument matches.</param>
     public static implicit operator Arg<T>(Func<T, bool> predicate) => new(new PredicateMatcher<T>(predicate!));
 
-    public static implicit operator Arg<T>(AnyArg _) => new(new AnyMatcher<T>());
+    public static implicit operator Arg<T>(AnyArg _) => new(AnyMatcher<T>.Instance);
 }

--- a/TUnit.Mocks/Matchers/AnyMatcher.cs
+++ b/TUnit.Mocks/Matchers/AnyMatcher.cs
@@ -20,6 +20,12 @@ internal sealed class AnyMatcher : IArgumentMatcher
 /// </summary>
 internal sealed class AnyMatcher<T> : IArgumentMatcher<T>
 {
+    /// <summary>
+    /// Cached singleton — <see cref="AnyMatcher{T}"/> is stateless, so a single instance per closed
+    /// generic type avoids a per-call allocation on the common <see cref="Arg.Any{T}"/> path.
+    /// </summary>
+    public static readonly AnyMatcher<T> Instance = new();
+
     public bool Matches(T? value) => true;
 
     public bool Matches(object? value) => true;

--- a/TUnit.Mocks/Matchers/EmptyMatcher.cs
+++ b/TUnit.Mocks/Matchers/EmptyMatcher.cs
@@ -7,6 +7,8 @@ namespace TUnit.Mocks.Matchers;
 /// </summary>
 internal sealed class EmptyMatcher : IArgumentMatcher
 {
+    public static readonly EmptyMatcher Instance = new();
+
     public bool Matches(object? value)
     {
         if (value is System.Collections.ICollection collection)

--- a/TUnit.Mocks/Matchers/NotNullMatcher.cs
+++ b/TUnit.Mocks/Matchers/NotNullMatcher.cs
@@ -7,6 +7,8 @@ namespace TUnit.Mocks.Matchers;
 /// </summary>
 internal sealed class NotNullMatcher<T> : IArgumentMatcher<T>
 {
+    public static readonly NotNullMatcher<T> Instance = new();
+
     public bool Matches(T? value) => value is not null;
 
     public bool Matches(object? value) => value is not null;

--- a/TUnit.Mocks/Matchers/NullMatcher.cs
+++ b/TUnit.Mocks/Matchers/NullMatcher.cs
@@ -7,6 +7,8 @@ namespace TUnit.Mocks.Matchers;
 /// </summary>
 internal sealed class NullMatcher<T> : IArgumentMatcher<T>
 {
+    public static readonly NullMatcher<T> Instance = new();
+
     public bool Matches(T? value) => value is null;
 
     public bool Matches(object? value) => value is null;

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -47,8 +47,8 @@ public sealed class MethodSetup
     [EditorBrowsable(EditorBrowsableState.Never)]
     public string? RequiredState
     {
-        get => Volatile.Read(ref _rareState)?.RequiredState;
-        set => EnsureRareState().RequiredState = value;
+        get => Volatile.Read(ref _rareState) is { } rare ? Volatile.Read(ref rare.RequiredState) : null;
+        set => Volatile.Write(ref EnsureRareState().RequiredState, value);
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ public sealed class MethodSetup
     [EditorBrowsable(EditorBrowsableState.Never)]
     public string? TransitionTarget
     {
-        get => Volatile.Read(ref _rareState)?.TransitionTarget;
-        set => EnsureRareState().TransitionTarget = value;
+        get => Volatile.Read(ref _rareState) is { } rare ? Volatile.Read(ref rare.TransitionTarget) : null;
+        set => Volatile.Write(ref EnsureRareState().TransitionTarget, value);
     }
 
     /// <summary>
@@ -95,12 +95,22 @@ public sealed class MethodSetup
     private Lock EnsureBehaviorLock()
     {
         var rare = EnsureRareState();
-        if (rare.BehaviorLock is { } existing) return existing;
+        if (Volatile.Read(ref rare.BehaviorLock) is { } existing) return existing;
         Interlocked.CompareExchange(ref rare.BehaviorLock, new Lock(), null);
-        return rare.BehaviorLock!;
+        return Volatile.Read(ref rare.BehaviorLock)!;
     }
 
-    private Lock BehaviorLock => Volatile.Read(ref _rareState)?.BehaviorLock ?? EnsureBehaviorLock();
+    private Lock BehaviorLock
+    {
+        get
+        {
+            if (Volatile.Read(ref _rareState) is { } rare && Volatile.Read(ref rare.BehaviorLock) is { } existing)
+            {
+                return existing;
+            }
+            return EnsureBehaviorLock();
+        }
+    }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void IncrementInvokeCount() => Interlocked.Increment(ref _invokeCount);

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -88,7 +88,7 @@ public sealed class MethodSetup
         var existing = Volatile.Read(ref _rareState);
         if (existing is not null) return existing;
         Interlocked.CompareExchange(ref _rareState, new RareState(), null);
-        return _rareState!;
+        return Volatile.Read(ref _rareState)!;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -11,16 +11,23 @@ namespace TUnit.Mocks.Setup;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class MethodSetup
 {
-    private readonly IArgumentMatcher[] _matchers;
-    private Lock? _behaviorLock;
-    private Lock BehaviorLock => _behaviorLock ?? EnsureBehaviorLock();
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private Lock EnsureBehaviorLock()
+    /// <summary>
+    /// Rarely-used setup state. Lazily allocated to keep MethodSetup small on the common path
+    /// (single behavior, no events, no out/ref, no state machine).
+    /// </summary>
+    private sealed class RareState
     {
-        Interlocked.CompareExchange(ref _behaviorLock, new Lock(), null);
-        return _behaviorLock!;
+        public Lock? BehaviorLock;
+        public List<EventRaiseInfo>? EventRaises;
+        public EventRaiseInfo[]? EventRaisesSnapshot;
+        public Dictionary<int, object?>? OutRefAssignments;
+        public string? RequiredState;
+        public string? TransitionTarget;
     }
+
+    private readonly IArgumentMatcher[] _matchers;
+    private RareState? _rareState;
+
     /// <summary>Fast path for the common single-behavior case. Avoids list + lock on read.</summary>
     /// <remarks>
     /// Not declared volatile to avoid CS0420 with Interlocked.CompareExchange.
@@ -29,9 +36,6 @@ public sealed class MethodSetup
     private IBehavior? _singleBehavior;
     /// <remarks>See <see cref="_singleBehavior"/> for volatility rationale.</remarks>
     private List<IBehavior>? _behaviors;
-    private List<EventRaiseInfo>? _eventRaises;
-    private EventRaiseInfo[]? _eventRaisesSnapshot;
-    private Dictionary<int, object?>? _outRefAssignments;
     private int _callIndex;
 
     public int MemberId { get; }
@@ -41,14 +45,22 @@ public sealed class MethodSetup
     /// Used for state machine mocking.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public string? RequiredState { get; set; }
+    public string? RequiredState
+    {
+        get => Volatile.Read(ref _rareState)?.RequiredState;
+        set => EnsureRareState().RequiredState = value;
+    }
 
     /// <summary>
     /// If non-null, the engine transitions to this state after the behavior executes.
     /// Used for state machine mocking.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public string? TransitionTarget { get; set; }
+    public string? TransitionTarget
+    {
+        get => Volatile.Read(ref _rareState)?.TransitionTarget;
+        set => EnsureRareState().TransitionTarget = value;
+    }
 
     /// <summary>
     /// The number of times this setup has been matched and invoked.
@@ -70,6 +82,25 @@ public sealed class MethodSetup
         _matchers = matchers;
         MemberName = memberName;
     }
+
+    private RareState EnsureRareState()
+    {
+        var existing = Volatile.Read(ref _rareState);
+        if (existing is not null) return existing;
+        Interlocked.CompareExchange(ref _rareState, new RareState(), null);
+        return _rareState!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Lock EnsureBehaviorLock()
+    {
+        var rare = EnsureRareState();
+        if (rare.BehaviorLock is { } existing) return existing;
+        Interlocked.CompareExchange(ref rare.BehaviorLock, new Lock(), null);
+        return rare.BehaviorLock!;
+    }
+
+    private Lock BehaviorLock => Volatile.Read(ref _rareState)?.BehaviorLock ?? EnsureBehaviorLock();
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void IncrementInvokeCount() => Interlocked.Increment(ref _invokeCount);
@@ -277,30 +308,32 @@ public sealed class MethodSetup
 
     public void AddEventRaise(EventRaiseInfo raiseInfo)
     {
+        var rare = EnsureRareState();
         lock (BehaviorLock)
         {
-            var list = _eventRaises ??= new();
+            var list = rare.EventRaises ??= new();
             list.Add(raiseInfo);
-            _eventRaisesSnapshot = null;
+            rare.EventRaisesSnapshot = null;
         }
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public IReadOnlyList<EventRaiseInfo> GetEventRaises()
     {
-        if (Volatile.Read(ref _eventRaises) is null)
+        var rare = Volatile.Read(ref _rareState);
+        if (rare is null || Volatile.Read(ref rare.EventRaises) is null)
         {
             return [];
         }
 
-        if (Volatile.Read(ref _eventRaisesSnapshot) is { } snapshot)
+        if (Volatile.Read(ref rare.EventRaisesSnapshot) is { } snapshot)
         {
             return snapshot;
         }
 
         lock (BehaviorLock)
         {
-            return _eventRaisesSnapshot ??= _eventRaises!.ToArray();
+            return rare.EventRaisesSnapshot ??= rare.EventRaises!.ToArray();
         }
     }
 
@@ -327,10 +360,11 @@ public sealed class MethodSetup
     /// <param name="value">The value to assign.</param>
     public void SetOutRefValue(int paramIndex, object? value)
     {
+        var rare = EnsureRareState();
         lock (BehaviorLock)
         {
-            _outRefAssignments ??= new Dictionary<int, object?>();
-            _outRefAssignments[paramIndex] = value;
+            rare.OutRefAssignments ??= new Dictionary<int, object?>();
+            rare.OutRefAssignments[paramIndex] = value;
         }
     }
 
@@ -342,9 +376,11 @@ public sealed class MethodSetup
     {
         get
         {
+            var rare = Volatile.Read(ref _rareState);
+            if (rare is null) return null;
             lock (BehaviorLock)
             {
-                return _outRefAssignments;
+                return rare.OutRefAssignments;
             }
         }
     }


### PR DESCRIPTION
## Summary

Reduces allocations in the mock setup/verify/callback hot paths with no API changes.

- **Hoist rare `MethodSetup` fields** (event raises, out/ref assignments, state-machine strings, behavior lock) into a lazy `RareState` side-class. Saves ~40B per setup on the common path (single behavior, no events, no out/ref, no state machine).
- **CAS-based lazy init in generated `EnsureSetup`**: replaces `LazyInitializer.EnsureInitialized(…, Func<T>)` with an `Interlocked.CompareExchange` fast path. Drops the per-wrapper Func closure and two scratch fields (`_builderInitialized`, `_builderLock`).
- **Cache stateless matchers as singletons**: `AnyMatcher<T>`, `NullMatcher<T>`, `NotNullMatcher<T>`, and `EmptyMatcher` now expose `static readonly Instance`. `Arg.Any<T>() / IsNull<T>() / IsNotNull<T>() / IsEmpty<T>()` reuse these — one instance per closed T instead of one per call.

Estimated per-iteration allocation savings on mock benchmarks (rough):
- Callback (2 matchers): ~80B
- Setup (6 matchers across 3 methods): ~180B
- Verification (6 matchers): ~150B

No hot-path changes; no public API changes.

## Test plan
- [x] `TUnit.Mocks.Tests` full suite passes (904/904 on net10.0)
- [ ] Nightly mock benchmark workflow confirms alloc reduction with no time regression