### PR TITLE
fix(mocks): implement indexer in generated mock (#5676)

### DIFF
--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1064,67 +1064,21 @@ internal static class MockImplBuilder
     /// to the base implementation. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
     /// </summary>
     private static void GeneratePartialIndexer(CodeWriter writer, MockMemberModel prop)
-    {
-        var accessModifier = prop.IsProtected ? "protected" : "public";
-        var paramList = FormatIndexerParameterList(prop);
-        var argPassList = string.Join(", ", prop.Parameters.Select(p => p.Name));
-        var argsArray = GetIndexerGetterArgsArray(prop);
-        writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
-        writer.AppendLine($"{accessModifier} override {prop.ReturnType} this[{paramList}]");
-        writer.OpenBrace();
-
-        if (prop.HasGetter)
-        {
-            writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
-            if (prop.IsAbstractMember)
-            {
-                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
-            }
-            else
-            {
-                writer.AppendLine("get");
-                writer.OpenBrace();
-                writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault}, out var __result))");
-                writer.AppendLine("{");
-                writer.IncreaseIndent();
-                writer.AppendLine("return __result;");
-                writer.DecreaseIndent();
-                writer.AppendLine("}");
-                writer.AppendLine($"return base[{argPassList}];");
-                writer.CloseBrace();
-            }
-        }
-
-        if (prop.HasSetter)
-        {
-            var setterArgs = GetIndexerSetterArgsArray(prop);
-            writer.AppendLineIfNotEmpty(prop.SetterObsoleteAttribute);
-            if (prop.IsAbstractMember)
-            {
-                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
-            }
-            else
-            {
-                writer.AppendLine("set");
-                writer.OpenBrace();
-                writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs}))");
-                writer.AppendLine("{");
-                writer.IncreaseIndent();
-                writer.AppendLine($"base[{argPassList}] = value;");
-                writer.DecreaseIndent();
-                writer.AppendLine("}");
-                writer.CloseBrace();
-            }
-        }
-
-        writer.CloseBrace();
-    }
+        => GenerateOverrideIndexer(writer, prop, fallbackTarget: "base");
 
     /// <summary>
     /// Emits an overriding indexer for a wrap mock. Tries the engine first; on miss, falls back
     /// to the wrapped instance. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
     /// </summary>
     private static void GenerateWrapIndexer(CodeWriter writer, MockMemberModel prop)
+        => GenerateOverrideIndexer(writer, prop, fallbackTarget: "_wrappedInstance");
+
+    /// <summary>
+    /// Emits an <c>override</c> indexer that tries the engine first and, on miss, forwards to
+    /// <paramref name="fallbackTarget"/> (e.g. <c>base</c> for partial mocks, <c>_wrappedInstance</c>
+    /// for wrap mocks). For abstract members there is no fallback — the engine call is unconditional.
+    /// </summary>
+    private static void GenerateOverrideIndexer(CodeWriter writer, MockMemberModel prop, string fallbackTarget)
     {
         var accessModifier = prop.IsProtected ? "protected" : "public";
         var paramList = FormatIndexerParameterList(prop);
@@ -1146,12 +1100,10 @@ internal static class MockImplBuilder
                 writer.AppendLine("get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault}, out var __result))");
-                writer.AppendLine("{");
-                writer.IncreaseIndent();
+                writer.OpenBrace();
                 writer.AppendLine("return __result;");
-                writer.DecreaseIndent();
-                writer.AppendLine("}");
-                writer.AppendLine($"return _wrappedInstance[{argPassList}];");
+                writer.CloseBrace();
+                writer.AppendLine($"return {fallbackTarget}[{argPassList}];");
                 writer.CloseBrace();
             }
         }
@@ -1169,11 +1121,9 @@ internal static class MockImplBuilder
                 writer.AppendLine("set");
                 writer.OpenBrace();
                 writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs}))");
-                writer.AppendLine("{");
-                writer.IncreaseIndent();
-                writer.AppendLine($"_wrappedInstance[{argPassList}] = value;");
-                writer.DecreaseIndent();
-                writer.AppendLine("}");
+                writer.OpenBrace();
+                writer.AppendLine($"{fallbackTarget}[{argPassList}] = value;");
+                writer.CloseBrace();
                 writer.CloseBrace();
             }
         }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -65,10 +65,16 @@ internal static class MockImplBuilder
             // Properties — skip static abstract (they're in bridge DIMs)
             foreach (var prop in model.Properties)
             {
-                if (prop.IsIndexer) continue;
                 if (prop.IsStaticAbstract) continue;
                 writer.AppendLine();
-                GenerateInterfaceProperty(writer, prop, model);
+                if (prop.IsIndexer)
+                {
+                    GenerateInterfaceIndexer(writer, prop);
+                }
+                else
+                {
+                    GenerateInterfaceProperty(writer, prop, model);
+                }
             }
 
             // Events — skip static abstract (they're in bridge DIMs)
