### PR TITLE
perf(engine): batch per-test overhead cleanups (#5719)

### DIFF
--- a/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
+++ b/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
@@ -442,39 +442,33 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
     /// source-gen registration exists in the type's inheritance chain.
     /// </summary>
     private static InitializerPropertyInfo[]? GetFlattenedInitializerProperties(Type type)
-    {
-        if (FlattenedInitializerPropertiesCache.TryGetValue(type, out var cached))
+        => FlattenedInitializerPropertiesCache.GetOrAdd(type, static t =>
         {
-            return cached;
-        }
+            List<InitializerPropertyInfo>? merged = null;
+            HashSet<string>? seen = null;
 
-        List<InitializerPropertyInfo>? merged = null;
-        HashSet<string>? seen = null;
-
-        for (var currentType = type; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
-        {
-            var registered = InitializerPropertyRegistry.GetProperties(currentType);
-            if (registered == null)
+            for (var currentType = t; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
             {
-                continue;
-            }
-
-            merged ??= new List<InitializerPropertyInfo>(registered.Length);
-            seen ??= new HashSet<string>(StringComparer.Ordinal);
-
-            foreach (var p in registered)
-            {
-                if (seen.Add(p.PropertyName))
+                var registered = InitializerPropertyRegistry.GetProperties(currentType);
+                if (registered == null)
                 {
-                    merged.Add(p);
+                    continue;
+                }
+
+                merged ??= new List<InitializerPropertyInfo>(registered.Length);
+                seen ??= new HashSet<string>(StringComparer.Ordinal);
+
+                foreach (var p in registered)
+                {
+                    if (seen.Add(p.PropertyName))
+                    {
+                        merged.Add(p);
+                    }
                 }
             }
-        }
 
-        var result = merged?.ToArray();
-        FlattenedInitializerPropertiesCache[type] = result;
-        return result;
-    }
+            return merged?.ToArray();
+        });
 
     /// <summary>
     /// Traverses the pre-flattened source-generated IAsyncInitializer properties.

--- a/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
+++ b/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
@@ -62,6 +62,17 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
     // Thread-safe collection of discovery errors for diagnostics
     private static readonly ConcurrentBag<DiscoveryError> DiscoveryErrors = [];
 
+    // Memoize ShouldSkipType — Namespace.StartsWith("System") is expensive when repeated
+    // across every per-test initializer traversal.
+    private static readonly ConcurrentDictionary<Type, bool> ShouldSkipTypeCache = new();
+
+    // Cached flattened InitializerPropertyInfo[] for each type, including base-class
+    // properties with derived-first precedence. Traversal would otherwise walk the
+    // inheritance chain and allocate a HashSet<string> on every call.
+    // - non-null array: type has registered source-gen metadata (at this or an ancestor level).
+    // - null           : no source-gen registration anywhere in hierarchy — use reflection fallback.
+    private static readonly ConcurrentDictionary<Type, InitializerPropertyInfo[]?> FlattenedInitializerPropertiesCache = new();
+
     /// <summary>
     /// Gets all discovery errors that occurred during object graph traversal.
     /// Useful for debugging and diagnostics when property access fails.
@@ -249,18 +260,20 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
     {
         PropertyCacheManager.ClearCache();
         TypeHierarchyCache.Clear();
+        ShouldSkipTypeCache.Clear();
+        FlattenedInitializerPropertiesCache.Clear();
         ClearDiscoveryErrors();
     }
 
     /// <summary>
-    /// Checks if a type should be skipped during discovery.
+    /// Checks if a type should be skipped during discovery. Result is memoized per type —
+    /// the underlying check (Namespace.StartsWith) is stable for any given type.
     /// </summary>
     private static bool ShouldSkipType(Type type)
-    {
-        return type.IsPrimitive ||
-               SkipTypes.Contains(type) ||
-               type.Namespace?.StartsWith("System") == true;
-    }
+        => ShouldSkipTypeCache.GetOrAdd(type, static t =>
+            t.IsPrimitive ||
+            SkipTypes.Contains(t) ||
+            t.Namespace?.StartsWith("System", StringComparison.Ordinal) == true);
 
     /// <summary>
     /// Add to HashSet at specified depth. Returns true if added (not duplicate).
@@ -408,47 +421,70 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
             return;
         }
 
-        // Track processed property names to handle overrides correctly
-        // (derived class properties take precedence over base class properties)
-        var processedPropertyNames = new HashSet<string>(StringComparer.Ordinal);
-        var hasAnySourceGenRegistration = false;
+        // Fetch the pre-flattened source-gen property list for this type. The flattening
+        // walks the inheritance chain once and caches the deduplicated result, so per-test
+        // traversal does not re-walk BaseType nor allocate a HashSet<string>.
+        var flattened = GetFlattenedInitializerProperties(type);
 
-        // Walk up the inheritance chain to find all IAsyncInitializer properties
-        // This ensures base class properties are discovered even when derived class has source-gen registration
-        var currentType = type;
-        while (currentType != null && currentType != typeof(object))
+        if (flattened != null)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var registeredProperties = InitializerPropertyRegistry.GetProperties(currentType);
-            if (registeredProperties != null)
-            {
-                hasAnySourceGenRegistration = true;
-                TraverseRegisteredInitializerPropertiesWithTracking(
-                    obj, currentType, registeredProperties, processedPropertyNames,
-                    tryAdd, recurse, currentDepth, cancellationToken);
-            }
-
-            currentType = currentType.BaseType;
+            TraverseFlattenedInitializerProperties(obj, type, flattened, tryAdd, recurse, currentDepth, cancellationToken);
+            return;
         }
 
