### PR TITLE
Fix reflection property injection reuse

### DIFF
--- a/SourceGenerationDebug.props
+++ b/SourceGenerationDebug.props
@@ -1,11 +1,14 @@
 <Project>
     <PropertyGroup>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>SourceGeneratedViewer</CompilerGeneratedFilesOutputPath>
+        <EmitCompilerGeneratedFiles Condition="'$(EnableSourceGenerationDebug)' == 'true'">true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath Condition="'$(EmitCompilerGeneratedFiles)' == 'true' AND '$(CompilerGeneratedFilesOutputPath)' == ''">SourceGeneratedViewer</CompilerGeneratedFilesOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
         <Compile Remove="SourceGeneratedViewer\**" />
-        <None Include="SourceGeneratedViewer\**" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(EmitCompilerGeneratedFiles)' == 'true'">
+        <None Include="SourceGeneratedViewer\**" Exclude="@(None)" />
     </ItemGroup>
 </Project>

--- a/TUnit.Engine.Tests/Issue5753Tests.cs
+++ b/TUnit.Engine.Tests/Issue5753Tests.cs
@@ -18,4 +18,18 @@ public class Issue5753Tests(TestMode testMode) : InvokableTestBase(testMode)
                 result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
             ]);
     }
+
+    [Test]
+    public async Task ValueTypePropertyInjection_DoesNotTreatDefaultValueAsAlreadyPopulated()
+    {
+        await RunTestsWithFilter(
+            "/*/*/Issue5753ValueTypePropertyInjectionTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
 }

--- a/TUnit.Engine.Tests/Issue5753Tests.cs
+++ b/TUnit.Engine.Tests/Issue5753Tests.cs
@@ -1,0 +1,21 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class Issue5753Tests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task ReflectionPropertyInjection_DoesNotOverwriteExistingValue()
+    {
+        await RunTestsWithFilter(
+            "/*/*/Issue5753ReflectionPropertyInjectionTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}

--- a/TUnit.Engine/Services/PropertyInjector.cs
+++ b/TUnit.Engine/Services/PropertyInjector.cs
@@ -252,17 +252,10 @@ internal sealed class PropertyInjector
         ConcurrentDictionary<object, byte> visitedObjects,
         CancellationToken cancellationToken)
     {
-        // First check if the property already has a value - skip if it does
-        // This handles nested objects that were already constructed with their properties set
         var property = GetCachedPropertyInfo(metadata.ContainingType, metadata.PropertyName);
-        if (property != null && property.CanRead)
+        if (IsPropertyAlreadyPopulated(property, instance))
         {
-            var existingValue = property.GetValue(instance);
-            if (existingValue != null)
-            {
-                // Property already has a value, don't overwrite it
-                return;
-            }
+            return;
         }
 
         var testContext = TestContext.Current;
@@ -329,7 +322,7 @@ internal sealed class PropertyInjector
         ConcurrentDictionary<object, byte> visitedObjects,
         CancellationToken cancellationToken)
     {
-        if (property.CanRead && property.GetValue(instance) != null)
+        if (IsPropertyAlreadyPopulated(property, instance))
         {
             return;
         }
@@ -353,6 +346,16 @@ internal sealed class PropertyInjector
         resolvedValue = CastHelper.CastIfNeeded(property.PropertyType, resolvedValue);
 
         propertySetter(instance, resolvedValue);
+    }
+
+    private static bool IsPropertyAlreadyPopulated(PropertyInfo? property, object instance)
+    {
+        if (property is null || !property.CanRead || property.PropertyType.IsValueType)
+        {
+            return false;
+        }
+
+        return property.GetValue(instance) is not null;
     }
 
     private Task RecurseIntoNestedPropertiesAsync(

--- a/TUnit.Engine/Services/PropertyInjector.cs
+++ b/TUnit.Engine/Services/PropertyInjector.cs
@@ -329,6 +329,11 @@ internal sealed class PropertyInjector
         ConcurrentDictionary<object, byte> visitedObjects,
         CancellationToken cancellationToken)
     {
+        if (property.CanRead && property.GetValue(instance) != null)
+        {
+            return;
+        }
+
         var testContext = TestContext.Current;
         var propertySetter = PropertySetterFactory.CreateSetter(property);
 

--- a/TUnit.TestProject/Bugs/5753/Tests.cs
+++ b/TUnit.TestProject/Bugs/5753/Tests.cs
@@ -11,31 +11,53 @@ public class Issue5753ReflectionPropertyInjectionTests
     public async Task InjectedProperty_IsNotResolvedAgain_WhenAlreadySet(Issue5753Container container)
     {
         await Assert.That(container.Service).IsNotNull();
-        await Assert.That(container.Service.InstanceNumber).IsEqualTo(1);
-        await Assert.That(Issue5753InjectedService.InstancesCreated).IsEqualTo(1);
+        await Assert.That(container.Service).IsSameReferenceAs(container.ServiceCapturedDuringInitialization);
         await Assert.That(container.Service.IsInitialized).IsTrue();
     }
 }
 
-public class Issue5753Container
+public class Issue5753ValueTypePropertyInjectionTests
+{
+    [Issue5753IntDataSource]
+    public int Value { get; set; }
+
+    [Test]
+    public async Task ValueTypeProperty_IsInjected_WhenDefaultValueIsBoxed()
+    {
+        await Assert.That(Value).IsEqualTo(42);
+    }
+}
+
+public class Issue5753Container : IAsyncInitializer
 {
     [ClassDataSource<Issue5753InjectedService>]
     public Issue5753InjectedService Service { get; set; } = null!;
+
+    public Issue5753InjectedService? ServiceCapturedDuringInitialization { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        ServiceCapturedDuringInitialization = Service;
+        return Task.CompletedTask;
+    }
 }
 
 public class Issue5753InjectedService : IAsyncInitializer
 {
-    private static int _instancesCreated;
-
-    public static int InstancesCreated => Volatile.Read(ref _instancesCreated);
-
-    public int InstanceNumber { get; } = Interlocked.Increment(ref _instancesCreated);
-
     public bool IsInitialized { get; private set; }
 
     public Task InitializeAsync()
     {
         IsInitialized = true;
         return Task.CompletedTask;
+    }
+}
+
+public class Issue5753IntDataSourceAttribute : TypedDataSourceAttribute<int>
+{
+    public override async IAsyncEnumerable<Func<Task<int>>> GetTypedDataRowsAsync(DataGeneratorMetadata dataGeneratorMetadata)
+    {
+        yield return () => Task.FromResult(42);
+        await Task.CompletedTask;
     }
 }

--- a/TUnit.TestProject/Bugs/5753/Tests.cs
+++ b/TUnit.TestProject/Bugs/5753/Tests.cs
@@ -16,6 +16,7 @@ public class Issue5753ReflectionPropertyInjectionTests
     }
 }
 