@@ -113,10 +119,16 @@ internal static class MockImplBuilder
             // Properties — skip static abstract (they're in bridge DIMs)
             foreach (var prop in model.Properties)
             {
-                if (prop.IsIndexer) continue;
                 if (prop.IsStaticAbstract) continue;
                 writer.AppendLine();
-                GenerateWrapProperty(writer, prop, model);
+                if (prop.IsIndexer)
+                {
+                    GenerateWrapIndexer(writer, prop);
+                }
+                else
+                {
+                    GenerateWrapProperty(writer, prop, model);
+                }
             }
 
             // Events — skip static abstract (they're in bridge DIMs)
@@ -451,10 +463,16 @@ internal static class MockImplBuilder
             // Properties — skip static abstract (they're in bridge DIMs)
             foreach (var prop in model.Properties)
             {
-                if (prop.IsIndexer) continue;
                 if (prop.IsStaticAbstract) continue;
                 writer.AppendLine();
-                GeneratePartialProperty(writer, prop, model);
+                if (prop.IsIndexer)
+                {
+                    GeneratePartialIndexer(writer, prop);
+                }
+                else
+                {
+                    GeneratePartialProperty(writer, prop, model);
+                }
             }
 
             // Events — skip static abstract (they're in bridge DIMs)
@@ -1009,6 +1027,177 @@ internal static class MockImplBuilder
         }
 
         writer.CloseBrace();
