### PR TITLE
fix(assertions): prevent implicit-to-string op from NREing on null (#5692)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5692/ImplicitStringOperatorOverloadTests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5692/ImplicitStringOperatorOverloadTests.cs
@@ -185,6 +185,7 @@ public class ImplicitStringOperatorOverloadTests
         await Assert.That(assertion).IsTypeOf<MutableDictionaryAssertion<string, int>>();
     }
 
+#if NET5_0_OR_GREATER
     [Test]
     public async Task MemoryOfChar_RoutesToMemoryAssertion()
     {
@@ -200,6 +201,7 @@ public class ImplicitStringOperatorOverloadTests
         var assertion = Assert.That(mem);
         await Assert.That(assertion).IsTypeOf<ReadOnlyMemoryAssertion<char>>();
     }
+#endif
 
     // ============ Delegate / Task overloads unchanged ============
 

--- a/TUnit.Assertions.Tests/Bugs/Issue5692/ImplicitStringOperatorOverloadTests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5692/ImplicitStringOperatorOverloadTests.cs
@@ -1,0 +1,278 @@
+#pragma warning disable TUnitAssertions0002 // Assert statements must be awaited — inspecting returned assertion type
+using System.Collections;
+using TUnit.Assertions.Sources;
+
+namespace TUnit.Assertions.Tests.Bugs.Issue5692;
+
+/// <summary>
+/// Regression guard for https://github.com/thomhurst/TUnit/issues/5692.
+///
+/// The fix replaces the <c>Assert.That(string?)</c> parameter with a wrapper struct so that user
+/// types declaring <c>implicit operator string</c> no longer silently bind to the string overload
+/// and trigger a <see cref="NullReferenceException"/> at the call site.
+///
+/// These tests verify the bug is fixed AND lock down every other <c>Assert.That</c> routing path
+/// so the change cannot silently re-route values between assertion types.
+/// </summary>
+public class ImplicitStringOperatorOverloadTests
+{
+    public record Id(string Value)
+    {
+        public static implicit operator string(Id id) => id.Value;
+    }
+
+    public sealed class Envelope
+    {
+        public Id? ConversationId { get; set; }
+    }
+
+    // ============ Bug #5692: implicit-to-string must not hit string overload ============
+
+    [Test]
+    public async Task NullId_WithImplicitToString_IsNull_DoesNotNRE()
+    {
+        var envelope = new Envelope();
+        await Assert.That(envelope.ConversationId).IsNull();
+    }
+
+    [Test]
+    public async Task NullId_WithImplicitToString_IsEqualTo_DoesNotNRE()
+    {
+        var envelope = new Envelope();
+        await Assert.That(envelope.ConversationId).IsEqualTo((Id?)null);
+    }
+
+    [Test]
+    public async Task NonNullId_WithImplicitToString_RoutesToValueAssertionOfId()
+    {
+        var id = new Id("abc");
+        var assertion = Assert.That(id);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<Id>>();
+    }
+
+    // ============ String: static overload still wins (no char-collection routing) ============
+
+    [Test]
+    public async Task StringLiteral_RoutesToValueAssertionOfString()
+    {
+        var assertion = Assert.That("hello");
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<string>>();
+    }
+
+    [Test]
+    public async Task StringVariable_RoutesToValueAssertionOfString()
+    {
+        string value = "hello";
+        var assertion = Assert.That(value);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<string>>();
+    }
+
+    [Test]
+    public async Task NullableStringVariable_Null_RoutesToValueAssertionOfString()
+    {
+        string? value = null;
+        var assertion = Assert.That(value);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<string>>();
+    }
+
+    [Test]
+    public async Task NullableStringVariable_NonNull_RoutesToValueAssertionOfString()
+    {
+        string? value = "hello";
+        var assertion = Assert.That(value);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<string>>();
+    }
+
+    [Test]
+    public async Task String_IsEqualTo_StillCompares_AsString()
+    {
+        await Assert.That("hello").IsEqualTo("hello");
+    }
+
+    // ============ Explicit char-collection casts still route to CollectionAssertion<char> ============
+
+    [Test]
+    public async Task StringCastToIEnumerableOfChar_RoutesToCollectionAssertion()
+    {
+        var assertion = Assert.That((IEnumerable<char>)"ABC");
+        await Assert.That(assertion).IsTypeOf<CollectionAssertion<char>>();
+    }
+
+    [Test]
+    public async Task StringCastToIEnumerableOfChar_Contains_Works()
+    {
+        await Assert.That((IEnumerable<char>)"ABC").Contains('B');
+    }
+
+    [Test]
+    public async Task StringToCharArray_RoutesToArrayAssertion()
+    {
+        var assertion = Assert.That("ABC".ToCharArray());
+        await Assert.That(assertion).IsTypeOf<ArrayAssertion<char>>();
+    }
+
+    // ============ Collection overloads unchanged ============
+
+    [Test]
+    public async Task IntArray_RoutesToArrayAssertion()
+    {
+        int[] arr = [1, 2, 3];
+        var assertion = Assert.That(arr);
+        await Assert.That(assertion).IsTypeOf<ArrayAssertion<int>>();
+    }
+
+    [Test]
+    public async Task ListOfInt_RoutesToListAssertion()
+    {
+        List<int> list = [1, 2, 3];
+        var assertion = Assert.That(list);
+        await Assert.That(assertion).IsTypeOf<ListAssertion<int>>();
+    }
+
+    [Test]
+    public async Task IListOfInt_RoutesToListAssertion()
+    {
+        IList<int> list = new List<int> { 1, 2, 3 };
+        var assertion = Assert.That(list);
+        await Assert.That(assertion).IsTypeOf<ListAssertion<int>>();
+    }
+
+    [Test]
+    public async Task IReadOnlyListOfInt_RoutesToReadOnlyListAssertion()
+    {
+        IReadOnlyList<int> list = new List<int> { 1, 2, 3 };
+        var assertion = Assert.That(list);
+        await Assert.That(assertion).IsTypeOf<ReadOnlyListAssertion<int>>();
+    }
+
+    [Test]
+    public async Task HashSetOfInt_RoutesToHashSetAssertion()
+    {
+        var set = new HashSet<int> { 1, 2, 3 };
+        var assertion = Assert.That(set);
+        await Assert.That(assertion).IsTypeOf<HashSetAssertion<int>>();
+    }
+
+    [Test]
+    public async Task IEnumerableOfInt_RoutesToCollectionAssertion()
+    {
+        IEnumerable<int> items = new[] { 1, 2, 3 };
+        var assertion = Assert.That(items);
+        await Assert.That(assertion).IsTypeOf<CollectionAssertion<int>>();
+    }
+
+    [Test]
+    public async Task IQueryableOfInt_RoutesToCollectionAssertion()
+    {
+        IQueryable<int> queryable = new[] { 1, 2, 3 }.AsQueryable();
+        var assertion = Assert.That(queryable);
+        await Assert.That(assertion).IsTypeOf<CollectionAssertion<int>>();
+    }
+
+    [Test]
+    public async Task NonGenericIEnumerable_RoutesToCollectionAssertionOfObject()
+    {
+        IEnumerable enumerable = new ArrayList { 1, 2, 3 };
+        var assertion = Assert.That(enumerable);
+        await Assert.That(assertion).IsTypeOf<CollectionAssertion<object?>>();
+    }
+
+    [Test]
+    public async Task DictionaryOfStringInt_RoutesToMutableDictionaryAssertion()
+    {
+        var dict = new Dictionary<string, int> { ["a"] = 1 };
+        var assertion = Assert.That(dict);
+        await Assert.That(assertion).IsTypeOf<MutableDictionaryAssertion<string, int>>();
+    }
+
+    [Test]
+    public async Task MemoryOfChar_RoutesToMemoryAssertion()
+    {
+        Memory<char> mem = new[] { 'a', 'b', 'c' };
+        var assertion = Assert.That(mem);
+        await Assert.That(assertion).IsTypeOf<MemoryAssertion<char>>();
+    }
+
+    [Test]
+    public async Task ReadOnlyMemoryOfChar_RoutesToReadOnlyMemoryAssertion()
+    {
+        ReadOnlyMemory<char> mem = new[] { 'a', 'b', 'c' };
+        var assertion = Assert.That(mem);
+        await Assert.That(assertion).IsTypeOf<ReadOnlyMemoryAssertion<char>>();
+    }
+
+    // ============ Delegate / Task overloads unchanged ============
+
+    [Test]
+    public async Task Action_RoutesToDelegateAssertion()
+    {
+        Action action = () => { };
+        var assertion = Assert.That(action);
+        await Assert.That(assertion).IsTypeOf<DelegateAssertion>();
+    }
+
+    [Test]
+    public async Task AsyncLambda_RoutesToAsyncDelegateAssertion()
+    {
+        Func<Task> action = () => Task.CompletedTask;
+        var assertion = Assert.That(action);
+        await Assert.That(assertion).IsTypeOf<AsyncDelegateAssertion>();
+    }
+
+    [Test]
+    public async Task Task_RoutesToAsyncDelegateAssertion()
+    {
+        Task task = Task.CompletedTask;
+        var assertion = Assert.That(task);
+        await Assert.That(assertion).IsTypeOf<AsyncDelegateAssertion>();
+    }
+
+    [Test]
+    public async Task TaskOfInt_RoutesToTaskAssertion()
+    {
+        Task<int> task = Task.FromResult(42);
+        var assertion = Assert.That(task);
+        await Assert.That(assertion).IsTypeOf<TaskAssertion<int>>();
+    }
+
+    [Test]
+    public async Task FuncOfInt_RoutesToFuncAssertion()
+    {
+        Func<int> func = () => 42;
+        var assertion = Assert.That(func);
+        await Assert.That(assertion).IsTypeOf<FuncAssertion<int>>();
+    }
+
+    [Test]
+    public async Task FuncOfEnumerable_RoutesToFuncCollectionAssertion()
+    {
+        Func<IEnumerable<int>> func = () => new[] { 1, 2, 3 };
+        var assertion = Assert.That(func);
+        await Assert.That(assertion).IsTypeOf<FuncCollectionAssertion<int>>();
+    }
+
+    // ============ Value-type arguments unchanged ============
+
+    [Test]
+    public async Task Int_RoutesToValueAssertionOfInt()
+    {
+        var assertion = Assert.That(42);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<int>>();
+    }
+
+    [Test]
+    public async Task NullableInt_RoutesToValueAssertion()
+    {
+        int? value = 42;
+        var assertion = Assert.That(value);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<int?>>();
+    }
+
+    [Test]
+    public async Task CustomRefType_WithoutImplicitToString_RoutesToValueAssertion()
+    {
+        var obj = new Uri("http://example.com");
+        var assertion = Assert.That(obj);
+        await Assert.That(assertion).IsTypeOf<ValueAssertion<Uri>>();
+    }
+}