-        // If no source-gen registration was found in the entire hierarchy, fall back to reflection
-        // Reflection path already handles inheritance correctly via GetProperties without DeclaredOnly
-        if (!hasAnySourceGenRegistration)
-        {
-            TraverseInitializerPropertiesViaReflection(obj, type, tryAdd, recurse, currentDepth, cancellationToken);
-        }
+        // No source-gen registration anywhere in the hierarchy → fall back to reflection.
+        TraverseInitializerPropertiesViaReflection(obj, type, tryAdd, recurse, currentDepth, cancellationToken);
     }
 
     /// <summary>
-    /// Traverses source-generated IAsyncInitializer properties with property name tracking.
-    /// Skips properties that have already been processed (handles overrides in derived classes).
+    /// Returns the cached flattened InitializerPropertyInfo[] for a type (inheritance-walked,
+    /// derived-first precedence, deduplicated by property name). Returns null when no
+    /// source-gen registration exists in the type's inheritance chain.
     /// </summary>
-    private static void TraverseRegisteredInitializerPropertiesWithTracking(
+    private static InitializerPropertyInfo[]? GetFlattenedInitializerProperties(Type type)
+    {
+        if (FlattenedInitializerPropertiesCache.TryGetValue(type, out var cached))
+        {
+            return cached;
+        }
+
+        List<InitializerPropertyInfo>? merged = null;
+        HashSet<string>? seen = null;
+
+        for (var currentType = type; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
+        {
+            var registered = InitializerPropertyRegistry.GetProperties(currentType);
+            if (registered == null)
+            {
+                continue;
+            }
+
+            merged ??= new List<InitializerPropertyInfo>(registered.Length);
+            seen ??= new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var p in registered)
+            {
+                if (seen.Add(p.PropertyName))
+                {
+                    merged.Add(p);
+                }
+            }
+        }
+
+        var result = merged?.ToArray();
+        FlattenedInitializerPropertiesCache[type] = result;
+        return result;
+    }
+
+    /// <summary>
+    /// Traverses the pre-flattened source-generated IAsyncInitializer properties.
+    /// No per-call inheritance walk or HashSet allocation — that work was done once
+    /// during flattening and cached in <see cref="FlattenedInitializerPropertiesCache"/>.
+    /// </summary>
+    private static void TraverseFlattenedInitializerProperties(
         object obj,
         Type type,
         InitializerPropertyInfo[] properties,
-        HashSet<string> processedPropertyNames,
         TryAddObjectFunc tryAdd,
         RecurseFunc recurse,
         int currentDepth,
@@ -458,12 +494,6 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Skip if already processed (overridden in derived class)
-            if (!processedPropertyNames.Add(propInfo.PropertyName))
-            {
-                continue;
-            }
-
             try
             {
                 var value = propInfo.GetValue(obj);
@@ -472,7 +502,6 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
                     continue;
                 }
 
-                // Only discover IAsyncInitializer objects
                 if (value is IAsyncInitializer && tryAdd(value, currentDepth))
                 {
                     recurse(value, currentDepth + 1);
@@ -480,15 +509,12 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
             }
             catch (OperationCanceledException)
             {
-                throw; // Propagate cancellation
+                throw;
             }
             catch (Exception ex)
             {
-                // Record error for diagnostics (still available via GetDiscoveryErrors())
                 DiscoveryErrors.Add(new DiscoveryError(type.Name, propInfo.PropertyName, ex.Message, ex));
 
-                // Propagate the exception with context about which property failed
-                // This ensures data source failures are reported as test failures
                 throw DataSourceException.FromNestedFailure(
                     $"Failed to access property '{propInfo.PropertyName}' on type '{type.Name}' during object graph discovery. " +
                     $"This may indicate that a data source or its nested dependencies failed to initialize. " +

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -403,6 +403,13 @@ public partial class TestContext : Context,
     internal object? CachedClassInstance { get; set; }
 
     /// <summary>
+    /// Fast-path gate for EnsureEventReceiversCached. A single bool check replaces the
+    /// previous "cache-array is non-null" inspection that ran in every per-test receiver
+    /// getter (see <see cref="TUnit.Engine.Extensions.TestContextExtensions"/>).
+    /// </summary>
+    internal bool EventReceiversBuilt { get; set; }
+
+    /// <summary>
     /// Invalidates all cached event receiver data. Called when class instance changes (e.g., on retry).
     /// </summary>
     internal void InvalidateEventReceiverCaches()
@@ -421,6 +428,7 @@ public partial class TestContext : Context,
         CachedTestDiscoveryReceivers = null;
         CachedTestRegisteredReceivers = null;
         CachedClassInstance = null;
+        EventReceiversBuilt = false;
     }
 
     internal ConcurrentDictionary<string, object?> ObjectBag => _testBuilderContext.StateBag;

--- a/TUnit.Engine/Extensions/TestContextExtensions.cs
+++ b/TUnit.Engine/Extensions/TestContextExtensions.cs
@@ -19,8 +19,10 @@ internal static class TestContextExtensions
     /// When this happens, eligible event objects may include the new instance (if it implements
     /// event receiver interfaces), so all caches must be invalidated and rebuilt.
     /// </remarks>
-    // Inlined so the fast-path (cache-hit) check collapses to a field load + branch at every
-    // call site, eliminating call overhead for the 99%+ already-built case.
+    // Fast-path gate: small enough (~10 bytes IL) for RyuJIT to reliably inline at every call
+    // site, collapsing the 99%+ cache-hit case into a field-load + branch + return. The heavy
+    // build work is outlined into BuildEventReceiverCaches so the JIT's inliner size budget
+    // never rejects this wrapper.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void EnsureEventReceiversCached(TestContext testContext)
     {
@@ -33,6 +35,15 @@ internal static class TestContextExtensions
             return;
         }
 
+        BuildEventReceiverCaches(testContext, currentClassInstance);
+    }
+
+    // Explicitly NoInlining so the JIT keeps a single outlined copy instead of duplicating
+    // ~100 bytes of IL into every caller. currentClassInstance is threaded through from the
+    // gate to avoid a redundant field re-read.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void BuildEventReceiverCaches(TestContext testContext, object? currentClassInstance)
+    {
         // Invalidate stale caches if class instance changed
         if (testContext.CachedClassInstance != null &&
             !ReferenceEquals(testContext.CachedClassInstance, currentClassInstance))

--- a/TUnit.Engine/Extensions/TestContextExtensions.cs
+++ b/TUnit.Engine/Extensions/TestContextExtensions.cs
@@ -18,24 +18,16 @@ internal static class TestContextExtensions
     /// When this happens, eligible event objects may include the new instance (if it implements
     /// event receiver interfaces), so all caches must be invalidated and rebuilt.
     /// </remarks>
-    private static void EnsureEventReceiversCached(TestContext testContext)
+    public static void EnsureEventReceiversCached(this TestContext testContext)
     {
         var currentClassInstance = testContext.Metadata.TestDetails.ClassInstance;
 
-        // Check if caches are valid (populated and class instance hasn't changed)
-#if NET
-        if (testContext.CachedTestStartReceiversEarly != null &&
+        // Fast path: caches populated and class instance unchanged since last build.
+        if (testContext.EventReceiversBuilt &&
             ReferenceEquals(testContext.CachedClassInstance, currentClassInstance))
         {
             return;
         }
-#else
-        if (testContext.CachedTestStartReceivers != null &&
-            ReferenceEquals(testContext.CachedClassInstance, currentClassInstance))
-        {
-            return;
-        }
-#endif
 
         // Invalidate stale caches if class instance changed
         if (testContext.CachedClassInstance != null &&
@@ -138,6 +130,7 @@ internal static class TestContextExtensions
 
         // Update cached class instance last
         testContext.CachedClassInstance = currentClassInstance;
+        testContext.EventReceiversBuilt = true;
     }
 
     private static T[] SortAndFilter<T>(List<T>? receivers) where T : class, IEventReceiver
@@ -157,7 +150,7 @@ internal static class TestContextExtensions
     public static IEnumerable<object> GetEligibleEventObjects(this TestContext testContext)
     {
         // Use EnsureEventReceiversCached which builds eligible objects as part of cache initialization
-        EnsureEventReceiversCached(testContext);
+        testContext.EnsureEventReceiversCached();
         return testContext.CachedEligibleEventObjects!;
     }
 
@@ -265,11 +258,12 @@ internal static class TestContextExtensions
 
     /// <summary>
     /// Gets pre-computed test start receivers (filtered, sorted, scoped-attribute filtered).
+    /// Assumes <see cref="EnsureEventReceiversCached"/> has been called by the lifecycle
+    /// coordinator — hot-path callers (per-test start/end/skipped) skip the guard.
     /// </summary>
 #if NET
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext, EventReceiverStage stage)
     {
-        EnsureEventReceiversCached(testContext);
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestStartReceiversEarly!
             : testContext.CachedTestStartReceiversLate!;
@@ -277,7 +271,6 @@ internal static class TestContextExtensions
 #else
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext)
     {
-        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestStartReceivers!;
     }
 #endif
@@ -288,7 +281,6 @@ internal static class TestContextExtensions
 #if NET
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext, EventReceiverStage stage)
     {
-        EnsureEventReceiversCached(testContext);
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestEndReceiversEarly!
             : testContext.CachedTestEndReceiversLate!;
@@ -296,7 +288,6 @@ internal static class TestContextExtensions
 #else
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext)
     {
-        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestEndReceivers!;
     }
 #endif
@@ -306,25 +297,26 @@ internal static class TestContextExtensions
     /// </summary>
     public static ITestSkippedEventReceiver[] GetTestSkippedReceivers(this TestContext testContext)
     {
-        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestSkippedReceivers!;
     }
 
     /// <summary>
     /// Gets pre-computed test discovery receivers (filtered, sorted, scoped-attribute filtered).
+    /// Called from discovery / out-of-lifecycle paths, so the guard still builds on demand.
     /// </summary>
     public static ITestDiscoveryEventReceiver[] GetTestDiscoveryReceivers(this TestContext testContext)
     {
-        EnsureEventReceiversCached(testContext);
+        testContext.EnsureEventReceiversCached();
         return testContext.CachedTestDiscoveryReceivers!;
     }
 
     /// <summary>
     /// Gets pre-computed test registered receivers (filtered, sorted, scoped-attribute filtered).
+    /// Called from discovery / out-of-lifecycle paths, so the guard still builds on demand.
     /// </summary>
     public static ITestRegisteredEventReceiver[] GetTestRegisteredReceivers(this TestContext testContext)
     {
-        EnsureEventReceiversCached(testContext);
+        testContext.EnsureEventReceiversCached();
         return testContext.CachedTestRegisteredReceivers!;
     }
 }

--- a/TUnit.Engine/Extensions/TestContextExtensions.cs
+++ b/TUnit.Engine/Extensions/TestContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+﻿using System.Runtime.CompilerServices;
 using TUnit.Core;
 using TUnit.Core.Enums;
 using TUnit.Core.Interfaces;
@@ -19,7 +19,10 @@ internal static class TestContextExtensions
     /// When this happens, eligible event objects may include the new instance (if it implements
     /// event receiver interfaces), so all caches must be invalidated and rebuilt.
     /// </remarks>
-    public static void EnsureEventReceiversCached(this TestContext testContext)
+    // Inlined so the fast-path (cache-hit) check collapses to a field load + branch at every
+    // call site, eliminating call overhead for the 99%+ already-built case.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void EnsureEventReceiversCached(TestContext testContext)
     {
         var currentClassInstance = testContext.Metadata.TestDetails.ClassInstance;
 
@@ -151,7 +154,7 @@ internal static class TestContextExtensions
     public static IEnumerable<object> GetEligibleEventObjects(this TestContext testContext)
     {
         // Use EnsureEventReceiversCached which builds eligible objects as part of cache initialization
-        testContext.EnsureEventReceiversCached();
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedEligibleEventObjects!;
     }
 
@@ -259,13 +262,11 @@ internal static class TestContextExtensions
 
     /// <summary>
     /// Gets pre-computed test start receivers (filtered, sorted, scoped-attribute filtered).
-    /// Assumes <see cref="EnsureEventReceiversCached"/> has been called by the lifecycle
-    /// coordinator — hot-path callers (per-test start/end/skipped) skip the guard.
     /// </summary>
 #if NET
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext, EventReceiverStage stage)
     {
-        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestStartReceivers — caller is on the hot path and skips the guard.");
+        EnsureEventReceiversCached(testContext);
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestStartReceiversEarly!
             : testContext.CachedTestStartReceiversLate!;
@@ -273,7 +274,7 @@ internal static class TestContextExtensions
 #else
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext)
     {
-        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestStartReceivers — caller is on the hot path and skips the guard.");
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestStartReceivers!;
     }
 #endif
@@ -284,7 +285,7 @@ internal static class TestContextExtensions
 #if NET
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext, EventReceiverStage stage)
     {
-        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestEndReceivers — caller is on the hot path and skips the guard.");
+        EnsureEventReceiversCached(testContext);
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestEndReceiversEarly!
             : testContext.CachedTestEndReceiversLate!;
@@ -292,7 +293,7 @@ internal static class TestContextExtensions
 #else
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext)
     {
-        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestEndReceivers — caller is on the hot path and skips the guard.");
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestEndReceivers!;
     }
 #endif
@@ -302,27 +303,25 @@ internal static class TestContextExtensions
     /// </summary>
     public static ITestSkippedEventReceiver[] GetTestSkippedReceivers(this TestContext testContext)
     {
-        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestSkippedReceivers — caller is on the hot path and skips the guard.");
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestSkippedReceivers!;
     }
 
     /// <summary>
     /// Gets pre-computed test discovery receivers (filtered, sorted, scoped-attribute filtered).
-    /// Called from discovery / out-of-lifecycle paths, so the guard still builds on demand.
     /// </summary>
     public static ITestDiscoveryEventReceiver[] GetTestDiscoveryReceivers(this TestContext testContext)
     {
-        testContext.EnsureEventReceiversCached();
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestDiscoveryReceivers!;
     }
 
     /// <summary>
     /// Gets pre-computed test registered receivers (filtered, sorted, scoped-attribute filtered).
-    /// Called from discovery / out-of-lifecycle paths, so the guard still builds on demand.
     /// </summary>
     public static ITestRegisteredEventReceiver[] GetTestRegisteredReceivers(this TestContext testContext)
     {
-        testContext.EnsureEventReceiversCached();
+        EnsureEventReceiversCached(testContext);
         return testContext.CachedTestRegisteredReceivers!;
     }
 }