+    }
+
+    /// <summary>
+    /// Emits an indexer (<c>this[...]</c>) implementation for an interface mock that routes
+    /// get/set calls through the engine. Each get is dispatched as <c>get_Item</c> and each set
+    /// as <c>set_Item</c>; the index parameters (and value, for setters) become the matchable
+    /// arguments, so distinct index values produce independent setups and verifications.
+    /// </summary>
+    private static void GenerateInterfaceIndexer(CodeWriter writer, MockMemberModel prop)
+    {
+        var paramList = FormatIndexerParameterList(prop);
+        var argsArray = GetIndexerGetterArgsArray(prop);
+        writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
+        writer.AppendLine($"public {prop.ReturnType} this[{paramList}]");
+        writer.OpenBrace();
+
+        if (prop.HasGetter)
+        {
+            writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
+            writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
+        }
+
+        if (prop.HasSetter)
+        {
+            var setterArgs = GetIndexerSetterArgsArray(prop);
+            writer.AppendLineIfNotEmpty(prop.SetterObsoleteAttribute);
+            writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
+        }
+
+        writer.CloseBrace();
+    }
+
+    /// <summary>
+    /// Emits an overriding indexer for a partial mock. Tries the engine first; on miss, falls back
+    /// to the base implementation. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
+    /// </summary>
+    private static void GeneratePartialIndexer(CodeWriter writer, MockMemberModel prop)
+    {
+        var accessModifier = prop.IsProtected ? "protected" : "public";
+        var paramList = FormatIndexerParameterList(prop);
+        var argPassList = string.Join(", ", prop.Parameters.Select(p => p.Name));
+        var argsArray = GetIndexerGetterArgsArray(prop);
+        writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
+        writer.AppendLine($"{accessModifier} override {prop.ReturnType} this[{paramList}]");
+        writer.OpenBrace();
+
+        if (prop.HasGetter)
+        {
+            writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
+            if (prop.IsAbstractMember)
+            {
+                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
+            }
+            else
+            {
+                writer.AppendLine("get");
+                writer.OpenBrace();
+                writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault}, out var __result))");
+                writer.AppendLine("{");
+                writer.IncreaseIndent();
+                writer.AppendLine("return __result;");
+                writer.DecreaseIndent();
+                writer.AppendLine("}");
+                writer.AppendLine($"return base[{argPassList}];");
+                writer.CloseBrace();
+            }
+        }
+
+        if (prop.HasSetter)
+        {
+            var setterArgs = GetIndexerSetterArgsArray(prop);
+            writer.AppendLineIfNotEmpty(prop.SetterObsoleteAttribute);
+            if (prop.IsAbstractMember)
+            {
+                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
+            }
+            else
+            {
+                writer.AppendLine("set");
+                writer.OpenBrace();
+                writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs}))");
+                writer.AppendLine("{");
+                writer.IncreaseIndent();
+                writer.AppendLine($"base[{argPassList}] = value;");
+                writer.DecreaseIndent();
+                writer.AppendLine("}");
+                writer.CloseBrace();
+            }
+        }
+
+        writer.CloseBrace();
+    }
+
+    /// <summary>
+    /// Emits an overriding indexer for a wrap mock. Tries the engine first; on miss, falls back
+    /// to the wrapped instance. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
+    /// </summary>
+    private static void GenerateWrapIndexer(CodeWriter writer, MockMemberModel prop)
+    {
+        var accessModifier = prop.IsProtected ? "protected" : "public";
+        var paramList = FormatIndexerParameterList(prop);
+        var argPassList = string.Join(", ", prop.Parameters.Select(p => p.Name));
+        var argsArray = GetIndexerGetterArgsArray(prop);
+        writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
+        writer.AppendLine($"{accessModifier} override {prop.ReturnType} this[{paramList}]");
+        writer.OpenBrace();
+
+        if (prop.HasGetter)
+        {
+            writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
+            if (prop.IsAbstractMember)
+            {
+                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
+            }
+            else
+            {
+                writer.AppendLine("get");
+                writer.OpenBrace();
+                writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault}, out var __result))");
+                writer.AppendLine("{");
+                writer.IncreaseIndent();
+                writer.AppendLine("return __result;");
+                writer.DecreaseIndent();
+                writer.AppendLine("}");
+                writer.AppendLine($"return _wrappedInstance[{argPassList}];");
+                writer.CloseBrace();
+            }
+        }
+
+        if (prop.HasSetter)
+        {
+            var setterArgs = GetIndexerSetterArgsArray(prop);
+            writer.AppendLineIfNotEmpty(prop.SetterObsoleteAttribute);
+            if (prop.IsAbstractMember)
+            {
+                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
+            }
+            else
+            {
+                writer.AppendLine("set");
+                writer.OpenBrace();
+                writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs}))");
+                writer.AppendLine("{");
+                writer.IncreaseIndent();
+                writer.AppendLine($"_wrappedInstance[{argPassList}] = value;");
+                writer.DecreaseIndent();
+                writer.AppendLine("}");
+                writer.CloseBrace();
+            }
+        }
+
+        writer.CloseBrace();
+    }
+
+    private static string FormatIndexerParameterList(MockMemberModel indexer)
+    {
+        return string.Join(", ", indexer.Parameters.Select(p => $"{p.FullyQualifiedType} {p.Name}"));
+    }
+
+    private static string GetIndexerGetterArgsArray(MockMemberModel indexer)
+    {
+        if (indexer.Parameters.Length == 0) return "global::System.Array.Empty<object?>()";
+        var args = string.Join(", ", indexer.Parameters.Select(p => p.Name));
+        return $"new object?[] {{ {args} }}";
+    }
+
+    private static string GetIndexerSetterArgsArray(MockMemberModel indexer)
+    {
+        if (indexer.Parameters.Length == 0) return "new object?[] { value }";
+        var args = string.Join(", ", indexer.Parameters.Select(p => p.Name)) + ", value";
+        return $"new object?[] {{ {args} }}";
     }
 
     private static void GenerateEvent(CodeWriter writer, MockEventModel evt)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1029,22 +1029,16 @@ internal static class MockImplBuilder
         writer.CloseBrace();
     }
 
-    /// <summary>
-    /// Emits an indexer (<c>this[...]</c>) implementation for an interface mock that routes
-    /// get/set calls through the engine. Each get is dispatched as <c>get_Item</c> and each set
-    /// as <c>set_Item</c>; the index parameters (and value, for setters) become the matchable
-    /// arguments, so distinct index values produce independent setups and verifications.
-    /// </summary>
     private static void GenerateInterfaceIndexer(CodeWriter writer, MockMemberModel prop)
     {
         var paramList = FormatIndexerParameterList(prop);
-        var argsArray = GetIndexerGetterArgsArray(prop);
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
         writer.AppendLine($"public {prop.ReturnType} this[{paramList}]");
         writer.OpenBrace();
 
         if (prop.HasGetter)
         {
+            var argsArray = GetIndexerGetterArgsArray(prop);
             writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
             writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
         }
@@ -1059,37 +1053,24 @@ internal static class MockImplBuilder
         writer.CloseBrace();
     }
 
