### PR TITLE
fix(engine): allow keyed NotInParallel tests to run alongside unconstrained tests (#5700)

### DIFF
--- a/TUnit.AspNetCore.Tests/AutoConfigureOpenTelemetryTests.cs
+++ b/TUnit.AspNetCore.Tests/AutoConfigureOpenTelemetryTests.cs
@@ -12,12 +12,10 @@ namespace TUnit.AspNetCore.Tests;
 /// correlation processor + ASP.NET Core instrumentation.
 /// </summary>
 /// <remarks>
-/// Serialized against sibling auto-wire tests because <see cref="OpenTelemetry.Sdk"/>
-/// attaches a process-global <see cref="ActivityListener"/> per <c>TracerProvider</c>,
-/// so a parallel factory's correlation processor can tag activities created by another
-/// factory's SUT. Serializing keeps assertions observing only their own factory's wiring.
+/// AutoWires asserts presence of its own <c>TestId</c> tag, so foreign spans observed
+/// via the global ASP.NET Core <see cref="System.Diagnostics.ActivitySource"/> do not
+/// affect it — no key needed.
 /// </remarks>
-[NotInParallel(nameof(AutoConfigureOpenTelemetryTests))]
 public class AutoConfigureOpenTelemetryTests : WebApplicationTest<TestWebAppFactory, Program>
 {
     private readonly List<Activity> _exported = [];
@@ -54,7 +52,16 @@ public class AutoConfigureOpenTelemetryTests : WebApplicationTest<TestWebAppFact
     }
 }
 
