### PR TITLE
fix(assertions): gate IsEqualTo<TValue, TOther> overload to net9+ (#5765)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -1,9 +1,4 @@
-// The IsEqualTo<TValue, TOther> overload these tests exercise lives behind
-// `#if NET9_0_OR_GREATER` in TUnit.Assertions (see issue #5765 / #5751) because it
-// relies on [OverloadResolutionPriority] for disambiguation, which is only honored
-// by C# 13+ and only present in System.Runtime.CompilerServices on .NET 9+. The
-// assertions test project multi-targets net8.0/net9.0/net10.0, so this file must
-// match the same gate to keep the net8.0 build green.
+// Gated to match ImplicitConversionEqualityExtensions.cs — see issue #5765.
 #if NET9_0_OR_GREATER
 namespace TUnit.Assertions.Tests.Bugs;
 

--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -1,3 +1,10 @@
+// The IsEqualTo<TValue, TOther> overload these tests exercise lives behind
+// `#if NET9_0_OR_GREATER` in TUnit.Assertions (see issue #5765 / #5751) because it
+// relies on [OverloadResolutionPriority] for disambiguation, which is only honored
+// by C# 13+ and only present in System.Runtime.CompilerServices on .NET 9+. The
+// assertions test project multi-targets net8.0/net9.0/net10.0, so this file must
+// match the same gate to keep the net8.0 build green.
+#if NET9_0_OR_GREATER
 namespace TUnit.Assertions.Tests.Bugs;
 
 /// <summary>
@@ -191,3 +198,5 @@ public class Issue5720Tests
             $"No implicit conversion operator from '{typeof(UnrelatedType)}' to '{typeof(string)}' was found.");
     }
 }
+
+#endif

--- a/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
@@ -2,23 +2,10 @@ using System.Net;
 
 namespace TUnit.Assertions.Tests.Bugs;
 
