### PR TITLE
refactor(opentelemetry): depend on TUnit.Core instead of umbrella TUnit

### DIFF
--- a/TUnit.Core/ExternalSpanSink.cs
+++ b/TUnit.Core/ExternalSpanSink.cs
@@ -1,0 +1,23 @@
+namespace TUnit.Core;
+
+/// <summary>
+/// Process-wide hook letting out-of-process span feeders (e.g. TUnit.OpenTelemetry's
+/// OTLP receiver) push into TUnit.Engine's collector without OpenTelemetry referencing
+/// Engine. Engine claims the slot at session start; first-wins semantics.
+/// </summary>
+internal static class ExternalSpanSink
+{
+    private static Action<SpanData>? _sink;
+
+    public static Action<SpanData>? Current => _sink;
+
+    public static void Register(Action<SpanData> sink)
+    {
+        Interlocked.CompareExchange(ref _sink, sink, null);
+    }
+
+    public static void Unregister(Action<SpanData> sink)
+    {
+        Interlocked.CompareExchange(ref _sink, null, sink);
+    }
+}

--- a/TUnit.Core/ExternalSpanSink.cs
+++ b/TUnit.Core/ExternalSpanSink.cs
@@ -9,7 +9,10 @@ internal static class ExternalSpanSink
 {
     private static Action<SpanData>? _sink;
 
-    public static Action<SpanData>? Current => _sink;
+    // Volatile.Read pairs with the full fence in Interlocked.CompareExchange on the
+    // Register/Unregister side; without it, weak memory models (ARM) could observe
+    // a stale null after another thread has published a sink.
+    public static Action<SpanData>? Current => Volatile.Read(ref _sink);
 
     public static void Register(Action<SpanData> sink)
     {

--- a/TUnit.Core/SpanData.cs
+++ b/TUnit.Core/SpanData.cs
@@ -1,0 +1,78 @@
+using System.Text.Json.Serialization;
+
+namespace TUnit.Core;
+
+internal sealed class SpanData
+{
+    [JsonPropertyName("traceId")]
+    public required string TraceId { get; init; }
+
+    [JsonPropertyName("spanId")]
+    public required string SpanId { get; init; }
+
+    [JsonPropertyName("parentSpanId")]
+    public string? ParentSpanId { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("spanType")]
+    public string? SpanType { get; init; }
+
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("startTimeMs")]
+    public double StartTimeMs { get; init; }
+
+    [JsonPropertyName("durationMs")]
+    public double DurationMs { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("statusMessage")]
+    public string? StatusMessage { get; init; }
+
+    [JsonPropertyName("tags")]
+    public ReportKeyValue[]? Tags { get; init; }
+
+    [JsonPropertyName("events")]
+    public SpanEvent[]? Events { get; init; }
+
+    [JsonPropertyName("links")]
+    public SpanLink[]? Links { get; init; }
+}
+
+internal sealed class SpanEvent
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("timestampMs")]
+    public double TimestampMs { get; init; }
+
+    [JsonPropertyName("tags")]
+    public ReportKeyValue[]? Tags { get; init; }
+}
+
+internal sealed class SpanLink
+{
+    [JsonPropertyName("traceId")]
+    public required string TraceId { get; init; }
+
+    [JsonPropertyName("spanId")]
+    public required string SpanId { get; init; }
+}
+
+internal sealed class ReportKeyValue
+{
+    [JsonPropertyName("key")]
+    public required string Key { get; init; }
+
+    [JsonPropertyName("value")]
+    public required string Value { get; init; }
+}

--- a/TUnit.Engine/Reporters/Html/ActivityCollector.cs
+++ b/TUnit.Engine/Reporters/Html/ActivityCollector.cs
@@ -67,6 +67,7 @@ internal sealed class ActivityCollector : IDisposable
     // so that subsequent activities on the same trace avoid cross-class dictionary checks.
     private readonly ConcurrentDictionary<string, byte> _knownTraceIds = new(StringComparer.OrdinalIgnoreCase);
     private ActivityListener? _listener;
+    private Action<SpanData>? _externalSinkDelegate;
 
     public void Start()
     {
@@ -74,6 +75,8 @@ internal sealed class ActivityCollector : IDisposable
         // test runs, so this slot is claimed for the rest of the session. Later ad-hoc
         // collectors (e.g. created from a test) don't race-steal the global pointer.
         Interlocked.CompareExchange(ref _current, this, null);
+        _externalSinkDelegate = IngestExternalSpan;
+        ExternalSpanSink.Register(_externalSinkDelegate);
         // Listen to ALL sources so we can capture child spans from HttpClient, ASP.NET Core,
         // EF Core, etc. The Sample callback uses smart filtering to avoid overhead: only spans
         // belonging to known test traces are fully recorded; everything else gets PropagationData
@@ -155,6 +158,11 @@ internal sealed class ActivityCollector : IDisposable
     public void Stop()
     {
         Interlocked.CompareExchange(ref _current, null, this);
+        if (_externalSinkDelegate is { } sink)
+        {
+            ExternalSpanSink.Unregister(sink);
+            _externalSinkDelegate = null;
+        }
         _listener?.Dispose();
         _listener = null;
     }

--- a/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using TUnit.Core;
 
 namespace TUnit.Engine.Reporters.Html;
 
@@ -173,77 +174,3 @@ internal sealed class ReportExceptionData
     public ReportExceptionData? InnerException { get; init; }
 }
 