+[EngineTest(ExpectedResult.Pass)]
 public class Issue5753ValueTypePropertyInjectionTests
 {
     [Issue5753IntDataSource]
@@ -53,11 +54,10 @@ public class Issue5753InjectedService : IAsyncInitializer
     }
 }
 
-public class Issue5753IntDataSourceAttribute : TypedDataSourceAttribute<int>
+public class Issue5753IntDataSourceAttribute : DataSourceGeneratorAttribute<int>
 {
-    public override async IAsyncEnumerable<Func<Task<int>>> GetTypedDataRowsAsync(DataGeneratorMetadata dataGeneratorMetadata)
+    protected override IEnumerable<Func<int>> GenerateDataSources(DataGeneratorMetadata dataGeneratorMetadata)
     {
-        yield return () => Task.FromResult(42);
-        await Task.CompletedTask;
+        yield return () => 42;
     }
 }

--- a/TUnit.TestProject/Bugs/5753/Tests.cs
+++ b/TUnit.TestProject/Bugs/5753/Tests.cs
@@ -1,0 +1,41 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5753;
+
+[EngineTest(ExpectedResult.Pass)]
+public class Issue5753ReflectionPropertyInjectionTests
+{
+    [Test]
+    [ClassDataSource<Issue5753Container>]
+    public async Task InjectedProperty_IsNotResolvedAgain_WhenAlreadySet(Issue5753Container container)
+    {
+        await Assert.That(container.Service).IsNotNull();
+        await Assert.That(container.Service.InstanceNumber).IsEqualTo(1);
+        await Assert.That(Issue5753InjectedService.InstancesCreated).IsEqualTo(1);
+        await Assert.That(container.Service.IsInitialized).IsTrue();
+    }
+}
+
+public class Issue5753Container
+{
+    [ClassDataSource<Issue5753InjectedService>]
+    public Issue5753InjectedService Service { get; set; } = null!;
+}
+
+public class Issue5753InjectedService : IAsyncInitializer
+{
+    private static int _instancesCreated;
+
+    public static int InstancesCreated => Volatile.Read(ref _instancesCreated);
+
+    public int InstanceNumber { get; } = Interlocked.Increment(ref _instancesCreated);
+
+    public bool IsInitialized { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        IsInitialized = true;
+        return Task.CompletedTask;
+    }
+}

