### PR TITLE
fix(migration): preserve comments/XML docs when removing sole attributes (#5698)

### DIFF
--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -764,9 +764,7 @@ public class MigrationTransformer
 
                 if (attributeList.Attributes.Count == 1)
                 {
-                    // Remove the entire attribute list without keeping its trivia
-                    // This prevents extra indentation from being left behind
-                    currentRoot = currentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
+                    currentRoot = RemoveAttributeListPreservingComments(currentRoot, attributeList);
                 }
                 else
                 {
@@ -1233,4 +1231,77 @@ public class MigrationTransformer
         var existingTrivia = root.GetLeadingTrivia();
         return root.WithLeadingTrivia(SyntaxFactory.TriviaList(commentTrivia).AddRange(existingTrivia));
     }
+
+    private static CompilationUnitSyntax RemoveAttributeListPreservingComments(
+        CompilationUnitSyntax root,
+        AttributeListSyntax attributeList)
+    {
+        var preservedTrivia = ExtractMeaningfulLeadingTrivia(attributeList.GetLeadingTrivia());
+        var nextToken = attributeList.CloseBracketToken.GetNextToken();
+
+        if (preservedTrivia.Count == 0 || nextToken == default)
+        {
+            return root.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
+        }
+
+        // Track the attribute list so we can locate it after ReplaceToken rewrites the tree.
+        var tracked = root.TrackNodes(attributeList);
+        var trackedList = tracked.GetCurrentNode(attributeList)!;
+        var trackedNextToken = trackedList.CloseBracketToken.GetNextToken();
+
+        tracked = tracked.ReplaceToken(
+            trackedNextToken,
+            trackedNextToken.WithLeadingTrivia(preservedTrivia.AddRange(trackedNextToken.LeadingTrivia)));
+
+        var refoundList = tracked.GetCurrentNode(attributeList)!;
+        return tracked.RemoveNode(refoundList, SyntaxRemoveOptions.KeepNoTrivia)!;
+    }
+
+    private static SyntaxTriviaList ExtractMeaningfulLeadingTrivia(SyntaxTriviaList leading)
+    {
+        int first = -1;
+        int last = -1;
+        for (int i = 0; i < leading.Count; i++)
+        {
+            if (IsMeaningfulTrivia(leading[i]))
+            {
+                if (first < 0) first = i;
+                last = i;
+            }
+        }
+
+        if (first < 0)
+        {
+            return SyntaxFactory.TriviaList();
+        }
+
+        // Include the trailing EOL so the next declaration lands on its own line.
+        int endInclusive = last;
+        if (endInclusive + 1 < leading.Count && leading[endInclusive + 1].IsKind(SyntaxKind.EndOfLineTrivia))
+        {
+            endInclusive++;
+        }
+
+        return SyntaxFactory.TriviaList(leading.Skip(first).Take(endInclusive - first + 1));
+    }
+
+    private static bool IsMeaningfulTrivia(SyntaxTrivia trivia) => trivia.Kind() switch
+    {
+        SyntaxKind.SingleLineCommentTrivia
+            or SyntaxKind.MultiLineCommentTrivia
+            or SyntaxKind.SingleLineDocumentationCommentTrivia
+            or SyntaxKind.MultiLineDocumentationCommentTrivia
+            or SyntaxKind.RegionDirectiveTrivia
+            or SyntaxKind.EndRegionDirectiveTrivia
+            or SyntaxKind.IfDirectiveTrivia
+            or SyntaxKind.ElseDirectiveTrivia
+            or SyntaxKind.ElifDirectiveTrivia
+            or SyntaxKind.EndIfDirectiveTrivia
+            or SyntaxKind.DefineDirectiveTrivia
+            or SyntaxKind.UndefDirectiveTrivia
+            or SyntaxKind.PragmaWarningDirectiveTrivia
+            or SyntaxKind.PragmaChecksumDirectiveTrivia
+            or SyntaxKind.NullableDirectiveTrivia => true,
+        _ => false
+    };
 }

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -1237,9 +1237,8 @@ public class MigrationTransformer
         AttributeListSyntax attributeList)
     {
         var preservedTrivia = ExtractMeaningfulLeadingTrivia(attributeList.GetLeadingTrivia());
-        var nextToken = attributeList.CloseBracketToken.GetNextToken();
 
-        if (preservedTrivia.Count == 0 || nextToken == default)
+        if (preservedTrivia.Count == 0)
         {
             return root.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
         }
@@ -1248,6 +1247,11 @@ public class MigrationTransformer
         var tracked = root.TrackNodes(attributeList);
         var trackedList = tracked.GetCurrentNode(attributeList)!;
         var trackedNextToken = trackedList.CloseBracketToken.GetNextToken();
+
+        if (trackedNextToken == default)
+        {
+            return root.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
+        }
 
         tracked = tracked.ReplaceToken(
             trackedNextToken,
@@ -1276,6 +1280,8 @@ public class MigrationTransformer
         }
 
         // Include the trailing EOL so the next declaration lands on its own line.
+        // (Documentation comment trivia embeds its own EOL, so this only kicks in for
+        // line/block comments and preprocessor directives.)
         int endInclusive = last;
         if (endInclusive + 1 < leading.Count && leading[endInclusive + 1].IsKind(SyntaxKind.EndOfLineTrivia))
         {

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -1282,26 +1282,15 @@ public class MigrationTransformer
             endInclusive++;
         }
 
+        // Whitespace and EOL between the first and last meaningful items are intentionally
+        // included via the contiguous slice — preserving original spacing/structure between them.
         return SyntaxFactory.TriviaList(leading.Skip(first).Take(endInclusive - first + 1));
     }
 