--- a/TUnit.Assertions/Extensions/Assert.cs
+++ b/TUnit.Assertions/Extensions/Assert.cs
@@ -50,12 +50,16 @@ public static class Assert
     /// Example: await Assert.That("hello").IsEqualTo("hello");
     /// Example: await Assert.That((IEnumerable&lt;char&gt;)"ABC").Contains('B');
     /// </summary>
+    /// <remarks>
+    /// Accepts <see cref="StringValue"/> rather than <c>string?</c> so user types with their own
+    /// <c>implicit operator string</c> do not bind here. See <see cref="StringValue"/> for details.
+    /// </remarks>
     [OverloadResolutionPriority(2)]
     public static ValueAssertion<string> That(
-        string? value,
+        StringValue value,
         [CallerArgumentExpression(nameof(value))] string? expression = null)
     {
-        return new ValueAssertion<string>(value, expression);
+        return new ValueAssertion<string>(value.Value, expression);
     }
 
     /// <summary>

--- a/TUnit.Assertions/StringValue.cs
+++ b/TUnit.Assertions/StringValue.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace TUnit.Assertions;
+
+/// <summary>
+/// Infrastructure wrapper used by the <c>Assert.That(string?)</c> overload to prevent user types
+/// with an implicit conversion to <see cref="string"/> from silently binding to it.
+/// </summary>
+/// <remarks>
+/// C# allows only one user-defined implicit conversion in a single conversion chain. A value
+/// whose static type is a user record with <c>implicit operator string</c> would, if the
+/// parameter type were <c>string?</c>, invoke that operator at the call site — producing a
+/// <see cref="NullReferenceException"/> when the receiver is null, inside user code, before the
+/// assertion method ever runs (see issue #5692). By accepting <see cref="StringValue"/> — which
+/// declares an implicit conversion only from <c>string?</c> — a value of that user type cannot
+/// form a valid conversion chain (<c>Id → string → StringValue</c> would require two
+/// user-defined steps) and is routed to the generic <c>Assert.That&lt;TValue&gt;</c> overload
+/// instead.
+/// <para>
+/// Not intended for direct use. Construction happens implicitly from <see cref="string"/>.
+/// </para>
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public readonly struct StringValue
+{
+    public string? Value { get; }
+
+    private StringValue(string? value) => Value = value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator StringValue(string? value) => new(value);
+}

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -189,7 +189,7 @@ namespace
         public static . That(<.> action, [.("action")] string? expression = null) { }
         public static . That(. task, [.("task")] string? expression = null) { }
         [.(2)]