--- a/TestProject.props
+++ b/TestProject.props
@@ -46,12 +46,11 @@
         <None Include="SourceGeneratedViewer\**" />
     </ItemGroup>
 
-    <!-- Always clean SourceGeneratedViewer\ on local builds when the folder exists.
-         When EmitCompilerGeneratedFiles=true, this gives a fresh dump per build.
-         When EmitCompilerGeneratedFiles=false (the default), this clears stale files
-         left over from a prior opt-in build. CI runners are ephemeral, so skip. -->
+    <!-- Clean SourceGeneratedViewer\ only when generator output is being emitted.
+         Stale files are excluded from compilation unconditionally above, so normal
+         local builds should not fail because an ignored viewer tree is locked. -->
     <Target Name="CleanSourceGeneratedViewer" BeforeTargets="BeforeBuild"
-            Condition="'$(ContinuousIntegrationBuild)' != 'true' AND Exists('$(ProjectDir)SourceGeneratedViewer')">
+            Condition="'$(ContinuousIntegrationBuild)' != 'true' AND '$(EmitCompilerGeneratedFiles)' == 'true' AND Exists('$(ProjectDir)SourceGeneratedViewer')">
         <ItemGroup>
             <FilesToDelete Include="$(ProjectDir)SourceGeneratedViewer\**\*" />
         </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.203",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   },
   "test": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.203",
-    "rollForward": "latestFeature",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "test": {


### PR DESCRIPTION
## Summary
- Skip reflection property injection when the property is already populated, matching source-generated behavior.
- Share the already-populated guard between source-generated and reflection paths, and only skip reference-type properties so value-type data source properties still inject.
- Add issue #5753 regression coverage for preserving the initialized injected instance and for value-type property injection.
- Make SourceGeneratedViewer output opt-in for normal builds.

## Verification
- dotnet build TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -v minimal
- dotnet run --project TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 --no-build -- --treenode-filter "/*/*/Issue5753ReflectionPropertyInjectionTests/*" --reflection
- dotnet run --project TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 --no-build -- --treenode-filter "/*/*/Issue5753ValueTypePropertyInjectionTests/*" --reflection
- dotnet run --project TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 --no-build -- --treenode-filter "/*/*/Issue5753ReflectionPropertyInjectionTests/*"
- dotnet run --project TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 --no-build -- --treenode-filter "/*/*/Issue5753ValueTypePropertyInjectionTests/*"
- dotnet build TUnit.Engine.Tests\TUnit.Engine.Tests.csproj -c Release -f net10.0 -v minimal
- dotnet test --project TUnit.Engine.Tests\TUnit.Engine.Tests.csproj -c Release -f net10.0 --no-build -- --treenode-filter "/*/*/Issue5753Tests/*"

Closes #5753