--- a/TUnit.Engine/Extensions/TestContextExtensions.cs
+++ b/TUnit.Engine/Extensions/TestContextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TUnit.Core;
+﻿using System.Diagnostics;
+using TUnit.Core;
 using TUnit.Core.Enums;
 using TUnit.Core.Interfaces;
 using TUnit.Engine.Utilities;
@@ -264,6 +265,7 @@ internal static class TestContextExtensions
 #if NET
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext, EventReceiverStage stage)
     {
+        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestStartReceivers — caller is on the hot path and skips the guard.");
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestStartReceiversEarly!
             : testContext.CachedTestStartReceiversLate!;
@@ -271,6 +273,7 @@ internal static class TestContextExtensions
 #else
     public static ITestStartEventReceiver[] GetTestStartReceivers(this TestContext testContext)
     {
+        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestStartReceivers — caller is on the hot path and skips the guard.");
         return testContext.CachedTestStartReceivers!;
     }
 #endif
@@ -281,6 +284,7 @@ internal static class TestContextExtensions
 #if NET
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext, EventReceiverStage stage)
     {
+        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestEndReceivers — caller is on the hot path and skips the guard.");
         return stage == EventReceiverStage.Early
             ? testContext.CachedTestEndReceiversEarly!
             : testContext.CachedTestEndReceiversLate!;
@@ -288,6 +292,7 @@ internal static class TestContextExtensions
 #else
     public static ITestEndEventReceiver[] GetTestEndReceivers(this TestContext testContext)
     {
+        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestEndReceivers — caller is on the hot path and skips the guard.");
         return testContext.CachedTestEndReceivers!;
     }
 #endif
@@ -297,6 +302,7 @@ internal static class TestContextExtensions
     /// </summary>
     public static ITestSkippedEventReceiver[] GetTestSkippedReceivers(this TestContext testContext)
     {
+        Debug.Assert(testContext.EventReceiversBuilt, "EnsureEventReceiversCached must run before GetTestSkippedReceivers — caller is on the hot path and skips the guard.");
         return testContext.CachedTestSkippedReceivers!;
     }
 

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -27,7 +27,9 @@ internal sealed class TestScheduler : ITestScheduler
     private readonly StaticPropertyHandler _staticPropertyHandler;
     private readonly IDynamicTestQueue _dynamicTestQueue;
     private readonly Lazy<int> _maxParallelism;
+#if !NET8_0_OR_GREATER
     private readonly Lazy<SemaphoreSlim> _maxParallelismSemaphore;
+#endif
 
     public TestScheduler(
         TUnitFrameworkLogger logger,
@@ -57,8 +59,13 @@ internal sealed class TestScheduler : ITestScheduler
 
         _maxParallelism = new Lazy<int>(() => GetMaxParallelism(logger, commandLineOptions));
 
+#if !NET8_0_OR_GREATER
+        // The .NET 8+ path uses Parallel.ForEachAsync which caps concurrency via
+        // ParallelOptions.MaxDegreeOfParallelism — the semaphore is only needed
+        // for the netstandard2.0 fallback path.
         _maxParallelismSemaphore = new Lazy<SemaphoreSlim>(() =>
             new SemaphoreSlim(_maxParallelism.Value, _maxParallelism.Value));
+#endif
     }
 
     #if NET8_0_OR_GREATER
@@ -310,10 +317,14 @@ internal sealed class TestScheduler : ITestScheduler
         AbstractExecutableTest[] tests,
         CancellationToken cancellationToken)
     {
-        // All paths run through the semaphore-backed limiter so the DOP cap is
-        // unified in GetMaxParallelism. "Unlimited" is resolved to the default
-        // cap (ProcessorCount * 4) there rather than being a separate code path.
+        // All paths run through the shared limiter so the DOP cap is unified in
+        // GetMaxParallelism. "Unlimited" is resolved to the default cap
+        // (ProcessorCount * 4) there rather than being a separate code path.
+#if NET8_0_OR_GREATER
+        return ExecuteWithGlobalLimitAsync(tests, cancellationToken);
+#else
         return ExecuteWithGlobalLimitAsync(tests, _maxParallelismSemaphore.Value, cancellationToken);
+#endif
     }
 
 #if NET8_0_OR_GREATER