-        public static .<string> That(string? value, [.("value")] string? expression = null) { }
+        public static .<string> That(.StringValue value, [.("value")] string? expression = null) { }
         [.(3)]
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
         [.(1)]
@@ -270,6 +270,11 @@ namespace
         public override string ToString() { }
         public static .StringMatcher AsRegex(string pattern) { }
         public static .StringMatcher AsWildcard(string pattern) { }
+    }
+    public readonly struct StringValue
+    {
+        public string? Value { get; }
+        public static .StringValue op_Implicit(string? value) { }
     }
 }
 namespace .

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -188,7 +188,7 @@ namespace
         public static .<object?> That(.IEnumerable value, [.("value")] string? expression = null) { }
         public static . That(<.> action, [.("action")] string? expression = null) { }
         public static . That(. task, [.("task")] string? expression = null) { }
-        public static .<string> That(string? value, [.("value")] string? expression = null) { }
+        public static .<string> That(.StringValue value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem> value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
@@ -253,6 +253,11 @@ namespace
         public override string ToString() { }
         public static .StringMatcher AsRegex(string pattern) { }
         public static .StringMatcher AsWildcard(string pattern) { }
+    }
+    public readonly struct StringValue
+    {
+        public string? Value { get; }
+        public static .StringValue op_Implicit(string? value) { }
     }
 }
 namespace .

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -189,7 +189,7 @@ namespace
         public static . That(<.> action, [.("action")] string? expression = null) { }
         public static . That(. task, [.("task")] string? expression = null) { }
         [.(2)]