-[NotInParallel(nameof(AutoConfigureOpenTelemetryTests))]
+/// <remarks>
+/// Global <see cref="NotInParallelAttribute"/> (no key): asserts <em>absence</em> of any
+/// <see cref="TUnitActivitySource.TagTestId"/> tag, but every <see cref="TracerProvider"/>
+/// with <c>AddAspNetCoreInstrumentation()</c> subscribes to the process-global
+/// <c>Microsoft.AspNetCore</c> <see cref="System.Diagnostics.ActivitySource"/> and a parallel
+/// factory's correlation processor stamps spans with its own <c>TestId</c> before they reach
+/// this exporter. A keyed constraint cannot enumerate every parallel <see cref="WebApplicationTest{TFactory,TEntryPoint}"/>;
+/// draining alone is the only reliable isolation until per-factory filtering lands.
+/// </remarks>
+[NotInParallel]
 public class AutoConfigureOpenTelemetryOptOutTests : WebApplicationTest<TestWebAppFactory, Program>
 {
     private readonly List<Activity> _exported = [];

--- a/TUnit.AspNetCore.Tests/AutoConfigureOpenTelemetryTests.cs
+++ b/TUnit.AspNetCore.Tests/AutoConfigureOpenTelemetryTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
@@ -14,11 +15,14 @@ namespace TUnit.AspNetCore.Tests;
 /// <remarks>
 /// AutoWires asserts presence of its own <c>TestId</c> tag, so foreign spans observed
 /// via the global ASP.NET Core <see cref="System.Diagnostics.ActivitySource"/> do not
-/// affect it — no key needed.
+/// affect it — no key needed. Parallel <see cref="WebApplicationTest{TFactory,TEntryPoint}"/>
+/// instances stamp activities (subscribed via <c>AddAspNetCoreInstrumentation</c>) on
+/// background continuations, so the exporter sink must be thread-safe — polling
+/// <see cref="LockedActivityList"/> snapshots its items under a lock.
 /// </remarks>
 public class AutoConfigureOpenTelemetryTests : WebApplicationTest<TestWebAppFactory, Program>
 {
-    private readonly List<Activity> _exported = [];
+    private readonly LockedActivityList _exported = [];
 
     protected override void ConfigureTestServices(IServiceCollection services)
     {
@@ -40,7 +44,14 @@ public class AutoConfigureOpenTelemetryTests : WebApplicationTest<TestWebAppFact
         Activity? taggedSpan = null;
         while (Environment.TickCount64 < deadline)
         {
-            taggedSpan = _exported.FirstOrDefault(a => (a.GetTagItem(TUnitActivitySource.TagTestId) as string) == testId);
+            foreach (var activity in _exported.Snapshot())
+            {
+                if (activity.GetTagItem(TUnitActivitySource.TagTestId) as string == testId)
+                {
+                    taggedSpan = activity;
+                    break;
+                }
+            }
             if (taggedSpan is not null)
             {
                 break;
@@ -64,7 +75,7 @@ public class AutoConfigureOpenTelemetryTests : WebApplicationTest<TestWebAppFact
 [NotInParallel]
 public class AutoConfigureOpenTelemetryOptOutTests : WebApplicationTest<TestWebAppFactory, Program>
 {
-    private readonly List<Activity> _exported = [];
+    private readonly LockedActivityList _exported = [];
 
     protected override void ConfigureTestOptions(WebApplicationTestOptions options)
     {
@@ -85,9 +96,44 @@ public class AutoConfigureOpenTelemetryOptOutTests : WebApplicationTest<TestWebA
         var response = await client.GetAsync("/ping");
         response.EnsureSuccessStatusCode();
 
-        foreach (var activity in _exported)
+        foreach (var activity in _exported.Snapshot())
         {
             await Assert.That(activity.GetTagItem(TUnitActivitySource.TagTestId)).IsNull();
         }
     }
+}
+
+/// <summary>
+/// OpenTelemetry's <c>AddInMemoryExporter</c> calls <c>ICollection&lt;T&gt;.Add</c> on a
+/// background batch thread without locking, so a plain <see cref="List{T}"/> races with
+/// any reader (the test's poll loop) and intermittently throws "Collection was modified".
+/// This wrapper synchronises every mutation and exposes a <see cref="Snapshot"/> for
+/// safe iteration.
+/// </summary>
+internal sealed class LockedActivityList : ICollection<Activity>
+{
+    private readonly List<Activity> _items = [];
+
+    public int Count
+    {
+        get { lock (_items) return _items.Count; }
+    }
+
+    public bool IsReadOnly => false;
+
+    public void Add(Activity item) { lock (_items) _items.Add(item); }
+
+    public void Clear() { lock (_items) _items.Clear(); }
+
+    public bool Contains(Activity item) { lock (_items) return _items.Contains(item); }
+
+    public void CopyTo(Activity[] array, int arrayIndex) { lock (_items) _items.CopyTo(array, arrayIndex); }
+
+    public bool Remove(Activity item) { lock (_items) return _items.Remove(item); }
+
+    public Activity[] Snapshot() { lock (_items) return _items.ToArray(); }
+
+    public IEnumerator<Activity> GetEnumerator() => ((IEnumerable<Activity>)Snapshot()).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/TUnit.Engine.Tests/Scheduling/KeyedNotInParallelCrossPhaseTests.cs
+++ b/TUnit.Engine.Tests/Scheduling/KeyedNotInParallelCrossPhaseTests.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests.Scheduling;
+
+/// <summary>
+/// Regression for https://github.com/thomhurst/TUnit/discussions/5700.
+/// An unconstrained [Test] must run concurrently with [Test, NotInParallel("key")] tests
+/// in the same class — keyed NotInParallel only blocks tests sharing a key, it must not
+/// serialize against the rest of the suite.
+/// </summary>
+public class KeyedNotInParallelCrossPhaseTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task UnconstrainedTest_RunsAlongsideKeyedNotInParallelTest()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await RunTestsWithFilter("/*/*/Repro5700/*",
+        [
+            result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+            result => result.ResultSummary.Counters.Total.ShouldBe(3),
+            result => result.ResultSummary.Counters.Passed.ShouldBe(3),
+            result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+        ],
+        new RunOptions().WithForcefulCancellationToken(cts.Token));
+    }
+}

--- a/TUnit.Engine.Tests/Scheduling/KeyedNotInParallelCrossPhaseTests.cs
+++ b/TUnit.Engine.Tests/Scheduling/KeyedNotInParallelCrossPhaseTests.cs
@@ -25,4 +25,19 @@ public class KeyedNotInParallelCrossPhaseTests(TestMode testMode) : InvokableTes
         ],
         new RunOptions().WithForcefulCancellationToken(cts.Token));
     }
+
+    [Test]
+    public async Task KeyedNotInParallel_DifferentKeys_RunInParallel()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await RunTestsWithFilter("/*/*/CrossKeyOverlap5700/*",
+        [
+            result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+            result => result.ResultSummary.Counters.Total.ShouldBe(2),
+            result => result.ResultSummary.Counters.Passed.ShouldBe(2),
+            result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+        ],
+        new RunOptions().WithForcefulCancellationToken(cts.Token));
+    }
 }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -171,6 +171,18 @@ internal sealed class TestScheduler : ITestScheduler
         // Start dynamic test queue processing in background
         var dynamicTestProcessingTask = ProcessDynamicTestQueueAsync(cancellationToken);
 