@@ -330,19 +341,16 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-    private async Task ExecuteWithGlobalLimitAsync(
+#if NET8_0_OR_GREATER
+    private Task ExecuteWithGlobalLimitAsync(
         AbstractExecutableTest[] tests,
-        SemaphoreSlim globalSemaphore,
         CancellationToken cancellationToken)
     {
-        var maxParallelism = _maxParallelism.Value;
-
-#if NET8_0_OR_GREATER
-        await Parallel.ForEachAsync(
+        return Parallel.ForEachAsync(
             tests,
             new ParallelOptions
             {
-                MaxDegreeOfParallelism = maxParallelism,
+                MaxDegreeOfParallelism = _maxParallelism.Value,
                 CancellationToken = cancellationToken
             },
             async (test, ct) =>
@@ -350,8 +358,14 @@ internal sealed class TestScheduler : ITestScheduler
                 test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, ct).AsTask();
                 await test.ExecutionTask.ConfigureAwait(false);
             }
-        ).ConfigureAwait(false);
+        );
+    }
 #else
+    private async Task ExecuteWithGlobalLimitAsync(
+        AbstractExecutableTest[] tests,
+        SemaphoreSlim globalSemaphore,
+        CancellationToken cancellationToken)
+    {
         // Fallback for netstandard2.0: Manual bounded concurrency using existing semaphore
         var tasks = new Task[tests.Length];
         for (var i = 0; i < tests.Length; i++)
@@ -372,8 +386,8 @@ internal sealed class TestScheduler : ITestScheduler
             }, CancellationToken.None);
         }
         await Task.WhenAll(tasks).ConfigureAwait(false);
