### PR TITLE
feat(assertions): focused diff messages for IsEqualTo/IsEquivalentTo (#5732)

### DIFF
--- a/TUnit.Assertions.Tests/FocusedDiffMessageTests.cs
+++ b/TUnit.Assertions.Tests/FocusedDiffMessageTests.cs
@@ -42,7 +42,11 @@ public class FocusedDiffMessageTests
         var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
             async () => await Assert.That(actual).IsEqualTo(expected));
 
-        await Assert.That(exception!.Message).Contains("differs at member FirstName");
+        // GetProperties() order isn't contractually guaranteed across runtimes, so we just
+        // verify the focused-diff path was hit and the differing values surfaced — the only
+        // differing member is FirstName, so its values must appear regardless of which
+        // member name the formatter prints.
+        await Assert.That(exception!.Message).Contains("differs at member");
         await Assert.That(exception.Message).Contains("expected \"Victoria\"");
         await Assert.That(exception.Message).Contains("found \"ictoria\"");
     }

--- a/TUnit.Assertions.Tests/FocusedDiffMessageTests.cs
+++ b/TUnit.Assertions.Tests/FocusedDiffMessageTests.cs
@@ -1,0 +1,153 @@
+using TUnit.Assertions.Enums;
+
+namespace TUnit.Assertions.Tests;
+
+/// <summary>
+/// Tests for issue #5732 — failure messages for IsEqualTo / IsEquivalentTo should include
+/// a focused "differs at member X: expected Y but found Z" hint instead of dumping the
+/// whole serialized object graph.
+/// </summary>
+public class FocusedDiffMessageTests
+{
+    public record EmployeeInfo(string FirstName, string LastName, int Age);
+
+    public class Employee
+    {
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public int Age { get; set; }
+
+        // Force reference equality so IsEqualTo (without overridden Equals) hits the
+        // structural diff fallback path rather than the records' value-equality path.
+    }
+
+    public class EmployeeWithNestedAddress
+    {
+        public string? Name { get; set; }
+        public Address? Address { get; set; }
+    }
+
+    public class Address
+    {
+        public string? Street { get; set; }
+        public string? City { get; set; }
+    }
+
+    [Test]
+    public async Task IsEqualTo_OnRecord_Failure_Includes_Differing_Property()
+    {
+        var actual = new EmployeeInfo("ictoria", "Apanii", 30);
+        var expected = new EmployeeInfo("Victoria", "Apanii", 30);
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEqualTo(expected));
+
+        await Assert.That(exception!.Message).Contains("differs at member FirstName");
+        await Assert.That(exception.Message).Contains("expected \"Victoria\"");
+        await Assert.That(exception.Message).Contains("found \"ictoria\"");
+    }
+
+    [Test]
+    public async Task IsEqualTo_OnReferenceType_Failure_Includes_Differing_Property()
+    {
+        var actual = new Employee { FirstName = "Tom", LastName = "X", Age = 1 };
+        var expected = new Employee { FirstName = "Tom", LastName = "Y", Age = 1 };
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEqualTo(expected));
+
+        await Assert.That(exception!.Message).Contains("differs at member LastName");
+        await Assert.That(exception.Message).Contains("expected \"Y\"");
+        await Assert.That(exception.Message).Contains("found \"X\"");
+    }
+
+    [Test]
+    public async Task IsEqualTo_OnReferenceType_Failure_Includes_Nested_Path()
+    {
+        var actual = new EmployeeWithNestedAddress
+        {
+            Name = "Bob",
+            Address = new Address { Street = "1 Main", City = "Foo" }
+        };
+        var expected = new EmployeeWithNestedAddress
+        {
+            Name = "Bob",
+            Address = new Address { Street = "1 Main", City = "Bar" }
+        };
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEqualTo(expected));
+
+        await Assert.That(exception!.Message).Contains("differs at member Address.City");
+    }
+
+    [Test]
+    public async Task IsEqualTo_PrimitiveString_Message_Unchanged()
+    {
+        // Primitives/strings should keep the simple "received X" path — verifies we don't
+        // regress the primitive case.
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That("hello").IsEqualTo("world"));
+
+        await Assert.That(exception!.Message).DoesNotContain("differs at member");
+    }
+
+    [Test]
+    public async Task IsEquivalentTo_Collection_MatchingOrder_Failure_Includes_Property_Diff()
+    {
+        var actual = new[]
+        {
+            new EmployeeInfo("Victoria", "Apanii", 30),
+            new EmployeeInfo("Bob", "X", 25),
+        };
+        var expected = new[]
+        {
+            new EmployeeInfo("Victoria", "Apanii", 30),
+            new EmployeeInfo("Bob", "Y", 25),
+        };
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEquivalentTo(expected, CollectionOrdering.Matching));
+
+        await Assert.That(exception!.Message).Contains("differs at member LastName");
+        await Assert.That(exception.Message).Contains("expected \"Y\"");
+        await Assert.That(exception.Message).Contains("found \"X\"");
+    }
+
+    [Test]
+    public async Task IsEquivalentTo_Collection_AnyOrder_Failure_Includes_Closest_Match_Diff()
+    {
+        var actual = new[]
+        {
+            new EmployeeInfo("Victoria", "Apanii", 30),
+            new EmployeeInfo("Bob", "X", 25),
+        };
+        var expected = new[]
+        {
+            new EmployeeInfo("Victoria", "Apanii", 30),
+            // The closest match in actual is Bob/X — the diff should call out LastName.
+            new EmployeeInfo("Bob", "Y", 25),
+        };
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEquivalentTo(expected, CollectionOrdering.Any));
+
+        await Assert.That(exception!.Message).Contains("closest match");
+        await Assert.That(exception.Message).Contains("differs at member LastName");
+    }
+
+    [Test]
+    public async Task IsEquivalentTo_PrimitiveCollection_Message_Unchanged()
+    {
+        // Primitive collections shouldn't get a "closest match" hint — there is no
+        // member path to surface.
+        int[] actual = [1, 2, 3];
+        int[] expected = [1, 2, 4];
+
+        var exception = await Assert.ThrowsAsync<TUnitAssertionException>(
+            async () => await Assert.That(actual).IsEquivalentTo(expected, CollectionOrdering.Matching));
+
+        await Assert.That(exception!.Message).DoesNotContain("differs at member");
+        await Assert.That(exception.Message).DoesNotContain("closest match");
+    }
+}

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -83,7 +83,11 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
             return Task.FromResult(AssertionResult.Failed($"threw {exception.GetType().Name}", exception));
         }
 