+        await ExecuteAllPhasesAsync(groupedTests, cancellationToken).ConfigureAwait(false);
+
+        // Mark the queue as complete and wait for remaining dynamic tests to finish
+        _dynamicTestQueue.Complete();
+        await dynamicTestProcessingTask.ConfigureAwait(false);
+    }
+
+    #if NET
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
+    #endif
+    private async Task ExecuteAllPhasesAsync(GroupedTests groupedTests, CancellationToken cancellationToken)
+    {
         // Unconstrained Parallel and KeyedNotInParallel buckets share no state — keyed tests
         // only block other tests sharing a key (per docs/parallelism.md). Running them
         // sequentially makes a `[Test] T1` always run before `[Test, NotInParallel("k")] T2`
@@ -195,6 +207,8 @@ internal sealed class TestScheduler : ITestScheduler
 
         await RunPhasesConcurrentlyAsync(parallelPhase, keyedPhase, cancellationToken).ConfigureAwait(false);
 
+        // Each ParallelGroup runs to completion before the next — tests are bucketed
+        // into a group precisely because they must not overlap with tests in another group.
         foreach (var group in groupedTests.ParallelGroups)
         {
             var totalCount = 0;
@@ -235,10 +249,6 @@ internal sealed class TestScheduler : ITestScheduler
                 await _logger.LogTraceAsync($"Starting {groupedTests.NotInParallel.Length} global NotInParallel tests").ConfigureAwait(false);
             await ExecuteSequentiallyAsync(groupedTests.NotInParallel, cancellationToken).ConfigureAwait(false);
         }
-
-        // Mark the queue as complete and wait for remaining dynamic tests to finish
-        _dynamicTestQueue.Complete();
-        await dynamicTestProcessingTask.ConfigureAwait(false);
     }
 
     #if NET
@@ -266,21 +276,7 @@ internal sealed class TestScheduler : ITestScheduler
                 if (_logger.IsTraceEnabled)
                     await _logger.LogTraceAsync($"Executing {dynamicTests.Count} dynamic test(s)").ConfigureAwait(false);
 
-                // Group and execute just like regular tests
-                var dynamicTestsArray = dynamicTests.ToArray();
-                var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTestsArray).ConfigureAwait(false);
-
-                // Execute the grouped dynamic tests (recursive call handles sub-dynamics)
-                if (groupedDynamicTests.Parallel.Length > 0)
-                {
-                    await ExecuteTestsAsync(groupedDynamicTests.Parallel, cancellationToken).ConfigureAwait(false);
-                }
-
-                if (groupedDynamicTests.NotInParallel.Length > 0)
-                {
-                    await ExecuteSequentiallyAsync(groupedDynamicTests.NotInParallel, cancellationToken).ConfigureAwait(false);
-                }
-
+                await ExecuteDynamicBatchAsync(dynamicTests, cancellationToken).ConfigureAwait(false);
                 dynamicTests.Clear();
             }
         }
@@ -299,19 +295,20 @@ internal sealed class TestScheduler : ITestScheduler
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Executing {dynamicTests.Count} remaining dynamic test(s)").ConfigureAwait(false);
 
