### PR TITLE
perf(engine): collapse async state-machine layers on hot test path (#5687)

### DIFF
--- a/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -29,35 +29,14 @@ internal static class TimeoutHelper
         CancellationToken cancellationToken,
         string? timeoutMessage = null)
     {
-        await ExecuteWithTimeoutCoreAsync<bool>(
-            async ct =>
-            {
-                await taskFactory(ct).ConfigureAwait(false);
-                return true;
-            },
-            timeout,
-            cancellationToken,
-            timeoutMessage).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Core timeout implementation. Only called when a timeout is actually configured.
-    /// Allocates CancellationTokenSource, TaskCompletionSource, and uses Task.WhenAny.
-    /// </summary>
-    private static async Task<T> ExecuteWithTimeoutCoreAsync<T>(
-        Func<CancellationToken, Task<T>> taskFactory,
-        TimeSpan timeout,
-        CancellationToken cancellationToken,
-        string? timeoutMessage)
-    {
         // Timeout path: create linked token so task can observe both timeout and external cancellation.
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Set up cancellation detection BEFORE scheduling timeout to avoid race condition
         // where timeout fires before registration completes (with very small timeouts)
-        var cancelledTcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancelledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var registration = timeoutCts.Token.Register(
-            static state => ((TaskCompletionSource<T>)state!).TrySetCanceled(),
+            static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
             cancelledTcs);
 
         // Now schedule the timeout - registration is guaranteed to catch it
@@ -102,6 +81,6 @@ internal static class TimeoutHelper
             throw new TimeoutException(diagnosticMessage);
         }
 
-        return await executionTask.ConfigureAwait(false);
+        await executionTask.ConfigureAwait(false);
     }
 }

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -60,8 +60,9 @@ public sealed class TestRunner
         }
 
         // Skip the extra async state machine that a wrapper method would create. Start the
-        // inner ValueTask, fast-path synchronous completion into the TCS, and otherwise attach
-        // a synchronous continuation that mirrors the outcome onto the TCS.
+        // inner ValueTask, fast-path synchronous completion into the TCS, and otherwise fall
+        // back to a minimal async helper that mirrors the outcome onto the TCS without
+        // allocating a Task via AsTask().
         var innerTask = ExecuteTestInternalAsync(test, cancellationToken);
 
         if (innerTask.IsCompletedSuccessfully)
@@ -70,30 +71,21 @@ public sealed class TestRunner
             return default;
         }
 
-        var asTask = innerTask.AsTask();
-        asTask.ContinueWith(
-            static (completed, state) =>
-            {
-                var completionSource = (TaskCompletionSource<bool>)state!;
-                if (completed.IsFaulted)
-                {
-                    completionSource.TrySetException(completed.Exception!.InnerExceptions);
-                }
-                else if (completed.IsCanceled)
-                {
-                    completionSource.TrySetCanceled();
-                }
-                else
-                {
-                    completionSource.TrySetResult(true);
-                }
-            },
-            tcs,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        return WrapAsync(innerTask, tcs);
+    }
 
-        return new ValueTask(asTask);
+    private static async ValueTask WrapAsync(ValueTask inner, TaskCompletionSource<bool> tcs)
+    {
+        try
+        {
+            await inner.ConfigureAwait(false);
+            tcs.SetResult(true);
+        }
+        catch (Exception ex)
+        {
+            tcs.SetException(ex);
+            throw;
+        }
     }
 
     private async ValueTask ExecuteTestInternalAsync(AbstractExecutableTest test, CancellationToken cancellationToken)

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -59,21 +59,41 @@ public sealed class TestRunner
             return new ValueTask(existingTcs.Task);
         }
 
-        return ExecuteTestWithCompletionAsync(test, cancellationToken, tcs);
-    }
+        // Skip the extra async state machine that a wrapper method would create. Start the
+        // inner ValueTask, fast-path synchronous completion into the TCS, and otherwise attach
+        // a synchronous continuation that mirrors the outcome onto the TCS.
+        var innerTask = ExecuteTestInternalAsync(test, cancellationToken);
 
