### PR TITLE
fix(tests): refresh net472 PublicAPI snapshot, bump CloudShop fulfilment timeout

### DIFF
--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -3360,9 +3360,6 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
-            "efined operators.")]
-        [.(-1)]
         public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
@@ -4192,9 +4189,6 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
-            "efined operators.")]
-        [.(-1)]
         public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions

--- a/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
+++ b/examples/CloudShop/CloudShop.Tests/Tests/Orders/OrderWorkflowTests.cs
@@ -94,7 +94,7 @@ public class OrderWorkflowTests
                 await Customer.Client.GetFromJsonAsync<OrderResponse>($"/api/orders/{orderId}"))
             .WaitsFor(
                 assert => assert.Satisfies(o => o?.Status == OrderStatus.Fulfilled),
-                timeout: TimeSpan.FromSeconds(120),
+                timeout: TimeSpan.FromSeconds(180),
                 pollingInterval: TimeSpan.FromMilliseconds(500));
 
         await Assert.That(order).IsNotNull();


### PR DESCRIPTION
## Summary

Cleans up two CI failures inherited from #5740's merge (which was admin-merged with red checks):

- **net472 PublicAPI snapshot stale**: #5720 / #5751 added new `IsEqualTo<TValue, TOther>` overloads carrying `[OverloadResolutionPriority(-1)]` and `[RequiresUnreferencedCode]`. Those attributes don't exist on netstandard2.0, so the generated public API for net472 doesn't render them — but the verified snapshot still includes the six attribute lines. Drop them so net472 matches reality.
- **CloudShop `Step3_Worker_Fulfills_Order`**: ubuntu-latest hit the 120s WaitsFor timeout (test ran 119719ms). RabbitMQ + Worker pipeline under concurrent load needs more headroom; bump to 180s. Behavioral guard is still "must observe Fulfilled state at all", not "must do so in <120s".

## Test plan
- [x] `dotnet run -c Release -f net472` in `TUnit.PublicAPI` — 3/3 passed locally on Windows
- [ ] CI: ubuntu/macos/windows modular pipeline green
- [ ] CI: CloudShop integration tests green