-/// <summary>
-/// Regression tests for GitHub issue #5765:
-/// 1.40.0 introduced a second IsEqualTo overload alongside the source-generated one to
-/// support wrapper Value Objects with implicit conversions (#5720). When called with a
-/// same-type expected value the two overloads were equally applicable and overload
-/// resolution failed with CS0121 — affecting effectively every existing test suite that
-/// compared enums, primitives, value types, or records to a value of their own type.
-///
-/// The implicit-conversion overloads now live behind <c>#if NET9_0_OR_GREATER</c> because
-/// they rely on <c>[OverloadResolutionPriority]</c> to disambiguate, and that attribute is
-/// only honored by C# 13+ (which lines up with .NET 9). On older library targets the new
-/// overload is omitted entirely so the source-generated overload binds without contest.
-/// </summary>
 public class Issue5765Tests
 {
     [Test]
-    public async Task IsEqualTo_SameType_Enum_Compiles_And_Passes()
+    public async Task IsEqualTo_SameType_Enum()
     {
         var status = HttpStatusCode.OK;
 
@@ -26,7 +13,7 @@ public class Issue5765Tests
     }
 
     [Test]
-    public async Task IsEqualTo_SameType_Primitive_Compiles_And_Passes()
+    public async Task IsEqualTo_SameType_Primitive()
     {
         var value = 42;
 
@@ -34,7 +21,7 @@ public class Issue5765Tests
     }
 
     [Test]
-    public async Task IsEqualTo_SameType_Record_Compiles_And_Passes()
+    public async Task IsEqualTo_SameType_Record()
     {
         var point = new Point(1, 2);
 
@@ -42,7 +29,7 @@ public class Issue5765Tests
     }
 
     [Test]
-    public async Task IsNotEqualTo_SameType_Enum_Compiles_And_Passes()
+    public async Task IsNotEqualTo_SameType_Enum()
     {
         var status = HttpStatusCode.OK;
 

--- a/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for GitHub issue #5765:
+/// 1.40.0 introduced a second IsEqualTo overload alongside the source-generated one to
+/// support wrapper Value Objects with implicit conversions (#5720). When called with a
+/// same-type expected value the two overloads were equally applicable and overload
+/// resolution failed with CS0121 — affecting effectively every existing test suite that
+/// compared enums, primitives, value types, or records to a value of their own type.
+///
+/// The implicit-conversion overloads now live behind <c>#if NET9_0_OR_GREATER</c> because
+/// they rely on <c>[OverloadResolutionPriority]</c> to disambiguate, and that attribute is
+/// only honored by C# 13+ (which lines up with .NET 9). On older library targets the new
+/// overload is omitted entirely so the source-generated overload binds without contest.
+/// </summary>
+public class Issue5765Tests
+{
+    [Test]
+    public async Task IsEqualTo_SameType_Enum_Compiles_And_Passes()
+    {
+        var status = HttpStatusCode.OK;
+
+        await Assert.That(status).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task IsEqualTo_SameType_Primitive_Compiles_And_Passes()
+    {
+        var value = 42;
+
+        await Assert.That(value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task IsEqualTo_SameType_Record_Compiles_And_Passes()
+    {
+        var point = new Point(1, 2);
+
+        await Assert.That(point).IsEqualTo(new Point(1, 2));
+    }
+
+    [Test]
+    public async Task IsNotEqualTo_SameType_Enum_Compiles_And_Passes()
+    {
+        var status = HttpStatusCode.OK;
+
+        await Assert.That(status).IsNotEqualTo(HttpStatusCode.NotFound);
+    }
+
+    private sealed record Point(int X, int Y);
+}

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -1,12 +1,7 @@
-// The IsEqualTo<TValue, TOther> / IsNotEqualTo<TValue, TOther> overloads below
-// rely on [OverloadResolutionPriority] to disambiguate against the source-generated
-// IsEqualTo<TValue> / IsNotEqualTo<TValue> overloads when called with a same-type
-// expected value. That attribute is only honored by the C# 13+ compiler and is only
-// present in System.Runtime.CompilerServices on .NET 9+. On older targets the
-// attribute is silently dropped (Polyfill does not supply it), every same-type
-// IsEqualTo call becomes ambiguous (CS0121), and we break effectively every existing
-// test suite. Gating the entire feature to .NET 9+ keeps net8.0 / netstandard2.0
-// consumers on the original well-defined overload. See issue #5765.
+// Gated to .NET 9+ because these overloads rely on [OverloadResolutionPriority] to
+// lose to the source-generated single-generic IsEqualTo / IsNotEqualTo on same-type
+// calls, and that attribute is silently dropped on net8.0 / netstandard2.0 (Polyfill
+// does not supply it), causing CS0121. See issue #5765.
 #if NET9_0_OR_GREATER
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -1,3 +1,13 @@
+// The IsEqualTo<TValue, TOther> / IsNotEqualTo<TValue, TOther> overloads below
+// rely on [OverloadResolutionPriority] to disambiguate against the source-generated
+// IsEqualTo<TValue> / IsNotEqualTo<TValue> overloads when called with a same-type
+// expected value. That attribute is only honored by the C# 13+ compiler and is only
+// present in System.Runtime.CompilerServices on .NET 9+. On older targets the
+// attribute is silently dropped (Polyfill does not supply it), every same-type
+// IsEqualTo call becomes ambiguous (CS0121), and we break effectively every existing
+// test suite. Gating the entire feature to .NET 9+ keeps net8.0 / netstandard2.0
+// consumers on the original well-defined overload. See issue #5765.
+#if NET9_0_OR_GREATER
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -146,3 +156,4 @@ internal static class ImplicitConversionCache
         return null;
     }
 }
+#endif

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -3767,9 +3767,6 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
-            "efined operators.")]
-        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4696,9 +4693,6 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
-            "efined operators.")]
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -3360,7 +3360,6 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -4189,7 +4188,6 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
-        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {


### PR DESCRIPTION
Fixes #5765.

## Summary

- The `IsEqualTo<TValue, TOther>` / `IsNotEqualTo<TValue, TOther>` overloads added in 1.40.0 (#5751) rely on `[OverloadResolutionPriority(-1)]` to lose to the source-generated single-generic overload when both apply. That attribute is only honored by **C# 13+** and only present in `System.Runtime.CompilerServices` on **.NET 9+**. On the `net8.0` / `netstandard2.0` builds of `TUnit.Assertions`, Polyfill silently drops the attribute and every same-type `IsEqualTo` call becomes ambiguous (CS0121) — breaking effectively every existing test suite.
- Gated the new overloads (and the `ImplicitConversionCache` they use) behind `#if NET9_0_OR_GREATER` in `ImplicitConversionEqualityExtensions.cs`. On `net8.0` / `netstandard2.0` the new overload simply doesn't exist, so the original well-defined overload binds without contest.
- Public API snapshots for `net8.0` and `netstandard2.0` (`Net4_7`) updated to drop the gated overloads.
- `Issue5720Tests` (which exercises the gated overload) gated to match.
- Added `Issue5765Tests` regression covering same-type `IsEqualTo` for enum / primitive / record across all TFMs.

## Verification

Reproduced CS0121 against `TUnit` 1.40.0 nuget:
```csharp
HttpStatusCode code = HttpStatusCode.OK;
await Assert.That(code).IsEqualTo(HttpStatusCode.OK); // CS0121 on net8.0
```
With this fix applied, the same repro `dotnet build`s clean on `net8.0`, `net9.0`, and `net10.0`.

Inspected the built assemblies to confirm the gate landed where expected:
| TFM | `ImplicitConversionCache` | `IsEqualTo` symbols |
|---|---|---|
| `net8.0` | absent | 5 |
| `net9.0` | present | 6 |
| `net10.0` | present | 6 |

Test suite results after the change:
- `net8.0`: 1999 / 1999 passed (Issue5720Tests gated out)
- `net9.0`: 2066 / 2066 passed
- `net10.0`: 2066 / 2066 passed

## Known limitation worth flagging in release notes

A consumer using **.NET 8 SDK (C# 12)** that targets `net9.0` / `net10.0` will still hit CS0121, because their compiler does not honor `[OverloadResolutionPriority]`. This matches what the issue reporter likely encountered when they noted reproduction on net 9 / 10 too. The fix on their side is to upgrade to .NET 9+ SDK.

## Test plan

- [x] Reproduce CS0121 on `net8.0` against TUnit 1.40.0 nuget — confirmed
- [x] Confirm fix removes CS0121 on `net8.0`, `net9.0`, `net10.0`
- [x] `dotnet build` `TUnit.Assertions` for all TFMs — clean
- [x] `dotnet build` `TUnit.Assertions.Tests` for all TFMs — clean
- [x] Run `Issue5765Tests` + `Issue5720Tests` + `NullabilityWarningTests` on `net8.0` / `net9.0` / `net10.0` — all green
- [ ] CI green across the rest of the matrix