### PR TITLE
fix(pipeline): skip TestBaseModule frameworks with missing binaries

### DIFF
--- a/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
+++ b/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
@@ -30,10 +31,19 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
 
         foreach (var framework in TestableFrameworks)
         {
+            var (testOptions, executionOptions) = await GetTestOptions(context, framework, cancellationToken);
+
+            // Test projects no longer multi-target every TFM by default (see TestProject.props).
+            // Skip frameworks that this project did not actually build to avoid spurious
+            // "process cannot find the file" errors for missing per-TFM output binaries.
+            if (!HasFrameworkOutput(executionOptions, framework))
+            {
+                context.Logger.LogInformation($"Skipping {framework}: no build output found for this test project.");
+                continue;
+            }
+
             var testResult = await context.SubModule<CommandResult>(framework, async () =>
             {
-                var (testOptions, executionOptions) = await GetTestOptions(context, framework, cancellationToken);
-
                 var finalExecutionOptions = SetDefaults(testOptions, executionOptions ?? new CommandExecutionOptions(), framework);
 
                 return await context.DotNet().Run(testOptions, finalExecutionOptions, cancellationToken);
@@ -43,6 +53,19 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         }
 
         return results;
+    }
+
+    private static bool HasFrameworkOutput(CommandExecutionOptions? executionOptions, string framework)
+    {
+        var workingDirectory = executionOptions?.WorkingDirectory;
+        if (string.IsNullOrEmpty(workingDirectory))
+        {
+            // Cannot determine — fall through to attempt the run (preserves prior behaviour).
+            return true;
+        }
+
+        var binPath = Path.Combine(workingDirectory, "bin", "Release", framework);
+        return Directory.Exists(binPath);
     }
 
     private CommandExecutionOptions SetDefaults(DotNetRunOptions testOptions, CommandExecutionOptions executionOptions, string framework)

--- a/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
+++ b/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
@@ -31,7 +31,7 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
             // Skip frameworks that this project did not actually build to avoid spurious
             // "process cannot find the file" errors for missing per-TFM output binaries.
             var configuration = testOptions.Configuration ?? "Release";
-            if (!HasFrameworkOutput(context, executionOptions, framework, configuration))
+            if (!HasFrameworkOutput(context.Logger, executionOptions, framework, configuration))
             {
                 context.Logger.LogInformation("Skipping {Framework}: no build output found for this test project.", framework);
                 continue;
@@ -50,13 +50,13 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         return results;
     }
 
-    private static bool HasFrameworkOutput(IModuleContext context, CommandExecutionOptions? executionOptions, string framework, string configuration)
+    private static bool HasFrameworkOutput(ILogger logger, CommandExecutionOptions? executionOptions, string framework, string configuration)
     {
         var workingDirectory = executionOptions?.WorkingDirectory;
         if (string.IsNullOrEmpty(workingDirectory))
         {
             // Cannot determine — fall through to attempt the run (preserves prior behaviour).
-            context.Logger.LogWarning("Cannot probe build output for {Framework}: no WorkingDirectory set on execution options.", framework);
+            logger.LogWarning("Cannot probe build output for {Framework}: no WorkingDirectory set on execution options.", framework);
             return true;
         }
 

--- a/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
+++ b/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
@@ -13,17 +13,11 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
 {
     protected virtual IEnumerable<string> TestableFrameworks
     {
-        get
-        {
-            yield return "net10.0";
-            yield return "net8.0";
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                yield return "net472";
-            }
-        }
+        get { yield return "net10.0"; }
     }
+
+    /// <summary>True on Windows, where legacy .NET Framework TFMs (net4xx) can be tested.</summary>
+    protected static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     protected sealed override async Task<IReadOnlyList<CommandResult>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -67,7 +61,19 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         }
 
         var binPath = Path.Combine(workingDirectory, "bin", configuration, framework);
-        return Directory.Exists(binPath);
+
+        // Probe for an actual built binary, not just the directory: a stale empty
+        // bin/<config>/<tfm> folder (e.g. from `dotnet clean`) would otherwise be treated
+        // as a successful build and trigger a misleading "process cannot find the file" later.
+        try
+        {
+            return Directory.EnumerateFiles(binPath, "*.dll", SearchOption.TopDirectoryOnly).Any()
+                || Directory.EnumerateFiles(binPath, "*.exe", SearchOption.TopDirectoryOnly).Any();
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
     }
 
     private CommandExecutionOptions SetDefaults(DotNetRunOptions testOptions, CommandExecutionOptions executionOptions, string framework)
@@ -95,5 +101,10 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         };
     }
 
+    /// <summary>
+    /// Called once per framework in <see cref="TestableFrameworks"/>, <em>before</em> the
+    /// missing-output skip check. Keep this cheap — expensive work (e.g. awaiting other modules)
+    /// is wasted on TFMs the project did not build for.
+    /// </summary>
     protected abstract Task<(DotNetRunOptions Options, CommandExecutionOptions? ExecutionOptions)> GetTestOptions(IModuleContext context, string framework, CancellationToken cancellationToken);
 }

