### PR TITLE
chore(templates): unify TUnit version pinning to 1.* (#5709)

### DIFF
--- a/TUnit.Templates/content/Directory.Build.props
+++ b/TUnit.Templates/content/Directory.Build.props
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+    <!-- TUnit-family package version policy (see #5709):
+         All TUnit-owned packages referenced by templates (TUnit, TUnit.Aspire, TUnit.Playwright,
+         TUnit.Assertions.FSharp) MUST use Version="1.*" floating-range pinning in their template
+         .csproj/.fsproj/.vbproj files. This:
+           - eliminates Renovate maintenance PRs against template content, and
+           - ensures freshly-scaffolded projects always restore the latest published version.
+         Do NOT re-pin these packages to specific versions. Third-party packages should continue
+         to use exact versions as normal. -->
+
     <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.fsproj'">
         <!-- TUnit.Assertions.props auto-adds TUnit.Assertions.FSharp for F# projects;
              template fsproj files also include it explicitly with a pinned version -->

--- a/TUnit.Templates/content/TUnit.AspNet.FSharp/TestProject/TestProject.fsproj
+++ b/TUnit.Templates/content/TUnit.AspNet.FSharp/TestProject/TestProject.fsproj
@@ -10,8 +10,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-		<PackageReference Include="TUnit" Version="1.39.0" />
-		<PackageReference Include="TUnit.Assertions.FSharp" Version="1.39.0" />
+		<PackageReference Include="TUnit" Version="1.*" />
+		<PackageReference Include="TUnit.Assertions.FSharp" Version="1.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TUnit.Templates/content/TUnit.AspNet/TestProject/TestProject.csproj
+++ b/TUnit.Templates/content/TUnit.AspNet/TestProject/TestProject.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="TUnit" Version="1.39.0" />
+    <PackageReference Include="TUnit" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TUnit.Templates/content/TUnit.FSharp/TestProject.fsproj
+++ b/TUnit.Templates/content/TUnit.FSharp/TestProject.fsproj
@@ -10,8 +10,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-		<PackageReference Include="TUnit" Version="1.39.0" />
-		<PackageReference Include="TUnit.Assertions.FSharp" Version="1.39.0" />
+		<PackageReference Include="TUnit" Version="1.*" />
+		<PackageReference Include="TUnit.Assertions.FSharp" Version="1.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TUnit.Templates/content/TUnit.Playwright/TestProject.csproj
+++ b/TUnit.Templates/content/TUnit.Playwright/TestProject.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="TUnit.Playwright" Version="1.39.0" />
+        <PackageReference Include="TUnit.Playwright" Version="1.*" />
     </ItemGroup>
 
 </Project>

--- a/TUnit.Templates/content/TUnit.VB/TestProject.vbproj
+++ b/TUnit.Templates/content/TUnit.VB/TestProject.vbproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="TUnit" Version="1.39.0" />
+	  <PackageReference Include="TUnit" Version="1.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #5709

## Summary
- AspNet, FSharp, AspNet.FSharp, VB, Playwright templates now use `1.*` wildcard, matching the basic TUnit template
- Aspire templates intentionally untouched — addressed by sibling PR for #5708
- Eliminates Renovate maintenance PRs for these templates

## Test plan
- [x] All affected templates parse and resolve
- [x] No Directory.Build.props swap regression