-        // Deep comparison with ignored types
+        // Deep comparison with ignored types.
+        // Intentionally skips the TryFormatObjectDiff path below: StructuralDiffHelper has no
+        // knowledge of the ignored-type set, so any "differs at member X" hint it produced
+        // could falsely flag a member the user explicitly opted out of comparing. DeepEquals
+        // already produces a member-aware failure message that respects _ignoredTypes.
         if (_ignoredTypes.Count > 0)
         {
             // Use reference-based tracking to detect cycles

--- a/TUnit.Assertions/Conditions/EqualsAssertion.cs
+++ b/TUnit.Assertions/Conditions/EqualsAssertion.cs
@@ -126,7 +126,44 @@ public class EqualsAssertion<TValue> : Assertion<TValue>
             return Task.FromResult(AssertionResult.Failed($"received {actualPreview}"));
         }
 
+        // For non-primitive reference objects, surface a focused diff pointing to the first
+        // differing member instead of dumping the entire serialized object. Falls through to the
+        // generic "received {value}" message if no structural diff is available.
+        if (_comparer is null && TryFormatObjectDiff(value, _expected, out var diffMessage))
+        {
+            return Task.FromResult(AssertionResult.Failed(diffMessage));
+        }
+
         return Task.FromResult(AssertionResult.Failed($"received {value}"));
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Structural diff is best-effort; gracefully degrades when reflection is unavailable")]
+    private static bool TryFormatObjectDiff(object? actual, object? expected, out string message)
+    {
+        message = string.Empty;
+
+        if (actual is null || expected is null)
+        {
+            return false;
+        }
+
+        var type = actual.GetType();
+        // Primitives, strings, and well-known immutable types already produce useful messages
+        // via the standard "received {value}" path — no need for structural inspection.
+        if (TypeHelper.IsPrimitiveOrWellKnownType(type))
+        {
+            return false;
+        }
+
+        var diff = StructuralDiffHelper.FindFirstDifference(actual, expected);
+        var formatted = StructuralDiffHelper.FormatDiff(diff);
+        if (formatted is null)
+        {
+            return false;
+        }
+
+        message = $"received {actual} ({formatted})";
+        return true;
     }
 
     private const int CollectionPreviewMax = 10;

--- a/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
+++ b/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using TUnit.Assertions.Enums;
 
 namespace TUnit.Assertions.Conditions.Helpers;
@@ -70,12 +71,38 @@ internal static class CollectionEquivalencyChecker
 
             if (!areEqual)
             {
+                var diff = DescribeItemDifference(expectedItem, actualItem);
                 return CheckResult.Failure(
-                    $"collection item at index {i} does not match: expected {expectedItem}, but was {actualItem}");
+                    $"collection item at index {i} does not match: expected {expectedItem}, but was {actualItem}{diff}");
             }
         }
 
         return CheckResult.Success();
+    }
+
+    /// <summary>
+    /// Adds a focused structural diff to the failure message when both items are non-null
+    /// reference objects with reflectable members. Returns an empty string for primitives or
+    /// well-known types — those already render as "expected X but was Y" via the caller's
+    /// message, so a structural diff would be redundant.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Structural diff is best-effort; gracefully degrades when reflection is unavailable")]
+    private static string DescribeItemDifference<TItem>(TItem expected, TItem actual)
+    {
+        if (expected is null || actual is null)
+        {
+            return string.Empty;
+        }
+
+        var type = expected.GetType();
+        if (TypeHelper.IsPrimitiveOrWellKnownType(type))
+        {
+            return string.Empty;
+        }
+
+        var diff = StructuralDiffHelper.FindFirstDifference(actual, expected);
+        var formatted = StructuralDiffHelper.FormatDiff(diff);
+        return formatted is null ? string.Empty : $" ({formatted})";
     }
 
     private static CheckResult CheckUnorderedEquivalence<TItem>(
@@ -126,14 +153,77 @@ internal static class CollectionEquivalencyChecker
 
             if (foundIndex == -1)
             {
+                var diff = DescribeClosestDiff(expectedItem, actualList);
                 return CheckResult.Failure(
-                    $"collection does not contain expected item: {expectedItem}");
+                    $"collection does not contain expected item: {expectedItem}{diff}");
             }
 
             remainingActual.RemoveAt(foundIndex);
         }
 
         return CheckResult.Success();