-    /// <summary>
-    /// Emits an overriding indexer for a partial mock. Tries the engine first; on miss, falls back
-    /// to the base implementation. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
-    /// </summary>
     private static void GeneratePartialIndexer(CodeWriter writer, MockMemberModel prop)
         => GenerateOverrideIndexer(writer, prop, fallbackTarget: "base");
 
-    /// <summary>
-    /// Emits an overriding indexer for a wrap mock. Tries the engine first; on miss, falls back
-    /// to the wrapped instance. See <see cref="GenerateInterfaceIndexer"/> for the dispatch shape.
-    /// </summary>
     private static void GenerateWrapIndexer(CodeWriter writer, MockMemberModel prop)
         => GenerateOverrideIndexer(writer, prop, fallbackTarget: "_wrappedInstance");
 
-    /// <summary>
-    /// Emits an <c>override</c> indexer that tries the engine first and, on miss, forwards to
-    /// <paramref name="fallbackTarget"/> (e.g. <c>base</c> for partial mocks, <c>_wrappedInstance</c>
-    /// for wrap mocks). For abstract members there is no fallback — the engine call is unconditional.
-    /// </summary>
     private static void GenerateOverrideIndexer(CodeWriter writer, MockMemberModel prop, string fallbackTarget)
     {
         var accessModifier = prop.IsProtected ? "protected" : "public";
         var paramList = FormatIndexerParameterList(prop);
         var argPassList = string.Join(", ", prop.Parameters.Select(p => p.Name));
-        var argsArray = GetIndexerGetterArgsArray(prop);
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
         writer.AppendLine($"{accessModifier} override {prop.ReturnType} this[{paramList}]");
         writer.OpenBrace();
 
         if (prop.HasGetter)
         {
+            var argsArray = GetIndexerGetterArgsArray(prop);
             writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
             if (prop.IsAbstractMember)
             {
@@ -1132,9 +1113,7 @@ internal static class MockImplBuilder
     }
 
     private static string FormatIndexerParameterList(MockMemberModel indexer)
-    {
-        return string.Join(", ", indexer.Parameters.Select(p => $"{p.FullyQualifiedType} {p.Name}"));
-    }
+        => FormatParameterList(indexer.Parameters);
 
     private static string GetIndexerGetterArgsArray(MockMemberModel indexer)
     {

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -73,6 +73,19 @@ internal static class MockMembersBuilder
                     GeneratePropertyExtensionBlock(writer, memberProps, model, safeName);
                 }
 
+                // Indexers -- expose as Item(...)/SetItem(..., value) extension methods so
+                // setups and verifications can target distinct index values independently.
+                // Each indexer overload (different parameter signature) gets its own pair.
+                var indexers = model.Properties
+                    .Where(p => p.IsIndexer && !p.IsStaticAbstract)
+                    .ToList();
+                foreach (var indexer in indexers)
+                {
+                    if (!firstMember) writer.AppendLine();
+                    firstMember = false;
+                    GenerateIndexerExtensionMethods(writer, indexer, model);
+                }
+
                 // Raise extension methods for events (skip static abstract)
                 if (instanceEvents.Length > 0)
                 {
@@ -1025,6 +1038,54 @@ internal static class MockMembersBuilder
 
                 writer.AppendLine($"public global::TUnit.Mocks.PropertyMockCall<{prop.ReturnType}> {safePropName}");
                 writer.AppendLine($"    => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {getterMemberId}, {setterMemberId}, \"{prop.Name}\", {hasGetter}, {hasSetter});");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits <c>Item(args...)</c> and (optionally) <c>SetItem(args..., value)</c> extension methods
+    /// for an indexer, returning <see cref="MockMethodCall{TReturn}"/> / <see cref="VoidMockMethodCall"/>
+    /// so that callers can configure (<c>.Returns()</c>) and verify (<c>.WasCalled()</c>) per-index.
+    /// </summary>
+    private static void GenerateIndexerExtensionMethods(CodeWriter writer, MockMemberModel indexer, MockTypeModel model)
+    {
+        var mockableType = MockImplBuilder.GetMockableTypeName(model);
+        var typeParams = MockImplBuilder.GetTypeParameterList(model);
+        var constraints = MockImplBuilder.GetConstraintClauses(model);
+        var extensionParam = $"this global::TUnit.Mocks.Mock<{mockableType}> mock";
+
+        // Indexer parameters as Arg<T> so callers can pass a literal, Arg.Any<T>(), etc.
+        var argParams = string.Join(", ", indexer.Parameters.Select(p =>
+            $"global::TUnit.Mocks.Arguments.Arg<{p.FullyQualifiedType}> {p.Name}"));
+        var matcherList = indexer.Parameters.Length == 0
+            ? "global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>()"
+            : $"new global::TUnit.Mocks.Arguments.IArgumentMatcher[] {{ {string.Join(", ", indexer.Parameters.Select(p => $"{p.Name}.Matcher"))} }}";
+
+        if (indexer.HasGetter)
+        {
+            writer.AppendLineIfNotEmpty(indexer.ObsoleteAttribute);
+            var getterParams = string.IsNullOrEmpty(argParams) ? extensionParam : $"{extensionParam}, {argParams}";
+            using (writer.Block($"public static global::TUnit.Mocks.MockMethodCall<{indexer.ReturnType}> Item{typeParams}({getterParams}){constraints}"))
+            {
+                writer.AppendLine($"var matchers = {matcherList};");
+                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{indexer.ReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {indexer.MemberId}, \"get_Item\", matchers);");
+            }
+        }
+
+        if (indexer.HasSetter)
+        {
+            if (indexer.HasGetter) writer.AppendLine();
+            writer.AppendLineIfNotEmpty(indexer.ObsoleteAttribute);
+            var valueParam = $"global::TUnit.Mocks.Arguments.Arg<{indexer.ReturnType}> value";
+            var setterArgParams = string.IsNullOrEmpty(argParams) ? valueParam : $"{argParams}, {valueParam}";
+            var setterParams = $"{extensionParam}, {setterArgParams}";
+            var setterMatcherList = indexer.Parameters.Length == 0
+                ? "new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { value.Matcher }"
+                : $"new global::TUnit.Mocks.Arguments.IArgumentMatcher[] {{ {string.Join(", ", indexer.Parameters.Select(p => $"{p.Name}.Matcher"))}, value.Matcher }}";
+            using (writer.Block($"public static global::TUnit.Mocks.VoidMockMethodCall SetItem{typeParams}({setterParams}){constraints}"))
+            {
+                writer.AppendLine($"var matchers = {setterMatcherList};");
+                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {indexer.SetterMemberId}, \"set_Item\", matchers);");
             }
         }
     }

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -777,7 +777,7 @@ internal static class MemberDiscovery
                     Name = EscapeIdentifier(p.Name),
                     Type = p.Type.GetMinimallyQualifiedNameWithNullability(),
                     FullyQualifiedType = p.Type.GetFullyQualifiedNameWithNullability(),
-                    Direction = ParameterDirection.In
+                    Direction = p.GetParameterDirection()
                 }).ToImmutableArray()
             ),
             ExplicitInterfaceName = explicitInterfaceName,