-            var dynamicTestsArray = dynamicTests.ToArray();
-            var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTestsArray).ConfigureAwait(false);
-
-            if (groupedDynamicTests.Parallel.Length > 0)
-            {
-                await ExecuteTestsAsync(groupedDynamicTests.Parallel, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (groupedDynamicTests.NotInParallel.Length > 0)
-            {
-                await ExecuteSequentiallyAsync(groupedDynamicTests.NotInParallel, cancellationToken).ConfigureAwait(false);
-            }
+            await ExecuteDynamicBatchAsync(dynamicTests, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    #if NET
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
+    #endif
+    private async Task ExecuteDynamicBatchAsync(List<AbstractExecutableTest> dynamicTests, CancellationToken cancellationToken)
+    {
+        // Route through the same phase pipeline as the main test set so dynamically-added
+        // tests with [NotInParallel(key)], [ParallelGroup(...)] etc. honour their constraints
+        // instead of being silently dropped.
+        var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTests.ToArray()).ConfigureAwait(false);
+        await ExecuteAllPhasesAsync(groupedDynamicTests, cancellationToken).ConfigureAwait(false);
     }
 
 #if NET
@@ -393,6 +390,10 @@ internal sealed class TestScheduler : ITestScheduler
     }
 #endif
 
+    // The cancellation token is forwarded only so WaitForTasksWithFailFastHandling can
+    // distinguish a fail-fast cancellation from a normal task fault when both phases run.
+    // Tasks `a` and `b` are already started and carry their own token internally, so the
+    // single-phase short-circuits do not need to inspect it.
     private Task RunPhasesConcurrentlyAsync(Task? a, Task? b, CancellationToken cancellationToken)
     {
         if (a is null) return b ?? Task.CompletedTask;

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -177,26 +177,23 @@ internal sealed class TestScheduler : ITestScheduler
         // which is observable as "Test1 never overlaps Test2" (discussion #5700). Run them
         // concurrently instead. ParallelGroups still serialize (cross-group exclusion) and
         // global NotInParallel still drains last (must run alone).
-        var concurrentPhases = new List<Task>(2);
-
+        Task? parallelPhase = null;
         if (groupedTests.Parallel.Length > 0)
         {
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
-            concurrentPhases.Add(ExecuteTestsAsync(groupedTests.Parallel, cancellationToken));
+            parallelPhase = ExecuteTestsAsync(groupedTests.Parallel, cancellationToken);
         }
 
+        Task? keyedPhase = null;
         if (groupedTests.KeyedNotInParallel.Length > 0)
         {
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
-            concurrentPhases.Add(_constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).AsTask());
+            keyedPhase = _constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).AsTask();
         }
 
-        if (concurrentPhases.Count > 0)
-        {
-            await WaitForTasksWithFailFastHandling(concurrentPhases, cancellationToken).ConfigureAwait(false);
-        }
+        await RunPhasesConcurrentlyAsync(parallelPhase, keyedPhase, cancellationToken).ConfigureAwait(false);
 
         foreach (var group in groupedTests.ParallelGroups)
         {
@@ -223,19 +220,13 @@ internal sealed class TestScheduler : ITestScheduler
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting constrained parallel group '{kvp.Key}' with {constrainedTests.UnconstrainedTests.Length} unconstrained and {constrainedTests.KeyedTests.Length} keyed tests").ConfigureAwait(false);
 
-            var tasks = new List<Task>();
-            if (constrainedTests.UnconstrainedTests.Length > 0)
-            {
-                tasks.Add(ExecuteTestsAsync(constrainedTests.UnconstrainedTests, cancellationToken));
-            }
-            if (constrainedTests.KeyedTests.Length > 0)
-            {
-                tasks.Add(_constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(constrainedTests.KeyedTests, cancellationToken).AsTask());
-            }
-            if (tasks.Count > 0)
-            {
-                await WaitForTasksWithFailFastHandling(tasks.ToArray(), cancellationToken).ConfigureAwait(false);
-            }
+            var unconstrainedPhase = constrainedTests.UnconstrainedTests.Length > 0
+                ? ExecuteTestsAsync(constrainedTests.UnconstrainedTests, cancellationToken)
+                : null;
+            var groupKeyedPhase = constrainedTests.KeyedTests.Length > 0
+                ? _constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(constrainedTests.KeyedTests, cancellationToken).AsTask()
+                : null;
+            await RunPhasesConcurrentlyAsync(unconstrainedPhase, groupKeyedPhase, cancellationToken).ConfigureAwait(false);
         }
 
         if (groupedTests.NotInParallel.Length > 0)
