### PR TITLE
perf(engine): reduce message-bus contention on test start (#5685)

### DIFF
--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using TUnit.Core;
@@ -80,10 +81,11 @@ internal sealed class EventReceiverOrchestrator
         vlb.Dispose();
     }
 
-    // ClassInstance is null at the initial RegisterReceivers call, so only it needs registering here.
+    // Precondition: ClassInstance has just been assigned; the initial RegisterReceivers call (with ClassInstance still null) already covered every other eligible object.
     public void RegisterClassInstanceReceiver(TestContext context)
     {
         var classInstance = context.Metadata.TestDetails.ClassInstance;
+        Debug.Assert(classInstance is not null, "RegisterClassInstanceReceiver should only be called after ClassInstance is assigned.");
         if (classInstance is null)
         {
             return;

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -80,12 +80,7 @@ internal sealed class EventReceiverOrchestrator
         vlb.Dispose();
     }
 
-    /// <summary>
-    /// Registers the freshly created ClassInstance as an event receiver if it is one,
-    /// without iterating the full eligible-event-object set (which otherwise re-checks
-    /// attributes, arguments, etc. that were already processed by the earlier
-    /// <see cref="RegisterReceivers"/> call). See #5685.
-    /// </summary>
+    // ClassInstance is null at the initial RegisterReceivers call, so only it needs registering here.
     public void RegisterClassInstanceReceiver(TestContext context)
     {
         var classInstance = context.Metadata.TestDetails.ClassInstance;

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -91,6 +91,14 @@ internal sealed class EventReceiverOrchestrator
             return;
         }
 
+        // Defense-in-depth: SkippedTestInstance is a sentinel singleton for tests skipped
+        // at registration time and should never be treated as an event receiver. Callers
+        // already short-circuit on this sentinel, but guard here too.
+        if (classInstance is SkippedTestInstance)
+        {
+            return;
+        }
+
         if (!_initializedObjects.Add(classInstance))
         {
             return;

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -43,7 +43,7 @@ internal sealed class EventReceiverOrchestrator
         _logger = logger;
     }
 
-    public void RegisterReceivers(TestContext context, CancellationToken cancellationToken)
+    public void RegisterReceivers(TestContext context)
     {
         var vlb = new ValueListBuilder<object>([null, null, null, null]);
 

--- a/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -80,6 +80,37 @@ internal sealed class EventReceiverOrchestrator
         vlb.Dispose();
     }
 
+    /// <summary>
+    /// Registers the freshly created ClassInstance as an event receiver if it is one,
+    /// without iterating the full eligible-event-object set (which otherwise re-checks
+    /// attributes, arguments, etc. that were already processed by the earlier
+    /// <see cref="RegisterReceivers"/> call). See #5685.
+    /// </summary>
+    public void RegisterClassInstanceReceiver(TestContext context)
+    {
+        var classInstance = context.Metadata.TestDetails.ClassInstance;
+        if (classInstance is null)
+        {
+            return;
+        }
+
+        if (!_initializedObjects.Add(classInstance))
+        {
+            return;
+        }
+
+        if (classInstance is IFirstTestInTestSessionEventReceiver
+            or IFirstTestInAssemblyEventReceiver
+            or IFirstTestInClassEventReceiver)
+        {
+            if (!_registeredFirstEventReceiverTypes.Add(classInstance.GetType()))
+            {
+                return;
+            }
+        }
+
+        _registry.RegisterReceiver(classInstance);
+    }
 
     // Fast-path checks with inlining
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -64,7 +64,7 @@ internal sealed class TestCoordinator : ITestCoordinator
 
             // Register event receivers early so that skip event receivers work
             // even when the test is skipped before full initialization.
-            _eventReceiverOrchestrator.RegisterReceivers(test.Context, cancellationToken);
+            _eventReceiverOrchestrator.RegisterReceivers(test.Context);
 
             // Check if test was already marked as skipped during registration
             // (e.g., by a derived SkipAttribute evaluated in OnTestRegistered).

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -55,13 +55,17 @@ internal sealed class TestCoordinator : ITestCoordinator
         try
         {
             _stateManager.MarkRunning(test);
-            // Fire-and-forget InProgress - it's informational and doesn't need to block test execution
-            _ = _messageBus.InProgress(test.Context);
+            // Await InProgress so back-pressure from MTP's bounded channel spreads publishes
+            // across each test task rather than fanning 1000+ fire-and-forget writers into
+            // the channel at once (#5685).
+            await _messageBus.InProgress(test.Context).ConfigureAwait(false);
 
             _contextRestorer.RestoreContext(test);
 
             // Register event receivers early so that skip event receivers work
             // even when the test is skipped before full initialization.
+            // A second, targeted registration for the freshly created ClassInstance happens
+            // in TestInitializer.PrepareTest (#5685).
             _eventReceiverOrchestrator.RegisterReceivers(test.Context, cancellationToken);
 
             // Check if test was already marked as skipped during registration

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -57,15 +57,13 @@ internal sealed class TestCoordinator : ITestCoordinator
             _stateManager.MarkRunning(test);
             // Await InProgress so back-pressure from MTP's bounded channel spreads publishes
             // across each test task rather than fanning 1000+ fire-and-forget writers into
-            // the channel at once (#5685).
+            // the channel at once.
             await _messageBus.InProgress(test.Context).ConfigureAwait(false);
 
             _contextRestorer.RestoreContext(test);
 
             // Register event receivers early so that skip event receivers work
             // even when the test is skipped before full initialization.
-            // A second, targeted registration for the freshly created ClassInstance happens
-            // in TestInitializer.PrepareTest (#5685).
             _eventReceiverOrchestrator.RegisterReceivers(test.Context, cancellationToken);
 
             // Check if test was already marked as skipped during registration

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -292,7 +292,7 @@ internal sealed class TestCoordinator : ITestCoordinator
 
         test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 
-        // Invalidate cached eligible event objects since ClassInstance changed
+        // Drop the cached eligible-objects list so any later consumer rebuilds it with the new ClassInstance included — the initial list was built before the instance existed.
         test.Context.CachedEligibleEventObjects = null;
 
         // Check if this test should be skipped (after creating instance).
@@ -312,7 +312,7 @@ internal sealed class TestCoordinator : ITestCoordinator
 
         try
         {
-            _testInitializer.PrepareTest(test, cancellationToken);
+            _testInitializer.PrepareTest(test);
             test.Context.RestoreExecutionContext();
             var testTimeout = test.Context.Metadata.TestDetails.Timeout;
             await _testExecutor.ExecuteAsync(test, _testInitializer, cancellationToken, testTimeout).ConfigureAwait(false);

--- a/TUnit.Engine/TestInitializer.cs
+++ b/TUnit.Engine/TestInitializer.cs
@@ -22,11 +22,13 @@ internal class TestInitializer
 
     public void PrepareTest(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
-        // Register event receivers
-        _eventReceiverOrchestrator.RegisterReceivers(test.Context, cancellationToken);
+        // Register the freshly created ClassInstance as an event receiver. The initial
+        // registration happens before instance creation, so re-iterating the full
+        // eligible-event-object set would duplicate work — only the ClassInstance is new.
+        _eventReceiverOrchestrator.RegisterClassInstanceReceiver(test.Context);
 
-        // Prepare test: set cached property values on the instance
-        // Does NOT call IAsyncInitializer - that is deferred until after BeforeClass hooks
+        // Prepare test: set cached property values on the instance.
+        // Does NOT call IAsyncInitializer - that is deferred until after BeforeClass hooks.
         _objectLifecycleService.PrepareTest(test.Context);
     }
 

--- a/TUnit.Engine/TestInitializer.cs
+++ b/TUnit.Engine/TestInitializer.cs
@@ -20,7 +20,7 @@ internal class TestInitializer
         _objectLifecycleService = objectLifecycleService;
     }
 
-    public void PrepareTest(AbstractExecutableTest test, CancellationToken cancellationToken)
+    public void PrepareTest(AbstractExecutableTest test)
     {
         // Register the freshly created ClassInstance as an event receiver. The initial
         // registration happens before instance creation, so re-iterating the full


### PR DESCRIPTION
Closes #5685.

## Summary

CPU profile of ~1000-test runs showed `WaitHandle.WaitOneNoCheck` at 12.95% exclusive CPU — the largest non-idle cost in the trace — traceable to the per-test messaging layer. Two surgical fixes:

### 1. `InProgress` is now awaited instead of fire-and-forget
`TestCoordinator.ExecuteTestInternalAsync` previously discarded the `InProgress` `ValueTask`, which fanned 1000+ concurrent `PublishAsync` writers into MTP's bounded `AsynchronousMessageBus` channel at startup. Awaiting the call lets each test task back-pressure naturally against the channel, spreading publishes across the run instead of clustering them.

Ordering is preserved: `InProgress` still completes before the terminal `Passed`/`Failed`/`Skipped`/`Cancelled` message for each test. Published message count is unchanged.

### 2. `RegisterReceivers` no longer called twice per test
`TestInitializer.PrepareTest` was re-iterating the full eligible-event-object set even though only the freshly created `ClassInstance` can newly become a receiver between the first call (pre-instance creation, in `TestCoordinator`) and the second call (post-instance creation, in `PrepareTest`).

Added `EventReceiverOrchestrator.RegisterClassInstanceReceiver(TestContext)` — a targeted single-object variant that honors the same dedup invariants (`_initializedObjects`, `_registeredFirstEventReceiverTypes`) used by the full method. `TestInitializer.PrepareTest` now calls the targeted variant.

## Verification

- `dotnet build TUnit.Engine/TUnit.Engine.csproj` — 0 warnings, 0 errors across net8.0/net9.0/net10.0/netstandard2.0.
- `dotnet test TUnit.Engine.Tests/TUnit.Engine.Tests.csproj --framework net10.0` — 148 passed, 0 failed, 99 skipped (environmental AOT/OS skips).
- `dotnet test TUnit.UnitTests/TUnit.UnitTests.csproj --framework net10.0` — 180 passed, 0 failed.
- `dotnet test TUnit.Core.SourceGenerator.Tests/... --framework net10.0` — 116 passed, 0 failed, 1 skipped (pre-existing).
- Specifically verified `FirstEventReceiversRegressionTest.EventReceiversCalledOncePerScope` (which exercises the `ClassInstance`-as-receiver path) still passes.

## Test plan
- [x] TUnit.Engine.Tests net10.0
- [x] TUnit.UnitTests net10.0
- [x] TUnit.Core.SourceGenerator.Tests net10.0
- [x] Dual-mode safe (both source-gen and reflection hit the same TestCoordinator/TestInitializer code paths)