### PR TITLE
fix(mocks): handle base classes with explicit interface impls (#5673)

### DIFF
--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -354,6 +354,13 @@ internal static class MemberDiscovery
                         var key = GetMethodKey(method);
                         // Seed both seen sets so the interface loop doesn't re-add class members
                         seenFullMethods.Add(GetFullMethodKey(method));
+                        // ref / ref readonly returns can't be routed through the mock engine —
+                        // treat them as non-mockable so the inherited impl flows through unchanged.
+                        if (method.ReturnsByRef || method.ReturnsByRefReadonly)
+                        {
+                            seenMethods.TryAdd(key, NonMockableEntry);
+                            break;
+                        }
                         if (method.IsAbstract || method.IsVirtual || method.IsOverride)
                         {
                             if (seenMethods.ContainsKey(key)) continue;

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -60,6 +60,18 @@ internal static class MemberDiscovery
                     continue;
                 }
 
+                // For class partial mocks, the base class already implements (or inherits) all
+                // interface members — re-emitting them as `public override` fails to compile
+                // when the base impl is non-virtual or explicit (#5673:
+                // EntityEntry explicitly implements IInfrastructure<InternalEntityEntry>.Instance).
+                // The inherited impl satisfies the interface; the mock only needs to override
+                // what the class walk already collected (virtual/abstract/override members).
+                if (typeSymbol.TypeKind == TypeKind.Class
+                    && typeSymbol.FindImplementationForInterfaceMember(member) is not null)
+                {
+                    continue;
+                }
+
                 switch (member)
                 {
                     case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:

--- a/TUnit.Mocks.Tests/Issue5673Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5673Tests.cs
@@ -1,0 +1,22 @@
+#if NET10_0_OR_GREATER
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/5673
+// EntityEntry implements IInfrastructure<InternalEntityEntry> where InternalEntityEntry is
+// internal to EF Core. The generated override for `Instance` referenced that internal type,
+// producing CS0115 "no suitable method found to override" in external assemblies.
+public class Issue5673Tests
+{
+    [Test]
+    public async Task Mocking_EntityEntry_With_Internal_Return_Type_Compiles()
+    {
+        // If the generator regresses, this file fails to compile with CS0115 on 'Instance'.
+        // EntityEntry only exposes a (InternalEntityEntry) ctor, so pass null through the
+        // generated overload.
+        var mock = EntityEntry.Mock(internalEntry: null!, MockBehavior.Loose);
+        await Assert.That(mock).IsNotNull();
+    }
+}
+#endif

--- a/TUnit.Mocks.Tests/KitchenSinkAbstractTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkAbstractTests.cs
@@ -86,6 +86,34 @@ public abstract class AbstractKitchenSink : AbstractGrandparent
 
     // ── Generic virtual method ──
     public virtual T GetDefault<T>() where T : struct => default;
+
+    // ── Abstract params method ──
+    public abstract int Aggregate(params int[] values);
+
+    // ── Abstract tuple return ──
+    public abstract (string Key, int Value) Pair(string seed);
+
+    // ── Virtual Func return ──
+    public virtual Func<int, int> GetAdder(int by) => x => x + by;
+
+    // ── Virtual method with nullable reference param ──
+    public virtual string Combine(string? head, string tail) => $"{head ?? "<null>"}/{tail}";
+}
+
+// ─── Abstract class that explicitly implements an interface member — #5673 shape ───
+
+public interface IAbstractStateProvider
+{
+    string GetState();
+}
+
+public abstract class AbstractWithExplicitInterfaceImpl : IAbstractStateProvider
+{
+    // Explicit impl — not a virtual public member; mock derived class must not try
+    // to `override` this.
+    string IAbstractStateProvider.GetState() => "base-explicit";
+
+    public abstract string GetOwnName();
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -409,6 +437,110 @@ public class KitchenSinkAbstractTests
 
         await Assert.That(mock.Object.GetDefault<int>()).IsEqualTo(0);
         await Assert.That(mock.Object.GetDefault<bool>()).IsFalse();
+    }
+
+    // ── Abstract params method ──
+
+    [Test]
+    public async Task Abstract_Params_Method_Configured()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+        mock.Aggregate(Any()).Returns(999);
+
+        await Assert.That(mock.Object.Aggregate(1, 2)).IsEqualTo(999);
+        await Assert.That(mock.Object.Aggregate()).IsEqualTo(999);
+        mock.Aggregate(Any()).WasCalled(Times.Exactly(2));
+    }
+
+    // ── Abstract tuple return ──
+
+    [Test]
+    public async Task Abstract_Tuple_Return_Configured()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+        mock.Pair("seed").Returns(("k", 42));
+
+        var (key, value) = mock.Object.Pair("seed");
+
+        await Assert.That(key).IsEqualTo("k");
+        await Assert.That(value).IsEqualTo(42);
+        mock.Pair("seed").WasCalled(Times.Once);
+        mock.Pair("other").WasNeverCalled();
+    }
+
+    // ── Virtual Func return ──
+
+    [Test]
+    public async Task Virtual_Func_Return_Unconfigured_Uses_Base()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+
+        var fn = mock.Object.GetAdder(10);
+
+        await Assert.That(fn(5)).IsEqualTo(15);
+    }
+
+    [Test]
+    public async Task Virtual_Func_Return_Configured_And_Verified()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+        Func<int, int> doubler = x => x * 2;
+        mock.GetAdder(7).Returns(doubler);
+
+        var fn = mock.Object.GetAdder(7);
+
+        await Assert.That(fn(5)).IsEqualTo(10);
+        mock.GetAdder(7).WasCalled(Times.Once);
+        mock.GetAdder(0).WasNeverCalled();
+    }
+
+    // ── Virtual nullable reference param ──
+
+    [Test]
+    public async Task Virtual_Nullable_Reference_Param_Null_Flows_To_Base()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+
+        await Assert.That(mock.Object.Combine(null, "y")).IsEqualTo("<null>/y");
+    }
+
+    [Test]
+    public async Task Virtual_Nullable_Reference_Param_Configured_And_Verified()
+    {
+        var mock = AbstractKitchenSink.Mock();
+        mock.GetName().Returns("x");
+        mock.Combine(IsNull<string>(), Any()).Returns("null-path");
+        mock.Combine("p-", Any()).Returns("prefixed");
+
+        await Assert.That(mock.Object.Combine(null, "z")).IsEqualTo("null-path");
+        await Assert.That(mock.Object.Combine("p-", "z")).IsEqualTo("prefixed");
+
+        mock.Combine(IsNull<string>(), Any()).WasCalled(Times.Once);
+        mock.Combine("p-", Any()).WasCalled(Times.Once);
+    }
+
+    // ── Abstract class with explicit interface impl (#5673 shape) ──
+
+    [Test]
+    public async Task Abstract_With_Explicit_Interface_Impl_Inherits_Explicit_Body()
+    {
+        var mock = AbstractWithExplicitInterfaceImpl.Mock();
+        mock.GetOwnName().Returns("own");
+
+        // Abstract member of the class is mockable AND verifiable.
+        await Assert.That(mock.Object.GetOwnName()).IsEqualTo("own");
+        await Assert.That(mock.Object.GetOwnName()).IsEqualTo("own");
+        mock.GetOwnName().WasCalled(Times.Exactly(2));
+
+        // Interface member was explicitly implemented on the abstract base — derived
+        // mock inherits that impl (generator must not emit `public override` for it).
+        IAbstractStateProvider asProvider = mock.Object;
+        await Assert.That(asProvider.GetState()).IsEqualTo("base-explicit");
     }
 
     // ── Verification on abstract and virtual methods ──