@@ -401,6 +392,13 @@ internal sealed class TestScheduler : ITestScheduler
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 #endif
+
+    private Task RunPhasesConcurrentlyAsync(Task? a, Task? b, CancellationToken cancellationToken)
+    {
+        if (a is null) return b ?? Task.CompletedTask;
+        if (b is null) return a;
+        return WaitForTasksWithFailFastHandling([a, b], cancellationToken);
+    }
 
     private async Task WaitForTasksWithFailFastHandling(IEnumerable<Task> tasks, CancellationToken cancellationToken)
     {

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -195,7 +195,7 @@ internal sealed class TestScheduler : ITestScheduler
 
         if (concurrentPhases.Count > 0)
         {
-            await WaitForTasksWithFailFastHandling(concurrentPhases.ToArray(), cancellationToken).ConfigureAwait(false);
+            await WaitForTasksWithFailFastHandling(concurrentPhases, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var group in groupedTests.ParallelGroups)

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -171,11 +171,31 @@ internal sealed class TestScheduler : ITestScheduler
         // Start dynamic test queue processing in background
         var dynamicTestProcessingTask = ProcessDynamicTestQueueAsync(cancellationToken);
 
+        // Unconstrained Parallel and KeyedNotInParallel buckets share no state — keyed tests
+        // only block other tests sharing a key (per docs/parallelism.md). Running them
+        // sequentially makes a `[Test] T1` always run before `[Test, NotInParallel("k")] T2`
+        // which is observable as "Test1 never overlaps Test2" (discussion #5700). Run them
+        // concurrently instead. ParallelGroups still serialize (cross-group exclusion) and
+        // global NotInParallel still drains last (must run alone).
+        var concurrentPhases = new List<Task>(2);
+
         if (groupedTests.Parallel.Length > 0)
         {
             if (_logger.IsTraceEnabled)
                 await _logger.LogTraceAsync($"Starting {groupedTests.Parallel.Length} parallel tests").ConfigureAwait(false);
-            await ExecuteTestsAsync(groupedTests.Parallel, cancellationToken).ConfigureAwait(false);
+            concurrentPhases.Add(ExecuteTestsAsync(groupedTests.Parallel, cancellationToken));
+        }
+
+        if (groupedTests.KeyedNotInParallel.Length > 0)
+        {
+            if (_logger.IsTraceEnabled)
+                await _logger.LogTraceAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
+            concurrentPhases.Add(_constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).AsTask());
+        }
+
+        if (concurrentPhases.Count > 0)
+        {
+            await WaitForTasksWithFailFastHandling(concurrentPhases.ToArray(), cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var group in groupedTests.ParallelGroups)
@@ -216,13 +236,6 @@ internal sealed class TestScheduler : ITestScheduler
             {
                 await WaitForTasksWithFailFastHandling(tasks.ToArray(), cancellationToken).ConfigureAwait(false);
             }
-        }
-
-        if (groupedTests.KeyedNotInParallel.Length > 0)
-        {
-            if (_logger.IsTraceEnabled)
-                await _logger.LogTraceAsync($"Starting {groupedTests.KeyedNotInParallel.Length} keyed NotInParallel tests").ConfigureAwait(false);
-            await _constraintKeyScheduler.ExecuteTestsWithConstraintsAsync(groupedTests.KeyedNotInParallel, cancellationToken).ConfigureAwait(false);
         }
 
         if (groupedTests.NotInParallel.Length > 0)

--- a/TUnit.TestProject/Bugs/5700/CrossKeyOverlap.cs
+++ b/TUnit.TestProject/Bugs/5700/CrossKeyOverlap.cs
@@ -1,0 +1,37 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5700;
+
+/// <summary>
+/// Companion to Repro5700. Verifies the symmetric scenario for #5700:
+/// two [NotInParallel] tests with different keys live in the same keyed
+/// bucket and must overlap each other (their keys do not intersect).
+/// Uses a TaskCompletionSource rendezvous so it does not depend on timing.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class CrossKeyOverlap5700
+{
+    private const string KeyA = "Tests.5700.A";
+    private const string KeyB = "Tests.5700.B";
+
+    private static readonly TaskCompletionSource KeyALive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static readonly TaskCompletionSource KeyBLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    [Test]
+    [NotInParallel(KeyA)]
+    public async Task KeyedA_RunsAlongsideKeyedB()
+    {
+        KeyALive.TrySetResult();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await KeyBLive.Task.WaitAsync(cts.Token);
+    }
+
+    [Test]
+    [NotInParallel(KeyB)]
+    public async Task KeyedB_RunsAlongsideKeyedA()
+    {
+        KeyBLive.TrySetResult();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await KeyALive.Task.WaitAsync(cts.Token);
+    }
+}

--- a/TUnit.TestProject/Bugs/5700/CrossKeyOverlap.cs
+++ b/TUnit.TestProject/Bugs/5700/CrossKeyOverlap.cs
@@ -17,12 +17,15 @@ public class CrossKeyOverlap5700
     private static readonly TaskCompletionSource KeyALive = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static readonly TaskCompletionSource KeyBLive = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    // See Repro5700 for why the rendezvous deadline is generous.
+    private static readonly TimeSpan RendezvousTimeout = TimeSpan.FromSeconds(60);
+
     [Test]
     [NotInParallel(KeyA)]
     public async Task KeyedA_RunsAlongsideKeyedB()
     {
         KeyALive.TrySetResult();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var cts = new CancellationTokenSource(RendezvousTimeout);
         await KeyBLive.Task.WaitAsync(cts.Token);
     }
 
@@ -31,7 +34,7 @@ public class CrossKeyOverlap5700
     public async Task KeyedB_RunsAlongsideKeyedA()
     {
         KeyBLive.TrySetResult();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var cts = new CancellationTokenSource(RendezvousTimeout);
         await KeyALive.Task.WaitAsync(cts.Token);
     }
 }