--- a/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
@@ -165,10 +165,14 @@ public interface ITagLarge : ITagSmall
     new long Tag { get; }
 }
 
-// ─── T14 SKIPPED. Interfaces with an indexer produce CS0535
-//     ("does not implement IHasIndexer.this[int]") because the mock-impl builder
-//     skips indexer emission without providing a stub. Tracked as a separate
-//     generator gap — not in scope of the #5673 fix.
+// ─── T14. Interface with indexer ────────────────────────────────────────────
+
+public interface IHasIndexer
+{
+    string this[int index] { get; set; }
+    int Regular { get; set; }
+}
+
 // ─── T15 SKIPPED. Mocking a class that implements a static-abstract interface
 //     hits the bridge builder, which treats the target as an interface ("Type
 //     in interface list is not an interface"). Separate generator issue.
@@ -433,7 +437,44 @@ public class KitchenSinkEdgeCasesTests
         await Assert.That(asSmall.Tag).IsEqualTo((short)0);
     }
 
-    // T14, T15 tests elided — see the SKIPPED notes above the type declarations.
+    // ── T14 ──
+
+    [Test]
+    public async Task T14_Interface_With_Indexer_Compiles_Regular_Property_Works()
+    {
+        var mock = IHasIndexer.Mock();
+        mock.Regular.Returns(123);
+
+        await Assert.That(mock.Object.Regular).IsEqualTo(123);
+        mock.Regular.WasCalled(Times.Once);
+    }
+
+    [Test]
+    public async Task T14_Interface_With_Indexer_Get_Set_Configurable_And_Verifiable()
+    {
+        var mock = IHasIndexer.Mock();
+        mock.Item(0).Returns("zero");
+        mock.Item(1).Returns("one");
+
+        await Assert.That(mock.Object[0]).IsEqualTo("zero");
+        await Assert.That(mock.Object[1]).IsEqualTo("one");
+        await Assert.That(mock.Object[0]).IsEqualTo("zero");
+
+        mock.Object[5] = "five";
+        mock.Object[5] = "five-again";
+        mock.Object[6] = "six";
+
+        // Distinct index values produce independent setups (verified by the get_*).
+        mock.Item(0).WasCalled(Times.Exactly(2));
+        mock.Item(1).WasCalled(Times.Once);
+
+        // Setter verification per index value.
+        mock.SetItem(5, Any<string>()).WasCalled(Times.Exactly(2));
+        mock.SetItem(6, "six").WasCalled(Times.Once);
+        mock.SetItem(Any<int>(), Any<string>()).WasCalled(Times.Exactly(3));
+    }
+
+    // T15 test elided — see the SKIPPED note above the type declarations.
 
     // ── T16 ──
 