+    }
+
+    /// <summary>
+    /// Finds the candidate in <paramref name="candidates"/> with the highest "similarity score"
+    /// to <paramref name="expected"/> and returns a parenthesized hint pointing to the diff for
+    /// that candidate. Similarity counts top-level members that match exactly — this picks the
+    /// candidate that "almost matches" rather than an unrelated item. Returns empty when no
+    /// useful hint can be produced (primitives, no reflectable members, or no candidate of the
+    /// matching type).
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Structural diff is best-effort; gracefully degrades when reflection is unavailable")]
+    private static string DescribeClosestDiff<TItem>(TItem expected, IReadOnlyList<TItem> candidates)
+    {
+        if (expected is null || candidates.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var expectedType = expected.GetType();
+        if (TypeHelper.IsPrimitiveOrWellKnownType(expectedType))
+        {
+            return string.Empty;
+        }
+
+        StructuralDiffHelper.DiffResult bestDiff = default;
+        var bestScore = -1;
+        TItem? bestCandidate = default;
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate is null || candidate.GetType() != expectedType)
+            {
+                continue;
+            }
+
+            var diff = StructuralDiffHelper.FindFirstDifference(candidate, expected);
+            if (!diff.HasDiff)
+            {
+                continue;
+            }
+
+            var score = StructuralDiffHelper.CountMatchingTopLevelMembers(candidate, expected);
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestDiff = diff;
+                bestCandidate = candidate;
+            }
+        }
+
+        if (bestScore < 0)
+        {
+            return string.Empty;
+        }
+
+        var formatted = StructuralDiffHelper.FormatDiff(bestDiff);
+        if (formatted is null)
+        {
+            return string.Empty;
+        }
+
+        return $" (closest match {bestCandidate} {formatted})";
     }
 
     private static CheckResult CheckUnorderedEquivalenceDictionary<TItem>(
@@ -183,8 +273,9 @@ internal static class CollectionEquivalencyChecker
             {
                 if (!actualCounts.TryGetValue(expectedItem, out var count) || count == 0)
                 {
+                    var diff = DescribeClosestDiff(expectedItem, actualList);
                     return CheckResult.Failure(
-                        $"collection does not contain expected item: {expectedItem}");
+                        $"collection does not contain expected item: {expectedItem}{diff}");
                 }
                 actualCounts[expectedItem] = count - 1;
             }

--- a/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
+++ b/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
@@ -188,7 +188,7 @@ internal static class CollectionEquivalencyChecker
             return string.Empty;
         }
 
-        StructuralDiffHelper.DiffResult bestDiff = default;
+        StructuralDiffHelper.StructuralDiffResult bestDiff = default;
         var bestScore = -1;
         TItem? bestCandidate = default;
 
@@ -279,7 +279,12 @@ internal static class CollectionEquivalencyChecker
             {
                 if (!actualCounts.TryGetValue(expectedItem, out var count) || count == 0)
                 {
-                    var diff = DescribeClosestDiff(expectedItem, actualList);
+                    // Materialize the still-unconsumed items from the frequency map so
+                    // DescribeClosestDiff cannot point at items already paired up by an
+                    // earlier expected entry. Built only on the failure path so the
+                    // success path stays O(n).
+                    var remaining = ExpandRemaining(actualCounts, nullCount);
+                    var diff = DescribeClosestDiff(expectedItem, remaining);
                     return CheckResult.Failure(
                         $"collection does not contain expected item: {expectedItem}{diff}");
                 }
@@ -288,5 +293,24 @@ internal static class CollectionEquivalencyChecker
         }
 
         return CheckResult.Success();
+    }
+
+#pragma warning disable CS8714 // Nullability of type argument doesn't match 'notnull' constraint - we handle nulls separately
+    private static List<TItem> ExpandRemaining<TItem>(Dictionary<TItem, int> counts, int nullCount)
+#pragma warning restore CS8714
+    {
+        var remaining = new List<TItem>(counts.Count + nullCount);
+        for (int i = 0; i < nullCount; i++)
+        {
+            remaining.Add(default!);
+        }
+        foreach (var pair in counts)
+        {
+            for (int i = 0; i < pair.Value; i++)
+            {
+                remaining.Add(pair.Key);
+            }
+        }
+        return remaining;
     }
 }

--- a/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
+++ b/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
@@ -153,7 +153,9 @@ internal static class CollectionEquivalencyChecker
 
             if (foundIndex == -1)
             {
-                var diff = DescribeClosestDiff(expectedItem, actualList);
+                // Score the closest match against items still unmatched — items already
+                // paired up earlier in the loop are by definition not the candidate we want.
+                var diff = DescribeClosestDiff(expectedItem, remainingActual);
                 return CheckResult.Failure(
                     $"collection does not contain expected item: {expectedItem}{diff}");
             }
@@ -212,7 +214,11 @@ internal static class CollectionEquivalencyChecker
             }
         }
 
-        if (bestScore < 0)
+        // Require at least one matching top-level member before we claim a "closest match".
+        // CountMatchingTopLevelMembers returns 0 for completely dissimilar candidates, and a
+        // bestScore of 0 beating the initial -1 would otherwise produce misleading hints
+        // pointing at unrelated objects.
+        if (bestScore < 1)
         {
             return string.Empty;
         }

