### PR TITLE
perf(engine): collapse async state machines on hook cache-hit / empty-hook path (#5713)

### DIFF
--- a/TUnit.Engine/Interfaces/IHookDelegateBuilder.cs
+++ b/TUnit.Engine/Interfaces/IHookDelegateBuilder.cs
@@ -19,6 +19,17 @@ internal interface IHookDelegateBuilder
     ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectBeforeEveryTestHooksAsync(Type testClassType);
     ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectAfterEveryTestHooksAsync(Type testClassType);
 
+    /// <summary>
+    /// Synchronous fast-path accessors: return <c>true</c> when the per-type Before/After(Test) hook
+    /// list is already materialized. Used by <see cref="HookExecutor"/> to skip async state-machine
+    /// allocation on the steady-state cache-hit path. The BeforeEvery/AfterEvery lists are always
+    /// available synchronously via the existing ValueTask accessors (populated during initialization).
+    /// </summary>
+    bool TryGetCachedBeforeTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks);
+    bool TryGetCachedAfterTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks);
+    IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedBeforeEveryTestHooks();
+    IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedAfterEveryTestHooks();
+
     ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectBeforeClassHooksAsync(Type testClassType);
     ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectAfterClassHooksAsync(Type testClassType);
     ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectBeforeEveryClassHooksAsync();

--- a/TUnit.Engine/Services/HookDelegateBuilder.cs
+++ b/TUnit.Engine/Services/HookDelegateBuilder.cs
@@ -188,14 +188,31 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         }
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectBeforeTestHooksAsync(Type testClassType)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectBeforeTestHooksAsync(Type testClassType)
     {
         if (_beforeTestHooksCache.TryGetValue(testClassType, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildBeforeTestHooksAsync(testClassType);
+        return BuildAndCacheBeforeTestHooksAsync(testClassType);
+    }
+
+    public bool TryGetCachedBeforeTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks)
+    {
+        if (_beforeTestHooksCache.TryGetValue(testClassType, out var cached))
+        {
+            hooks = cached;
+            return true;
+        }
+
+        hooks = [];
+        return false;
+    }
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> BuildAndCacheBeforeTestHooksAsync(Type testClassType)
+    {
+        var hooks = await BuildBeforeTestHooksAsync(testClassType).ConfigureAwait(false);
         _beforeTestHooksCache.TryAdd(testClassType, hooks);
         return hooks;
     }
@@ -255,14 +272,37 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         return finalHooks;
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectAfterTestHooksAsync(Type testClassType)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectAfterTestHooksAsync(Type testClassType)
     {
         if (_afterTestHooksCache.TryGetValue(testClassType, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildAfterTestHooksAsync(testClassType);
+        return BuildAndCacheAfterTestHooksAsync(testClassType);
+    }
+
+    public bool TryGetCachedAfterTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks)
+    {
+        if (_afterTestHooksCache.TryGetValue(testClassType, out var cached))
+        {
+            hooks = cached;
+            return true;
+        }
+
+        hooks = [];
+        return false;
+    }
+
+    public IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedBeforeEveryTestHooks()
+        => _beforeEveryTestHooks ?? [];
+
+    public IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedAfterEveryTestHooks()
+        => _afterEveryTestHooks ?? [];
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> BuildAndCacheAfterTestHooksAsync(Type testClassType)
+    {
+        var hooks = await BuildAfterTestHooksAsync(testClassType).ConfigureAwait(false);
         _afterTestHooksCache.TryAdd(testClassType, hooks);
         return hooks;
     }
@@ -331,14 +371,19 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         return new ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>>(_afterEveryTestHooks ?? []);
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectBeforeClassHooksAsync(Type testClassType)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectBeforeClassHooksAsync(Type testClassType)
     {
         if (_beforeClassHooksCache.TryGetValue(testClassType, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildBeforeClassHooksAsync(testClassType);
+        return BuildAndCacheBeforeClassHooksAsync(testClassType);
+    }
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> BuildAndCacheBeforeClassHooksAsync(Type testClassType)
+    {
+        var hooks = await BuildBeforeClassHooksAsync(testClassType).ConfigureAwait(false);
         _beforeClassHooksCache.TryAdd(testClassType, hooks);
         return hooks;
     }
@@ -395,14 +440,19 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         return finalHooks;
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectAfterClassHooksAsync(Type testClassType)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectAfterClassHooksAsync(Type testClassType)
     {
         if (_afterClassHooksCache.TryGetValue(testClassType, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildAfterClassHooksAsync(testClassType);
+        return BuildAndCacheAfterClassHooksAsync(testClassType);
+    }
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> BuildAndCacheAfterClassHooksAsync(Type testClassType)
+    {
+        var hooks = await BuildAfterClassHooksAsync(testClassType).ConfigureAwait(false);
         _afterClassHooksCache.TryAdd(testClassType, hooks);
         return hooks;
     }
@@ -457,14 +507,19 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         return finalHooks;
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> CollectBeforeAssemblyHooksAsync(Assembly assembly)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> CollectBeforeAssemblyHooksAsync(Assembly assembly)
     {
         if (_beforeAssemblyHooksCache.TryGetValue(assembly, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildBeforeAssemblyHooksAsync(assembly);
+        return BuildAndCacheBeforeAssemblyHooksAsync(assembly);
+    }
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> BuildAndCacheBeforeAssemblyHooksAsync(Assembly assembly)
+    {
+        var hooks = await BuildBeforeAssemblyHooksAsync(assembly).ConfigureAwait(false);
         _beforeAssemblyHooksCache.TryAdd(assembly, hooks);
         return hooks;
     }
@@ -487,14 +542,19 @@ internal sealed class HookDelegateBuilder : IHookDelegateBuilder
         return SortAndProject(allHooks);
     }
 
-    public async ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> CollectAfterAssemblyHooksAsync(Assembly assembly)
+    public ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> CollectAfterAssemblyHooksAsync(Assembly assembly)
     {
         if (_afterAssemblyHooksCache.TryGetValue(assembly, out var cachedHooks))
         {
-            return cachedHooks;
+            return new ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>>(cachedHooks);
         }
 
-        var hooks = await BuildAfterAssemblyHooksAsync(assembly);
+        return BuildAndCacheAfterAssemblyHooksAsync(assembly);
+    }
+
+    private async ValueTask<IReadOnlyList<NamedHookDelegate<AssemblyHookContext>>> BuildAndCacheAfterAssemblyHooksAsync(Assembly assembly)
+    {
+        var hooks = await BuildAfterAssemblyHooksAsync(assembly).ConfigureAwait(false);
         _afterAssemblyHooksCache.TryAdd(assembly, hooks);
         return hooks;
     }

--- a/TUnit.Engine/Services/HookExecutor.cs
+++ b/TUnit.Engine/Services/HookExecutor.cs
@@ -476,13 +476,28 @@ internal sealed class HookExecutor
     }
 #endif
 
-    public async ValueTask ExecuteBeforeTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    public ValueTask ExecuteBeforeTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         var testClassType = test.Metadata.TestClassType;
 
-        // Execute BeforeEvery(Test) hooks first (global test hooks run before specific hooks)
-        var beforeEveryTestHooks = await _hookCollectionService.CollectBeforeEveryTestHooksAsync(testClassType).ConfigureAwait(false);
+        var beforeEveryTestHooks = _hookCollectionService.GetCachedBeforeEveryTestHooks();
+        var hasCachedBeforeTestHooks = _hookCollectionService.TryGetCachedBeforeTestHooks(testClassType, out var beforeTestHooks);
 
+        if (beforeEveryTestHooks.Count == 0 && hasCachedBeforeTestHooks && beforeTestHooks.Count == 0)
+        {
+            return default;
+        }
+
+        return ExecuteBeforeTestHooksCoreAsync(test, testClassType, beforeEveryTestHooks, hasCachedBeforeTestHooks ? beforeTestHooks : null, cancellationToken);
+    }
+
+    private async ValueTask ExecuteBeforeTestHooksCoreAsync(
+        AbstractExecutableTest test,
+        Type testClassType,
+        IReadOnlyList<NamedHookDelegate<TestContext>> beforeEveryTestHooks,
+        IReadOnlyList<NamedHookDelegate<TestContext>>? cachedBeforeTestHooks,
+        CancellationToken cancellationToken)
+    {
         if (beforeEveryTestHooks.Count > 0)
         {
             foreach (var hook in beforeEveryTestHooks)
@@ -509,8 +524,8 @@ internal sealed class HookExecutor
             }
         }
 
-        // Execute Before(Test) hooks after BeforeEvery hooks
-        var beforeTestHooks = await _hookCollectionService.CollectBeforeTestHooksAsync(testClassType).ConfigureAwait(false);
+        var beforeTestHooks = cachedBeforeTestHooks
+            ?? await _hookCollectionService.CollectBeforeTestHooksAsync(testClassType).ConfigureAwait(false);
 
         if (beforeTestHooks.Count > 0)
         {
@@ -539,14 +554,32 @@ internal sealed class HookExecutor
         }
     }
 
-    public async ValueTask<IReadOnlyList<Exception>> ExecuteAfterTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    public ValueTask<IReadOnlyList<Exception>> ExecuteAfterTestHooksAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
-        // Defer exception list allocation until actually needed
-        List<Exception>? exceptions = null;
         var testClassType = test.Metadata.TestClassType;
 
-        // Execute After(Test) hooks first (specific hooks run before global hooks for cleanup)
-        var afterTestHooks = await _hookCollectionService.CollectAfterTestHooksAsync(testClassType).ConfigureAwait(false);
+        var afterEveryTestHooks = _hookCollectionService.GetCachedAfterEveryTestHooks();
+        var hasCachedAfterTestHooks = _hookCollectionService.TryGetCachedAfterTestHooks(testClassType, out var afterTestHooks);
+
+        if (afterEveryTestHooks.Count == 0 && hasCachedAfterTestHooks && afterTestHooks.Count == 0)
+        {
+            return new ValueTask<IReadOnlyList<Exception>>([]);
+        }
+
+        return ExecuteAfterTestHooksCoreAsync(test, testClassType, afterEveryTestHooks, hasCachedAfterTestHooks ? afterTestHooks : null, cancellationToken);
+    }
+
+    private async ValueTask<IReadOnlyList<Exception>> ExecuteAfterTestHooksCoreAsync(
+        AbstractExecutableTest test,
+        Type testClassType,
+        IReadOnlyList<NamedHookDelegate<TestContext>> afterEveryTestHooks,
+        IReadOnlyList<NamedHookDelegate<TestContext>>? cachedAfterTestHooks,
+        CancellationToken cancellationToken)
+    {
+        List<Exception>? exceptions = null;
+
+        var afterTestHooks = cachedAfterTestHooks
+            ?? await _hookCollectionService.CollectAfterTestHooksAsync(testClassType).ConfigureAwait(false);
 
         if (afterTestHooks.Count > 0)
         {
@@ -564,9 +597,6 @@ internal sealed class HookExecutor
                 }
             }
         }
-
-        // Execute AfterEvery(Test) hooks after After hooks (global test hooks run last for cleanup)
-        var afterEveryTestHooks = await _hookCollectionService.CollectAfterEveryTestHooksAsync(testClassType).ConfigureAwait(false);
 
         if (afterEveryTestHooks.Count > 0)
         {

--- a/TUnit.UnitTests/SessionActivityLifecycleTests.cs
+++ b/TUnit.UnitTests/SessionActivityLifecycleTests.cs
@@ -335,6 +335,18 @@ public class SessionActivityLifecycleTests
             new([]);
         public ValueTask<IReadOnlyList<NamedHookDelegate<TestContext>>> CollectAfterEveryTestHooksAsync(Type testClassType) =>
             new([]);
+        public bool TryGetCachedBeforeTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks)
+        {
+            hooks = [];
+            return true;
+        }
+        public bool TryGetCachedAfterTestHooks(Type testClassType, out IReadOnlyList<NamedHookDelegate<TestContext>> hooks)
+        {
+            hooks = [];
+            return true;
+        }
+        public IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedBeforeEveryTestHooks() => [];
+        public IReadOnlyList<NamedHookDelegate<TestContext>> GetCachedAfterEveryTestHooks() => [];
         public ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectBeforeClassHooksAsync(Type testClassType) =>
             new([]);
         public ValueTask<IReadOnlyList<NamedHookDelegate<ClassHookContext>>> CollectAfterClassHooksAsync(Type testClassType) =>


### PR DESCRIPTION
Closes #5713

## Summary
- Per-test hot path previously materialized ~4 async state machines even when the per-class hook cache was populated and the hook lists were empty. `HookDelegateBuilder.Collect*(Test|Class|Assembly)HooksAsync` were marked `async` and still boxed a state machine on cache hit; `HookExecutor.Execute(Before|After)TestHooksAsync` awaited every hook accessor even when both lists were empty.
- Split each `Collect*HooksAsync` into a sync `ValueTask`-returning wrapper (cache hit returns synchronously) plus a private `async` builder helper used only on cache miss.
- Added sync `TryGetCached(Before|After)TestHooks` + `GetCached(Before|After)EveryTestHooks` accessors to `IHookDelegateBuilder`. `HookExecutor.Execute(Before|After)TestHooksAsync` is now a non-async wrapper that returns a completed `ValueTask` when both lists are known-empty, and delegates to a private core helper only when hooks exist.
- Hook ordering semantics preserved: `beforeEvery -> before` for Before, `after -> afterEvery` for After.

## Expected impact
- ~1% CPU per test on the steady-state path.
- 4 fewer async state machines allocated per test.

## Test plan
- [x] `dotnet build TUnit.slnx -c Release` (0 errors, 237 warnings — all pre-existing)
- [x] `TUnit.Core.SourceGenerator.Tests` snapshot suite (net10.0): 116 passed, 1 pre-existing skip
- [x] `TUnit.TestProject -- --treenode-filter "/*/*/HookExecutorTests/*"` (net10.0): 5/5 pass
- [x] `TUnit.TestProject -- --treenode-filter "/*/*/HookExecutorHookTests_*/*"` (net10.0): 4/4 pass
- [x] `TUnit.Engine.Tests -- --treenode-filter "/*/*/HookExecutionOrderTests/*"` (net10.0): 1/1 pass (ordering invariant holds)
- [x] `TUnit.UnitTests` (net10.0): 180/180 pass (exercises `StubHookDelegateBuilder` with the new interface members)