-        public static .<string> That(string? value, [.("value")] string? expression = null) { }
+        public static .<string> That(.StringValue value, [.("value")] string? expression = null) { }
         [.(3)]
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
         [.(1)]
@@ -270,6 +270,11 @@ namespace
         public override string ToString() { }
         public static .StringMatcher AsRegex(string pattern) { }
         public static .StringMatcher AsWildcard(string pattern) { }
+    }
+    public readonly struct StringValue
+    {
+        public string? Value { get; }
+        public static .StringValue op_Implicit(string? value) { }
     }
 }
 namespace .

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -151,7 +151,7 @@ namespace
         public static .<object?> That(.IEnumerable value, [.("value")] string? expression = null) { }
         public static . That(<.> action, [.("action")] string? expression = null) { }
         public static . That(. task, [.("task")] string? expression = null) { }
-        public static .<string> That(string? value, [.("value")] string? expression = null) { }
+        public static .<string> That(.StringValue value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
         public static .<TItem> That<TItem>(.<TItem>? value, [.("value")] string? expression = null) { }
@@ -212,6 +212,11 @@ namespace
         public override string ToString() { }
         public static .StringMatcher AsRegex(string pattern) { }
         public static .StringMatcher AsWildcard(string pattern) { }
+    }
+    public readonly struct StringValue
+    {
+        public string? Value { get; }
+        public static .StringValue op_Implicit(string? value) { }
     }
 }
 namespace .