-    private static bool IsMeaningfulTrivia(SyntaxTrivia trivia) => trivia.Kind() switch
-    {
-        SyntaxKind.SingleLineCommentTrivia
+    private static bool IsMeaningfulTrivia(SyntaxTrivia trivia) =>
+        trivia.IsDirective ||
+        trivia.Kind() is SyntaxKind.SingleLineCommentTrivia
             or SyntaxKind.MultiLineCommentTrivia
             or SyntaxKind.SingleLineDocumentationCommentTrivia
-            or SyntaxKind.MultiLineDocumentationCommentTrivia
-            or SyntaxKind.RegionDirectiveTrivia
-            or SyntaxKind.EndRegionDirectiveTrivia
-            or SyntaxKind.IfDirectiveTrivia
-            or SyntaxKind.ElseDirectiveTrivia
-            or SyntaxKind.ElifDirectiveTrivia
-            or SyntaxKind.EndIfDirectiveTrivia
-            or SyntaxKind.DefineDirectiveTrivia
-            or SyntaxKind.UndefDirectiveTrivia
-            or SyntaxKind.PragmaWarningDirectiveTrivia
-            or SyntaxKind.PragmaChecksumDirectiveTrivia
-            or SyntaxKind.NullableDirectiveTrivia => true,
-        _ => false
-    };
+            or SyntaxKind.MultiLineDocumentationCommentTrivia;
 }

--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -86,6 +86,40 @@ public class MSTestMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task MSTest_TestClass_Attribute_Removed_Preserves_Leading_Comments_And_Docstring()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                // TODO Fix this
+                /// <summary>
+                /// This class is testing X
+                /// </summary>
+                {|#0:[TestClass]|}
+                public class MyClass
+                {
+                    [TestMethod]
+                    public void MyMethod() { }
+                }
+                """,
+            Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
+            """
+                // TODO Fix this
+                /// <summary>
+                /// This class is testing X
+                /// </summary>
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            ConfigureMSTestTest
+        );
+    }
+
+    [Test]
     public async Task MSTest_Assertions_Converted()
     {
         await CodeFixer.VerifyCodeFixAsync(

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -120,6 +120,36 @@ public class NUnitMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task NUnit_TestFixture_Attribute_Removed_Followed_By_Another_Attribute_List_Preserves_Comments()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using NUnit.Framework;
+
+                // Critical comment
+                {|#0:[TestFixture]|}
+                [Category("Smoke")]
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
+            """
+                // Critical comment
+                [Category("Smoke")]
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            ConfigureNUnitTest
+        );
+    }
+
+    [Test]
     public async Task NUnit_TestFixture_Attribute_Removed_Preserves_Single_Line_Comment()
     {
         await CodeFixer.VerifyCodeFixAsync(

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -86,6 +86,68 @@ public class NUnitMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task NUnit_TestFixture_Attribute_Removed_Preserves_Leading_Comments_And_Docstring()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using NUnit.Framework;
+
+                // TODO Fix this
+                /// <summary>
+                /// This class is testing X
+                /// </summary>
+                {|#0:[TestFixture]|}
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
+            """
+                // TODO Fix this
+                /// <summary>
+                /// This class is testing X
+                /// </summary>
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            ConfigureNUnitTest
+        );
+    }
+
+    [Test]
+    public async Task NUnit_TestFixture_Attribute_Removed_Preserves_Single_Line_Comment()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using NUnit.Framework;
+
+                // Important note about this class
+                {|#0:[TestFixture]|}
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
+            """
+                // Important note about this class
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod() { }
+                }
+                """,
+            ConfigureNUnitTest
+        );
+    }
+
+    [Test]
     public async Task NUnit_Assert_That_Converted()
     {
         await CodeFixer.VerifyCodeFixAsync(


### PR DESCRIPTION
## Summary

- Fixes #5698 — NUnit/XUnit/MSTest migration code fix dropped class & method comments and XML docstrings whenever the attribute list above them held a single attribute (e.g. `[TestFixture]`).
- `MigrationTransformer.RemoveAttributes` removed the entire `AttributeListSyntax` with `SyntaxRemoveOptions.KeepNoTrivia`, throwing away the leading trivia.
- Now extracts meaningful leading trivia (comments, doc comments, preprocessor directives) and moves it onto the next token before removing the attribute list. Surrounding whitespace is still discarded so no extra indentation is left behind, preserving the original intent of `KeepNoTrivia`.

Repro from the issue now produces the expected output:
```csharp
// TODO Fix this
/// <summary>
/// This class is testing X
/// </summary>
public class MyTest { ... }
```

## Test plan

- [x] New TUnit test reproducing the exact case in the issue (`NUnit_TestFixture_Attribute_Removed_Preserves_Leading_Comments_And_Docstring`)
- [x] Additional coverage for a single-line comment variant
- [x] All NUnit migration tests pass (167)
- [x] All XUnit migration tests pass (82, 1 skipped pre-existing)
- [x] All MSTest migration tests pass (52)