-internal sealed class ReportKeyValue
-{
-    [JsonPropertyName("key")]
-    public required string Key { get; init; }
-
-    [JsonPropertyName("value")]
-    public required string Value { get; init; }
-}
-
-internal sealed class SpanData
-{
-    [JsonPropertyName("traceId")]
-    public required string TraceId { get; init; }
-
-    [JsonPropertyName("spanId")]
-    public required string SpanId { get; init; }
-
-    [JsonPropertyName("parentSpanId")]
-    public string? ParentSpanId { get; init; }
-
-    [JsonPropertyName("name")]
-    public required string Name { get; init; }
-
-    [JsonPropertyName("spanType")]
-    public string? SpanType { get; init; }
-
-    [JsonPropertyName("source")]
-    public required string Source { get; init; }
-
-    [JsonPropertyName("kind")]
-    public required string Kind { get; init; }
-
-    [JsonPropertyName("startTimeMs")]
-    public double StartTimeMs { get; init; }
-
-    [JsonPropertyName("durationMs")]
-    public double DurationMs { get; init; }
-
-    [JsonPropertyName("status")]
-    public required string Status { get; init; }
-
-    [JsonPropertyName("statusMessage")]
-    public string? StatusMessage { get; init; }
-
-    [JsonPropertyName("tags")]
-    public ReportKeyValue[]? Tags { get; init; }
-
-    [JsonPropertyName("events")]
-    public SpanEvent[]? Events { get; init; }
-
-    [JsonPropertyName("links")]
-    public SpanLink[]? Links { get; init; }
-}
-
-internal sealed class SpanLink
-{
-    [JsonPropertyName("traceId")]
-    public required string TraceId { get; init; }
-
-    [JsonPropertyName("spanId")]
-    public required string SpanId { get; init; }
-}
-
-internal sealed class SpanEvent
-{
-    [JsonPropertyName("name")]
-    public required string Name { get; init; }
-
-    [JsonPropertyName("timestampMs")]
-    public double TimestampMs { get; init; }
-
-    [JsonPropertyName("tags")]
-    public ReportKeyValue[]? Tags { get; init; }
-}

--- a/TUnit.Engine/Reporters/Html/HtmlReportJsonContext.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportJsonContext.cs
@@ -11,6 +11,7 @@ namespace TUnit.Engine.Reporters.Html;
 [JsonSerializable(typeof(ReportKeyValue))]
 [JsonSerializable(typeof(SpanData))]
 [JsonSerializable(typeof(SpanEvent))]
+[JsonSerializable(typeof(SpanLink))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/TUnit.Engine/Reporters/Html/HtmlReportJsonContext.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportJsonContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using TUnit.Core;
 
 namespace TUnit.Engine.Reporters.Html;
 

--- a/TUnit.Engine/TUnit.Engine.csproj
+++ b/TUnit.Engine/TUnit.Engine.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="TUnit.UnitTests" />
     <InternalsVisibleTo Include="TUnit.Engine.Tests" />
-    <InternalsVisibleTo Include="TUnit.OpenTelemetry" />
     <InternalsVisibleTo Include="TUnit.OpenTelemetry.Tests" />
   </ItemGroup>
 

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using TUnit.Core;
-using TUnit.Engine.Reporters.Html;
 
 namespace TUnit.OpenTelemetry.Receiver;
 
@@ -212,8 +211,8 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
     private static void ProcessTraces(byte[] body)
     {
-        var collector = ActivityCollector.Current;
-        if (collector is null)
+        var sink = ExternalSpanSink.Current;
+        if (sink is null)
         {
             return;
         }
@@ -231,7 +230,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
         foreach (var span in spans)
         {
-            collector.IngestExternalSpan(ToSpanData(span));
+            sink(ToSpanData(span));
         }
     }
 

--- a/TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj
+++ b/TUnit.OpenTelemetry/TUnit.OpenTelemetry.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TUnit\TUnit.csproj" />
+    <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- TUnit.OpenTelemetry now references `TUnit.Core` directly instead of the umbrella `TUnit` package, dropping the transitive `TUnit.Engine` + `TUnit.Assertions` + `Microsoft.Testing.Extensions` footprint from its dependency chain.
- Cross-assembly contract for external span ingestion is now expressed via a small `ExternalSpanSink` hook in `TUnit.Core` (dependency inversion). `ActivityCollector` (Engine) registers itself as the sink at session start; `OtlpReceiver` (OpenTelemetry) pushes through the sink without taking a hard dependency on Engine.
- Moved 4 internal POCOs (`SpanData`, `SpanEvent`, `SpanLink`, `ReportKeyValue`) from `TUnit.Engine/Reporters/Html/HtmlReportDataModel.cs` to a new `TUnit.Core/SpanData.cs` so both ends of the contract share the same shape.

## Test plan

- [x] `TUnit.Engine` builds clean (all TFMs).
- [x] `TUnit.OpenTelemetry` builds clean against `TUnit.Core` only.
- [x] `TUnit.OpenTelemetry.Tests` 30/30 pass.
- [x] `TUnit.Aspire.Tests` 92/92 pass.