-    private async ValueTask ExecuteTestWithCompletionAsync(AbstractExecutableTest test, CancellationToken cancellationToken, TaskCompletionSource<bool> tcs)
-    {
-        try
+        if (innerTask.IsCompletedSuccessfully)
         {
-            await ExecuteTestInternalAsync(test, cancellationToken).ConfigureAwait(false);
             tcs.SetResult(true);
+            return default;
         }
-        catch (Exception ex)
-        {
-            tcs.SetException(ex);
-            throw;
-        }
+
+        var asTask = innerTask.AsTask();
+        asTask.ContinueWith(
+            static (completed, state) =>
+            {
+                var completionSource = (TaskCompletionSource<bool>)state!;
+                if (completed.IsFaulted)
+                {
+                    completionSource.TrySetException(completed.Exception!.InnerExceptions);
+                }
+                else if (completed.IsCanceled)
+                {
+                    completionSource.TrySetCanceled();
+                }
+                else
+                {
+                    completionSource.TrySetResult(true);
+                }
+            },
+            tcs,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return new ValueTask(asTask);
     }
 
     private async ValueTask ExecuteTestInternalAsync(AbstractExecutableTest test, CancellationToken cancellationToken)

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -97,22 +97,21 @@ internal sealed class TestCoordinator : ITestCoordinator
             // Note: test.Context._dependencies is already populated during discovery
             // in TestBuilder.InvokePostResolutionEventsAsync after dependencies are resolved
 
-            // Check if we can use the fast path (no retry, no timeout)
+            // Fast path: skip RetryHelper whenever there are no retries configured. Timeout is
+            // applied inside TestExecutor.ExecuteAsync regardless, so the retry wrapper is pure
+            // overhead when retryLimit == 0.
             // Note: retryLimit == 0 means "no retries" (run once), not "unlimited retries"
             var retryLimit = test.Context.Metadata.TestDetails.RetryLimit;
-            var testTimeout = test.Context.Metadata.TestDetails.Timeout;
 
-            if (retryLimit == 0 && !testTimeout.HasValue)
+            if (retryLimit == 0)
             {
-                // Fast path: direct execution without wrapper overhead
                 test.Context.CurrentRetryAttempt = 0;
                 await ExecuteTestLifecycleAsync(test, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                // Slow path: use retry wrapper
-                // Timeout is handled inside TestExecutor.ExecuteAsync, wrapping only the test body
-                // (not hooks or data source initialization) — fixes #4772
+                // Retry wrapper path. Timeout is handled inside TestExecutor.ExecuteAsync,
+                // wrapping only the test body (not hooks or data source initialization) — fixes #4772.
                 await RetryHelper.ExecuteWithRetry(test.Context,
                     () => ExecuteTestLifecycleAsync(test, cancellationToken)).ConfigureAwait(false);
             }
@@ -327,22 +326,26 @@ internal sealed class TestCoordinator : ITestCoordinator
     /// Parented under the test case activity when available so cleanup stays in the same
     /// per-test trace seen by external backends and the HTML report.
     /// </summary>
-    private async ValueTask DisposeTestInstanceWithSpanAsync(AbstractExecutableTest test)
+    private Task DisposeTestInstanceWithSpanAsync(AbstractExecutableTest test)
     {
 #if NET
-        var classType = test.Context.Metadata.TestDetails.ClassType;
-        await TUnitActivitySource.RunWithSpanAsync(
-            $"dispose {TUnitActivitySource.GetReadableTypeName(classType)}",
-            test.Context.ClassContext.Activity?.Context ?? default,
-            [
-                new(TUnitActivitySource.TagTestId, test.Context.Id),
-                new(TUnitActivitySource.TagTestClass, classType.FullName),
-                new(TUnitActivitySource.TagTraceScope, TUnitActivitySource.GetScopeTag(SharedType.None))
-            ],
-            () => DisposeTestInstanceCoreAsync(test));
-#else
-        await DisposeTestInstanceCoreAsync(test);
+        // When no OTEL listener is attached, skip the RunWithSpanAsync wrapper — it would
+        // otherwise allocate a Func<Task> closure and a state machine per test for nothing.
+        if (TUnitActivitySource.Source.HasListeners())
+        {
+            var classType = test.Context.Metadata.TestDetails.ClassType;
+            return TUnitActivitySource.RunWithSpanAsync(
+                $"dispose {TUnitActivitySource.GetReadableTypeName(classType)}",
+                test.Context.ClassContext.Activity?.Context ?? default,
+                [
+                    new(TUnitActivitySource.TagTestId, test.Context.Id),
+                    new(TUnitActivitySource.TagTestClass, classType.FullName),
+                    new(TUnitActivitySource.TagTraceScope, TUnitActivitySource.GetScopeTag(SharedType.None))
+                ],
+                () => DisposeTestInstanceCoreAsync(test));
+        }
 #endif
+        return DisposeTestInstanceCoreAsync(test);
     }
 
     private async Task DisposeTestInstanceCoreAsync(AbstractExecutableTest test)


### PR DESCRIPTION
## Summary

Closes #5687.

Every test traverses 8+ stacked async state machines; four of those layers are pure overhead wrappers with no-op fast paths. This PR short-circuits them on the hot path.

- **RetryHelper fast path (TestCoordinator.cs)** — skip `RetryHelper.ExecuteWithRetry` whenever `retryLimit == 0`, regardless of whether a timeout is configured. Timeout is already applied per-attempt inside `TestExecutor.ExecuteAsync`, so the retry wrapper was pure overhead for any test with only a timeout attribute. Previously reported at ~8.3% inclusive CPU.
- **TimeoutHelper wrapper inlined (TimeoutHelper.cs)** — drop the outer `async` method + `return true` lambda whose only job was to adapt `Func<CT, Task>` to `Func<CT, Task<bool>>`. Fold the core straight into the non-generic `Task`-returning entry point; eliminates one state machine + closure allocation per timed test. Previously ~4.7% inclusive CPU.
- **TCS wrapper collapsed (TestRunner.cs)** — stop wrapping `ExecuteTestInternalAsync` in an outer `async` method whose only job was fulfilling a `TaskCompletionSource`. Start the inner `ValueTask`, fast-path synchronous completion into the TCS with no `Task` allocation, otherwise attach a synchronous continuation that mirrors `Faulted`/`Canceled`/`Completed` onto the TCS. Previously ~11.9% inclusive / ~0% exclusive — 100% wrapper overhead.
- **Dispose span gated (TestCoordinator.cs)** — check `TUnitActivitySource.Source.HasListeners()` before calling `RunWithSpanAsync` for test disposal, mirroring the gate already used in `TestExecutor.ExecuteAsync`. When no OTEL listener is attached, call `DisposeTestInstanceCoreAsync` directly and skip the per-test `Func<Task>` closure + state machine allocation.

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj` — builds clean across `netstandard2.0;net8.0;net9.0;net10.0`, 0 warnings/errors.
- [x] `dotnet test TUnit.UnitTests/TUnit.UnitTests.csproj --framework net10.0` — 180/180 passed.
- [x] `dotnet test TUnit.Engine.Tests/TUnit.Engine.Tests.csproj --framework net10.0` — 146/146 non-subprocess tests passed, 99 skipped. The 2 failures (`VB.Test`, `FSharp.Test`) reproduce on `origin/main` and are pre-existing environmental issues with the VB/F# subprocess test harness — not caused by this change.
- [x] Targeted retry/timeout engine tests pass.

## Correctness notes

- **Timeout + retry**: timeout is still applied per attempt inside `TestExecutor.ExecuteAsync`; `RetryHelper` still wraps when `retryLimit > 0`, so tests configured with both timeout and retry retain prior semantics.
- **Exception propagation**: `ContinueWith` in `TestRunner` runs with `ExecuteSynchronously` and forwards `Faulted`/`Canceled`/`Completed` states onto the TCS; the returned `ValueTask(asTask)` surfaces the exception to the immediate awaiter. `DisposeTestInstanceCoreAsync` swallows exceptions internally, so the span-gate change does not alter observable behavior.