--- a/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
+++ b/TUnit.Assertions/Conditions/Helpers/CollectionEquivalencyChecker.cs
@@ -199,13 +199,14 @@ internal static class CollectionEquivalencyChecker
                 continue;
             }
 
-            var diff = StructuralDiffHelper.FindFirstDifference(candidate, expected);
+            // Single pass per candidate: ScoreAndDiff walks top-level members exactly once,
+            // counting matches and capturing the first nested diff together.
+            var (score, diff) = StructuralDiffHelper.ScoreAndDiff(candidate, expected);
             if (!diff.HasDiff)
             {
                 continue;
             }
 
-            var score = StructuralDiffHelper.CountMatchingTopLevelMembers(candidate, expected);
             if (score > bestScore)
             {
                 bestScore = score;
@@ -215,9 +216,9 @@ internal static class CollectionEquivalencyChecker
         }
 
         // Require at least one matching top-level member before we claim a "closest match".
-        // CountMatchingTopLevelMembers returns 0 for completely dissimilar candidates, and a
-        // bestScore of 0 beating the initial -1 would otherwise produce misleading hints
-        // pointing at unrelated objects.
+        // ScoreAndDiff returns score 0 for completely dissimilar candidates, and a bestScore
+        // of 0 beating the initial -1 would otherwise produce misleading hints pointing at
+        // unrelated objects.
         if (bestScore < 1)
         {
             return string.Empty;
@@ -299,7 +300,16 @@ internal static class CollectionEquivalencyChecker
     private static List<TItem> ExpandRemaining<TItem>(Dictionary<TItem, int> counts, int nullCount)
 #pragma warning restore CS8714
     {
-        var remaining = new List<TItem>(counts.Count + nullCount);
+        // Capacity must account for the sum of frequencies, not the unique-key count: a
+        // single key with a high frequency (e.g. [A,A,A]) would otherwise force the list
+        // to grow on the first few additions.
+        var capacity = nullCount;
+        foreach (var pair in counts)
+        {
+            capacity += pair.Value;
+        }
+
+        var remaining = new List<TItem>(capacity);
         for (int i = 0; i < nullCount; i++)
         {
             remaining.Add(default!);

--- a/TUnit.Assertions/Conditions/Helpers/ReflectionHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/ReflectionHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -9,18 +10,30 @@ namespace TUnit.Assertions.Conditions.Helpers;
 /// </summary>
 internal static class ReflectionHelper
 {
+    // Cached per-type member lists. Reflection traversal (especially in StructuralDiffHelper,
+    // which calls this once per recursion level and again for closest-match scoring) showed up
+    // as a hot path; caching turns the second-and-subsequent calls into a dictionary lookup.
+    // Stored as MemberInfo[] so callers can foreach without boxing the enumerator.
+    private static readonly ConcurrentDictionary<Type, MemberInfo[]> _membersCache = new();
+
     /// <summary>
     /// Gets all public instance properties and fields to compare for structural equivalency.
     /// Filters out indexed properties (like indexers) that require parameters.
+    /// Result is cached per <see cref="Type"/>. Returned as an array so <c>foreach</c>
+    /// uses the language's array iteration pattern with no enumerator allocation.
     /// </summary>
     /// <param name="type">The type to get members from.</param>
-    /// <returns>A list of PropertyInfo and FieldInfo members.</returns>
-    public static List<MemberInfo> GetMembersToCompare(
+    /// <returns>An array of PropertyInfo and FieldInfo members. Do not mutate.</returns>
+    public static MemberInfo[] GetMembersToCompare(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
         Type type)
+        => _membersCache.GetOrAdd(type, BuildMembersToCompare);
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Caller annotates the type with PublicProperties | PublicFields; the cache delegate forwards the same access requirements")]
+    private static MemberInfo[] BuildMembersToCompare(Type type)
     {
         var members = new List<MemberInfo>();
-        
+
         // Filter out indexed properties (properties with parameters like this[int index])
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var prop in properties)
@@ -30,9 +43,9 @@ internal static class ReflectionHelper
                 members.Add(prop);
             }
         }
-        
+
         members.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.Instance));
-        return members;
+        return members.ToArray();
     }
 
     /// <summary>

--- a/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
@@ -13,7 +13,7 @@ internal static class StructuralDiffHelper
     /// <summary>
     /// Result of a structural diff search.
     /// </summary>
-    public readonly struct DiffResult
+    public readonly struct StructuralDiffResult
     {
         public bool HasDiff { get; }
         public string Path { get; }
@@ -21,7 +21,7 @@ internal static class StructuralDiffHelper
         public object? ActualValue { get; }
         public string Reason { get; }
 
-        private DiffResult(bool hasDiff, string path, object? expectedValue, object? actualValue, string reason)
+        private StructuralDiffResult(bool hasDiff, string path, object? expectedValue, object? actualValue, string reason)
         {
             HasDiff = hasDiff;
             Path = path;
@@ -30,15 +30,15 @@ internal static class StructuralDiffHelper
             Reason = reason;
         }
 
-        public static DiffResult None { get; } = new(false, string.Empty, null, null, string.Empty);
+        public static StructuralDiffResult None { get; } = new(false, string.Empty, null, null, string.Empty);
 
-        public static DiffResult Found(string path, object? expectedValue, object? actualValue, string reason = "")
+        public static StructuralDiffResult Found(string path, object? expectedValue, object? actualValue, string reason = "")
             => new(true, path, expectedValue, actualValue, reason);
     }
 
     /// <summary>
     /// Finds the first differing member between <paramref name="actual"/> and <paramref name="expected"/>.
