### PR TITLE
fix(templates): floating TUnit.Aspire version (#5708)

### DIFF
--- a/TUnit.Templates/content/TUnit.Aspire.Starter/ExampleNamespace.TestProject/ExampleNamespace.TestProject.csproj
+++ b/TUnit.Templates/content/TUnit.Aspire.Starter/ExampleNamespace.TestProject/ExampleNamespace.TestProject.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit.Aspire" Version="1.14.0" />
+    <PackageReference Include="TUnit.Aspire" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TUnit.Templates/content/TUnit.Aspire.Test/ExampleNamespace.csproj
+++ b/TUnit.Templates/content/TUnit.Aspire.Test/ExampleNamespace.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit.Aspire" Version="1.14.0" />
+    <PackageReference Include="TUnit.Aspire" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #5708

## Summary
- Aspire templates now use `1.*` for `TUnit.Aspire` (matched to basic TUnit template strategy)
- Directory.Build.props local-project swap still resolves correctly during in-repo builds
- End-user installs from NuGet templates now scaffold with current TUnit.Aspire instead of stale 1.14.0

## Test plan
- [x] Restore succeeds for affected csproj files
- [x] Local ProjectReference swap unaffected