--- a/TUnit.TestProject/Bugs/5700/Repro.cs
+++ b/TUnit.TestProject/Bugs/5700/Repro.cs
@@ -28,15 +28,21 @@ public class Repro5700
     private static int _test2Active;
     private static int _test2ConcurrentViolations;
 
+    // Deadline is generous because the engine-test harness runs Repro5700 inside a
+    // subprocess populated with every `[EngineTest=Pass]` test in the project
+    // (hundreds). On a busy CI runner the parallel queue can be saturated by other
+    // unconstrained tests, so allow a full minute for either side to be dispatched.
+    // The bug being guarded — keyed tests deferred behind the entire parallel
+    // bucket — would manifest as Test1Live/Test2Live never being set at all, not as
+    // a 60-second scheduling delay.
+    private static readonly TimeSpan RendezvousTimeout = TimeSpan.FromSeconds(60);
+
     [Test]
     public async Task Test1_RunsAlongsideKeyedTest2()
     {
         Test1Live.TrySetResult();
 
-        // If keyed Test2 cannot run alongside Test1, this wait never completes.
-        // The 15s ceiling is enough headroom for any plausible scheduling delay
-        // while still failing fast on the bug.
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var cts = new CancellationTokenSource(RendezvousTimeout);
         await Test2Live.Task.WaitAsync(cts.Token);
     }
 
@@ -56,7 +62,7 @@ public class Repro5700
 
             Test2Live.TrySetResult();
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            using var cts = new CancellationTokenSource(RendezvousTimeout);
             await Test1Live.Task.WaitAsync(cts.Token);
 
             // Hold the key briefly so the second Test2 invocation queues behind

--- a/TUnit.TestProject/Bugs/5700/Repro.cs
+++ b/TUnit.TestProject/Bugs/5700/Repro.cs
@@ -11,33 +11,33 @@ namespace TUnit.TestProject.Bugs._5700;
 /// tests to completion before starting keyed-NotInParallel tests, so Test1
 /// never overlapped Test2.
 ///
-/// Assertions:
-/// - Test1 must observe Test2 running concurrently (proves cross-phase parallelism).
-/// - Test2 invocations must never run concurrently with each other (proves keyed
-///   serialization still works).
+/// The test uses a rendezvous (TaskCompletionSource) rather than wall-clock
+/// sampling so it stays deterministic on slow CI runners: Test1 waits for
+/// any Test2 invocation to start, and each Test2 invocation waits for Test1
+/// to be live. Either side timing out → fix is broken.
+///
+/// Test2 also asserts the keyed constraint still serializes its own invocations.
 /// </summary>
 [EngineTest(ExpectedResult.Pass)]
 public class Repro5700
 {
     private const string Test2Key = "Tests.Test2";
 
+    private static readonly TaskCompletionSource Test1Live = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static readonly TaskCompletionSource Test2Live = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static int _test2Active;
-    private static int _test1ObservedTest2;
     private static int _test2ConcurrentViolations;
 
     [Test]
     public async Task Test1_RunsAlongsideKeyedTest2()
     {
-        // Test1 = 3s sample window; Test2 cases serialize to ~2s, so Test1
-        // must overlap at least one Test2 invocation when the fix is in place.
-        for (var i = 0; i < 60; i++)
-        {
-            if (Volatile.Read(ref _test2Active) > 0)
-            {
-                Interlocked.Increment(ref _test1ObservedTest2);
-            }
-            await Task.Delay(50);
-        }
+        Test1Live.TrySetResult();
+
+        // If keyed Test2 cannot run alongside Test1, this wait never completes.
+        // The 15s ceiling is enough headroom for any plausible scheduling delay
+        // while still failing fast on the bug.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await Test2Live.Task.WaitAsync(cts.Token);
     }
 
     [Test]
@@ -53,7 +53,15 @@ public class Repro5700
             {
                 Interlocked.Increment(ref _test2ConcurrentViolations);
             }
-            await Task.Delay(1000);
+
+            Test2Live.TrySetResult();
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await Test1Live.Task.WaitAsync(cts.Token);
+
+            // Hold the key briefly so the second Test2 invocation queues behind
+            // us, exposing any concurrency-violation in keyed serialization.
+            await Task.Delay(200);
         }
         finally
         {
@@ -62,9 +70,8 @@ public class Repro5700
     }
 
     [After(Class)]