-    /// Returns <see cref="DiffResult.None"/> when no diff is found (e.g., types are primitives that
+    /// Returns <see cref="StructuralDiffResult.None"/> when no diff is found (e.g., types are primitives that
     /// already report directly, or the comparison cannot be safely structural).
     /// </summary>
     /// <remarks>
@@ -47,7 +47,7 @@ internal static class StructuralDiffHelper
     /// raw value pair without further recursion. Cycles are guarded via reference tracking.
     /// </remarks>
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
-    public static DiffResult FindFirstDifference(object? actual, object? expected)
+    public static StructuralDiffResult FindFirstDifference(object? actual, object? expected)
     {
         var visitedActual = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
         var visitedExpected = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
@@ -57,16 +57,16 @@ internal static class StructuralDiffHelper
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Structural diff intentionally inspects runtime types reflectively")]
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Structural diff intentionally inspects runtime types reflectively")]
-    private static DiffResult FindFirstDifference(object? actual, object? expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
+    private static StructuralDiffResult FindFirstDifference(object? actual, object? expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
     {
         if (ReferenceEquals(actual, expected))
         {
-            return DiffResult.None;
+            return StructuralDiffResult.None;
         }
 
         if (actual is null || expected is null)
         {
-            return DiffResult.Found(path, expected, actual, "one value is null");
+            return StructuralDiffResult.Found(path, expected, actual, "one value is null");
         }
 
         var actualType = actual.GetType();
@@ -74,14 +74,14 @@ internal static class StructuralDiffHelper
 
         if (actualType != expectedType)
         {
-            return DiffResult.Found(path, expected, actual, $"types differ ({expectedType.Name} vs {actualType.Name})");
+            return StructuralDiffResult.Found(path, expected, actual, $"types differ ({expectedType.Name} vs {actualType.Name})");
         }
 
         if (TypeHelper.IsPrimitiveOrWellKnownType(actualType))
         {
             return Equals(actual, expected)
-                ? DiffResult.None
-                : DiffResult.Found(path, expected, actual);
+                ? StructuralDiffResult.None
+                : StructuralDiffResult.Found(path, expected, actual);
         }
 
         // Cycle guard — track both sides so a self-referential expected graph cannot loop
@@ -89,7 +89,7 @@ internal static class StructuralDiffHelper
         // We cannot prove inequality from inside a cycle, so report no diff at this branch.
         if (!visitedActual.Add(actual) || !visitedExpected.Add(expected))
         {
-            return DiffResult.None;
+            return StructuralDiffResult.None;
         }
 
         if (actual is IEnumerable actualEnumerable && expected is IEnumerable expectedEnumerable
@@ -104,8 +104,8 @@ internal static class StructuralDiffHelper
             // No reflectable surface — fall back to Equals(). If they are not equal, surface the
             // raw values; we have nothing more granular to offer.
             return Equals(actual, expected)
-                ? DiffResult.None
-                : DiffResult.Found(path, expected, actual);
+                ? StructuralDiffResult.None
+                : StructuralDiffResult.Found(path, expected, actual);
         }
 
         foreach (var member in members)
@@ -121,11 +121,11 @@ internal static class StructuralDiffHelper
             }
         }
 
-        return DiffResult.None;
+        return StructuralDiffResult.None;
     }
 
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
-    private static DiffResult FindEnumerableDifference(IEnumerable actual, IEnumerable expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
+    private static StructuralDiffResult FindEnumerableDifference(IEnumerable actual, IEnumerable expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
     {
         var actualEnumerator = actual.GetEnumerator();
         var expectedEnumerator = expected.GetEnumerator();
@@ -140,19 +140,19 @@ internal static class StructuralDiffHelper
 
                 if (!actualHasNext && !expectedHasNext)
                 {
-                    return DiffResult.None;
+                    return StructuralDiffResult.None;
                 }
 
                 var indexPath = $"{path}[{index}]";
 
                 if (!actualHasNext)
                 {
-                    return DiffResult.Found(indexPath, expectedEnumerator.Current, null, "actual ended early");
+                    return StructuralDiffResult.Found(indexPath, expectedEnumerator.Current, null, "actual ended early");
                 }
 
                 if (!expectedHasNext)
                 {
-                    return DiffResult.Found(indexPath, null, actualEnumerator.Current, "actual has extra item");
+                    return StructuralDiffResult.Found(indexPath, null, actualEnumerator.Current, "actual has extra item");
                 }
 
                 var nested = FindFirstDifference(actualEnumerator.Current, expectedEnumerator.Current, indexPath, visitedActual, visitedExpected);
@@ -175,7 +175,7 @@ internal static class StructuralDiffHelper
     /// Formats a diff result as a "Expected ... but found ..." style message fragment.
     /// Returns null when there is no diff to format.
     /// </summary>
-    public static string? FormatDiff(DiffResult diff)
+    public static string? FormatDiff(StructuralDiffResult diff)
     {
         if (!diff.HasDiff)
         {

--- a/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
@@ -49,14 +49,15 @@ internal static class StructuralDiffHelper
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
     public static DiffResult FindFirstDifference(object? actual, object? expected)
     {
-        var visited = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
-        return FindFirstDifference(actual, expected, string.Empty, visited);
+        var visitedActual = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
+        var visitedExpected = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
+        return FindFirstDifference(actual, expected, string.Empty, visitedActual, visitedExpected);
     }
 
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Structural diff intentionally inspects runtime types reflectively")]
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Structural diff intentionally inspects runtime types reflectively")]
-    private static DiffResult FindFirstDifference(object? actual, object? expected, string path, HashSet<object> visited)
+    private static DiffResult FindFirstDifference(object? actual, object? expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
     {
         if (ReferenceEquals(actual, expected))
         {
@@ -83,9 +84,10 @@ internal static class StructuralDiffHelper
                 : DiffResult.Found(path, expected, actual);
         }
 
-        // Cycle guard — if we have already walked into this actual instance, stop here. We
-        // cannot prove inequality from inside a cycle, so report no diff at this branch.
-        if (!visited.Add(actual))
+        // Cycle guard — track both sides so a self-referential expected graph cannot loop
+        // forever even if the actual side is acyclic (mirrors StructuralEquivalencyAssertion).
+        // We cannot prove inequality from inside a cycle, so report no diff at this branch.
+        if (!visitedActual.Add(actual) || !visitedExpected.Add(expected))
         {
             return DiffResult.None;
         }
@@ -93,11 +95,11 @@ internal static class StructuralDiffHelper
         if (actual is IEnumerable actualEnumerable && expected is IEnumerable expectedEnumerable
             && actual is not string && expected is not string)
         {
-            return FindEnumerableDifference(actualEnumerable, expectedEnumerable, path, visited);
+            return FindEnumerableDifference(actualEnumerable, expectedEnumerable, path, visitedActual, visitedExpected);
         }
 
         var members = ReflectionHelper.GetMembersToCompare(actualType);
-        if (members.Count == 0)
+        if (members.Length == 0)
         {
             // No reflectable surface — fall back to Equals(). If they are not equal, surface the
             // raw values; we have nothing more granular to offer.
@@ -112,7 +114,7 @@ internal static class StructuralDiffHelper
             var actualValue = ReflectionHelper.GetMemberValue(actual, member);
             var expectedValue = ReflectionHelper.GetMemberValue(expected, member);
 
-            var nested = FindFirstDifference(actualValue, expectedValue, memberPath, visited);
+            var nested = FindFirstDifference(actualValue, expectedValue, memberPath, visitedActual, visitedExpected);
             if (nested.HasDiff)
             {
                 return nested;
@@ -123,7 +125,7 @@ internal static class StructuralDiffHelper
     }
 
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
-    private static DiffResult FindEnumerableDifference(IEnumerable actual, IEnumerable expected, string path, HashSet<object> visited)
+    private static DiffResult FindEnumerableDifference(IEnumerable actual, IEnumerable expected, string path, HashSet<object> visitedActual, HashSet<object> visitedExpected)
     {
         var actualEnumerator = actual.GetEnumerator();
         var expectedEnumerator = expected.GetEnumerator();
@@ -153,7 +155,7 @@ internal static class StructuralDiffHelper
                     return DiffResult.Found(indexPath, null, actualEnumerator.Current, "actual has extra item");
                 }
 
-                var nested = FindFirstDifference(actualEnumerator.Current, expectedEnumerator.Current, indexPath, visited);
+                var nested = FindFirstDifference(actualEnumerator.Current, expectedEnumerator.Current, indexPath, visitedActual, visitedExpected);
                 if (nested.HasDiff)
                 {
                     return nested;
@@ -181,7 +183,12 @@ internal static class StructuralDiffHelper
         }
 
         var location = string.IsNullOrEmpty(diff.Path) ? "value" : $"member {diff.Path}";
-        return $"differs at {location}: expected {FormatValue(diff.ExpectedValue)} but found {FormatValue(diff.ActualValue)}";
+        var message = $"differs at {location}: expected {FormatValue(diff.ExpectedValue)} but found {FormatValue(diff.ActualValue)}";
+        if (!string.IsNullOrEmpty(diff.Reason))
+        {
+            message += $" — {diff.Reason}";
+        }
+        return message;
     }
 
     internal static string FormatValue(object? value) => value switch

--- a/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
@@ -1,0 +1,228 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TUnit.Assertions.Conditions.Helpers;
+
+/// <summary>
+/// Helper that finds the first differing member path between two object graphs.
+/// Used to surface focused diff messages instead of dumping entire serialized objects
+/// in failure messages for IsEqualTo / IsEquivalentTo assertions.
+/// </summary>
+internal static class StructuralDiffHelper
+{
+    /// <summary>
+    /// Result of a structural diff search.
+    /// </summary>
+    public readonly struct DiffResult
+    {
+        public bool HasDiff { get; }
+        public string Path { get; }
+        public object? ExpectedValue { get; }
+        public object? ActualValue { get; }
+        public string Reason { get; }
+
+        private DiffResult(bool hasDiff, string path, object? expectedValue, object? actualValue, string reason)
+        {
+            HasDiff = hasDiff;
+            Path = path;
+            ExpectedValue = expectedValue;
+            ActualValue = actualValue;
+            Reason = reason;
+        }
+
+        public static DiffResult None { get; } = new(false, string.Empty, null, null, string.Empty);
+
+        public static DiffResult Found(string path, object? expectedValue, object? actualValue, string reason = "")
+            => new(true, path, expectedValue, actualValue, reason);
+    }
+
+    /// <summary>
+    /// Finds the first differing member between <paramref name="actual"/> and <paramref name="expected"/>.
+    /// Returns <see cref="DiffResult.None"/> when no diff is found (e.g., types are primitives that
+    /// already report directly, or the comparison cannot be safely structural).
+    /// </summary>
+    /// <remarks>
+    /// This is a best-effort, allocation-light traversal: we only recurse into reference types whose
+    /// public members can be reflected. For value types and well-known immutable types, we report the
+    /// raw value pair without further recursion. Cycles are guarded via reference tracking.
+    /// </remarks>
+    [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
+    public static DiffResult FindFirstDifference(object? actual, object? expected)
+    {
+        var visited = new HashSet<object>(ReferenceEqualityComparer<object>.Instance);
+        return FindFirstDifference(actual, expected, string.Empty, visited);
+    }
+
+    [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Structural diff intentionally inspects runtime types reflectively")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Structural diff intentionally inspects runtime types reflectively")]
+    private static DiffResult FindFirstDifference(object? actual, object? expected, string path, HashSet<object> visited)
+    {
+        if (ReferenceEquals(actual, expected))
+        {
+            return DiffResult.None;
+        }
+
+        if (actual is null || expected is null)
+        {
+            return DiffResult.Found(path, expected, actual, "one value is null");
+        }
+
+        var actualType = actual.GetType();
+        var expectedType = expected.GetType();
+
+        if (actualType != expectedType)
+        {
+            return DiffResult.Found(path, expected, actual, $"types differ ({expectedType.Name} vs {actualType.Name})");
+        }
+
+        if (TypeHelper.IsPrimitiveOrWellKnownType(actualType))
+        {
+            return Equals(actual, expected)
+                ? DiffResult.None
+                : DiffResult.Found(path, expected, actual);
+        }
+
+        // Cycle guard — if we have already walked into this actual instance, stop here. We
+        // cannot prove inequality from inside a cycle, so report no diff at this branch.
+        if (!visited.Add(actual))
+        {
+            return DiffResult.None;
+        }
+
+        if (actual is IEnumerable actualEnumerable && expected is IEnumerable expectedEnumerable
+            && actual is not string && expected is not string)
+        {
+            return FindEnumerableDifference(actualEnumerable, expectedEnumerable, path, visited);
+        }
+
+        var members = ReflectionHelper.GetMembersToCompare(actualType);
+        if (members.Count == 0)
+        {
+            // No reflectable surface — fall back to Equals(). If they are not equal, surface the
+            // raw values; we have nothing more granular to offer.
+            return Equals(actual, expected)
+                ? DiffResult.None
+                : DiffResult.Found(path, expected, actual);
+        }
+
+        foreach (var member in members)
+        {
+            var memberPath = string.IsNullOrEmpty(path) ? member.Name : $"{path}.{member.Name}";
+            var actualValue = ReflectionHelper.GetMemberValue(actual, member);
+            var expectedValue = ReflectionHelper.GetMemberValue(expected, member);
+
+            var nested = FindFirstDifference(actualValue, expectedValue, memberPath, visited);
+            if (nested.HasDiff)
+            {
+                return nested;
+            }
+        }
+
+        return DiffResult.None;
+    }
+
+    [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
+    private static DiffResult FindEnumerableDifference(IEnumerable actual, IEnumerable expected, string path, HashSet<object> visited)
+    {
+        var actualEnumerator = actual.GetEnumerator();
+        var expectedEnumerator = expected.GetEnumerator();
+
+        try
+        {
+            var index = 0;
+            while (true)
+            {
+                var actualHasNext = actualEnumerator.MoveNext();
+                var expectedHasNext = expectedEnumerator.MoveNext();
+
+                if (!actualHasNext && !expectedHasNext)
+                {
+                    return DiffResult.None;
+                }
+
+                var indexPath = $"{path}[{index}]";
+
+                if (!actualHasNext)
+                {
+                    return DiffResult.Found(indexPath, expectedEnumerator.Current, null, "actual ended early");
+                }
+
+                if (!expectedHasNext)
+                {
+                    return DiffResult.Found(indexPath, null, actualEnumerator.Current, "actual has extra item");
+                }
+
+                var nested = FindFirstDifference(actualEnumerator.Current, expectedEnumerator.Current, indexPath, visited);
+                if (nested.HasDiff)
+                {
+                    return nested;
+                }
+
+                index++;
+            }
+        }
+        finally
+        {
+            (actualEnumerator as IDisposable)?.Dispose();
+            (expectedEnumerator as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Formats a diff result as a "Expected ... but found ..." style message fragment.
+    /// Returns null when there is no diff to format.
+    /// </summary>
+    public static string? FormatDiff(DiffResult diff)
+    {
+        if (!diff.HasDiff)
+        {
+            return null;
+        }
+
+        var location = string.IsNullOrEmpty(diff.Path) ? "value" : $"member {diff.Path}";
+        return $"differs at {location}: expected {FormatValue(diff.ExpectedValue)} but found {FormatValue(diff.ActualValue)}";
+    }
+
+    internal static string FormatValue(object? value) => value switch
+    {
+        null => "null",
+        string s => $"\"{s}\"",
+        _ => value.ToString() ?? "null",
+    };
+
+    /// <summary>
+    /// Counts how many top-level public members of <paramref name="actual"/> and
+    /// <paramref name="expected"/> compare equal under <see cref="object.Equals(object?, object?)"/>.
+    /// Used as a similarity score when picking the "closest match" in a collection diff.
+    /// Returns 0 if either input is null or the runtime types differ.
+    /// </summary>
+    [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Structural diff intentionally inspects runtime types reflectively")]
+    public static int CountMatchingTopLevelMembers(object? actual, object? expected)
+    {
+        if (actual is null || expected is null)
+        {
+            return 0;
+        }
+
+        var type = actual.GetType();
+        if (type != expected.GetType())
+        {
+            return 0;
+        }
+
+        var members = ReflectionHelper.GetMembersToCompare(type);
+        var matches = 0;
+        foreach (var member in members)
+        {
+            var actualValue = ReflectionHelper.GetMemberValue(actual, member);
+            var expectedValue = ReflectionHelper.GetMemberValue(expected, member);
+            if (Equals(actualValue, expectedValue))
+            {
+                matches++;
+            }
+        }
+        return matches;
+    }
+}

--- a/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/StructuralDiffHelper.cs
@@ -199,37 +199,60 @@ internal static class StructuralDiffHelper
     };
 
     /// <summary>
-    /// Counts how many top-level public members of <paramref name="actual"/> and
-    /// <paramref name="expected"/> compare equal under <see cref="object.Equals(object?, object?)"/>.
-    /// Used as a similarity score when picking the "closest match" in a collection diff.
-    /// Returns 0 if either input is null or the runtime types differ.
+    /// Single-pass walk over top-level members of <paramref name="actual"/> and
+    /// <paramref name="expected"/>, returning both a similarity score (count of top-level
+    /// members that compare equal under <see cref="object.Equals(object?, object?)"/>) and
+    /// the first nested structural diff. Used by the "closest match" hint to avoid two
+    /// reflection walks per candidate.
     /// </summary>
     [RequiresUnreferencedCode("Structural diff uses reflection to inspect object members and is not compatible with AOT")]
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Structural diff intentionally inspects runtime types reflectively")]
-    public static int CountMatchingTopLevelMembers(object? actual, object? expected)
+    public static (int Score, StructuralDiffResult Diff) ScoreAndDiff(object? actual, object? expected)
     {
         if (actual is null || expected is null)
         {
-            return 0;
+            return (0, FindFirstDifference(actual, expected));
         }
 
         var type = actual.GetType();
         if (type != expected.GetType())
         {
-            return 0;
+            return (0, FindFirstDifference(actual, expected));
         }
 
         var members = ReflectionHelper.GetMembersToCompare(type);
+        if (members.Length == 0)
+        {
+            return (0, FindFirstDifference(actual, expected));
+        }
+
+        var visitedActual = new HashSet<object>(ReferenceEqualityComparer<object>.Instance) { actual };
+        var visitedExpected = new HashSet<object>(ReferenceEqualityComparer<object>.Instance) { expected };
+
         var matches = 0;
+        var firstDiff = StructuralDiffResult.None;
         foreach (var member in members)
         {
             var actualValue = ReflectionHelper.GetMemberValue(actual, member);
             var expectedValue = ReflectionHelper.GetMemberValue(expected, member);
+
+            // Match the scoring semantics of CountMatchingTopLevelMembers: a top-level member
+            // counts as "matching" iff Equals reports it equal. This avoids paying for a deep
+            // recursion on members that already compare equal at the top level.
             if (Equals(actualValue, expectedValue))
             {
                 matches++;
+                continue;
+            }
+
+            // Only descend for the first differing member — once we have a diff, additional
+            // recursion is wasted work since we only return the first one.
+            if (!firstDiff.HasDiff)
+            {
+                firstDiff = FindFirstDifference(actualValue, expectedValue, member.Name, visitedActual, visitedExpected);
             }
         }
-        return matches;
+
+        return (matches, firstDiff);
     }
 }

--- a/TUnit.Assertions/Conditions/Helpers/StructuralEqualityComparer.cs
+++ b/TUnit.Assertions/Conditions/Helpers/StructuralEqualityComparer.cs
@@ -108,7 +108,7 @@ public sealed class StructuralEqualityComparer<T> : IEqualityComparer<T>
         // When there are no public members to compare structurally (e.g., types with only
         // private state), fall back to Equals(). This respects IEquatable<T> implementations
         // and avoids false positives from empty member lists.
-        if (members.Count == 0)
+        if (members.Length == 0)
         {
             return Equals(x, y);
         }

--- a/TUnit.Assertions/Conditions/StructuralEquivalencyAssertion.cs
+++ b/TUnit.Assertions/Conditions/StructuralEquivalencyAssertion.cs
@@ -196,7 +196,7 @@ public class StructuralEquivalencyAssertion<TValue> : Assertion<TValue>
         // When there are no public members to compare structurally (e.g., types with only
         // private state), fall back to Equals(). This respects IEquatable<T> implementations
         // and avoids false positives from empty member lists.
-        if (expectedMembers.Count == 0)
+        if (expectedMembers.Length == 0)
         {
             if (!Equals(actual, expected))
             {


### PR DESCRIPTION
Closes #5732

## Summary
- Failure message now points to the first differing member path with both expected/actual values
- Falls back to existing full-object dump only when no comparer-based diff is available

## Test plan
- [x] Added tests covering object-equality diff and collection-equivalence diff
- [x] Existing assertion tests pass