--- a/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs
@@ -173,6 +173,14 @@ public interface IHasIndexer
     int Regular { get; set; }
 }
 
+// T14b. Indexer with `in` parameter — exercises modifier forwarding
+// in FormatIndexerParameterList. `in` is the only ref-kind C# permits on
+// indexer parameters.
+public interface IHasInIndexer
+{
+    string this[in int key] { get; }
+}
+
 // ─── T15 SKIPPED. Mocking a class that implements a static-abstract interface
 //     hits the bridge builder, which treats the target as an interface ("Type
 //     in interface list is not an interface"). Separate generator issue.
@@ -472,6 +480,17 @@ public class KitchenSinkEdgeCasesTests
         mock.SetItem(5, Any<string>()).WasCalled(Times.Exactly(2));
         mock.SetItem(6, "six").WasCalled(Times.Once);
         mock.SetItem(Any<int>(), Any<string>()).WasCalled(Times.Exactly(3));
+    }
+
+    [Test]
+    public async Task T14b_Indexer_With_In_Parameter_Compiles_And_Dispatches()
+    {
+        var mock = IHasInIndexer.Mock();
+        mock.Item(7).Returns("seven");
+
+        var k = 7;
+        await Assert.That(mock.Object[in k]).IsEqualTo("seven");
+        mock.Item(7).WasCalled(Times.Once);
     }
 
     // T15 test elided — see the SKIPPED note above the type declarations.


### PR DESCRIPTION
## Summary
- Implements interface/partial/wrap indexer emission in `MockImplBuilder`, replacing the three `if (prop.IsIndexer) continue;` skip sites that were leaving `IFoo.this[int]` unimplemented and producing CS0535.
- Adds `Item(args)` and `SetItem(args, value)` extension methods in `MockMembersBuilder` so per-index setups (`Returns`) and verifications (`WasCalled`) work via the existing `MockMethodCall<T>` / `VoidMockMethodCall` plumbing.
- Restores the SKIPPED `T14` kitchen-sink tests covering contract satisfaction, the regular-property co-resident path, per-index Returns/WasCalled, and setter verification with mixed `Any<T>()` / literal matchers.

## Why
Any interface with an indexer was previously unmockable — even if the consumer only needed the other members. The full-support route was small (the indexer model was already discovered) and avoids shipping a stub that would have made `IList`-style mocks throw at runtime.

## Known limitations
- `MockWrapperTypeBuilder.CanGenerateWrapper` still returns `false` when an indexer is present, so the typed `IFoo_Mock` wrapper is not emitted for indexer-bearing interfaces. The base `Mock<IFoo>` API works fully; only the typed-wrapper sugar is unavailable. Out of scope for this PR.
- Static-abstract indexers in `MockBridgeBuilder` are still skipped (separate code path, no interface contract failure).

## Test plan
- [x] T14 (2 tests in `TUnit.Mocks.Tests/KitchenSinkEdgeCasesTests.cs`) pass
- [x] `TUnit.Mocks.Tests` full suite (net10.0): 954/954
- [x] `TUnit.Mocks.SourceGenerator.Tests` (net10.0): 45/45
- [x] `TUnit.Mocks.Analyzers.Tests` (net10.0): 30/30

Closes #5676