-#endif
     }
+#endif
 
     private async Task WaitForTasksWithFailFastHandling(IEnumerable<Task> tasks, CancellationToken cancellationToken)
     {

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -27,7 +27,7 @@ internal sealed class TestScheduler : ITestScheduler
     private readonly StaticPropertyHandler _staticPropertyHandler;
     private readonly IDynamicTestQueue _dynamicTestQueue;
     private readonly Lazy<int> _maxParallelism;
-#if !NET8_0_OR_GREATER
+#if !NET
     private readonly Lazy<SemaphoreSlim> _maxParallelismSemaphore;
 #endif
 
@@ -59,7 +59,7 @@ internal sealed class TestScheduler : ITestScheduler
 
         _maxParallelism = new Lazy<int>(() => GetMaxParallelism(logger, commandLineOptions));
 
-#if !NET8_0_OR_GREATER
+#if !NET
         // The .NET 8+ path uses Parallel.ForEachAsync which caps concurrency via
         // ParallelOptions.MaxDegreeOfParallelism — the semaphore is only needed
         // for the netstandard2.0 fallback path.
@@ -68,7 +68,7 @@ internal sealed class TestScheduler : ITestScheduler
 #endif
     }
 
-    #if NET8_0_OR_GREATER
+    #if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     public async Task<bool> ScheduleAndExecuteAsync(
@@ -161,7 +161,7 @@ internal sealed class TestScheduler : ITestScheduler
         return true;
     }
 