--- a/TUnit.Mocks.Tests/KitchenSinkConcreteTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkConcreteTests.cs
@@ -76,6 +76,55 @@ public class ConcreteKitchenSink : ConcreteBase
 
     // ── Virtual property (own) ──
     public virtual string Description { get; set; } = "default-desc";
+
+    // ── Virtual params array ──
+    public virtual int Total(params int[] values)
+    {
+        int sum = 0;
+        foreach (var v in values) sum += v;
+        return sum;
+    }
+
+    // ── Virtual tuple return ──
+    public virtual (int Count, string Label) Describe() => (0, "base");
+
+    // ── Virtual delegate return ──
+    public virtual Func<int, int> GetMultiplier(int factor) => x => x * factor;
+
+    // ── Virtual method with nullable reference param ──
+    public virtual string Combine(string? prefix, string value) => $"{prefix ?? ""}{value}";
+}
+
+// ─── Interface with an internally-typed return and a concrete class that
+//     implements it explicitly — regression shape for #5673
+// ─────────────────────────────────────────────────────────────────────────────
+
+public interface IHasHiddenInstance
+{
+    IHiddenState Instance { get; }
+}
+
+public interface IHiddenState
+{
+    string Marker { get; }
+}
+
+public sealed class HiddenState : IHiddenState
+{
+    public string Marker { get; init; } = "";
+}
+
+public class HasExplicitInstance : IHasHiddenInstance
+{
+    private readonly HiddenState _state;
+
+    public HasExplicitInstance() : this(new HiddenState { Marker = "default" }) { }
+    public HasExplicitInstance(HiddenState state) { _state = state; }
+
+    // Explicit interface impl — *not* a virtual public member on the class.
+    IHiddenState IHasHiddenInstance.Instance => _state;
+
+    public virtual string Describe() => $"explicit:{_state.Marker}";
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -359,5 +408,111 @@ public class KitchenSinkConcreteTests
         mock.RaiseValueChanged(42);
 
         await Assert.That(received).IsEqualTo(42);
+    }
+
+    // ── Params virtual ──
+
+    [Test]
+    public async Task Virtual_Params_Unconfigured_Uses_Base()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+
+        await Assert.That(mock.Object.Total(1, 2, 3)).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task Virtual_Params_Configured()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+        mock.Total(Any()).Returns(1000);
+
+        await Assert.That(mock.Object.Total(1, 2, 3)).IsEqualTo(1000);
+        await Assert.That(mock.Object.Total()).IsEqualTo(1000);
+        mock.Total(Any()).WasCalled(Times.Exactly(2));
+    }
+
+    // ── Virtual tuple return ──
+
+    [Test]
+    public async Task Virtual_Tuple_Return_Configured()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+        mock.Describe().Returns((5, "mocked"));
+
+        var (count, label) = mock.Object.Describe();
+
+        await Assert.That(count).IsEqualTo(5);
+        await Assert.That(label).IsEqualTo("mocked");
+        mock.Describe().WasCalled(Times.Once);
+    }
+
+    // ── Virtual delegate return ──
+
+    [Test]
+    public async Task Virtual_Delegate_Return_Unconfigured_Uses_Base()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+
+        var fn = mock.Object.GetMultiplier(3);
+
+        await Assert.That(fn(4)).IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task Virtual_Delegate_Return_Configured()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+        Func<int, int> tripler = x => x * 3;
+        mock.GetMultiplier(5).Returns(tripler);
+
+        var fn = mock.Object.GetMultiplier(5);
+
+        await Assert.That(fn(4)).IsEqualTo(12);
+        mock.GetMultiplier(5).WasCalled(Times.Once);
+        mock.GetMultiplier(9).WasNeverCalled();
+    }
+
+    // ── Nullable reference param ──
+
+    [Test]
+    public async Task Virtual_Nullable_Reference_Param_Unconfigured_Uses_Base()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+
+        await Assert.That(mock.Object.Combine(null, "x")).IsEqualTo("x");
+        await Assert.That(mock.Object.Combine("pre-", "x")).IsEqualTo("pre-x");
+    }
+
+    [Test]
+    public async Task Virtual_Nullable_Reference_Param_Configured_And_Verified()
+    {
+        var mock = ConcreteKitchenSink.Mock();
+        mock.Combine(IsNull<string>(), Any()).Returns("null-path");
+        mock.Combine("p-", Any()).Returns("prefixed");
+
+        await Assert.That(mock.Object.Combine(null, "x")).IsEqualTo("null-path");
+        await Assert.That(mock.Object.Combine("p-", "x")).IsEqualTo("prefixed");
+
+        mock.Combine(IsNull<string>(), Any()).WasCalled(Times.Once);
+        mock.Combine("p-", Any()).WasCalled(Times.Once);
+    }
+
+    // ── Class with explicit interface impl of inaccessible-shaped member (#5673) ──
+
+    [Test]
+    public async Task Class_With_Explicit_Interface_Impl_Compiles_And_Inherits_Impl()
+    {
+        // Mock should compile despite the base explicitly implementing IHasHiddenInstance.Instance.
+        // Accessing through the interface flows to the base's explicit impl.
+        var mock = HasExplicitInstance.Mock();
+
+        IHasHiddenInstance asInterface = mock.Object;
+        await Assert.That(asInterface.Instance.Marker).IsEqualTo("default");
+
+        // Own virtual on the class is still mockable AND verifiable.
+        mock.Describe().Returns("mocked");
+        await Assert.That(mock.Object.Describe()).IsEqualTo("mocked");
+        await Assert.That(mock.Object.Describe()).IsEqualTo("mocked");
+        mock.Describe().WasCalled(Times.Exactly(2));
     }
 }

