### PR TITLE
fix(tests): unbreak main - disambiguate Count overload after IsEqualTo wrappers (#5751)

### DIFF
--- a/TUnit.Assertions.Tests/CollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionAssertionTests.cs
@@ -263,10 +263,11 @@ public class CollectionAssertionTests
     {
         var names = new[] { "Alice", "Bob", "Charlie" };
 
-        // For non-int collections, Count(c => c.IsEqualTo(3)) works unambiguously
+        // Use Count().IsEqualTo(3) to assert the count itself; Count(item => ...)
+        // is the per-item filter form (returns a count source without .And).
         await Assert.That(names)
             .IsNotEmpty()
-            .And.Count(c => c.IsEqualTo(3))
+            .And.Count().IsEqualTo(3)
             .And.Contains("Bob")
             .And.DoesNotContain("Dave");
     }

--- a/TUnit.Assertions.Tests/CollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionAssertionTests.cs
@@ -263,8 +263,7 @@ public class CollectionAssertionTests
     {
         var names = new[] { "Alice", "Bob", "Charlie" };
 
-        // Use Count().IsEqualTo(3) to assert the count itself; Count(item => ...)
-        // is the per-item filter form (returns a count source without .And).
+        // Count(predicate) is the per-item filter overload and returns a source without .And.
         await Assert.That(names)
             .IsNotEmpty()
             .And.Count().IsEqualTo(3)


### PR DESCRIPTION
## Summary
- Main is currently red on all 3 OS jobs of the .NET workflow with `CS1061: 'CollectionCountSource<string[], string>' does not contain a definition for 'And'` in `TUnit.Assertions.Tests/CollectionAssertionTests.cs:270`.
- Root cause: PR #5751 (`feat(assertions): IsEqualTo with implicitly-convertible wrappers`) added `IsEqualTo<TValue, TOther>` with an implicit-conversion fallback. That made `c.IsEqualTo(3)` against `IAssertionSource<string>` compile, where it previously didn't. The test relied on that earlier compile error to push overload resolution to the inline-count assertion form (`Count(Func<IAssertionSource<int>, Assertion<int>?>)`). Now resolution picks the per-item filter overload `Count(Func<IAssertionSource<TItem>, IAssertion?>)` which returns `CollectionCountSource<,>` — a builder with no `.And`.
- Fix: switch the test to the same pattern the int variant (`Chained_Collection_Assertions`) already uses: `.Count().IsEqualTo(3)`. The result is `CollectionCountEqualsAssertion` (a `CollectionAssertionBase`), so `.And` is available regardless of the item type.

No production code change; behaviour of `.Count(itemAssertion)` and `.IsEqualTo<,>` is unchanged.

## Test plan
- [x] `dotnet build TUnit.Assertions.Tests -c Release` → 0 errors locally
- [x] `dotnet run --framework net10.0 -- --treenode-filter "/*/*/CollectionAssertionTests/Chained_Collection_Assertions_WithStrings*"` → 1/1 passed
- [ ] Full `.NET` workflow on PR turns green (windows / ubuntu / macos)