-    #if NET8_0_OR_GREATER
+    #if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteGroupedTestsAsync(
@@ -237,7 +237,7 @@ internal sealed class TestScheduler : ITestScheduler
         await dynamicTestProcessingTask.ConfigureAwait(false);
     }
 
-    #if NET8_0_OR_GREATER
+    #if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ProcessDynamicTestQueueAsync(CancellationToken cancellationToken)
@@ -310,7 +310,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private Task ExecuteTestsAsync(
@@ -320,14 +320,14 @@ internal sealed class TestScheduler : ITestScheduler
         // All paths run through the shared limiter so the DOP cap is unified in
         // GetMaxParallelism. "Unlimited" is resolved to the default cap
         // (ProcessorCount * 4) there rather than being a separate code path.
-#if NET8_0_OR_GREATER
+#if NET
         return ExecuteWithGlobalLimitAsync(tests, cancellationToken);
 #else
         return ExecuteWithGlobalLimitAsync(tests, _maxParallelismSemaphore.Value, cancellationToken);
 #endif
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
     #endif
     private async Task ExecuteSequentiallyAsync(
@@ -341,7 +341,7 @@ internal sealed class TestScheduler : ITestScheduler
         }
     }
 
-#if NET8_0_OR_GREATER
+#if NET
     private Task ExecuteWithGlobalLimitAsync(
         AbstractExecutableTest[] tests,
         CancellationToken cancellationToken)

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -277,6 +277,15 @@ internal sealed class TestCoordinator : ITestCoordinator
     /// Timeout is passed through to TestExecutor.ExecuteAsync, which applies it only to the test
     /// body — hooks and data source initialization run outside the timeout scope (fixes #4772).
     /// </summary>