--- a/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
+++ b/TUnit.Pipeline/Modules/Abstract/TestBaseModule.cs
@@ -36,9 +36,10 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
             // Test projects no longer multi-target every TFM by default (see TestProject.props).
             // Skip frameworks that this project did not actually build to avoid spurious
             // "process cannot find the file" errors for missing per-TFM output binaries.
-            if (!HasFrameworkOutput(executionOptions, framework))
+            var configuration = testOptions.Configuration ?? "Release";
+            if (!HasFrameworkOutput(context, executionOptions, framework, configuration))
             {
-                context.Logger.LogInformation($"Skipping {framework}: no build output found for this test project.");
+                context.Logger.LogInformation("Skipping {Framework}: no build output found for this test project.", framework);
                 continue;
             }
 
@@ -55,16 +56,17 @@ public abstract class TestBaseModule : Module<IReadOnlyList<CommandResult>>
         return results;
     }
 
-    private static bool HasFrameworkOutput(CommandExecutionOptions? executionOptions, string framework)
+    private static bool HasFrameworkOutput(IModuleContext context, CommandExecutionOptions? executionOptions, string framework, string configuration)
     {
         var workingDirectory = executionOptions?.WorkingDirectory;
         if (string.IsNullOrEmpty(workingDirectory))
         {
             // Cannot determine — fall through to attempt the run (preserves prior behaviour).
+            context.Logger.LogWarning("Cannot probe build output for {Framework}: no WorkingDirectory set on execution options.", framework);
             return true;
         }
 
-        var binPath = Path.Combine(workingDirectory, "bin", "Release", framework);
+        var binPath = Path.Combine(workingDirectory, "bin", configuration, framework);
         return Directory.Exists(binPath);
     }
 

--- a/TUnit.Pipeline/Modules/RunPublicAPITestsModule.cs
+++ b/TUnit.Pipeline/Modules/RunPublicAPITestsModule.cs
@@ -11,6 +11,23 @@ namespace TUnit.Pipeline.Modules;
 [NotInParallel("SnapshotTests")]
 public class RunPublicAPITestsModule : TestBaseModule
 {
+    // Public API snapshots cover every supported consumer TFM — keep aligned with
+    // <TargetFrameworks> in TUnit.PublicAPI.csproj.
+    protected override IEnumerable<string> TestableFrameworks
+    {
+        get
+        {
+            yield return "net10.0";
+            yield return "net9.0";
+            yield return "net8.0";
+
+            if (IsWindows)
+            {
+                yield return "net472";
+            }
+        }
+    }
+
     protected override Task<(DotNetRunOptions Options, CommandExecutionOptions? ExecutionOptions)> GetTestOptions(IModuleContext context, string framework, CancellationToken cancellationToken)
     {
         var project = context.Git().RootDirectory.FindFile(x => x.Name == "TUnit.PublicAPI.csproj").AssertExists();

--- a/TUnit.Pipeline/Modules/RunSourceGeneratorTestsModule.cs
+++ b/TUnit.Pipeline/Modules/RunSourceGeneratorTestsModule.cs
@@ -11,6 +11,22 @@ namespace TUnit.Pipeline.Modules;
 [NotInParallel("SnapshotTests")]
 public class RunSourceGeneratorTestsModule : TestBaseModule
 {
+    // Generator output snapshots verify behaviour across consumer TFMs — keep aligned with
+    // <TargetFrameworks> in TUnit.Core.SourceGenerator.Tests.csproj.
+    protected override IEnumerable<string> TestableFrameworks
+    {
+        get
+        {
+            yield return "net10.0";
+            yield return "net8.0";
+
+            if (IsWindows)
+            {
+                yield return "net472";
+            }
+        }
+    }
+
     protected override Task<(DotNetRunOptions Options, CommandExecutionOptions? ExecutionOptions)> GetTestOptions(IModuleContext context, string framework, CancellationToken cancellationToken)
     {
         var project = context.Git().RootDirectory.FindFile(x => x.Name == "TUnit.Core.SourceGenerator.Tests.csproj").AssertExists();

--- a/TUnit.Pipeline/Modules/TestNugetPackageModule.cs
+++ b/TUnit.Pipeline/Modules/TestNugetPackageModule.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using ModularPipelines.Attributes;
+﻿using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Options;
@@ -44,7 +43,7 @@ public abstract class AbstractTestNugetPackageModule : TestBaseModule
             yield return "net10.0";
             yield return "net8.0";
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (IsWindows)
             {
                 yield return "net481";
                 yield return "net48";


### PR DESCRIPTION
## Summary
- After #5741 trimmed test projects to net10.0-only, `TestBaseModule` still iterates net472/net8.0 on Windows and tries `dotnet run --framework net472 --no-build` against projects that no longer build that TFM.
- The missing-binary error cascades and cancels other modules — every PR opened since #5741 has been failing Windows CI for this reason.
- `ExecuteAsync` now checks `bin/Release/{framework}` exists before invoking `dotnet run`. When absent it logs an info message and skips that TFM.

## Test plan
- [x] Pipeline builds clean
- [x] Restores green Windows CI on touched PRs without forcing every test project to multi-target

Extracted from #5750 so it can land independently and unblock the other open PRs.