### PR TITLE
fix(assertions): preserve specialised source in .Count(itemAssertion) (#5707)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
@@ -104,6 +104,20 @@ public class Issue5707Tests
     }
 
     [Test]
+    public async Task Count_ReadOnlySet_Items_Reach_IsSubsetOf_On_Inner()
+    {
+        var universe = new HashSet<int> { 1, 2, 3, 4, 5 };
+        var sets = new List<IReadOnlySet<int>>
+        {
+            new HashSet<int> { 1, 2 },
+            new HashSet<int> { 6 },
+            new HashSet<int> { 3, 4 },
+        };
+
+        await Assert.That(sets).Count(s => s.IsSubsetOf(universe)).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Count_Specialised_Source_Failure_Message_Mentions_Inner_Expectation()
     {
         IEnumerable<IEnumerable<int>> listOfLists = new List<List<int>>

--- a/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
@@ -1,0 +1,124 @@
+using TUnit.Assertions.Exceptions;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for GitHub issue #5707:
+/// `.Count(itemAssertion)` per-item overload only exposed a generic
+/// `IAssertionSource&lt;TItem&gt;` inside the lambda, so specialised
+/// assertions defined on collection / dictionary / set / list bases
+/// (e.g. <c>HasCount</c>, <c>ContainsKey</c>, <c>IsSubsetOf</c>,
+/// <c>HasItemAt</c>) were unreachable when the items themselves were
+/// collections, dictionaries or sets.
+///
+/// Specialised <c>Count</c> overloads now hand the lambda a typed
+/// source (CollectionAssertion, ListAssertion, DictionaryAssertion,
+/// SetAssertion, etc.) so the failure message also keeps the
+/// specialised assertion's expectation rather than a generic wrapper.
+/// </summary>
+public class Issue5707Tests
+{
+    [Test]
+    public async Task Count_String_Items_Use_String_Assertion_Source()
+    {
+        var items = new List<string> { "apple", "banana", "apricot", "cherry" };
+
+        await Assert.That(items).Count(s => s.IsEqualTo("apple")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Count_Enumerable_Items_Reach_HasCount_On_Inner()
+    {
+        IEnumerable<IEnumerable<int>> listOfLists = new List<List<int>>
+        {
+            new() { 1, 2, 3 },
+            new() { 1 },
+            new() { 1, 2, 3 },
+        };
+
+        await Assert.That(listOfLists).Count(l => l.Count().IsEqualTo(3)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_List_Items_Reach_HasItemAt_On_Inner()
+    {
+        var listOfLists = new List<IList<int>>
+        {
+            new List<int> { 10, 20 },
+            new List<int> { 99 },
+            new List<int> { 10, 30 },
+        };
+
+        await Assert.That(listOfLists).Count(l => l.HasItemAt(0, 10)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_ReadOnlyList_Items_Reach_HasItemAt_On_Inner()
+    {
+        var listOfLists = new List<IReadOnlyList<int>>
+        {
+            new List<int> { 10, 20 },
+            new List<int> { 99 },
+            new List<int> { 10, 30 },
+        };
+
+        await Assert.That(listOfLists).Count(l => l.HasItemAt(0, 10)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_ReadOnlyDictionary_Items_Reach_ContainsKey_On_Inner()
+    {
+        IReadOnlyDictionary<string, int> a = new Dictionary<string, int> { ["k"] = 1 };
+        IReadOnlyDictionary<string, int> b = new Dictionary<string, int> { ["other"] = 2 };
+        IReadOnlyDictionary<string, int> c = new Dictionary<string, int> { ["k"] = 5 };
+        var dicts = new List<IReadOnlyDictionary<string, int>> { a, b, c };
+
+        await Assert.That(dicts).Count(d => d.ContainsKey("k")).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_Dictionary_Items_Reach_ContainsKey_On_Inner()
+    {
+        var dicts = new List<IDictionary<string, int>>
+        {
+            new Dictionary<string, int> { ["k"] = 1 },
+            new Dictionary<string, int> { ["other"] = 2 },
+            new Dictionary<string, int> { ["k"] = 5 },
+        };
+
+        await Assert.That(dicts).Count(d => d.ContainsKey("k")).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_Set_Items_Reach_IsSubsetOf_On_Inner()
+    {
+        var universe = new HashSet<int> { 1, 2, 3, 4, 5 };
+        var sets = new List<ISet<int>>
+        {
+            new HashSet<int> { 1, 2 },
+            new HashSet<int> { 6 },
+            new HashSet<int> { 3, 4 },
+        };
+
+        await Assert.That(sets).Count(s => s.IsSubsetOf(universe)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_Specialised_Source_Failure_Message_Mentions_Inner_Expectation()
+    {
+        IEnumerable<IEnumerable<int>> listOfLists = new List<List<int>>
+        {
+            new() { 1 },
+            new() { 1 },
+        };
+
+        // Expect 5 items with inner-count==3 → there are 0; ensure failure message
+        // surfaces the specialised inner expectation rather than just "received 0".
+        var ex = await Assert.That(async () =>
+                await Assert.That(listOfLists).Count(l => l.Count().IsEqualTo(3)).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        // The chained expression should include `.Count(...)` per-item filter.
+        await Assert.That(ex.Message).Contains(".Count(l => l.Count().IsEqualTo(3))");
+    }
+}

--- a/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
@@ -19,8 +19,12 @@ namespace TUnit.Assertions.Tests.Bugs;
 public class Issue5707Tests
 {
     [Test]
-    public async Task Count_String_Items_Use_String_Assertion_Source()
+    public async Task Count_String_Items_Bind_To_Generic_Instance_Method()
     {
+        // Strings already resolve through the generic instance method on
+        // CollectionAssertionBase: `IEnumerable<TInner>` cannot bind to
+        // `string` via type inference (no concrete-to-interface unification),
+        // so no specialised string overload is needed.
         var items = new List<string> { "apple", "banana", "apricot", "cherry" };
 
         await Assert.That(items).Count(s => s.IsEqualTo("apple")).IsEqualTo(1);
@@ -128,6 +132,51 @@ public class Issue5707Tests
         };
 
         await Assert.That(listOfArrays).Count(a => a.IsSingleElement()).IsEqualTo(2);
+    }
+
+    // ---- Concrete-type item tests ---------------------------------------
+    // C# generic inference resolves TItem to the exact declared type, never
+    // to an interface, so e.g. List<List<int>> items must bind to a
+    // List<TInner> overload, not the IList<TInner> overload above.
+
+    [Test]
+    public async Task Count_ConcreteList_Items_Reach_HasItemAt_On_Inner()
+    {
+        var listOfLists = new List<List<int>>
+        {
+            new() { 10, 20 },
+            new() { 99 },
+            new() { 10, 30 },
+        };
+
+        await Assert.That(listOfLists).Count(l => l.HasItemAt(0, 10)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_ConcreteHashSet_Items_Reach_IsSubsetOf_On_Inner()
+    {
+        var universe = new HashSet<int> { 1, 2, 3, 4, 5 };
+        var sets = new List<HashSet<int>>
+        {
+            new() { 1, 2 },
+            new() { 6 },
+            new() { 3, 4 },
+        };
+
+        await Assert.That(sets).Count(s => s.IsSubsetOf(universe)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Count_ConcreteDictionary_Items_Reach_ContainsKey_On_Inner()
+    {
+        var dicts = new List<Dictionary<string, int>>
+        {
+            new() { ["k"] = 1 },
+            new() { ["other"] = 2 },
+            new() { ["k"] = 5 },
+        };
+
+        await Assert.That(dicts).Count(d => d.ContainsKey("k")).IsEqualTo(2);
     }
 
     [Test]

--- a/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
@@ -118,6 +118,19 @@ public class Issue5707Tests
     }
 
     [Test]
+    public async Task Count_Array_Items_Reach_IsSingleElement_On_Inner()
+    {
+        var listOfArrays = new List<int[]>
+        {
+            new[] { 10, 20 },
+            new[] { 99 },
+            new[] { 10 },
+        };
+
+        await Assert.That(listOfArrays).Count(a => a.IsSingleElement()).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Count_Specialised_Source_Failure_Message_Mentions_Inner_Expectation()
     {
         IEnumerable<IEnumerable<int>> listOfLists = new List<List<int>>
@@ -134,5 +147,103 @@ public class Issue5707Tests
 
         // The chained expression should include `.Count(...)` per-item filter.
         await Assert.That(ex.Message).Contains(".Count(l => l.Count().IsEqualTo(3))");
+    }
+
+    [Test]
+    public async Task Count_List_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var listOfLists = new List<IList<int>>
+        {
+            new List<int> { 99 },
+            new List<int> { 99 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(listOfLists).Count(l => l.HasItemAt(0, 10)).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(l => l.HasItemAt(0, 10))");
+    }
+
+    [Test]
+    public async Task Count_Dictionary_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var dicts = new List<IDictionary<string, int>>
+        {
+            new Dictionary<string, int> { ["other"] = 1 },
+            new Dictionary<string, int> { ["other"] = 2 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(dicts).Count(d => d.ContainsKey("k")).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(d => d.ContainsKey(\"k\"))");
+    }
+
+    [Test]
+    public async Task Count_Set_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var universe = new HashSet<int> { 1, 2, 3 };
+        var sets = new List<ISet<int>>
+        {
+            new HashSet<int> { 6 },
+            new HashSet<int> { 7 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(sets).Count(s => s.IsSubsetOf(universe)).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(s => s.IsSubsetOf(universe))");
+    }
+
+    [Test]
+    public async Task Count_ReadOnlyList_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var listOfLists = new List<IReadOnlyList<int>>
+        {
+            new List<int> { 99 },
+            new List<int> { 99 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(listOfLists).Count(l => l.HasItemAt(0, 10)).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(l => l.HasItemAt(0, 10))");
+    }
+
+    [Test]
+    public async Task Count_ReadOnlySet_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var universe = new HashSet<int> { 1, 2, 3 };
+        var sets = new List<IReadOnlySet<int>>
+        {
+            new HashSet<int> { 6 },
+            new HashSet<int> { 7 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(sets).Count(s => s.IsSubsetOf(universe)).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(s => s.IsSubsetOf(universe))");
+    }
+
+    [Test]
+    public async Task Count_Array_Failure_Message_Mentions_Specialised_Inner_Expectation()
+    {
+        var listOfArrays = new List<int[]>
+        {
+            new[] { 1, 2 },
+            new[] { 1, 2 },
+        };
+
+        var ex = await Assert.That(async () =>
+                await Assert.That(listOfArrays).Count(a => a.IsSingleElement()).IsEqualTo(5))
+            .Throws<AssertionException>();
+
+        await Assert.That(ex.Message).Contains(".Count(a => a.IsSingleElement())");
     }
 }

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -686,7 +686,7 @@ public class CollectionAllSatisfyAssertion<TCollection, TItem> : Sources.Collect
                     await assertion.AssertAsync();
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 return AssertionResult.Failed($"item at index {index} failed assertion: {ex.Message}", ex);
             }
@@ -753,7 +753,7 @@ public class CollectionAllSatisfyMappedAssertion<TCollection, TItem, TMapped> : 
                     await resultingAssertion.AssertAsync();
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 return AssertionResult.Failed($"item at index {index} (mapped by {_mapperDescription}) failed assertion: {ex.Message}", ex);
             }

--- a/TUnit.Assertions/Conditions/CollectionCountSource.cs
+++ b/TUnit.Assertions/Conditions/CollectionCountSource.cs
@@ -17,8 +17,11 @@ public class CollectionCountSource<TCollection, TItem>
     public CollectionCountSource(
         AssertionContext<TCollection> collectionContext,
         Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
-        : this(collectionContext, WrapWithValueAssertion(assertion))
     {
+        _collectionContext = collectionContext;
+        _itemAssertionFactory = assertion is null
+            ? null
+            : (item, index) => assertion(new ValueAssertion<TItem>(item, $"item[{index}]"));
     }
 
     /// <summary>
@@ -33,17 +36,6 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext = collectionContext;
         _itemAssertionFactory = itemAssertionFactory;
-    }
-
-    internal static Func<TItem, int, IAssertion?>? WrapWithValueAssertion(
-        Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
-    {
-        if (assertion is null)
-        {
-            return null;
-        }
-
-        return (item, index) => assertion(new ValueAssertion<TItem>(item, $"item[{index}]"));
     }
 
     /// <summary>
@@ -171,15 +163,6 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
 
     internal CollectionCountEqualsAssertion(
         AssertionContext<TCollection> context,
-        Func<IAssertionSource<TItem>, Assertion<TItem>?>? itemAssertion,
-        int expected,
-        CountComparison comparison)
-        : this(context, CollectionCountSource<TCollection, TItem>.WrapWithValueAssertion(itemAssertion), expected, comparison)
-    {
-    }
-
-    internal CollectionCountEqualsAssertion(
-        AssertionContext<TCollection> context,
         Func<TItem, int, IAssertion?>? itemAssertionFactory,
         int expected,
         CountComparison comparison)
@@ -232,7 +215,7 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
                         await resultingAssertion.AssertAsync();
                         _actualCount++;
                     }
-                    catch
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         // Item did not satisfy the assertion, don't count it
                     }

--- a/TUnit.Assertions/Conditions/CollectionCountSource.cs
+++ b/TUnit.Assertions/Conditions/CollectionCountSource.cs
@@ -14,7 +14,14 @@ public class CollectionCountSource<TCollection, TItem>
     private readonly AssertionContext<TCollection> _collectionContext;
     private readonly Func<TItem, int, IAssertion?>? _itemAssertionFactory;
 
-    public CollectionCountSource(
+    /// <summary>
+    /// Constructor used by the generic <see cref="CollectionAssertionBase{TCollection, TItem}.Count(System.Func{IAssertionSource{TItem}, Assertion{TItem}?}, string?)"/>
+    /// instance method: wraps each item with <see cref="ValueAssertion{TItem}"/> before
+    /// invoking the user-supplied lambda. Specialised <c>Count(itemAssertion)</c>
+    /// extension overloads use the per-item factory ctor below to preserve
+    /// item-shape-specific assertion sources (issue #5707).
+    /// </summary>
+    internal CollectionCountSource(
         AssertionContext<TCollection> collectionContext,
         Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
     {

--- a/TUnit.Assertions/Conditions/CollectionCountSource.cs
+++ b/TUnit.Assertions/Conditions/CollectionCountSource.cs
@@ -15,7 +15,7 @@ public class CollectionCountSource<TCollection, TItem>
     private readonly Func<TItem, int, IAssertion?>? _itemAssertionFactory;
 
     /// <summary>
-    /// Constructor used by the generic <see cref="CollectionAssertionBase{TCollection, TItem}.Count(System.Func{IAssertionSource{TItem}, Assertion{TItem}?}, string?)"/>
+    /// Constructor used by the generic <see cref="CollectionAssertionBase{TCollection, TItem}.Count(System.Func{IAssertionSource{TItem}, IAssertion?}, string?)"/>
     /// instance method: wraps each item with <see cref="ValueAssertion{TItem}"/> before
     /// invoking the user-supplied lambda. Specialised <c>Count(itemAssertion)</c>
     /// extension overloads use the per-item factory ctor below to preserve
@@ -23,7 +23,7 @@ public class CollectionCountSource<TCollection, TItem>
     /// </summary>
     internal CollectionCountSource(
         AssertionContext<TCollection> collectionContext,
-        Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
+        Func<IAssertionSource<TItem>, IAssertion?>? assertion)
     {
         _collectionContext = collectionContext;
         _itemAssertionFactory = assertion is null

--- a/TUnit.Assertions/Conditions/CollectionCountSource.cs
+++ b/TUnit.Assertions/Conditions/CollectionCountSource.cs
@@ -12,14 +12,38 @@ public class CollectionCountSource<TCollection, TItem>
     where TCollection : IEnumerable<TItem>
 {
     private readonly AssertionContext<TCollection> _collectionContext;
-    private readonly Func<IAssertionSource<TItem>, Assertion<TItem>?>? _assertion;
+    private readonly Func<TItem, int, IAssertion?>? _itemAssertionFactory;
 
     public CollectionCountSource(
         AssertionContext<TCollection> collectionContext,
         Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
+        : this(collectionContext, WrapWithValueAssertion(assertion))
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor that accepts a per-item assertion factory directly.
+    /// Used by specialised <c>Count(itemAssertion)</c> overloads that supply
+    /// item-shape-specific assertion sources (e.g. collection, dictionary, set)
+    /// instead of the generic <see cref="ValueAssertion{TItem}"/>.
+    /// </summary>
+    internal CollectionCountSource(
+        AssertionContext<TCollection> collectionContext,
+        Func<TItem, int, IAssertion?>? itemAssertionFactory)
     {
         _collectionContext = collectionContext;
-        _assertion = assertion;
+        _itemAssertionFactory = itemAssertionFactory;
+    }
+
+    internal static Func<TItem, int, IAssertion?>? WrapWithValueAssertion(
+        Func<IAssertionSource<TItem>, Assertion<TItem>?>? assertion)
+    {
+        if (assertion is null)
+        {
+            return null;
+        }
+
+        return (item, index) => assertion(new ValueAssertion<TItem>(item, $"item[{index}]"));
     }
 
     /// <summary>
@@ -32,7 +56,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsEqualTo({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.Equal);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.Equal);
     }
 
     /// <summary>
@@ -45,7 +69,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsNotEqualTo({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.NotEqual);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.NotEqual);
     }
 
     /// <summary>
@@ -58,7 +82,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsGreaterThan({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.GreaterThan);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.GreaterThan);
     }
 
     /// <summary>
@@ -71,7 +95,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsGreaterThanOrEqualTo({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.GreaterThanOrEqual);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.GreaterThanOrEqual);
     }
 
     /// <summary>
@@ -84,7 +108,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsLessThan({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.LessThan);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.LessThan);
     }
 
     /// <summary>
@@ -97,7 +121,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append($".IsLessThanOrEqualTo({expression})");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, expected, CountComparison.LessThanOrEqual);
+            _collectionContext, _itemAssertionFactory, expected, CountComparison.LessThanOrEqual);
     }
 
     /// <summary>
@@ -108,7 +132,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append(".IsZero()");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, 0, CountComparison.Equal);
+            _collectionContext, _itemAssertionFactory, 0, CountComparison.Equal);
     }
 
     /// <summary>
@@ -119,7 +143,7 @@ public class CollectionCountSource<TCollection, TItem>
     {
         _collectionContext.ExpressionBuilder.Append(".IsPositive()");
         return new CollectionCountEqualsAssertion<TCollection, TItem>(
-            _collectionContext, _assertion, 0, CountComparison.GreaterThan);
+            _collectionContext, _itemAssertionFactory, 0, CountComparison.GreaterThan);
     }
 }
 
@@ -140,7 +164,7 @@ internal enum CountComparison
 public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
     where TCollection : IEnumerable<TItem>
 {
-    private readonly Func<IAssertionSource<TItem>, Assertion<TItem>?>? _itemAssertion;
+    private readonly Func<TItem, int, IAssertion?>? _itemAssertionFactory;
     private readonly int _expected;
     private readonly CountComparison _comparison;
     private int _actualCount;
@@ -150,9 +174,18 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
         Func<IAssertionSource<TItem>, Assertion<TItem>?>? itemAssertion,
         int expected,
         CountComparison comparison)
+        : this(context, CollectionCountSource<TCollection, TItem>.WrapWithValueAssertion(itemAssertion), expected, comparison)
+    {
+    }
+
+    internal CollectionCountEqualsAssertion(
+        AssertionContext<TCollection> context,
+        Func<TItem, int, IAssertion?>? itemAssertionFactory,
+        int expected,
+        CountComparison comparison)
         : base(context)
     {
-        _itemAssertion = itemAssertion;
+        _itemAssertionFactory = itemAssertionFactory;
         _expected = expected;
         _comparison = comparison;
     }
@@ -173,7 +206,7 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
         }
 
         // Calculate count
-        if (_itemAssertion == null)
+        if (_itemAssertionFactory == null)
         {
             // Simple count without filtering
             _actualCount = value switch
@@ -190,8 +223,7 @@ public class CollectionCountEqualsAssertion<TCollection, TItem> : CollectionAsse
 
             foreach (var item in value)
             {
-                var itemAssertionSource = new ValueAssertion<TItem>(item, $"item[{index}]");
-                var resultingAssertion = _itemAssertion(itemAssertionSource);
+                var resultingAssertion = _itemAssertionFactory(item, index);
 
                 if (resultingAssertion != null)
                 {

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1968,6 +1968,26 @@ public static class AssertionExtensions
             expression);
     }
 
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IReadOnlySet{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves read-only sets; the lambda
+    /// receives a <see cref="ReadOnlySetAssertion{TInner}"/> with set-specific assertions
+    /// (IsSubsetOf, IsSupersetOf, Overlaps, etc.) in addition to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, IReadOnlySet<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, IReadOnlySet<TInner>> source,
+        Func<ReadOnlySetAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IReadOnlySet<TInner>>
+    {
+        return CountSpecialised<TCollection, IReadOnlySet<TInner>>(
+            source,
+            (item, index) => itemAssertion(new ReadOnlySetAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+#endif
+
     private static CollectionCountSource<TCollection, TItem> CountSpecialised<TCollection, TItem>(
         CollectionAssertionBase<TCollection, TItem> source,
         Func<TItem, int, IAssertion?> itemAssertionFactory,

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1827,36 +1827,28 @@ public static class AssertionExtensions
     //
     // The instance-method `Count(Func<IAssertionSource<TItem>, Assertion<TItem>?>, ...)`
     // on CollectionAssertionBase exposes only the generic `IAssertionSource<TItem>`
-    // inside the lambda. When TItem itself is a string, collection, dictionary
-    // or set, specialised assertions defined as instance methods on the
-    // matching assertion-source base (e.g. `HasCount`, `ContainsKey`, `IsSubsetOf`)
-    // are unreachable.
+    // inside the lambda. When TItem itself is a collection, dictionary or set,
+    // specialised assertions defined as instance methods on the matching
+    // assertion-source base (e.g. `HasCount`, `ContainsKey`, `IsSubsetOf`,
+    // `HasItemAt`) are unreachable.
     //
     // These extension methods preserve the specialised assertion source by
     // matching on the closed shape of TItem and constructing the appropriate
     // typed source per item. C# generic type inference requires an exact match
-    // on the receiver's TItem, so we expose one overload per concrete item
-    // shape. Items whose shape doesn't match a specialised overload still
-    // resolve to the generic instance method.
+    // on the receiver's TItem (it does not unify a concrete type with an
+    // interface), so we provide overloads for both the interface shapes
+    // (IList<T>, IDictionary<K,V>, ISet<T>, ...) and the most common concrete
+    // shapes (List<T>, Dictionary<K,V>, HashSet<T>, T[]). Items whose shape
+    // does not match a specialised overload still resolve to the generic
+    // instance method.
+    //
+    // No overload is needed for `string` items: the `IEnumerable<TInner>`
+    // overload below cannot bind to a string item (C# inference does not
+    // unify `string` with `IEnumerable<TInner>` for a generic type parameter),
+    // so the generic instance method already wraps each string in
+    // `ValueAssertion<string>` — which is exactly what a dedicated overload
+    // would do.
     // ========================================================================
-
-    /// <summary>
-    /// Counts items satisfying an assertion expressed against a string-typed source.
-    /// Use this overload when the collection's items are strings to ensure string-specific
-    /// assertions are reachable inside the lambda (rather than treating the string as
-    /// <see cref="IEnumerable{Char}"/>).
-    /// </summary>
-    public static CollectionCountSource<TCollection, string> Count<TCollection>(
-        this CollectionAssertionBase<TCollection, string> source,
-        Func<IAssertionSource<string>, IAssertion?> itemAssertion,
-        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
-        where TCollection : IEnumerable<string>
-    {
-        return CountSpecialised<TCollection, string>(
-            source,
-            (item, index) => itemAssertion(new ValueAssertion<string>(item, $"item[{index}]")),
-            expression);
-    }
 
     /// <summary>
     /// Counts items satisfying an assertion expressed against an <see cref="IEnumerable{TInner}"/>-typed source.
@@ -2004,6 +1996,71 @@ public static class AssertionExtensions
         return CountSpecialised<TCollection, TInner[]>(
             source,
             (item, index) => itemAssertion(new ArrayAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    // ----- Concrete-type overloads -----
+    // C# generic inference resolves TItem to the exact declared type, never to
+    // an interface, so e.g. `List<HashSet<int>>` items would not match the
+    // `ISet<TInner>` overload above. These cover the common BCL concrete types.
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against a <see cref="List{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves <see cref="List{TInner}"/> instances;
+    /// the lambda receives a <see cref="ListAssertion{TInner}"/> with index-based assertions in addition
+    /// to the standard collection surface. Without this overload, C# inference would not unify
+    /// <c>List&lt;TInner&gt;</c> with the <c>IList&lt;TInner&gt;</c> overload.
+    /// </summary>
+    public static CollectionCountSource<TCollection, List<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, List<TInner>> source,
+        Func<ListAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<List<TInner>>
+    {
+        return CountSpecialised<TCollection, List<TInner>>(
+            source,
+            (item, index) => itemAssertion(new ListAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against a <see cref="HashSet{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves <see cref="HashSet{TInner}"/> instances;
+    /// the lambda receives a <see cref="HashSetAssertion{TInner}"/> with set-specific assertions
+    /// (IsSubsetOf, IsSupersetOf, Overlaps, etc.) in addition to the standard collection surface.
+    /// Without this overload, C# inference would not unify <c>HashSet&lt;TInner&gt;</c> with the
+    /// <c>ISet&lt;TInner&gt;</c> overload.
+    /// </summary>
+    public static CollectionCountSource<TCollection, HashSet<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, HashSet<TInner>> source,
+        Func<HashSetAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<HashSet<TInner>>
+    {
+        return CountSpecialised<TCollection, HashSet<TInner>>(
+            source,
+            (item, index) => itemAssertion(new HashSetAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against a <see cref="Dictionary{TKey, TValue}"/>-typed source.
+    /// Use this overload when the collection's items are themselves <see cref="Dictionary{TKey, TValue}"/> instances;
+    /// the lambda receives a <see cref="MutableDictionaryAssertion{TKey, TValue}"/> with dictionary-specific
+    /// assertions (ContainsKey, ContainsValue, etc.) in addition to the standard collection surface.
+    /// Without this overload, C# inference would not unify <c>Dictionary&lt;TKey, TValue&gt;</c> with the
+    /// <c>IDictionary&lt;TKey, TValue&gt;</c> overload.
+    /// </summary>
+    public static CollectionCountSource<TCollection, Dictionary<TKey, TValue>> Count<TCollection, TKey, TValue>(
+        this CollectionAssertionBase<TCollection, Dictionary<TKey, TValue>> source,
+        Func<MutableDictionaryAssertion<TKey, TValue>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<Dictionary<TKey, TValue>>
+        where TKey : notnull
+    {
+        return CountSpecialised<TCollection, Dictionary<TKey, TValue>>(
+            source,
+            (item, index) => itemAssertion(new MutableDictionaryAssertion<TKey, TValue>(item, $"item[{index}]")),
             expression);
     }
 

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1988,13 +1988,32 @@ public static class AssertionExtensions
     }
 #endif
 
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against a <typeparamref name="TInner"/>[]-typed source.
+    /// Use this overload when the collection's items are themselves arrays; the lambda
+    /// receives an <see cref="ArrayAssertion{TInner}"/> so array-specific assertions
+    /// (e.g. <c>IsEmpty</c>, <c>IsSingleElement</c>) defined on <c>IAssertionSource&lt;TInner[]&gt;</c>
+    /// are reachable in addition to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, TInner[]> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, TInner[]> source,
+        Func<ArrayAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<TInner[]>
+    {
+        return CountSpecialised<TCollection, TInner[]>(
+            source,
+            (item, index) => itemAssertion(new ArrayAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
     private static CollectionCountSource<TCollection, TItem> CountSpecialised<TCollection, TItem>(
         CollectionAssertionBase<TCollection, TItem> source,
         Func<TItem, int, IAssertion?> itemAssertionFactory,
         string? expression)
         where TCollection : IEnumerable<TItem>
     {
-        var context = ((IAssertionSource<TCollection>)source).Context;
+        var context = source.InternalContext;
         context.ExpressionBuilder.Append($".Count({expression})");
         return new CollectionCountSource<TCollection, TItem>(context, itemAssertionFactory);
     }

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1822,4 +1822,160 @@ public static class AssertionExtensions
         return new Assertions.Enums.IsNotDefinedAssertion<TEnum>(source.Context);
     }
 
+    // ========================================================================
+    // Specialised Count(itemAssertion) overloads — issue #5707.
+    //
+    // The instance-method `Count(Func<IAssertionSource<TItem>, Assertion<TItem>?>, ...)`
+    // on CollectionAssertionBase exposes only the generic `IAssertionSource<TItem>`
+    // inside the lambda. When TItem itself is a string, collection, dictionary
+    // or set, specialised assertions defined as instance methods on the
+    // matching assertion-source base (e.g. `HasCount`, `ContainsKey`, `IsSubsetOf`)
+    // are unreachable.
+    //
+    // These extension methods preserve the specialised assertion source by
+    // matching on the closed shape of TItem and constructing the appropriate
+    // typed source per item. C# generic type inference requires an exact match
+    // on the receiver's TItem, so we expose one overload per concrete item
+    // shape. Items whose shape doesn't match a specialised overload still
+    // resolve to the generic instance method.
+    // ========================================================================
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against a string-typed source.
+    /// Use this overload when the collection's items are strings to ensure string-specific
+    /// assertions are reachable inside the lambda (rather than treating the string as
+    /// <see cref="IEnumerable{Char}"/>).
+    /// </summary>
+    public static CollectionCountSource<TCollection, string> Count<TCollection>(
+        this CollectionAssertionBase<TCollection, string> source,
+        Func<IAssertionSource<string>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<string>
+    {
+        return CountSpecialised<TCollection, string>(
+            source,
+            (item, index) => itemAssertion(new ValueAssertion<string>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IEnumerable{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves enumerables; the lambda
+    /// receives a <see cref="CollectionAssertion{TInner}"/> with the full collection assertion
+    /// surface (Contains, IsInOrder, HasCount, etc.).
+    /// </summary>
+    public static CollectionCountSource<TCollection, IEnumerable<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, IEnumerable<TInner>> source,
+        Func<CollectionAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IEnumerable<TInner>>
+    {
+        return CountSpecialised<TCollection, IEnumerable<TInner>>(
+            source,
+            (item, index) => itemAssertion(new CollectionAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IList{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves lists; the lambda
+    /// receives a <see cref="ListAssertion{TInner}"/> with index-based assertions in addition
+    /// to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, IList<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, IList<TInner>> source,
+        Func<ListAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IList<TInner>>
+    {
+        return CountSpecialised<TCollection, IList<TInner>>(
+            source,
+            (item, index) => itemAssertion(new ListAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IReadOnlyList{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves read-only lists; the lambda
+    /// receives a <see cref="ReadOnlyListAssertion{TInner}"/> with index-based assertions in addition
+    /// to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, IReadOnlyList<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, IReadOnlyList<TInner>> source,
+        Func<ReadOnlyListAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IReadOnlyList<TInner>>
+    {
+        return CountSpecialised<TCollection, IReadOnlyList<TInner>>(
+            source,
+            (item, index) => itemAssertion(new ReadOnlyListAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IReadOnlyDictionary{TKey, TValue}"/>-typed source.
+    /// Use this overload when the collection's items are themselves read-only dictionaries; the lambda
+    /// receives a <see cref="DictionaryAssertion{TKey, TValue}"/> with dictionary-specific assertions
+    /// (ContainsKey, ContainsValue, etc.) in addition to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, IReadOnlyDictionary<TKey, TValue>> Count<TCollection, TKey, TValue>(
+        this CollectionAssertionBase<TCollection, IReadOnlyDictionary<TKey, TValue>> source,
+        Func<DictionaryAssertion<TKey, TValue>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IReadOnlyDictionary<TKey, TValue>>
+        where TKey : notnull
+    {
+        return CountSpecialised<TCollection, IReadOnlyDictionary<TKey, TValue>>(
+            source,
+            (item, index) => itemAssertion(new DictionaryAssertion<TKey, TValue>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="IDictionary{TKey, TValue}"/>-typed source.
+    /// Use this overload when the collection's items are themselves dictionaries; the lambda
+    /// receives a <see cref="MutableDictionaryAssertion{TKey, TValue}"/> with dictionary-specific assertions
+    /// in addition to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, IDictionary<TKey, TValue>> Count<TCollection, TKey, TValue>(
+        this CollectionAssertionBase<TCollection, IDictionary<TKey, TValue>> source,
+        Func<MutableDictionaryAssertion<TKey, TValue>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<IDictionary<TKey, TValue>>
+        where TKey : notnull
+    {
+        return CountSpecialised<TCollection, IDictionary<TKey, TValue>>(
+            source,
+            (item, index) => itemAssertion(new MutableDictionaryAssertion<TKey, TValue>(item, $"item[{index}]")),
+            expression);
+    }
+
+    /// <summary>
+    /// Counts items satisfying an assertion expressed against an <see cref="ISet{TInner}"/>-typed source.
+    /// Use this overload when the collection's items are themselves sets; the lambda
+    /// receives a <see cref="SetAssertion{TInner}"/> with set-specific assertions
+    /// (IsSubsetOf, IsSupersetOf, Overlaps, etc.) in addition to the standard collection surface.
+    /// </summary>
+    public static CollectionCountSource<TCollection, ISet<TInner>> Count<TCollection, TInner>(
+        this CollectionAssertionBase<TCollection, ISet<TInner>> source,
+        Func<SetAssertion<TInner>, IAssertion?> itemAssertion,
+        [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
+        where TCollection : IEnumerable<ISet<TInner>>
+    {
+        return CountSpecialised<TCollection, ISet<TInner>>(
+            source,
+            (item, index) => itemAssertion(new SetAssertion<TInner>(item, $"item[{index}]")),
+            expression);
+    }
+
+    private static CollectionCountSource<TCollection, TItem> CountSpecialised<TCollection, TItem>(
+        CollectionAssertionBase<TCollection, TItem> source,
+        Func<TItem, int, IAssertion?> itemAssertionFactory,
+        string? expression)
+        where TCollection : IEnumerable<TItem>
+    {
+        var context = ((IAssertionSource<TCollection>)source).Context;
+        context.ExpressionBuilder.Append($".Count({expression})");
+        return new CollectionCountSource<TCollection, TItem>(context, itemAssertionFactory);
+    }
 }

--- a/TUnit.Assertions/Sources/CollectionAssertionBase.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertionBase.cs
@@ -139,7 +139,8 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     public CollectionCountSource<TCollection, TItem> Count()
     {
         Context.ExpressionBuilder.Append(".Count()");
-        return new CollectionCountSource<TCollection, TItem>(Context, null);
+        return new CollectionCountSource<TCollection, TItem>(
+            Context, (Func<TItem, int, IAssertion?>?)null);
     }
 
     /// <summary>
@@ -165,7 +166,7 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     /// Example: await Assert.That(list).Count(item => item.IsGreaterThan(10)).IsEqualTo(3).And.Contains(1);
     /// </summary>
     public CollectionCountSource<TCollection, TItem> Count(
-        Func<IAssertionSource<TItem>, Assertion<TItem>?> itemAssertion,
+        Func<IAssertionSource<TItem>, IAssertion?> itemAssertion,
         [CallerArgumentExpression(nameof(itemAssertion))] string? expression = null)
     {
         Context.ExpressionBuilder.Append($".Count({expression})");

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -817,7 +817,6 @@ namespace .Conditions
     public class CollectionCountSource<TCollection, TItem>
         where TCollection : .<TItem>
     {
-        public CollectionCountSource(.<TCollection> collectionContext, <.<TItem>, .<TItem>?>? assertion) { }
         public .<TCollection, TItem> IsEqualTo(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThan(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
@@ -2643,6 +2642,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<TInner[]> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2630,8 +2630,10 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
-        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
-            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
@@ -2644,6 +2646,9 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<TInner[]> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -6179,7 +6179,7 @@ namespace .Sources
         public .<TCollection, TItem> Contains(TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem> ContainsOnly(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> Count() { }
-        public .<TCollection, TItem> Count(<.<TItem>, .<TItem>?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public .<TCollection, TItem> Count(<.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
         [.(-1)]
         public .<TCollection, TItem> Count(<.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2641,6 +2641,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2631,6 +2631,22 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
+        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2609,8 +2609,10 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
-        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
-            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
@@ -2623,6 +2625,9 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<TInner[]> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -6110,7 +6110,7 @@ namespace .Sources
         public .<TCollection, TItem> Contains(TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem> ContainsOnly(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> Count() { }
-        public .<TCollection, TItem> Count(<.<TItem>, .<TItem>?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public .<TCollection, TItem> Count(<.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
         public .<TCollection, TItem> Count(<.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(TItem expected, [.("expected")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2610,6 +2610,22 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
+        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -800,7 +800,6 @@ namespace .Conditions
     public class CollectionCountSource<TCollection, TItem>
         where TCollection : .<TItem>
     {
-        public CollectionCountSource(.<TCollection> collectionContext, <.<TItem>, .<TItem>?>? assertion) { }
         public .<TCollection, TItem> IsEqualTo(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThan(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
@@ -2622,6 +2621,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<TInner[]> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2620,6 +2620,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -817,7 +817,6 @@ namespace .Conditions
     public class CollectionCountSource<TCollection, TItem>
         where TCollection : .<TItem>
     {
-        public CollectionCountSource(.<TCollection> collectionContext, <.<TItem>, .<TItem>?>? assertion) { }
         public .<TCollection, TItem> IsEqualTo(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThan(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
@@ -2643,6 +2642,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<TInner[]> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2630,8 +2630,10 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
-        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
-            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
@@ -2644,6 +2646,9 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<TInner[]> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -6179,7 +6179,7 @@ namespace .Sources
         public .<TCollection, TItem> Contains(TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem> ContainsOnly(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> Count() { }
-        public .<TCollection, TItem> Count(<.<TItem>, .<TItem>?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public .<TCollection, TItem> Count(<.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
         [.(-1)]
         public .<TCollection, TItem> Count(<.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2641,6 +2641,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2631,6 +2631,22 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
+        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -5349,7 +5349,7 @@ namespace .Sources
         public .<TCollection, TItem> Contains(TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem> ContainsOnly(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> Count() { }
-        public .<TCollection, TItem> Count(<.<TItem>, .<TItem>?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public .<TCollection, TItem> Count(<.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
         public .<TCollection, TItem> Count(<.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(<TItem, bool> predicate, [.("predicate")] string? expression = null) { }
         public .<TCollection, TItem> DoesNotContain(TItem expected, [.("expected")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2365,8 +2365,10 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
-        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
-            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
@@ -2377,6 +2379,9 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<TInner[]> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2366,6 +2366,22 @@ namespace .Extensions
     {
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
         public static . CompletesWithin(this . source,  timeout, [.("timeout")] string? expression = null) { }
+        public static .<TCollection, string> Count<TCollection>(this .<TCollection, string> source, <.<string>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<string> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TInner>> { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
+        public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<.<TKey, TValue>>
+            where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
         public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -657,7 +657,6 @@ namespace .Conditions
     public class CollectionCountSource<TCollection, TItem>
         where TCollection : .<TItem>
     {
-        public CollectionCountSource(.<TCollection> collectionContext, <.<TItem>, .<TItem>?>? assertion) { }
         public .<TCollection, TItem> IsEqualTo(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThan(int expected, [.("expected")] string? expression = null) { }
         public .<TCollection, TItem> IsGreaterThanOrEqualTo(int expected, [.("expected")] string? expression = null) { }
@@ -2376,6 +2375,8 @@ namespace .Extensions
             where TCollection : .<.<TInner>> { }
         public static .<TCollection, .<TInner>> Count<TCollection, TInner>(this .<TCollection, .<TInner>> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TInner>> { }
+        public static .<TCollection, TInner[]> Count<TCollection, TInner>(this .<TCollection, TInner[]> source, <.<TInner>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TCollection : .<TInner[]> { }
         public static .<TCollection, .<TKey, TValue>> Count<TCollection, TKey, TValue>(this .<TCollection, .<TKey, TValue>> source, <.<TKey, TValue>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }


### PR DESCRIPTION
Closes #5707

## Summary
- Per-item Count overload now propagates the inner assertion's specialised source instead of falling back to a generic wrapper
- Failure messages keep the typed diagnostic (mirrors the spirit of #5702)

## Test plan
- [x] Snapshot updates accepted
- [x] Unit test asserting message contains specialised source for Count(item-assertion)