### PR TITLE
fix(cloudshop): retry RabbitMQ publishes and surface failures

### DIFF
--- a/examples/CloudShop/CloudShop.ApiService/Endpoints/OrderEndpoints.cs
+++ b/examples/CloudShop/CloudShop.ApiService/Endpoints/OrderEndpoints.cs
@@ -55,7 +55,7 @@ public static class OrderEndpoints
                 order.CreatedAt, order.FulfilledAt));
         });
 
-        group.MapPost("/", async (CreateOrderRequest request, ClaimsPrincipal user, AppDbContext db, OrderEventPublisher publisher) =>
+        group.MapPost("/", async (CreateOrderRequest request, ClaimsPrincipal user, AppDbContext db, OrderEventPublisher publisher, ILogger<OrderEventPublisher> logger) =>
         {
             if (request.Items.Count == 0)
                 return Results.BadRequest(new ErrorResponse("Order must contain at least one item"));
@@ -104,9 +104,11 @@ public static class OrderEndpoints
             {
                 await publisher.PublishOrderCreatedAsync(new OrderCreatedEvent(order.Id, email, order.TotalAmount, order.CreatedAt));
             }
-            catch
+            catch (Exception ex)
             {
-                // Don't fail the order if messaging is down
+                logger.LogError(ex,
+                    "OrderCreated event for order {OrderId} was not published; downstream consumers will not see it",
+                    order.Id);
             }
 
             var response = new OrderResponse(
@@ -117,7 +119,7 @@ public static class OrderEndpoints
             return Results.Created($"/api/orders/{order.Id}", response);
         });
 
-        group.MapPost("/{id:int}/pay", async (int id, ProcessPaymentRequest request, ClaimsPrincipal user, AppDbContext db, OrderEventPublisher publisher) =>
+        group.MapPost("/{id:int}/pay", async (int id, ProcessPaymentRequest request, ClaimsPrincipal user, AppDbContext db, OrderEventPublisher publisher, ILogger<OrderEventPublisher> logger) =>
         {
             var email = user.FindFirstValue(ClaimTypes.Email)!;
             var order = await db.Orders.FirstOrDefaultAsync(o => o.Id == id && o.CustomerEmail == email);
@@ -133,9 +135,11 @@ public static class OrderEndpoints
             {
                 await publisher.PublishPaymentProcessedAsync(new OrderPaymentProcessedEvent(order.Id, request.PaymentMethod, DateTime.UtcNow));
             }
-            catch
+            catch (Exception ex)
             {
-                // Don't fail payment if messaging is down
+                logger.LogError(ex,
+                    "PaymentProcessed event for order {OrderId} was not published; worker will not fulfil this order",
+                    order.Id);
             }
 
             return Results.Ok(new { order.Id, order.Status });

--- a/examples/CloudShop/CloudShop.ApiService/Program.cs
+++ b/examples/CloudShop/CloudShop.ApiService/Program.cs
@@ -5,6 +5,7 @@ using CloudShop.ApiService.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using RabbitMQ.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -51,6 +52,18 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     await db.Database.EnsureCreatedAsync();
+}
+
+// Pre-declare exchange + durable queue + bindings so events published
+// before the worker subscribes are still queued (otherwise messages
+// routed to an unbound exchange are dropped on the floor).
+using (var scope = app.Services.CreateScope())
+{
+    var connection = scope.ServiceProvider.GetRequiredService<IConnection>();
+    await using var channel = await connection.CreateChannelAsync();
+    await channel.ExchangeDeclareAsync("order-events", ExchangeType.Topic, durable: true);
+    await channel.QueueDeclareAsync("order-processing", durable: true, exclusive: false, autoDelete: false);
+    await channel.QueueBindAsync("order-processing", "order-events", "order.payment-processed");
 }
 
 app.UseExceptionHandler();

--- a/examples/CloudShop/CloudShop.ApiService/Services/OrderEventPublisher.cs
+++ b/examples/CloudShop/CloudShop.ApiService/Services/OrderEventPublisher.cs
@@ -5,26 +5,48 @@ using RabbitMQ.Client;
 
 namespace CloudShop.ApiService.Services;
 
-public class OrderEventPublisher(IConnection rabbitConnection)
+public class OrderEventPublisher(IConnection rabbitConnection, ILogger<OrderEventPublisher> logger)
 {
-    public async Task PublishOrderCreatedAsync(OrderCreatedEvent orderEvent)
-    {
-        await PublishAsync("order-events", "order.created", orderEvent);
-    }
+    private const int MaxAttempts = 4;
+    private static readonly TimeSpan InitialBackoff = TimeSpan.FromMilliseconds(100);
 
-    public async Task PublishPaymentProcessedAsync(OrderPaymentProcessedEvent paymentEvent)
-    {
-        await PublishAsync("order-events", "order.payment-processed", paymentEvent);
-    }
+    public Task PublishOrderCreatedAsync(OrderCreatedEvent orderEvent)
+        => PublishAsync("order-events", "order.created", orderEvent);
+
+    public Task PublishPaymentProcessedAsync(OrderPaymentProcessedEvent paymentEvent)
+        => PublishAsync("order-events", "order.payment-processed", paymentEvent);
 
     private async Task PublishAsync<T>(string exchange, string routingKey, T message)
     {
-        await using var channel = await rabbitConnection.CreateChannelAsync();
-        await channel.ExchangeDeclareAsync(exchange, ExchangeType.Topic, durable: true);
-
         var json = JsonSerializer.Serialize(message);
         var body = Encoding.UTF8.GetBytes(json);
 
-        await channel.BasicPublishAsync(exchange, routingKey, body);
+        var backoff = InitialBackoff;
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                await using var channel = await rabbitConnection.CreateChannelAsync();
+                await channel.ExchangeDeclareAsync(exchange, ExchangeType.Topic, durable: true);
+                await channel.BasicPublishAsync(exchange, routingKey, body);
+                return;
+            }
+            catch (Exception ex)
+            {
+                if (attempt == MaxAttempts)
+                {
+                    logger.LogError(ex,
+                        "Failed to publish {RoutingKey} after {Max} attempts; giving up",
+                        routingKey, MaxAttempts);
+                    throw;
+                }
+
+                logger.LogWarning(ex,
+                    "Failed to publish {RoutingKey} (attempt {Attempt}/{Max}); retrying in {DelayMs}ms",
+                    routingKey, attempt, MaxAttempts, backoff.TotalMilliseconds);
+                await Task.Delay(backoff);
+                backoff *= 2;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `OrderEventPublisher` now retries publishes up to 4 times with exponential backoff (100ms → 200 → 400 → 800) and logs every attempt; final failure logged at error and rethrown.
- `OrderEndpoints` `POST /` and `POST /{id}/pay` still tolerate publish failure (so payment isn't rejected when RabbitMQ blips), but the previously empty `catch` blocks now log at error level so the "stuck order" failure mode becomes visible.

## Why
CloudShop integration test `Step3_Worker_Fulfills_Order` flaked on https://github.com/thomhurst/TUnit/actions/runs/24991112179 — order remained at `PaymentProcessed` for the full 180s polling window. Root cause: `POST /api/orders/{id}/pay` writes the new status to Postgres and then publishes `order.payment-processed` inside an empty `catch { }`. Any transient RabbitMQ hiccup (e.g. just after the broker enters Running) silently drops the event, so the worker never fulfils the order and the test times out with no signal as to why.

This doesn't fully solve dual-write (would need an outbox), but it sharply reduces the flake window and makes failures observable.

## Test plan
- [x] `dotnet build examples/CloudShop/CloudShop.ApiService/CloudShop.ApiService.csproj -c Release` — clean
- [ ] CI `integration-tests` job runs the CloudShop Aspire suite