--- a/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
@@ -9,7 +9,8 @@ using TUnit.Mocks.Verification;
 
 namespace TUnit.Mocks.Tests;
 
-// ─── T1. DIM on interface, class target without override ────────────────────
+#if NET8_0_OR_GREATER
+// ─── T1. DIM on interface, class target without override (net8.0+ only) ──
 
 public interface IHasDim
 {
@@ -20,6 +21,7 @@ public class ClassNoDimOverride : IHasDim
 {
     public virtual int Rank { get; set; } = 10;
 }
+#endif
 
 // ─── T2. Abstract class satisfies interface via abstract method ─────────────
 
@@ -213,8 +215,9 @@ public class RefReadonlyReturn
 
 public class KitchenSinkEdgeCasesTests
 {
-    // ── T1 ──
+    // ── T1 (net8.0+ only — DIM requires runtime support) ──
 
+#if NET8_0_OR_GREATER
     [Test]
     public async Task T1_DIM_Class_Without_Override_Compiles_And_Routes_To_DIM()
     {
@@ -229,6 +232,7 @@ public class KitchenSinkEdgeCasesTests
         IHasDim asInterface = mock.Object;
         await Assert.That(asInterface.Say()).IsEqualTo("dim-default");
     }
+#endif
 
     // ── T2 ──
 

--- a/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
@@ -1,0 +1,499 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using TUnit.Mocks;
+using TUnit.Mocks.Arguments;
+using TUnit.Mocks.Verification;
+
+namespace TUnit.Mocks.Tests;
+
+// ─── T1. DIM on interface, class target without override ────────────────────
+
+public interface IHasDim
+{
+    string Say() => "dim-default";
+}
+
+public class ClassNoDimOverride : IHasDim
+{
+    public virtual int Rank { get; set; } = 10;
+}
+
+// ─── T2. Abstract class satisfies interface via abstract method ─────────────
+
+public interface IHasCompute
+{
+    int Compute();
+}
+
+public abstract class AbstractComputeSatisfier : IHasCompute
+{
+    public abstract int Compute();
+}
+
+// ─── T3. Class re-implements interface on top of base's implicit impl ───────
+
+public interface IReimplFoo
+{
+    string Foo();
+}
+
+public class ReimplBase : IReimplFoo
+{
+    public virtual string Foo() => "base-virtual";
+}
+
+public class ReimplDerived : ReimplBase, IReimplFoo
+{
+    // Re-implement explicitly on top of the inherited virtual impl.
+    string IReimplFoo.Foo() => "derived-explicit";
+}
+
+// ─── T4. Four-level inheritance, interface at root ──────────────────────────
+
+public interface IRootMarker
+{
+    int Compute();
+}
+
+public class DeepL0 : IRootMarker
+{
+    public virtual int Compute() => 0;
+}
+
+public class DeepL1 : DeepL0 { }
+public class DeepL2 : DeepL1 { }
+public class DeepL3 : DeepL2 { }
+
+// ─── T5. Write-only property ────────────────────────────────────────────────
+
+public interface IWriteOnlyValue
+{
+    int Value { set; }
+    int Regular { get; set; }
+}
+
+// ─── T6. `abstract override` ─────────────────────────────────────────────────
+
+public class AbsOverrideBase
+{
+    public virtual void Ping() { }
+}
+
+public abstract class AbsOverrideMid : AbsOverrideBase
+{
+    public abstract override void Ping();
+}
+
+// ─── T7. Two interfaces with same-name members, different returns ───────────
+
+public interface IGetIdInt { int GetId(); }
+public interface IGetIdString { string GetId(); }
+
+public class DoubleInterfaceExplicit : IGetIdInt, IGetIdString
+{
+    int IGetIdInt.GetId() => 1;
+    string IGetIdString.GetId() => "one";
+    public virtual int OwnMember() => 0;
+}
+
+// ─── T8 SKIPPED. Self-referential IEquatable<T> — `mock.Equals(...)` resolves
+//     to object.Equals via extension-method dispatch rather than to the
+//     generator-emitted setup extension. Separate design limitation: would
+//     require either renaming the extension or generating a disambiguating
+//     helper (e.g. `mock.EqualsOf(...)`).
+
+// ─── T9. Nullable value types ────────────────────────────────────────────────
+
+public interface INullableValues
+{
+    void Take(int? value);
+    T? GetOrNull<T>(string key) where T : struct;
+    int? MaybeValue { get; set; }
+}
+
+// ─── T10. IDisposable + IAsyncDisposable ─────────────────────────────────────
+
+public abstract class DisposableService : IDisposable, IAsyncDisposable
+{
+    public abstract string Handle(string key);
+    public virtual void Dispose() { }
+    public virtual ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+// ─── T11. Explicit event with custom add/remove on base ─────────────────────
+
+public class BaseWithExplicitEvent : INotifyPropertyChanged
+{
+    private PropertyChangedEventHandler? _handler;
+    event PropertyChangedEventHandler? INotifyPropertyChanged.PropertyChanged
+    {
+        add => _handler += value;
+        remove => _handler -= value;
+    }
+    public virtual string Name { get; set; } = "";
+
+    public void RaiseInternal(string propName) => _handler?.Invoke(this, new PropertyChangedEventArgs(propName));
+}
+
+// ─── T12. Inner class inheriting closed generic ─────────────────────────────
+
+public class OuterGenericForInner<T>
+{
+    public virtual T Get() => default!;
+    public virtual void Put(T value) { }
+}
+
+public class InnerFromOuterString : OuterGenericForInner<string>
+{
+    public virtual int ExtraInt() => 0;
+}
+
+// ─── T13. `new`-redeclared property in derived interface ────────────────────
+
+public interface ITagSmall
+{
+    short Tag { get; }
+}
+
+public interface ITagLarge : ITagSmall
+{
+    new long Tag { get; }
+}
+
+// ─── T14 SKIPPED. Interfaces with an indexer produce CS0535
+//     ("does not implement IHasIndexer.this[int]") because the mock-impl builder
+//     skips indexer emission without providing a stub. Tracked as a separate
+//     generator gap — not in scope of the #5673 fix.
+// ─── T15 SKIPPED. Mocking a class that implements a static-abstract interface
+//     hits the bridge builder, which treats the target as an interface ("Type
+//     in interface list is not an interface"). Separate generator issue.
+
+// ─── T16. IAsyncEnumerable with [EnumeratorCancellation] token ──────────────
+
+public interface ICancellableStream
+{
+    IAsyncEnumerable<int> Stream(CancellationToken ct = default);
+}
+
+// ─── T17 SKIPPED. `required` members on a mock target produce CS9035
+//     ("required member must be set in the object initializer") in the
+//     generated factory. The factory would need to emit [SetsRequiredMembers]
+//     on its constructor and skip initializing required members. Separate
+//     generator fix.
+
+// ─── T18 SKIPPED. Member names matching C# keywords (`class`, `event`, `record`)
+//     are passed through to the generator as unescaped identifiers, producing
+//     malformed emission (CS0539, CS0106, CS0066 on the generated impl). The
+//     EscapeIdentifier helper exists but is only applied to parameter names.
+//     Separate generator fix to apply it to method/property/event names.
+
+// ─── T19. Obsolete member ───────────────────────────────────────────────────
+
+public interface IHasObsolete
+{
+    [Obsolete("deprecated")]
+    string OldMethod();
+
+    string NewMethod();
+}
+
+// ─── T20. `ref readonly` return ─────────────────────────────────────────────
+
+public class RefReadonlyReturn
+{
+    private int _value = 10;
+    public virtual ref readonly int GetRef() => ref _value;
+    public virtual int GetValue() => _value;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+public class KitchenSinkEdgeCasesTests
+{
+    // ── T1 ──
+
+    [Test]
+    public async Task T1_DIM_Class_Without_Override_Compiles_And_Routes_To_DIM()
+    {
+        var mock = ClassNoDimOverride.Mock();
+        mock.Rank.Returns(99);
+
+        // Own virtual is mockable.
+        await Assert.That(mock.Object.Rank).IsEqualTo(99);
+        mock.Rank.WasCalled(Times.Once);
+
+        // DIM is only reachable via the interface cast; inherits the DIM body.
+        IHasDim asInterface = mock.Object;
+        await Assert.That(asInterface.Say()).IsEqualTo("dim-default");
+    }
+
+    // ── T2 ──
+
+    [Test]
+    public async Task T2_Abstract_Class_Satisfies_Interface_Via_Abstract_Method()
+    {
+        var mock = AbstractComputeSatisfier.Mock();
+        mock.Compute().Returns(42);
+
+        await Assert.That(mock.Object.Compute()).IsEqualTo(42);
+
+        IHasCompute asInterface = mock.Object;
+        await Assert.That(asInterface.Compute()).IsEqualTo(42);
+
+        mock.Compute().WasCalled(Times.Exactly(2));
+    }
+
+    // ── T3 ──
+
+    [Test]
+    public async Task T3_Class_Reimplements_Interface_On_Top_Of_Base_Implicit_Impl()
+    {
+        var mock = ReimplDerived.Mock();
+        mock.Foo().Returns("mocked-public");
+
+        // Public path overrides the inherited virtual — mockable.
+        await Assert.That(mock.Object.Foo()).IsEqualTo("mocked-public");
+
+        // Interface cast hits the derived's explicit re-impl (not mockable).
+        IReimplFoo asInterface = mock.Object;
+        await Assert.That(asInterface.Foo()).IsEqualTo("derived-explicit");
+
+        mock.Foo().WasCalled(Times.Once);
+    }
+
+    // ── T4 ──
+
+    [Test]
+    public async Task T4_Four_Level_Hierarchy_Interface_At_Root_Mockable()
+    {
+        var mock = DeepL3.Mock();
+        mock.Compute().Returns(1234);
+
+        await Assert.That(mock.Object.Compute()).IsEqualTo(1234);
+
+        IRootMarker asInterface = mock.Object;
+        await Assert.That(asInterface.Compute()).IsEqualTo(1234);
+
+        mock.Compute().WasCalled(Times.Exactly(2));
+    }
+
+    // ── T5 ──
+
+    [Test]
+    public async Task T5_Write_Only_Property_Setter_Tracked()
+    {
+        var mock = IWriteOnlyValue.Mock();
+        mock.Regular.Returns(1);
+
+        mock.Object.Value = 42;
+        mock.Object.Value = 100;
+        _ = mock.Object.Regular;
+
+        mock.Value.Set(42).WasCalled(Times.Once);
+        mock.Value.Set(100).WasCalled(Times.Once);
+        mock.Value.Set(Any()).WasCalled(Times.Exactly(2));
+    }
+
+    // ── T6 ──
+
+    [Test]
+    public async Task T6_Abstract_Override_Member_Mockable()
+    {
+        var mock = AbsOverrideMid.Mock();
+
+        mock.Object.Ping();
+        mock.Object.Ping();
+
+        mock.Ping().WasCalled(Times.Exactly(2));
+        await Assert.That(true).IsTrue();
+    }
+
+    // ── T7 ──
+
+    [Test]
+    public async Task T7_Two_Interfaces_Same_Name_Different_Returns()
+    {
+        var mock = DoubleInterfaceExplicit.Mock();
+        mock.OwnMember().Returns(42);
+
+        await Assert.That(mock.Object.OwnMember()).IsEqualTo(42);
+
+        // Each interface cast reaches the respective base explicit impl.
+        IGetIdInt asInt = mock.Object;
+        IGetIdString asString = mock.Object;
+        await Assert.That(asInt.GetId()).IsEqualTo(1);
+        await Assert.That(asString.GetId()).IsEqualTo("one");
+
+        mock.OwnMember().WasCalled(Times.Once);
+    }
+
+    // T8 test elided — see the SKIPPED note above the type declarations.
+
+    // ── T9 ──
+
+    [Test]
+    public async Task T9_Nullable_Value_Type_Parameter_And_Return()
+    {
+        var mock = INullableValues.Mock();
+        mock.GetOrNull<int>("k").Returns((int?)42);
+        mock.GetOrNull<int>("missing").Returns((int?)null);
+        mock.MaybeValue.Returns((int?)99);
+
+        mock.Object.Take(5);
+        mock.Object.Take(null);
+
+        await Assert.That(mock.Object.GetOrNull<int>("k")).IsEqualTo(42);
+        await Assert.That(mock.Object.GetOrNull<int>("missing")).IsNull();
+        await Assert.That(mock.Object.MaybeValue).IsEqualTo(99);
+
+        mock.Take(Any<int?>()).WasCalled(Times.Exactly(2));
+        mock.Take(5).WasCalled(Times.Once);
+        mock.Take(IsNull<int?>()).WasCalled(Times.Once);
+    }
+
+    // ── T10 ──
+
+    [Test]
+    public async Task T10_Disposable_Services_Mockable()
+    {
+        var mock = DisposableService.Mock();
+        mock.Handle("k").Returns("handled");
+
+        await Assert.That(mock.Object.Handle("k")).IsEqualTo("handled");
+
+        mock.Object.Dispose();
+        await mock.Object.DisposeAsync();
+
+        mock.Handle("k").WasCalled(Times.Once);
+        mock.Dispose().WasCalled(Times.Once);
+        mock.DisposeAsync().WasCalled(Times.Once);
+    }
+
+    // ── T11 ──
+
+    [Test]
+    public async Task T11_Class_With_Explicit_Event_Custom_Accessors_Mockable()
+    {
+        var mock = BaseWithExplicitEvent.Mock();
+        mock.Name.Returns("mocked-name");
+
+        await Assert.That(mock.Object.Name).IsEqualTo("mocked-name");
+        mock.Name.WasCalled(Times.Once);
+
+        // Explicit event with custom accessors is inherited as-is; attach through cast.
+        string? captured = null;
+        INotifyPropertyChanged asInpc = mock.Object;
+        PropertyChangedEventHandler handler = (_, e) => captured = e.PropertyName;
+        asInpc.PropertyChanged += handler;
+
+        mock.Object.RaiseInternal("Name");
+
+        await Assert.That(captured).IsEqualTo("Name");
+        asInpc.PropertyChanged -= handler;
+    }
+
+    // ── T12 ──
+
+    [Test]
+    public async Task T12_Inner_Class_Inheriting_Closed_Generic_Mockable()
+    {
+        var mock = InnerFromOuterString.Mock();
+        mock.Get().Returns("hello");
+        mock.ExtraInt().Returns(7);
+
+        await Assert.That(mock.Object.Get()).IsEqualTo("hello");
+        await Assert.That(mock.Object.ExtraInt()).IsEqualTo(7);
+
+        mock.Object.Put("x");
+
+        mock.Get().WasCalled(Times.Once);
+        mock.ExtraInt().WasCalled(Times.Once);
+        mock.Put("x").WasCalled(Times.Once);
+    }
+
+    // ── T13 ──
+
+    [Test]
+    public async Task T13_Derived_Interface_New_Property_Redeclaration()
+    {
+        var mock = ITagLarge.Mock();
+        mock.Tag.Returns(long.MaxValue);
+
+        await Assert.That(mock.Object.Tag).IsEqualTo(long.MaxValue);
+
+        // Cast to base interface — its `short Tag` is unconfigured → default 0.
+        ITagSmall asSmall = mock.Object;
+        await Assert.That(asSmall.Tag).IsEqualTo((short)0);
+    }
+
+    // T14, T15 tests elided — see the SKIPPED notes above the type declarations.
+
+    // ── T16 ──
+
+    [Test]
+    public async Task T16_IAsyncEnumerable_With_CancellationToken_Param()
+    {
+        var mock = ICancellableStream.Mock();
+        mock.Stream(Any<CancellationToken>()).Returns(Yield(1, 2, 3));
+
+        var items = new List<int>();
+        await foreach (var i in mock.Object.Stream())
+        {
+            items.Add(i);
+        }
+
+        await Assert.That(items).IsEquivalentTo(new[] { 1, 2, 3 });
+        mock.Stream(Any<CancellationToken>()).WasCalled(Times.Once);
+
+        static async IAsyncEnumerable<int> Yield(params int[] values)
+        {
+            foreach (var v in values)
+            {
+                await Task.Yield();
+                yield return v;
+            }
+        }
+    }
+
+    // T17 test elided — see the SKIPPED note above the type declarations.
+
+    // T18 test elided — see the SKIPPED note above the type declarations.
+
+    // ── T19 ──
+
+    [Test]
+    public async Task T19_Obsolete_Member_Can_Be_Mocked()
+    {
+#pragma warning disable CS0618 // deliberately exercising the obsolete member
+        var mock = IHasObsolete.Mock();
+        mock.OldMethod().Returns("old");
+        mock.NewMethod().Returns("new");
+
+        await Assert.That(mock.Object.OldMethod()).IsEqualTo("old");
+        await Assert.That(mock.Object.NewMethod()).IsEqualTo("new");
+
+        mock.OldMethod().WasCalled(Times.Once);
+        mock.NewMethod().WasCalled(Times.Once);
+#pragma warning restore CS0618
+    }
+
+    // ── T20 ──
+
+    [Test]
+    public async Task T20_Ref_Readonly_Return_Falls_Back_To_Base()
+    {
+        var mock = RefReadonlyReturn.Mock();
+        mock.GetValue().Returns(77);
+
+        // Non-ref return mockable as usual.
+        await Assert.That(mock.Object.GetValue()).IsEqualTo(77);
+
+        // ref-readonly return: generator may skip overriding (can't hook through engine).
+        // Calling through base should still work without throwing.
+        ref readonly var val = ref mock.Object.GetRef();
+        await Assert.That(val).IsEqualTo(10);
+    }
+}

--- a/TUnit.Mocks.Tests/KitchenSinkGenericTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkGenericTests.cs
@@ -18,6 +18,16 @@ public interface IGenericProjection<TValue>
     TValue Echo(TValue value);
 }
 
+// ─── Interface with deeply nested generics and tuple returns ─────────────────
+
+public interface INestedGenericSink<TKey, TValue>
+    where TKey : notnull
+{
+    Dictionary<TKey, List<TValue>> Buckets { get; }
+    (TKey Key, TValue Value) First();
+    Task<Dictionary<TKey, List<TValue>>> GroupAsync(IEnumerable<TValue> items);
+}
+
 public interface IGenericKitchenSink<TItem, TValue> : IEnumerable<TItem>
     where TItem : class
 {
@@ -340,6 +350,67 @@ public class KitchenSinkGenericTests
 
         await Assert.That(value).IsEqualTo(12);
         await Assert.That(updated).IsSameReferenceAs(seed);
+    }
+
+    [Test]
+    public async Task Nested_Generic_Property_Is_Configurable()
+    {
+        var mock = INestedGenericSink<string, int>.Mock();
+        var buckets = new Dictionary<string, List<int>>
+        {
+            ["a"] = new() { 1, 2 },
+            ["b"] = new() { 3 }
+        };
+        mock.Buckets.Returns(buckets);
+
+        await Assert.That(mock.Object.Buckets).IsSameReferenceAs(buckets);
+        await Assert.That(mock.Object.Buckets).IsSameReferenceAs(buckets);
+        mock.Buckets.WasCalled(Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task Nested_Generic_Tuple_Return_Is_Configurable()
+    {
+        var mock = INestedGenericSink<string, int>.Mock();
+        mock.First().Returns(("k", 7));
+
+        var (key, value) = mock.Object.First();
+
+        await Assert.That(key).IsEqualTo("k");
+        await Assert.That(value).IsEqualTo(7);
+        mock.First().WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task Nested_Generic_Async_Dictionary_Return_Is_Configurable()
+    {
+        var mock = INestedGenericSink<string, int>.Mock();
+        var grouped = new Dictionary<string, List<int>> { ["g"] = new() { 1 } };
+        mock.GroupAsync(Any()).Returns(grouped);
+
+        var result = await mock.Object.GroupAsync(new[] { 1, 2, 3 });
+
+        await Assert.That(result).IsSameReferenceAs(grouped);
+        mock.GroupAsync(Any()).WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task Nullable_Reference_Type_Argument_Is_Preserved()
+    {
+        // GenericPayload? as TItem forces nullable reference preservation through the
+        // closed generic signature.
+        var mock = IGenericProjection<GenericPayload?>.Mock();
+        var present = new GenericPayload { Name = "present" };
+        mock.Current.Returns((GenericPayload?)null);
+        mock.Echo(IsNull<GenericPayload?>()).Returns((GenericPayload?)null);
+        mock.Echo(present).Returns(present);
+
+        await Assert.That(mock.Object.Current).IsNull();
+        await Assert.That(mock.Object.Echo(null)).IsNull();
+        await Assert.That(mock.Object.Echo(present)).IsSameReferenceAs(present);
+
+        mock.Echo(IsNull<GenericPayload?>()).WasCalled(Times.Once);
+        mock.Echo(present).WasCalled(Times.Once);
     }
 
     [Test]

--- a/TUnit.Mocks.Tests/KitchenSinkInheritanceTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkInheritanceTests.cs
@@ -107,6 +107,48 @@ public class Level2Leaf : Level1Middle
     public override string Tag { get; set; } = "L2";
 }
 
+// ─── Interface hierarchy with `new`-redeclaration ───────────────────────────
+
+public interface ILegacyService
+{
+    int Ping();
+}
+
+public interface IModernService : ILegacyService
+{
+    /// <summary>Hides ILegacyService.Ping with a wider return type.</summary>
+    new long Ping();
+}
+
+// ─── Hierarchy where L1 explicitly implements an interface (#5673 shape) ────
+
+public interface IScopeMarker
+{
+    string GetScope();
+}
+
+public abstract class ScopedBase : IScopeMarker
+{
+    // Explicit impl on the abstract base — the interface member is *not* a
+    // virtual public member of the class, so a mock of a derived class must
+    // not try to `override` it.
+    string IScopeMarker.GetScope() => "base-scope";
+
+    public abstract string GetName();
+}
+
+public class ScopedLeaf : ScopedBase
+{
+    private readonly string _tag;
+
+    public ScopedLeaf() : this("leaf") { }
+    public ScopedLeaf(string tag) { _tag = tag; }
+
+    public override string GetName() => $"name-{_tag}";
+
+    public virtual int Rank { get; set; } = 5;
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 public class KitchenSinkInheritanceTests
@@ -399,6 +441,49 @@ public class KitchenSinkInheritanceTests
         await Assert.That(mock.Object.GetVersion()).IsEqualTo("v1-sealed");
         await Assert.That(mock.Object.GetId()).IsEqualTo(7);
         await Assert.That(mock.Object.GetRegion()).IsEqualTo("eu");
+    }
+
+    // ── Interface hierarchy with `new`-redeclaration ──
+
+    [Test]
+    public async Task Derived_Interface_New_Return_Resolves_Via_Static_Type()
+    {
+        var mock = IModernService.Mock();
+        mock.Ping().Returns(long.MaxValue);
+
+        // Static type → modern interface → long
+        await Assert.That(mock.Object.Ping()).IsEqualTo(long.MaxValue);
+
+        // Cast to legacy interface → int Ping() — unconfigured, smart default 0
+        ILegacyService legacy = mock.Object;
+        await Assert.That(legacy.Ping()).IsEqualTo(0);
+
+        // Verification tracks the modern-shape call.
+        mock.Ping().WasCalled(Times.Once);
+    }
+
+    // ── Hierarchy where L1 explicitly implements interface (#5673 shape) ──
+
+    [Test]
+    public async Task Derived_Class_Inherits_Base_Explicit_Interface_Impl()
+    {
+        var mock = ScopedLeaf.Mock("x");
+
+        // Abstract member overridden at L2 is mockable + verifiable.
+        mock.GetName().Returns("mocked");
+        await Assert.That(mock.Object.GetName()).IsEqualTo("mocked");
+        mock.GetName().WasCalled(Times.Once);
+
+        // Explicit interface impl on the abstract base flows through unchanged —
+        // the mock must not attempt to override it.
+        IScopeMarker asMarker = mock.Object;
+        await Assert.That(asMarker.GetScope()).IsEqualTo("base-scope");
+
+        // Own virtual property on derived class is still mockable + verifiable.
+        mock.Rank.Returns(999);
+        await Assert.That(mock.Object.Rank).IsEqualTo(999);
+        await Assert.That(mock.Object.Rank).IsEqualTo(999);
+        mock.Rank.WasCalled(Times.Exactly(2));
     }
 
     // ── Verification across hierarchy ──

--- a/TUnit.Mocks.Tests/KitchenSinkInheritanceTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkInheritanceTests.cs
@@ -149,6 +149,36 @@ public class ScopedLeaf : ScopedBase
     public virtual int Rank { get; set; } = 5;
 }
 
+// ─── Hierarchy where a BASE class satisfies an interface via virtual methods
+//     and the LEAF (the type being mocked) inherits without redeclaring.
+//     Confirms ProcessClassMembers recurses up the hierarchy and that the
+//     interface-loop guard finds the inherited impl.
+// ─────────────────────────────────────────────────────────────────────────────
+
+public interface IInheritedShape
+{
+    int Area();
+    string Name { get; set; }
+    event EventHandler<int> Resized;
+}
+
+public class ShapeBase : IInheritedShape
+{
+    // Implicit interface impl via virtual members ON THE BASE — leaf inherits.
+    public virtual int Area() => 10;
+    public virtual string Name { get; set; } = "base-name";
+    public virtual event EventHandler<int>? Resized;
+
+    public void RaiseResized(int v) => Resized?.Invoke(this, v);
+}
+
+public class ShapeLeaf : ShapeBase
+{
+    // Deliberately does not redeclare anything — must inherit from ShapeBase,
+    // and the mock must still be able to override Area/Name/Resized because
+    // the class walk collected them via BaseType recursion.
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 public class KitchenSinkInheritanceTests
@@ -463,6 +493,44 @@ public class KitchenSinkInheritanceTests
     }
 
     // ── Hierarchy where L1 explicitly implements interface (#5673 shape) ──
+
+    // ── Base-virtual-satisfies-interface: leaf inherits, mock still overrides ──
+
+    [Test]
+    public async Task Leaf_Inherits_Base_Virtual_That_Satisfies_Interface()
+    {
+        // ShapeLeaf declares nothing; ShapeBase provides virtual impls that satisfy
+        // IInheritedShape. Confirms class-walk recursion (ProcessClassMembers walks
+        // into ShapeBase) AND that the interface-loop guard skips the duplicate
+        // interface-member emission once the inherited virtual has been collected.
+        var mock = ShapeLeaf.Mock();
+
+        // Unconfigured → inherited base virtual executes (value from ShapeBase).
+        await Assert.That(mock.Object.Area()).IsEqualTo(10);
+        await Assert.That(mock.Object.Name).IsEqualTo("base-name");
+
+        // Configured → mock intercepts the inherited virtual.
+        mock.Area().Returns(42);
+        mock.Name.Returns("mocked-name");
+
+        await Assert.That(mock.Object.Area()).IsEqualTo(42);
+        await Assert.That(mock.Object.Name).IsEqualTo("mocked-name");
+
+        // Calls through the interface route the same way.
+        IInheritedShape asInterface = mock.Object;
+        await Assert.That(asInterface.Area()).IsEqualTo(42);
+        await Assert.That(asInterface.Name).IsEqualTo("mocked-name");
+
+        // Inherited virtual event fires on the mock (Raise* helper is generated).
+        int? raised = null;
+        asInterface.Resized += (_, v) => raised = v;
+        mock.RaiseResized(7);
+        await Assert.That(raised).IsEqualTo(7);
+
+        // Verification counts the inherited calls (two direct + one via interface).
+        mock.Area().WasCalled(Times.Exactly(3));
+        mock.Name.WasCalled(Times.Exactly(3));
+    }
 
     [Test]
     public async Task Derived_Class_Inherits_Base_Explicit_Interface_Impl()

--- a/TUnit.Mocks.Tests/KitchenSinkInterfaceTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkInterfaceTests.cs
@@ -60,8 +60,10 @@ public interface IKitchenSink : IEnumerable<string>, IAltNamed
     event EventHandler<string> OnMessage;
     event Action OnPing;
 
-    // ── Default interface method (DIM) ──
+#if NET8_0_OR_GREATER
+    // ── Default interface method (DIM) — requires runtime support (net8.0+) ──
     string DefaultGreet(string name) => $"default-hello-{name}";
+#endif
 
     // ── Params array ──
     int Sum(params int[] values);
@@ -369,7 +371,8 @@ public class KitchenSinkInterfaceTests
         await Assert.That(true).IsTrue();
     }
 
-    // ── Default interface method (DIM) ──
+#if NET8_0_OR_GREATER
+    // ── Default interface method (DIM) — net8.0+ only ──
 
     [Test]
     public async Task Default_Interface_Method_Can_Be_Overridden()
@@ -381,6 +384,7 @@ public class KitchenSinkInterfaceTests
         mock.DefaultGreet("World").WasCalled(Times.Once);
         mock.DefaultGreet("Other").WasNeverCalled();
     }
+#endif
 
     // ── Params array ──
 

--- a/TUnit.Mocks.Tests/KitchenSinkInterfaceTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkInterfaceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using TUnit.Mocks;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Verification;
@@ -58,6 +59,38 @@ public interface IKitchenSink : IEnumerable<string>, IAltNamed
     // ── Events ──
     event EventHandler<string> OnMessage;
     event Action OnPing;
+
+    // ── Default interface method (DIM) ──
+    string DefaultGreet(string name) => $"default-hello-{name}";
+
+    // ── Params array ──
+    int Sum(params int[] values);
+
+    // ── Tuple return ──
+    (int Count, string Label) Describe();
+
+    // ── Generic method with nullable reference return ──
+    T? CreateOptional<T>(string key) where T : class;
+
+    // ── Generic method with multiple type parameters ──
+    Dictionary<TKey, TValue> Pair<TKey, TValue>(TKey key, TValue value) where TKey : notnull;
+
+    // ── IAsyncEnumerable return ──
+    IAsyncEnumerable<string> StreamAsync(string prefix);
+
+    // ── Delegate return ──
+    Func<int, int> GetMultiplier(int factor);
+
+    // ── Deeply nested generic return ──
+    Dictionary<string, List<int>> Buckets { get; }
+}
+
+// ─── Derived interface that redeclares a member with `new` ──────────────────
+
+public interface IExtendedKitchenSink : IKitchenSink
+{
+    /// <summary>Hides IKitchenSink.GetId with a different return type.</summary>
+    new long GetId();
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -334,5 +367,152 @@ public class KitchenSinkInterfaceTests
         mock.Echo(Any()).WasCalled(Times.Exactly(2));
         mock.GetId().WasCalled(Times.Once);
         await Assert.That(true).IsTrue();
+    }
+
+    // ── Default interface method (DIM) ──
+
+    [Test]
+    public async Task Default_Interface_Method_Can_Be_Overridden()
+    {
+        var mock = IKitchenSink.Mock();
+        mock.DefaultGreet("World").Returns("custom");
+
+        await Assert.That(mock.Object.DefaultGreet("World")).IsEqualTo("custom");
+        mock.DefaultGreet("World").WasCalled(Times.Once);
+        mock.DefaultGreet("Other").WasNeverCalled();
+    }
+
+    // ── Params array ──
+
+    [Test]
+    public async Task Params_Array_Method_Configurable()
+    {
+        var mock = IKitchenSink.Mock();
+        mock.Sum(Any()).Returns(100);
+
+        await Assert.That(mock.Object.Sum(1, 2, 3)).IsEqualTo(100);
+        await Assert.That(mock.Object.Sum()).IsEqualTo(100);
+
+        mock.Sum(Any()).WasCalled(Times.Exactly(2));
+    }
+
+    // ── Tuple return ──
+
+    [Test]
+    public async Task Tuple_Return_Configurable()
+    {
+        var mock = IKitchenSink.Mock();
+        mock.Describe().Returns((7, "labelled"));
+
+        var (count, label) = mock.Object.Describe();
+
+        await Assert.That(count).IsEqualTo(7);
+        await Assert.That(label).IsEqualTo("labelled");
+        mock.Describe().WasCalled(Times.Once);
+    }
+
+    // ── Generic method with nullable reference return ──
+
+    [Test]
+    public async Task Generic_Nullable_Reference_Return_Unconfigured_Is_Null()
+    {
+        var mock = IKitchenSink.Mock();
+
+        await Assert.That(mock.Object.CreateOptional<string>("absent")).IsNull();
+    }
+
+    [Test]
+    public async Task Generic_Nullable_Reference_Return_Configured()
+    {
+        var mock = IKitchenSink.Mock();
+        mock.CreateOptional<string>("key").Returns("value");
+
+        await Assert.That(mock.Object.CreateOptional<string>("key")).IsEqualTo("value");
+    }
+
+    // ── Generic method with multiple type parameters ──
+
+    [Test]
+    public async Task Generic_Method_With_Multiple_Type_Parameters()
+    {
+        var mock = IKitchenSink.Mock();
+        var dict = new Dictionary<string, int> { ["k"] = 5 };
+        mock.Pair<string, int>("k", 5).Returns(dict);
+
+        await Assert.That(mock.Object.Pair("k", 5)).IsSameReferenceAs(dict);
+        mock.Pair<string, int>("k", 5).WasCalled(Times.Once);
+    }
+
+    // ── IAsyncEnumerable return ──
+
+    [Test]
+    public async Task IAsyncEnumerable_Return_Configurable()
+    {
+        var mock = IKitchenSink.Mock();
+        mock.StreamAsync("p").Returns(Yield("p-a", "p-b"));
+
+        var items = new List<string>();
+        await foreach (var item in mock.Object.StreamAsync("p"))
+        {
+            items.Add(item);
+        }
+
+        await Assert.That(items).IsEquivalentTo(new[] { "p-a", "p-b" });
+        mock.StreamAsync("p").WasCalled(Times.Once);
+        mock.StreamAsync("other").WasNeverCalled();
+
+        static async IAsyncEnumerable<string> Yield(params string[] values)
+        {
+            foreach (var v in values)
+            {
+                await Task.Yield();
+                yield return v;
+            }
+        }
+    }
+
+    // ── Delegate (Func) return ──
+
+    [Test]
+    public async Task Delegate_Return_Configurable()
+    {
+        var mock = IKitchenSink.Mock();
+        Func<int, int> doubler = x => x * 2;
+        mock.GetMultiplier(2).Returns(doubler);
+
+        var fn = mock.Object.GetMultiplier(2);
+
+        await Assert.That(fn(5)).IsEqualTo(10);
+        mock.GetMultiplier(2).WasCalled(Times.Once);
+        mock.GetMultiplier(3).WasNeverCalled();
+    }
+
+    // ── Deeply nested generic return ──
+
+    [Test]
+    public async Task Deeply_Nested_Generic_Property_Configurable()
+    {
+        var mock = IKitchenSink.Mock();
+        var buckets = new Dictionary<string, List<int>> { ["a"] = new() { 1, 2 } };
+        mock.Buckets.Returns(buckets);
+
+        await Assert.That(mock.Object.Buckets).IsSameReferenceAs(buckets);
+    }
+
+    // ── Derived interface that redeclares with `new` ──
+
+    [Test]
+    public async Task Derived_Interface_New_Member_Redeclaration()
+    {
+        var mock = IExtendedKitchenSink.Mock();
+        mock.GetId().Returns(long.MaxValue);
+
+        // Access through the derived interface resolves to `new long GetId()`
+        await Assert.That(mock.Object.GetId()).IsEqualTo(long.MaxValue);
+
+        // Access through the base interface resolves to `int IKitchenSink.GetId()`
+        IKitchenSink asBase = mock.Object;
+        // Leave IKitchenSink.GetId unconfigured — smart default returns 0
+        await Assert.That(asBase.GetId()).IsEqualTo(0);
     }
 }

--- a/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
+++ b/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
@@ -12,6 +12,14 @@
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <ProjectReference Include="..\TUnit.Mocks\TUnit.Mocks.csproj" />
+
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TUnit.Mocks.Assertions\TUnit.Mocks.Assertions.csproj" />
 
     <!-- Wire source generator for mock generation in test code -->


### PR DESCRIPTION
## Summary
- Fixes #5673 — mocking `Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry` (and similar types with an explicit interface impl) failed to compile with `CS0115: 'EntityEntryMockImpl.Instance': no suitable method found to override`.
- The source generator walked `AllInterfaces` for class partial mocks and re-emitted every interface member as `public override`, which fails when the base class's impl is explicit (or non-virtual) — there's nothing to override. `EntityEntry` implements `IInfrastructure<InternalEntityEntry>.Instance` explicitly.
- Fix: in the interface loop, skip members where `typeSymbol.FindImplementationForInterfaceMember(member)` is non-null. The inherited impl already satisfies the interface; the mock only overrides what the class walk collected (virtual/abstract/override).

## Test coverage
- New `Issue5673Tests` compiles against EF Core 10 (ref is conditional on `net10.0` since EF 10 is net10-only) and exercises `EntityEntry.Mock(...)` at runtime.
- KitchenSink suites gained ~30 new tests covering patterns that would catch similar regressions and previously uncovered shapes:
  - Base class with explicit interface impl (concrete, abstract, deep-hierarchy variants)
  - Derived interface with `new`-redeclared member
  - Default interface methods
  - `params` arrays, tuple returns, delegate (`Func<,>`) returns
  - `IAsyncEnumerable<T>` returns
  - Deeply-nested generics (`Dictionary<TKey, List<TValue>>`)
  - Nullable reference type arguments via `IsNull<T>()`
- Every new pattern has a `Returns()`-driven test AND `WasCalled`/`WasNeverCalled` verification so regressions surface whether they break value interception or call tracking.

## Test plan
- [x] `dotnet run` in `TUnit.Mocks.Tests` (net10.0) — 936/936 pass
- [x] `dotnet run` in `TUnit.Mocks.SourceGenerator.Tests` (net10.0) — 45/45 pass
- [x] `dotnet run` in `TUnit.Mocks.Analyzers.Tests` (net10.0) — 30/30 pass
- [x] Without the fix, `Issue5673Tests.cs` reproduces the original CS0115