--- a/TUnit.TestProject/Bugs/5692/Tests.cs
+++ b/TUnit.TestProject/Bugs/5692/Tests.cs
@@ -1,0 +1,37 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5692;
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/issues/5692
+/// When the value passed to <c>Assert.That(...)</c> is null AND its static type
+/// declares an <c>implicit operator string</c>, the source-generated path must
+/// not invoke that operator — doing so NREs inside the user's conversion.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class ImplicitStringOperatorNullTests
+{
+    public record Id(string Value)
+    {
+        public static implicit operator string(Id id) => id.Value;
+    }
+
+    public sealed class Envelope
+    {
+        public Id? ConversationId { get; set; }
+    }
+
+    [Test]
+    public async Task IsNull_on_nullable_with_implicit_to_string()
+    {
+        var envelope = new Envelope();
+        await Assert.That(envelope.ConversationId).IsNull();
+    }
+
+    [Test]
+    public async Task IsEqualTo_null_on_nullable_with_implicit_to_string()
+    {
+        var envelope = new Envelope();
+        await Assert.That(envelope.ConversationId).IsEqualTo((Id?)null);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #5692. `Assert.That(value)` where `value`'s static type declared `implicit operator string` routed through the `Assert.That(string?)` overload, invoking the user's `op_Implicit` on a null receiver at the call site — NRE inside user code before the assertion ran.
- Replace the overload's parameter with a `StringValue` wrapper struct that exposes a single implicit conversion from `string?`. C# allows only one user-defined conversion per chain, so `Id → string → StringValue` is no longer applicable and the generic `Assert.That<TValue>` overload wins by exact-match betterness.
- Add 31 regression tests pinning every `Assert.That` routing path so future overload-set changes cannot silently re-route (string / `IEnumerable<char>` cast / `char[]` / `List<T>` / `IList<T>` / `IReadOnlyList<T>` / `HashSet<T>` / `IEnumerable<T>` / `IQueryable<T>` / non-generic `IEnumerable` / `Dictionary<K,V>` / `Memory<T>` / `ReadOnlyMemory<T>` / `Action` / `Func<Task>` / `Task` / `Task<T>` / `Func<T>` / `Func<IEnumerable<T>>` / value types / ref types without implicit-to-string).

## Why a wrapper struct (and not priority reshuffling)
The three required resolutions — `"hello"` → string overload, `Id` (implicit-to-string) → generic, `IQueryable<T>` → `IEnumerable` overload — impose a cycle in any priority ordering (string ≥ IEnumerable > generic ≥ string is unsatisfiable). A wrapper struct is the only fix that keeps existing overload semantics intact. No source-gen call rewriting involved.

## Test plan
- [x] `TUnit.TestProject/Bugs/5692` engine-mode repro passes (previously failed with NRE in `op_Implicit`)
- [x] New `ImplicitStringOperatorOverloadTests` — 31/31 green
- [x] Full `TUnit.Assertions.Tests` suite — 2017/2017 green