-    public static async Task AssertParallelismShape()
+    public static async Task AssertKeyedSerialization()
     {
         await Assert.That(_test2ConcurrentViolations).IsZero();
-        await Assert.That(_test1ObservedTest2).IsGreaterThan(0);
     }
 }

--- a/TUnit.TestProject/Bugs/5700/Repro.cs
+++ b/TUnit.TestProject/Bugs/5700/Repro.cs
@@ -5,7 +5,7 @@ namespace TUnit.TestProject.Bugs._5700;
 /// <summary>
 /// Regression test for https://github.com/thomhurst/TUnit/discussions/5700.
 ///
-/// Test1 has no parallel constraint. Test2 has [NotInParallel("Tests.Test2")] — a
+/// Test1 has no parallel constraint. Test2 has [NotInParallel(Test2Key)] — a
 /// keyed constraint that should only block other tests sharing the key (per
 /// docs/execution/parallelism.md). The buggy scheduler ran all unconstrained
 /// tests to completion before starting keyed-NotInParallel tests, so Test1
@@ -19,7 +19,8 @@ namespace TUnit.TestProject.Bugs._5700;
 [EngineTest(ExpectedResult.Pass)]
 public class Repro5700
 {
-    private static int _test1Active;
+    private const string Test2Key = "Tests.Test2";
+
     private static int _test2Active;
     private static int _test1ObservedTest2;
     private static int _test2ConcurrentViolations;
@@ -27,30 +28,22 @@ public class Repro5700
     [Test]
     public async Task Test1_RunsAlongsideKeyedTest2()
     {
-        Interlocked.Increment(ref _test1Active);
-        try
+        // Test1 = 3s sample window; Test2 cases serialize to ~2s, so Test1
+        // must overlap at least one Test2 invocation when the fix is in place.
+        for (var i = 0; i < 60; i++)
         {
-            // Sample for 3s; keyed Test2 cases serialize to ~2s so Test1 must
-            // overlap at least one Test2 invocation if cross-phase parallelism works.
-            for (var i = 0; i < 60; i++)
+            if (Volatile.Read(ref _test2Active) > 0)
             {
-                if (Volatile.Read(ref _test2Active) > 0)
-                {
-                    Interlocked.Increment(ref _test1ObservedTest2);
-                }
-                await Task.Delay(50);
+                Interlocked.Increment(ref _test1ObservedTest2);
             }
-        }
-        finally
-        {
-            Interlocked.Decrement(ref _test1Active);
+            await Task.Delay(50);
         }
     }
 
     [Test]
     [Arguments(1)]
     [Arguments(2)]
-    [NotInParallel("Tests.Test2")]
+    [NotInParallel(Test2Key)]
     public async Task Test2_KeyedSerializes(int param)
     {
         var concurrent = Interlocked.Increment(ref _test2Active);
@@ -61,7 +54,6 @@ public class Repro5700
                 Interlocked.Increment(ref _test2ConcurrentViolations);
             }
             await Task.Delay(1000);
-            _ = param;
         }
         finally
         {

--- a/TUnit.TestProject/Bugs/5700/Repro.cs
+++ b/TUnit.TestProject/Bugs/5700/Repro.cs
@@ -1,0 +1,78 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5700;
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/discussions/5700.
+///
+/// Test1 has no parallel constraint. Test2 has [NotInParallel("Tests.Test2")] — a
+/// keyed constraint that should only block other tests sharing the key (per
+/// docs/execution/parallelism.md). The buggy scheduler ran all unconstrained
+/// tests to completion before starting keyed-NotInParallel tests, so Test1
+/// never overlapped Test2.
+///
+/// Assertions:
+/// - Test1 must observe Test2 running concurrently (proves cross-phase parallelism).
+/// - Test2 invocations must never run concurrently with each other (proves keyed
+///   serialization still works).
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class Repro5700
+{
+    private static int _test1Active;
+    private static int _test2Active;
+    private static int _test1ObservedTest2;
+    private static int _test2ConcurrentViolations;
+
+    [Test]
+    public async Task Test1_RunsAlongsideKeyedTest2()
+    {
+        Interlocked.Increment(ref _test1Active);
+        try
+        {
+            // Sample for 3s; keyed Test2 cases serialize to ~2s so Test1 must
+            // overlap at least one Test2 invocation if cross-phase parallelism works.
+            for (var i = 0; i < 60; i++)
+            {
+                if (Volatile.Read(ref _test2Active) > 0)
+                {
+                    Interlocked.Increment(ref _test1ObservedTest2);
+                }
+                await Task.Delay(50);
+            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _test1Active);
+        }
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    [NotInParallel("Tests.Test2")]
+    public async Task Test2_KeyedSerializes(int param)
+    {
+        var concurrent = Interlocked.Increment(ref _test2Active);
+        try
+        {
+            if (concurrent > 1)
+            {
+                Interlocked.Increment(ref _test2ConcurrentViolations);
+            }
+            await Task.Delay(1000);
+            _ = param;
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _test2Active);
+        }
+    }
+
+    [After(Class)]
+    public static async Task AssertParallelismShape()
+    {
+        await Assert.That(_test2ConcurrentViolations).IsZero();
+        await Assert.That(_test1ObservedTest2).IsGreaterThan(0);
+    }
+}

--- a/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
+++ b/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
@@ -88,11 +88,13 @@ public class OrderWorkflowTests
         // The Worker service listens for PaymentProcessed events on RabbitMQ
         // and updates the order status to Fulfilled.
         // WaitsFor polls repeatedly until the assertion passes or the timeout expires.
+        // Generous timeout so the assertion doesn't trip on a busy CI runner where
+        // RabbitMQ delivery + Worker processing can lag behind under concurrent load.
         var order = await Assert.That(async () =>
                 await Customer.Client.GetFromJsonAsync<OrderResponse>($"/api/orders/{orderId}"))
             .WaitsFor(
                 assert => assert.Satisfies(o => o?.Status == OrderStatus.Fulfilled),
-                timeout: TimeSpan.FromSeconds(25),
+                timeout: TimeSpan.FromSeconds(60),
                 pollingInterval: TimeSpan.FromMilliseconds(500));
 
         await Assert.That(order).IsNotNull();

--- a/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
+++ b/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
@@ -94,7 +94,7 @@ public class OrderWorkflowTests
                 await Customer.Client.GetFromJsonAsync<OrderResponse>($"/api/orders/{orderId}"))
             .WaitsFor(
                 assert => assert.Satisfies(o => o?.Status == OrderStatus.Fulfilled),
-                timeout: TimeSpan.FromSeconds(60),
+                timeout: TimeSpan.FromSeconds(120),
                 pollingInterval: TimeSpan.FromMilliseconds(500));
 
         await Assert.That(order).IsNotNull();


