### PR TITLE
chore(mocks): regenerate source generator snapshots

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
@@ -10,6 +10,7 @@ namespace TUnit.Mocks.Generated
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         global::TUnit.Mocks.IMock? global::TUnit.Mocks.IMockObject.MockWrapper { get; set; }
 
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         internal StaticAbstractImplMockImpl(global::TUnit.Mocks.MockEngine<global::StaticAbstractImpl> engine) : base()
         {
             _engine = engine;


### PR DESCRIPTION
## Summary

Regenerate the TUnit.Mocks source-generator snapshot baselines to match the current generator output after the recent mocks fixes (#5677 / #5678 / #5679 / #5680 / #5681 / #5682 / #5683 / #5684).

## Changes

- 1 snapshot file updated: `Class_Implementing_Static_Abstract_Interface.verified.txt`
- The drift is a single-line addition of `[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]` on the generated mock constructor — directly matching the intent of #5678 ("fix(mocks): emit [SetsRequiredMembers] on generated mock ctor").

## Verification

- Spot-checked the diff: legitimate generator output change, not a bug. Generated C# is well-formed.
- Before regen: 48 passed / 1 failed (on net10.0).
- After regen: 49 passed / 0 failed.

## Test plan

- [x] `dotnet build TUnit.Mocks.SourceGenerator.Tests/TUnit.Mocks.SourceGenerator.Tests.csproj`
- [x] `dotnet run --framework net10.0 --no-build` in `TUnit.Mocks.SourceGenerator.Tests/` — all 49 tests pass
- [x] Only `.verified.txt` files touched; no `.received.txt` committed