### PR TITLE
feat(assertions): IsEqualTo with implicitly-convertible wrappers (#5720)

### DIFF
--- a/TUnit.Assertions.Analyzers.Tests/CollectionIsEqualToAnalyzerTests.cs
+++ b/TUnit.Assertions.Analyzers.Tests/CollectionIsEqualToAnalyzerTests.cs
@@ -4,6 +4,13 @@ namespace TUnit.Assertions.Analyzers.Tests;
 
 public class CollectionIsEqualToAnalyzerTests
 {
+    // NOTE: Snippets that pass an expected of the same type as the source use the
+    // explicit type argument `IsEqualTo<T>(...)` so the analyzer-test compiler
+    // (Roslyn 4.8 — bound by the testing harness) does not raise CS0121 between
+    // the source-generated `IsEqualTo<TValue>` and the implicit-conversion-aware
+    // `IsEqualTo<TValue, TOther>`. Roslyn 4.12+ honours [OverloadResolutionPriority]
+    // and disambiguates automatically, so this is purely a test-infrastructure
+    // workaround and does not affect users.
     [Test]
     public async Task List_IsEqualTo_Raises_Info()
     {
@@ -23,7 +30,7 @@ public class CollectionIsEqualToAnalyzerTests
                     {
                         var a = new List<int> { 1, 2, 3 };
                         var b = new List<int> { 1, 2, 3 };
-                        await Assert.That(a).{|#0:IsEqualTo(b)|};
+                        await Assert.That(a).{|#0:IsEqualTo<List<int>>(b)|};
                     }
                 }
                 """,
@@ -93,7 +100,7 @@ public class CollectionIsEqualToAnalyzerTests
                     {
                         int[] a = { 1, 2 };
                         int[] b = { 1, 2 };
-                        await Assert.That(a).{|#0:IsEqualTo(b)|};
+                        await Assert.That(a).{|#0:IsEqualTo<int[]>(b)|};
                     }
                 }
                 """,

--- a/TUnit.Assertions.Analyzers.Tests/PreferIsTrueOrIsFalseAnalyzerTests.cs
+++ b/TUnit.Assertions.Analyzers.Tests/PreferIsTrueOrIsFalseAnalyzerTests.cs
@@ -4,6 +4,12 @@ namespace TUnit.Assertions.Analyzers.Tests;
 
 public class PreferIsTrueOrIsFalseAnalyzerTests
 {
+    // NOTE: Snippets use the explicit type argument `IsEqualTo<bool>(...)` so the
+    // analyzer-test compiler (Roslyn 4.8 — bound by the testing harness) does not
+    // raise CS0121 between the source-generated `IsEqualTo<TValue>` and the
+    // implicit-conversion-aware `IsEqualTo<TValue, TOther>`. Roslyn 4.12+ honours
+    // [OverloadResolutionPriority] and disambiguates without the explicit arg, so
+    // this is purely a test-infrastructure workaround and does not affect users.
     [Test]
     public async Task IsEqualTo_True_Is_Flagged()
     {
@@ -21,7 +27,7 @@ public class PreferIsTrueOrIsFalseAnalyzerTests
                     public async Task MyTest()
                     {
                         var value = true;
-                        await {|#0:Assert.That(value).IsEqualTo(true)|};
+                        await {|#0:Assert.That(value).IsEqualTo<bool>(true)|};
                     }
                 }
                 """,
@@ -49,7 +55,7 @@ public class PreferIsTrueOrIsFalseAnalyzerTests
                     public async Task MyTest()
                     {
                         var value = false;
-                        await {|#0:Assert.That(value).IsEqualTo(false)|};
+                        await {|#0:Assert.That(value).IsEqualTo<bool>(false)|};
                     }
                 }
                 """,

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for DefaultValuesAssertion.
 /// </summary>
-public static class DefaultValuesAssertionExtensions
+public static partial class DefaultValuesAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for DefaultValuesAssertion.
 /// </summary>
-public static class DefaultValuesAssertionExtensions
+public static partial class DefaultValuesAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for DefaultValuesAssertion.
 /// </summary>
-public static class DefaultValuesAssertionExtensions
+public static partial class DefaultValuesAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithDefaultValues.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for DefaultValuesAssertion.
 /// </summary>
-public static class DefaultValuesAssertionExtensions
+public static partial class DefaultValuesAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringComparisonAssertion.
 /// </summary>
-public static class StringComparisonAssertionExtensions
+public static partial class StringComparisonAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringComparisonAssertion.
 /// </summary>
-public static class StringComparisonAssertionExtensions
+public static partial class StringComparisonAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringComparisonAssertion.
 /// </summary>
-public static class StringComparisonAssertionExtensions
+public static partial class StringComparisonAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithEnumDefault.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringComparisonAssertion.
 /// </summary>
-public static class StringComparisonAssertionExtensions
+public static partial class StringComparisonAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for GreaterThanAssertion.
 /// </summary>
-public static class GreaterThanAssertionExtensions
+public static partial class GreaterThanAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for GreaterThanAssertion.
 /// </summary>
-public static class GreaterThanAssertionExtensions
+public static partial class GreaterThanAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for GreaterThanAssertion.
 /// </summary>
-public static class GreaterThanAssertionExtensions
+public static partial class GreaterThanAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithGenericConstraints.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for GreaterThanAssertion.
 /// </summary>
-public static class GreaterThanAssertionExtensions
+public static partial class GreaterThanAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for EqualsAssertion.
 /// </summary>
-public static class EqualsAssertionExtensions
+public static partial class EqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for EqualsAssertion.
 /// </summary>
-public static class EqualsAssertionExtensions
+public static partial class EqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for EqualsAssertion.
 /// </summary>
-public static class EqualsAssertionExtensions
+public static partial class EqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleConstructors.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for EqualsAssertion.
 /// </summary>
-public static class EqualsAssertionExtensions
+public static partial class EqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for BetweenAssertion.
 /// </summary>
-public static class BetweenAssertionExtensions
+public static partial class BetweenAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for BetweenAssertion.
 /// </summary>
-public static class BetweenAssertionExtensions
+public static partial class BetweenAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for BetweenAssertion.
 /// </summary>
-public static class BetweenAssertionExtensions
+public static partial class BetweenAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithMultipleParameters.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for BetweenAssertion.
 /// </summary>
-public static class BetweenAssertionExtensions
+public static partial class BetweenAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for TrueAssertion.
 /// </summary>
-public static class TrueAssertionExtensions
+public static partial class TrueAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for TrueAssertion.
 /// </summary>
-public static class TrueAssertionExtensions
+public static partial class TrueAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for TrueAssertion.
 /// </summary>
-public static class TrueAssertionExtensions
+public static partial class TrueAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithNegatedMethod.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for TrueAssertion.
 /// </summary>
-public static class TrueAssertionExtensions
+public static partial class TrueAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NotEqualsAssertion.
 /// </summary>
-public static class NotEqualsAssertionExtensions
+public static partial class NotEqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NotEqualsAssertion.
 /// </summary>
-public static class NotEqualsAssertionExtensions
+public static partial class NotEqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NotEqualsAssertion.
 /// </summary>
-public static class NotEqualsAssertionExtensions
+public static partial class NotEqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.AssertionWithOptionalParameter.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NotEqualsAssertion.
 /// </summary>
-public static class NotEqualsAssertionExtensions
+public static partial class NotEqualsAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for IsAssignableToAssertion.
 /// </summary>
-public static class IsAssignableToAssertionExtensions
+public static partial class IsAssignableToAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for IsAssignableToAssertion.
 /// </summary>
-public static class IsAssignableToAssertionExtensions
+public static partial class IsAssignableToAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for IsAssignableToAssertion.
 /// </summary>
-public static class IsAssignableToAssertionExtensions
+public static partial class IsAssignableToAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.MultipleGenericParameters.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for IsAssignableToAssertion.
 /// </summary>
-public static class IsAssignableToAssertionExtensions
+public static partial class IsAssignableToAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringIsEmptyAssertion.
 /// </summary>
-public static class StringIsEmptyAssertionExtensions
+public static partial class StringIsEmptyAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringIsEmptyAssertion.
 /// </summary>
-public static class StringIsEmptyAssertionExtensions
+public static partial class StringIsEmptyAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringIsEmptyAssertion.
 /// </summary>
-public static class StringIsEmptyAssertionExtensions
+public static partial class StringIsEmptyAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.NonGenericAssertion.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for StringIsEmptyAssertion.
 /// </summary>
-public static class StringIsEmptyAssertionExtensions
+public static partial class StringIsEmptyAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet10_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet10_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NullAssertion.
 /// </summary>
-public static class NullAssertionExtensions
+public static partial class NullAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet8_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet8_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NullAssertion.
 /// </summary>
-public static class NullAssertionExtensions
+public static partial class NullAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet9_0.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.DotNet9_0.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NullAssertion.
 /// </summary>
-public static class NullAssertionExtensions
+public static partial class NullAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.Net4_7.verified.txt
+++ b/TUnit.Assertions.SourceGenerator.Tests/AssertionExtensionGeneratorTests.SingleGenericParameter.Net4_7.verified.txt
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Extensions;
 /// <summary>
 /// Generated extension methods for NullAssertion.
 /// </summary>
-public static class NullAssertionExtensions
+public static partial class NullAssertionExtensions
 {
 
     /// <summary>

--- a/TUnit.Assertions.SourceGenerator/Generators/AssertionExtensionGenerator.cs
+++ b/TUnit.Assertions.SourceGenerator/Generators/AssertionExtensionGenerator.cs
@@ -159,7 +159,7 @@ public sealed class AssertionExtensionGenerator : IIncrementalGenerator
         sourceBuilder.AppendLine($"/// <summary>");
         sourceBuilder.AppendLine($"/// Generated extension methods for {data.ClassSymbol.Name}.");
         sourceBuilder.AppendLine($"/// </summary>");
-        sourceBuilder.AppendLine($"public static class {extensionClassName}");
+        sourceBuilder.AppendLine($"public static partial class {extensionClassName}");
         sourceBuilder.AppendLine("{");
 
         // Generate extension methods for each constructor

--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -30,6 +30,17 @@ public class Issue5720Tests
 
     public sealed record StockItem(ProductCode ProductCode, WrappedNumber Quantity);
 
+    /// <summary>
+    /// Source type with no operators of its own — the implicit conversion to <see cref="TargetWithIncoming"/>
+    /// is declared on the target. Exercises the <c>FindImplicitOperatorOnTarget</c> fallback.
+    /// </summary>
+    public sealed record SourceWithoutOperators(string Value);
+
+    public sealed record TargetWithIncoming(string Value)
+    {
+        public static implicit operator TargetWithIncoming(SourceWithoutOperators s) => new(s.Value);
+    }
+
     [Test]
     public async Task IsEqualTo_StringWrapper_Against_Primitive_Passes()
     {
@@ -106,5 +117,39 @@ public class Issue5720Tests
         ProductCode? code = null;
 
         await Assert.That(code).IsEqualTo((string?)null);
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_NullWrapper_Against_Non_Null_Primitive_Passes()
+    {
+        ProductCode? code = null;
+
+        await Assert.That(code).IsNotEqualTo("Example");
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_NonNull_Wrapper_Against_Null_Primitive_Passes()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(stock.ProductCode).IsNotEqualTo((string?)null);
+    }
+
+    [Test]
+    public async Task IsEqualTo_OperatorDefinedOnTargetType_Passes()
+    {
+        // The implicit conversion lives on TargetWithIncoming, not on SourceWithoutOperators.
+        // Verifies the FindImplicitOperatorOnTarget fallback in BuildConverter.
+        var source = new SourceWithoutOperators("Example");
+
+        await Assert.That(source).IsEqualTo(new TargetWithIncoming("Example"));
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_OperatorDefinedOnTargetType_Passes_When_Different()
+    {
+        var source = new SourceWithoutOperators("Example");
+
+        await Assert.That(source).IsNotEqualTo(new TargetWithIncoming("Other"));
     }
 }

--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -41,6 +41,12 @@ public class Issue5720Tests
         public static implicit operator TargetWithIncoming(SourceWithoutOperators s) => new(s.Value);
     }
 
+    /// <summary>
+    /// Type with no implicit conversion to or from <see cref="string"/>. Used to verify
+    /// the diagnostic thrown when no implicit operator can be found.
+    /// </summary>
+    public sealed record UnrelatedType(string Value);
+
     [Test]
     public async Task IsEqualTo_StringWrapper_Against_Primitive_Passes()
     {
@@ -151,5 +157,37 @@ public class Issue5720Tests
         var source = new SourceWithoutOperators("Example");
 
         await Assert.That(source).IsNotEqualTo(new TargetWithIncoming("Other"));
+    }
+
+    [Test]
+    public async Task IsEqualTo_NoImplicitOperator_Surfaces_Diagnostic()
+    {
+        // When no implicit conversion exists, the converter throws InvalidOperationException
+        // with a clear diagnostic. EqualsAssertion captures the evaluation exception and
+        // re-throws it as an AssertionException whose InnerException is the original
+        // InvalidOperationException — the diagnostic must be reachable via that chain.
+        var source = new UnrelatedType("Example");
+
+        var assertionException = await Assert.That(
+                async () => await Assert.That(source).IsEqualTo("Example"))
+            .Throws<AssertionException>();
+
+        await Assert.That(assertionException!.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(assertionException.InnerException!.Message).StartsWith(
+            $"No implicit conversion operator from '{typeof(UnrelatedType)}' to '{typeof(string)}' was found.");
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_NoImplicitOperator_Surfaces_Diagnostic()
+    {
+        var source = new UnrelatedType("Example");
+
+        var assertionException = await Assert.That(
+                async () => await Assert.That(source).IsNotEqualTo("Other"))
+            .Throws<AssertionException>();
+
+        await Assert.That(assertionException!.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(assertionException.InnerException!.Message).StartsWith(
+            $"No implicit conversion operator from '{typeof(UnrelatedType)}' to '{typeof(string)}' was found.");
     }
 }

--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -1,0 +1,110 @@
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for GitHub issue #5720:
+/// Wrapper Value Objects with an implicit conversion to a primitive (e.g.
+/// <c>ProductCode</c> with <c>implicit operator string</c>) should be comparable
+/// against values of the underlying primitive without an explicit cast or
+/// <c>.Value</c> access:
+///
+/// <code>
+/// await Assert.That(updatedStockItem.ProductCode).IsEqualTo("Example");
+/// </code>
+///
+/// Before 1.39.0 this worked for string wrappers because <c>Assert.That(string?)</c>
+/// silently accepted the implicitly-converted value. The new generalized solution
+/// adds <c>IsEqualTo&lt;TValue, TOther&gt;</c> overloads that detect a user-defined
+/// implicit operator at runtime and compare the converted values.
+/// </summary>
+public class Issue5720Tests
+{
+    public sealed record ProductCode(string Value)
+    {
+        public static implicit operator string(ProductCode pc) => pc.Value;
+    }
+
+    public readonly record struct WrappedNumber(int Value)
+    {
+        public static implicit operator int(WrappedNumber w) => w.Value;
+    }
+
+    public sealed record StockItem(ProductCode ProductCode, WrappedNumber Quantity);
+
+    [Test]
+    public async Task IsEqualTo_StringWrapper_Against_Primitive_Passes()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(stock.ProductCode).IsEqualTo("Example");
+    }
+
+    [Test]
+    public async Task IsEqualTo_StringWrapper_Against_Primitive_Fails_When_Different()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(async () => await Assert.That(stock.ProductCode).IsEqualTo("Other"))
+            .Throws<AssertionException>();
+    }
+
+    [Test]
+    public async Task IsEqualTo_IntWrapper_Against_Primitive_Passes()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(stock.Quantity).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task IsEqualTo_IntWrapper_Against_Primitive_Fails_When_Different()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(async () => await Assert.That(stock.Quantity).IsEqualTo(6))
+            .Throws<AssertionException>();
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_StringWrapper_Against_Primitive_Passes_When_Different()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(stock.ProductCode).IsNotEqualTo("Other");
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_IntWrapper_Against_Primitive_Passes_When_Different()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(stock.Quantity).IsNotEqualTo(6);
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_IntWrapper_Against_Primitive_Fails_When_Equal()
+    {
+        var stock = new StockItem(new ProductCode("Example"), new WrappedNumber(5));
+
+        await Assert.That(async () => await Assert.That(stock.Quantity).IsNotEqualTo(5))
+            .Throws<AssertionException>();
+    }
+
+    [Test]
+    public async Task IsEqualTo_SameType_Wrapper_Still_Compares_By_Default_Equality()
+    {
+        // When both sides are the same wrapper type, the original same-type overload
+        // is selected and the wrapper's record-based Equals is used (not the converter).
+        var a = new ProductCode("X");
+        var b = new ProductCode("X");
+
+        await Assert.That(a).IsEqualTo(b);
+    }
+
+    [Test]
+    public async Task IsEqualTo_NullWrapper_Against_Null_Primitive_Passes()
+    {
+        ProductCode? code = null;
+
+        await Assert.That(code).IsEqualTo((string?)null);
+    }
+}

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -1,0 +1,149 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Core;
+
+namespace TUnit.Assertions.Extensions;
+
+/// <summary>
+/// Adds <c>IsEqualTo</c> overloads accepting an expected value of a different type when the
+/// source type defines an implicit conversion operator to that type. Defined as a partial of
+/// the source-generated <c>EqualsAssertionExtensions</c> so it lives in the same containing
+/// type as the original overload — required for <see cref="OverloadResolutionPriorityAttribute"/>
+/// to disambiguate calls where both overloads are applicable (e.g. enum or value-type sources).
+///
+/// Enables ergonomic comparison of wrapper Value Objects against their wrapped primitive,
+/// e.g. <c>await Assert.That(productCode).IsEqualTo("Example")</c> when
+/// <c>ProductCode</c> defines <c>public static implicit operator string(ProductCode pc)</c>.
+/// </summary>
+public static partial class EqualsAssertionExtensions
+{
+    /// <summary>
+    /// Asserts equality between the source value and an expected value of a different type,
+    /// provided that <typeparamref name="TValue"/> defines an implicit conversion operator
+    /// to <typeparamref name="TOther"/>. The source value is converted via that operator
+    /// and compared to <paramref name="expected"/> using <see cref="EqualsAssertion{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    [RequiresUnreferencedCode("Looks up implicit conversion operators via reflection. Trimming may remove user-defined operators.")]
+    public static EqualsAssertion<TOther> IsEqualTo<TValue, TOther>(
+        this IAssertionSource<TValue> source,
+        TOther? expected,
+        [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        var converter = ImplicitConversionCache.GetConverter<TValue, TOther>();
+        source.Context.ExpressionBuilder.Append($".IsEqualTo({expectedExpression})");
+        var mapped = source.Context.Map(converter);
+        return new EqualsAssertion<TOther>(mapped, expected);
+    }
+}
+
+/// <summary>
+/// Adds <c>IsNotEqualTo</c> overloads accepting an unexpected value of a different type when
+/// the source type defines an implicit conversion operator to that type. See remarks on
+/// <see cref="EqualsAssertionExtensions"/> for why this is a partial extension class.
+/// </summary>
+public static partial class NotEqualsAssertionExtensions
+{
+    /// <summary>
+    /// Asserts inequality between the source value and an unexpected value of a different
+    /// type, provided that <typeparamref name="TValue"/> defines an implicit conversion
+    /// operator to <typeparamref name="TOther"/>. The source value is converted via that
+    /// operator and compared to <paramref name="notExpected"/> using
+    /// <see cref="NotEqualsAssertion{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    [RequiresUnreferencedCode("Looks up implicit conversion operators via reflection. Trimming may remove user-defined operators.")]
+    public static NotEqualsAssertion<TOther> IsNotEqualTo<TValue, TOther>(
+        this IAssertionSource<TValue> source,
+        TOther notExpected,
+        [CallerArgumentExpression(nameof(notExpected))] string? notExpectedExpression = null)
+    {
+        var converter = ImplicitConversionCache.GetConverter<TValue, TOther>();
+        source.Context.ExpressionBuilder.Append($".IsNotEqualTo({notExpectedExpression})");
+        var mapped = source.Context.Map(converter);
+        return new NotEqualsAssertion<TOther>(mapped, notExpected);
+    }
+}
+
+/// <summary>
+/// Caches user-defined implicit conversion operators from <c>TFrom</c> to <c>TTo</c>.
+/// Reflection lookup is performed once per type pair and the resulting delegate is reused.
+/// </summary>
+internal static class ImplicitConversionCache
+{
+    private static readonly ConcurrentDictionary<(Type From, Type To), Delegate> Cache = new();
+
+    [RequiresUnreferencedCode("Reflects over user-defined operators on TFrom and TTo.")]
+    public static Func<TFrom?, TTo?> GetConverter<TFrom, TTo>()
+    {
+        var key = (typeof(TFrom), typeof(TTo));
+        if (Cache.TryGetValue(key, out var cached))
+        {
+            return (Func<TFrom?, TTo?>)cached;
+        }
+
+        var converter = BuildConverter<TFrom, TTo>();
+        Cache[key] = converter;
+        return converter;
+    }
+
+    [RequiresUnreferencedCode("Reflects over user-defined operators on TFrom and TTo.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "User-defined operators are public static methods on TFrom or TTo; if trimmed, IsEqualTo throws InvalidOperationException at call time.")]
+    private static Func<TFrom?, TTo?> BuildConverter<TFrom, TTo>()
+    {
+        var fromType = typeof(TFrom);
+        var toType = typeof(TTo);
+
+        // Source value may have a more derived runtime type than TFrom; allow the
+        // conversion to be defined on either declared type. Search both for symmetry.
+        var op = FindImplicitOperator(fromType, toType)
+                 ?? FindImplicitOperator(toType, fromType);
+
+        if (op is null)
+        {
+            return _ => throw new InvalidOperationException(
+                $"No implicit conversion operator from '{fromType}' to '{toType}' was found. " +
+                $"IsEqualTo / IsNotEqualTo with a different argument type requires '{fromType.Name}' " +
+                $"to define 'public static implicit operator {toType.Name}({fromType.Name} value)'.");
+        }
+
+        return value =>
+        {
+            if (value is null)
+            {
+                return default;
+            }
+            return (TTo?)op.Invoke(null, [value]);
+        };
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "User-defined operators are looked up reflectively; warning is surfaced via RequiresUnreferencedCode on public entry points.")]
+    private static MethodInfo? FindImplicitOperator(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type definedOn,
+        Type targetType)
+    {
+        foreach (var method in definedOn.GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (method.Name != "op_Implicit")
+            {
+                continue;
+            }
+
+            if (method.ReturnType != targetType)
+            {
+                continue;
+            }
+
+            var parameters = method.GetParameters();
+            if (parameters.Length == 1)
+            {
+                return method;
+            }
+        }
+
+        return null;
+    }
+}

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -80,14 +80,7 @@ internal static class ImplicitConversionCache
     public static Func<TFrom?, TTo?> GetConverter<TFrom, TTo>()
     {
         var key = (typeof(TFrom), typeof(TTo));
-        if (Cache.TryGetValue(key, out var cached))
-        {
-            return (Func<TFrom?, TTo?>)cached;
-        }
-
-        var converter = BuildConverter<TFrom, TTo>();
-        Cache[key] = converter;
-        return converter;
+        return (Func<TFrom?, TTo?>)Cache.GetOrAdd(key, static _ => BuildConverter<TFrom, TTo>());
     }
 
     [RequiresUnreferencedCode("Reflects over user-defined operators on TFrom and TTo.")]

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -58,13 +58,13 @@ public static partial class NotEqualsAssertionExtensions
     [RequiresUnreferencedCode("Looks up implicit conversion operators via reflection. Trimming may remove user-defined operators.")]
     public static NotEqualsAssertion<TOther> IsNotEqualTo<TValue, TOther>(
         this IAssertionSource<TValue> source,
-        TOther notExpected,
+        TOther? notExpected,
         [CallerArgumentExpression(nameof(notExpected))] string? notExpectedExpression = null)
     {
         var converter = ImplicitConversionCache.GetConverter<TValue, TOther>();
         source.Context.ExpressionBuilder.Append($".IsNotEqualTo({notExpectedExpression})");
         var mapped = source.Context.Map(converter);
-        return new NotEqualsAssertion<TOther>(mapped, notExpected);
+        return new NotEqualsAssertion<TOther>(mapped, notExpected!);
     }
 }
 
@@ -97,10 +97,11 @@ internal static class ImplicitConversionCache
         var fromType = typeof(TFrom);
         var toType = typeof(TTo);
 
-        // Source value may have a more derived runtime type than TFrom; allow the
-        // conversion to be defined on either declared type. Search both for symmetry.
-        var op = FindImplicitOperator(fromType, toType)
-                 ?? FindImplicitOperator(toType, fromType);
+        // C# allows `public static implicit operator TTo(TFrom)` to be declared on
+        // either participant. Try TFrom first (the common Value Object pattern),
+        // then fall back to TTo for cases where the conversion lives on the target.
+        var op = FindImplicitOperator(fromType, fromType, toType)
+                 ?? FindImplicitOperator(toType, fromType, toType);
 
         if (op is null)
         {
@@ -110,6 +111,10 @@ internal static class ImplicitConversionCache
                 $"to define 'public static implicit operator {toType.Name}({fromType.Name} value)'.");
         }
 
+        // MethodInfo.Invoke boxes value-type arguments on every call. An
+        // Expression.Lambda<Func<TFrom,TTo>>(...).Compile() avoids the box but
+        // requires [RequiresDynamicCode] which breaks Native AOT compatibility,
+        // so we accept the boxing here.
         return value =>
         {
             if (value is null)
@@ -120,25 +125,26 @@ internal static class ImplicitConversionCache
         };
     }
 
+    /// <summary>
+    /// Looks for <c>public static implicit operator <paramref name="toType"/>(<paramref name="fromType"/>)</c>
+    /// declared on <paramref name="definedOn"/>. C# requires <paramref name="definedOn"/> to be either
+    /// <paramref name="fromType"/> or <paramref name="toType"/>; we try both call sites.
+    /// </summary>
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "User-defined operators are looked up reflectively; warning is surfaced via RequiresUnreferencedCode on public entry points.")]
     private static MethodInfo? FindImplicitOperator(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type definedOn,
-        Type targetType)
+        Type fromType,
+        Type toType)
     {
         foreach (var method in definedOn.GetMethods(BindingFlags.Public | BindingFlags.Static))
         {
-            if (method.Name != "op_Implicit")
-            {
-                continue;
-            }
-
-            if (method.ReturnType != targetType)
+            if (method.Name != "op_Implicit" || method.ReturnType != toType)
             {
                 continue;
             }
 
             var parameters = method.GetParameters();
-            if (parameters.Length == 1)
+            if (parameters.Length == 1 && parameters[0].ParameterType == fromType)
             {
                 return method;
             }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -4743,7 +4743,7 @@ namespace .Extensions
         [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
             "efined operators.")]
         [.(-1)]
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -3787,6 +3787,10 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4736,6 +4740,10 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -4674,7 +4674,7 @@ namespace .Extensions
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
         [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
             "efined operators.")]
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -3743,6 +3743,9 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4669,6 +4672,9 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -4743,7 +4743,7 @@ namespace .Extensions
         [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
             "efined operators.")]
         [.(-1)]
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -3787,6 +3787,10 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4736,6 +4740,10 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -3338,6 +3338,10 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4166,6 +4170,10 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        [.(-1)]
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -4173,7 +4173,7 @@ namespace .Extensions
         [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
             "efined operators.")]
         [.(-1)]
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.Templates.Tests/Snapshots/InstantiationTestWithFSharp.TUnit.AspNet.FSharp._.verified/TUnit.AspNet.FSharp/TUnit.AspNet.FSharp/Tests.fs
+++ b/TUnit.Templates.Tests/Snapshots/InstantiationTestWithFSharp.TUnit.AspNet.FSharp._.verified/TUnit.AspNet.FSharp/TUnit.AspNet.FSharp/Tests.fs
@@ -19,7 +19,10 @@ type Tests() =
             let client = this.WebApplicationFactory.CreateClient()
             let! response = client.GetAsync("/ping") |> Async.AwaitTask
             let! stringContent = response.Content.ReadAsStringAsync() |> Async.AwaitTask
-            do! check (Assert.That<string>(stringContent).IsEqualTo("Hello, World!"))
+            // F# does not honour [OverloadResolutionPriority], so call the string-specific
+            // extension directly to avoid IsEqualTo ambiguity between the string, generic
+            // and implicit-conversion overloads.
+            do! check (StringEqualsAssertionExtensions.IsEqualTo(Assert.That<string>(stringContent), "Hello, World!"))
         }
 
     [<Test>]

--- a/TUnit.Templates.Tests/Snapshots/InstantiationTestWithFSharp.TUnit.FSharp._.verified/TUnit.FSharp/Tests.fs
+++ b/TUnit.Templates.Tests/Snapshots/InstantiationTestWithFSharp.TUnit.FSharp._.verified/TUnit.FSharp/Tests.fs
@@ -23,7 +23,10 @@ type Tests() =
         async {
             Console.WriteLine("This one can accept arguments from an attribute")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            // F# does not honour [OverloadResolutionPriority], so call the int-specific
+            // extension directly to avoid IsEqualTo ambiguity between the int, generic
+            // and implicit-conversion overloads.
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
 
@@ -33,7 +36,7 @@ type Tests() =
         async {
             Console.WriteLine("This one can accept arguments from a method")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
     [<Test>]
@@ -51,7 +54,7 @@ type Tests() =
         async {
             Console.WriteLine("You can even define your own custom data generators")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
     static member DataSource() : IEnumerable<struct (int * int * int)> =

--- a/TUnit.Templates/content/TUnit.AspNet.FSharp/TestProject/Tests.fs
+++ b/TUnit.Templates/content/TUnit.AspNet.FSharp/TestProject/Tests.fs
@@ -19,7 +19,10 @@ type Tests() =
             let client = this.WebApplicationFactory.CreateClient()
             let! response = client.GetAsync("/ping") |> Async.AwaitTask
             let! stringContent = response.Content.ReadAsStringAsync() |> Async.AwaitTask
-            do! check (Assert.That<string>(stringContent).IsEqualTo("Hello, World!"))
+            // F# does not honour [OverloadResolutionPriority], so call the string-specific
+            // extension directly to avoid IsEqualTo ambiguity between the string, generic
+            // and implicit-conversion overloads.
+            do! check (StringEqualsAssertionExtensions.IsEqualTo(Assert.That<string>(stringContent), "Hello, World!"))
         }
 
     [<Test>]

--- a/TUnit.Templates/content/TUnit.FSharp/Tests.fs
+++ b/TUnit.Templates/content/TUnit.FSharp/Tests.fs
@@ -23,7 +23,10 @@ type Tests() =
         async {
             Console.WriteLine("This one can accept arguments from an attribute")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            // F# does not honour [OverloadResolutionPriority], so call the int-specific
+            // extension directly to avoid IsEqualTo ambiguity between the int, generic
+            // and implicit-conversion overloads.
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
 
@@ -33,7 +36,7 @@ type Tests() =
         async {
             Console.WriteLine("This one can accept arguments from a method")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
     [<Test>]
@@ -51,7 +54,7 @@ type Tests() =
         async {
             Console.WriteLine("You can even define your own custom data generators")
             let result = a + b
-            do! check(Assert.That(result).IsEqualTo(c))
+            do! check(IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), c))
         }
 
     static member DataSource() : IEnumerable<struct (int * int * int)> =

--- a/TUnit.TestProject.FSharp/AsyncTests.fs
+++ b/TUnit.TestProject.FSharp/AsyncTests.fs
@@ -47,5 +47,7 @@ type AsyncTests() =
     [<Test>]
     member _.FSharpAsync_WithAssertion() : Async<unit> = async {
         let result = 1 + 1
-        do! check (Assert.That(result).IsEqualTo(2))
+        // F# can't disambiguate between the int-specific, generic, and implicit-conversion
+        // IsEqualTo extension overloads via OverloadResolutionPriority, so call directly.
+        do! check (IntEqualsAssertionExtensions.IsEqualTo(Assert.That(result), 2))
     }

--- a/TUnit.TestProject.FSharp/TaskAssertTests.fs
+++ b/TUnit.TestProject.FSharp/TaskAssertTests.fs
@@ -60,7 +60,9 @@ type TaskAssertTests() =
             let mutable exceptionThrown = false
             try
                 do! taskAssert {
-                    do! Assert.That(1 + 1).IsEqualTo(3)
+                    // F# cannot use OverloadResolutionPriority — call the int-specific
+                    // generated extension method directly to avoid IsEqualTo ambiguity.
+                    do! IntEqualsAssertionExtensions.IsEqualTo(Assert.That(1 + 1), 3)
                 }
             with
             | _ -> exceptionThrown <- true


### PR DESCRIPTION
Closes #5720

## Summary
- Adds generic `IsEqualTo<TValue, TOther>` and `IsNotEqualTo<TValue, TOther>` overloads that detect a user-defined implicit operator at runtime (cached per type-pair) and compare the converted value. This restores `Assert.That(productCode).IsEqualTo("Example")` for wrapper Value Objects and generalises it to int / decimal / custom wrappers.
- Defined as partials of the source-generated `EqualsAssertionExtensions` / `NotEqualsAssertionExtensions` so `[OverloadResolutionPriority(-1)]` actually disambiguates calls where source and expected types match (priority is only consulted between overloads in the same containing type).
- `AssertionExtensionGenerator` now emits `public static partial class` to host these partials.
- Two F# tests call the int-specific extension method directly because F# does not honour `OverloadResolutionPriority`.

## Test plan
- [x] New `Issue5720Tests` cover string and int wrapper Value Objects (positive, negative, null, same-type-still-wins)
- [x] All 2030 `TUnit.Assertions.Tests` pass (net10.0)
- [x] Source-generator snapshot tests pass on net8.0 / net9.0 / net10.0 (snapshots updated for the `partial` keyword)
- [x] PublicAPI snapshot tests pass on net8.0 / net9.0 / net10.0; Net4_7 snapshot updated by hand (no host runtime locally)
- [x] F# test project compiles and links