### PR DESCRIPTION
## Summary

- Discussion [#5700](https://github.com/thomhurst/TUnit/discussions/5700): with `[Test] T1` and `[Test, NotInParallel("k")] T2`, T1 was expected to run alongside T2 (per docs: "Tests with no common key may still run concurrently"), but T1 always finished before T2 started.
- `TestScheduler.ExecuteGroupedTestsAsync` awaited each grouping bucket sequentially — the unconstrained `Parallel` bucket drained fully before the `KeyedNotInParallel` bucket began. Now those two buckets run concurrently. `ParallelGroups`/`ConstrainedParallelGroups` still serialize cross-group, and the global `NotInParallel` bucket still drains last (must run alone).
- Adds a `Bugs/5700` regression that asserts T1 observes T2 active during its execution, plus an engine-level wrapper test.

## Test plan
- [x] `Repro5700` passes with the fix; verified it fails without (assertion `_test1ObservedTest2 > 0` is 0 on `main`).
- [x] `KeyedNotInParallelTests` (12) still passes — keyed serialization untouched.
- [x] `ConstraintKeyStressTests` (30) still passes — no deadlock under high-contention keys.
- [x] `KeyedNotInParallelCrossPhaseTests` engine wrapper passes (Reflection mode locally; AOT runs in CI).
- [x] Wall-clock evidence: regression class drops 6.4s → 4.3s after fix (T1=3s overlapping T2 serial=2s).

Closes the discussion.