+    /// <remarks>
+    /// Ordering invariant: <see cref="ExecuteTestInternalAsync"/> calls
+    /// <c>_eventReceiverOrchestrator.RegisterReceivers</c> (which invokes
+    /// <c>EnsureEventReceiversCached</c>) before entering this method. The hot-path
+    /// receiver getters used by <c>InvokeTest{Skipped,End}EventReceiversAsync</c> therefore
+    /// skip their own guards and rely on that upstream call to have populated the caches —
+    /// the skip-path branch below is safe because it cannot be reached without that
+    /// prerequisite having run.
+    /// </remarks>
     private async ValueTask ExecuteTestLifecycleAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         // Check if this test should be skipped before creating the class instance.
@@ -287,6 +296,7 @@ internal sealed class TestCoordinator : ITestCoordinator
         {
             _stateManager.MarkSkipped(test, test.Context.SkipReason!);
 
+            // Receiver caches are populated upstream (see <remarks> on this method).
             await _eventReceiverOrchestrator.InvokeTestSkippedEventReceiversAsync(test.Context, cancellationToken).ConfigureAwait(false);
 
             await _eventReceiverOrchestrator.InvokeTestEndEventReceiversAsync(test.Context, cancellationToken).ConfigureAwait(false);

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -3,6 +3,7 @@ using TUnit.Core;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Logging;
 using TUnit.Core.Tracking;
+using TUnit.Engine.Extensions;
 using TUnit.Engine.Helpers;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Logging;
@@ -295,8 +296,12 @@ internal sealed class TestCoordinator : ITestCoordinator
 
         test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 
-        // Drop the cached eligible-objects list so any later consumer rebuilds it with the new ClassInstance included — the initial list was built before the instance existed.
-        test.Context.CachedEligibleEventObjects = null;
+        // Rebuild the receiver cache now that ClassInstance is assigned — the initial build
+        // at RegisterReceivers time ran with the placeholder instance. EnsureEventReceiversCached
+        // detects the changed instance via its internal invalidation check. Hoisting the call
+        // here lets the five per-test receiver getters (GetTestStartReceivers/GetTestEndReceivers/...)
+        // skip their own guards on the hot path.
+        test.Context.EnsureEventReceiversCached();
 
         // Check if this test should be skipped (after creating instance).
         // This handles basic [Skip] attributes that use SkippedTestInstance as a sentinel,

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -3,7 +3,6 @@ using TUnit.Core;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Logging;
 using TUnit.Core.Tracking;
-using TUnit.Engine.Extensions;
 using TUnit.Engine.Helpers;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Logging;
@@ -277,15 +276,6 @@ internal sealed class TestCoordinator : ITestCoordinator
     /// Timeout is passed through to TestExecutor.ExecuteAsync, which applies it only to the test
     /// body — hooks and data source initialization run outside the timeout scope (fixes #4772).
     /// </summary>
-    /// <remarks>
-    /// Ordering invariant: <see cref="ExecuteTestInternalAsync"/> calls
-    /// <c>_eventReceiverOrchestrator.RegisterReceivers</c> (which invokes
-    /// <c>EnsureEventReceiversCached</c>) before entering this method. The hot-path
-    /// receiver getters used by <c>InvokeTest{Skipped,End}EventReceiversAsync</c> therefore
-    /// skip their own guards and rely on that upstream call to have populated the caches —
-    /// the skip-path branch below is safe because it cannot be reached without that
-    /// prerequisite having run.
-    /// </remarks>
     private async ValueTask ExecuteTestLifecycleAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         // Check if this test should be skipped before creating the class instance.
@@ -296,7 +286,6 @@ internal sealed class TestCoordinator : ITestCoordinator
         {
             _stateManager.MarkSkipped(test, test.Context.SkipReason!);
 
-            // Receiver caches are populated upstream (see <remarks> on this method).
             await _eventReceiverOrchestrator.InvokeTestSkippedEventReceiversAsync(test.Context, cancellationToken).ConfigureAwait(false);
 
             await _eventReceiverOrchestrator.InvokeTestEndEventReceiversAsync(test.Context, cancellationToken).ConfigureAwait(false);
@@ -306,12 +295,8 @@ internal sealed class TestCoordinator : ITestCoordinator
 
         test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 
-        // Rebuild the receiver cache now that ClassInstance is assigned — the initial build
-        // at RegisterReceivers time ran with the placeholder instance. EnsureEventReceiversCached
-        // detects the changed instance via its internal invalidation check. Hoisting the call
-        // here lets the five per-test receiver getters (GetTestStartReceivers/GetTestEndReceivers/...)
-        // skip their own guards on the hot path.
-        test.Context.EnsureEventReceiversCached();
+        // Drop the cached eligible-objects list so any later consumer rebuilds it with the new ClassInstance included — the initial list was built before the instance existed.
+        test.Context.CachedEligibleEventObjects = null;
 
         // Check if this test should be skipped (after creating instance).
         // This handles basic [Skip] attributes that use SkippedTestInstance as a sentinel,


### PR DESCRIPTION
## Summary

Batch of the smaller per-test overhead fixes surfaced in #5719. Individually modest (~0.2-1% each), collectively ~1% CPU across typical suites.

Closes #5719

### Shipped (4 of 5)

- **Hoist `EnsureEventReceiversCached`** out of the five per-test receiver getters. Replaced the per-getter cache-array probe with an `EventReceiversBuilt` bool on `TestContext`; `TestCoordinator.ExecuteTestLifecycleAsync` rebuilds once after `ClassInstance` is assigned. Hot-path getters (`GetTestStartReceivers`/`GetTestEndReceivers`/`GetTestSkippedReceivers`) are now plain field reads.
- **Cache `ObjectGraphDiscoverer.TraverseInitializerProperties` output per-type.** The inheritance walk + `HashSet<string>` dedupe now runs once and is memoized in a `ConcurrentDictionary<Type, InitializerPropertyInfo[]?>`. `ShouldSkipType` is memoized too, so `Namespace.StartsWith("System")` no longer runs per call.
- **Drop `Lazy<SemaphoreSlim> _maxParallelismSemaphore`** on the .NET 8+ path. `Parallel.ForEachAsync` caps concurrency via `ParallelOptions.MaxDegreeOfParallelism`; the semaphore is now only built on the netstandard2.0 fallback.

### Skipped (2 of 5)

- **Per-TestContext slot for `ObjectTracker` counters.** Requires a robust "shared vs per-test" signal at Track/Untrack time. The existing `_initializedObjects` set in `EventReceiverOrchestrator` only flags seen-before *after* the second test, so the bulk of per-test objects would still hit the shared dict on first track. Needs a dedicated sharing marker on the data-source side.
- **`RestoreExecutionContext` version-counter skip.** Implementation attempted a thread-static "last restored context + version" guard, but regressed `TUnit.TestProject/Bugs/1914/AsyncHookTests` (AsyncLocal-flow chain from `BeforeTestDiscovery` through `BeforeTestSession` / `BeforeAssembly` / `BeforeClass` / `BeforeTest`). The captured `ExecutionContext` on a context can carry AsyncLocal values set by hooks on the active async flow between Restore sites; the skip misses those flows when a continuation lands on a thread whose last-Restored context points elsewhere. Held back for a safer design.

## Test plan

- [x] `dotnet build TUnit.slnx -c Release` — 0 errors
- [x] `TUnit.Core.SourceGenerator.Tests` — 116 passed, 1 skipped (known)
- [x] `TUnit.TestProject` `BasicTests` filter — 3/3 passed
- [x] `TUnit.TestProject` `AsyncHookTests` filter (the 1914 regression guard) — 8/8 passed
- [x] `TUnit.TestProject` `DataDrivenTests` filter — 15/15 passed