### PR TITLE
perf(engine): skip second object-graph walk in ObjectLifecycleService (#5718)

### DIFF
--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -260,20 +260,28 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
         }
 
         // Finally initialize the test class and its nested objects.
+        // The class instance itself is not in TrackedObjects, so it still needs a graph
+        // walk to pick up non-data-source IAsyncInitializer properties (e.g., set in the
+        // constructor or by BeforeClass hooks). Tracked objects above skipped this walk
+        // because their nested dependencies are already in TrackedObjects at higher depths.
         // The test class instance is unregistered in TraceScopeRegistry, so
         // GetSharedType returns null → defaults to per-test scope automatically.
         var classInstance = testContext.Metadata.TestDetails.ClassInstance;
+        await InitializeNestedObjectsForExecutionAsync(classInstance, cancellationToken);
         await InitializeObjectWithSpanAsync(classInstance, testContext, cancellationToken);
     }
 
     /// <summary>
-    /// Initializes an object and its nested objects, wrapped in a scope-aware OpenTelemetry span.
+    /// Initializes an object wrapped in a scope-aware OpenTelemetry span.
     /// </summary>
+    /// <remarks>
+    /// Callers are responsible for ensuring nested dependencies are already initialized.
+    /// <see cref="InitializeTrackedObjectsAsync"/> achieves this by iterating the
+    /// pre-discovered <see cref="TestContext.TrackedObjects"/> sorted list from deepest
+    /// to shallowest, so a separate per-object graph walk is no longer needed here.
+    /// </remarks>
     private async Task InitializeObjectWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
     {
-        // First initialize nested objects depth-first
-        await InitializeNestedObjectsForExecutionAsync(obj, cancellationToken);
-
 #if NET
         var sharedType = TraceScopeRegistry.GetSharedType(obj);
         var activitySource = TUnitActivitySource.GetSourceForSharedType(sharedType);


### PR DESCRIPTION
Closes #5718

## Summary
- `InitializeTrackedObjectsAsync` now relies on the sorted `TrackedObjects` list populated at registration time, removing the per-tracked-object call to `DiscoverNestedObjectGraph` inside `InitializeObjectWithSpanAsync`.
- Each tracked object's nested `IAsyncInitializer` dependencies are already in `TrackedObjects` at higher depths and are initialized first by the outer depth-descending loop, so no per-object walk is needed.
- The class instance is the only object not in `TrackedObjects`; it still gets one nested graph walk at the end so non-data-source `IAsyncInitializer` properties (set in the constructor or by `BeforeClass` hooks) are still picked up.
- Removes ~half of `InitializeObjectWithSpanAsync` / `TraverseInitializerProperties` cost and a chunk of `HashSet<string>` allocations from the per-test hot path.

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release -f net10.0`
- [x] `TUnit.UnitTests` (180/180 pass)
- [x] `TUnit.TestProject` lifecycle / data-source / init slices: `PropertyInitializationTests`, `InitializableTestClassTests`, `CombinedDataSourceTests` (198), `AbstractBaseClassPropertyInjectionTests`, `Bugs.Bug3266` (4-level deep chain ordering, multi-fixture), `Bugs._3597`, `Bugs._1187`, `Bugs._2955`, `Bugs._3072`, `InjectedClassDataSourceWithAsyncInitializerTests`, `NestedClassDataSourceDrivenTests3`, `KeyedDataSourceTests`, `ParallelPropertyInjectionTests`, `ClassDataSourceSharedNoneRegressionTests`, `GenericPropertyInjectionTests`, `PropertySetterTests`, `PropertyInitTest` — all pass.
- [x] `Bugs.Bug3266.FourLevelDeepChainShouldInitializeInCorrectOrder` (deepest dependency must initialize first across 4 levels) passes — equivalence with prior behavior.