### PR TITLE
fix(reporters): unwrap TestFailedException for failure grouping

### DIFF
--- a/TUnit.Engine.Tests/GitHubReporterTests.cs
+++ b/TUnit.Engine.Tests/GitHubReporterTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.TestHost;
 using Shouldly;
+using TUnit.Engine.Exceptions;
 using TUnit.Engine.Reporters;
 
 namespace TUnit.Engine.Tests;
@@ -258,6 +259,27 @@ public class GitHubReporterTests
         var output = await File.ReadAllTextAsync(outputFile);
         output.ShouldContain("Quick diagnosis:");
         output.ShouldContain("Timeout");
+    }
+
+    [Test]
+    public async Task AfterRunAsync_Unwraps_TestFailedException_For_Grouping()
+    {
+        var (reporter, outputFile) = await SetupReporter();
+
+        var inner1 = new InvalidOperationException("Docker image not created");
+        var inner2 = new InvalidOperationException("Docker image not created");
+        await FeedTestMessages(reporter,
+            CreateFailedTestMessage("1", "T1", "Svc", new TestFailedException(inner1)),
+            CreateFailedTestMessage("2", "T2", "Svc", new TestFailedException(inner2))
+        );
+
+        await reporter.AfterRunAsync(1, CancellationToken.None);
+
+        var output = await File.ReadAllTextAsync(outputFile);
+        output.ShouldContain("InvalidOperationException (2 tests)");
+        output.ShouldNotContain("TestFailedException (");
+        output.ShouldContain("Docker image not created");
+        output.ShouldContain("2 × `InvalidOperationException`");
     }
 
     [Test]

--- a/TUnit.Engine/Exceptions/TUnitFailedException.cs
+++ b/TUnit.Engine/Exceptions/TUnitFailedException.cs
@@ -1,4 +1,5 @@
-﻿using TUnit.Core.Exceptions;
+﻿using System.Diagnostics.CodeAnalysis;
+using TUnit.Core.Exceptions;
 using TUnit.Core.Helpers;
 using TUnit.Engine.CommandLineProviders;
 
@@ -6,8 +7,11 @@ namespace TUnit.Engine.Exceptions;
 
 public abstract class TUnitFailedException : TUnitException
 {
+    public Exception? WrappedException { get; }
+
     protected TUnitFailedException(Exception exception) : base($"{exception.GetType().Name}: {exception.Message}", exception.InnerException)
     {
+        WrappedException = exception;
         StackTrace = FilterStackTrace(exception.StackTrace);
     }
 
@@ -17,6 +21,16 @@ public abstract class TUnitFailedException : TUnitException
     }
 
     public override string StackTrace { get; }
+
+    [return: NotNullIfNotNull(nameof(exception))]
+    public static Exception? Unwrap(Exception? exception)
+    {
+        while (exception is TUnitFailedException { WrappedException: { } wrapped })
+        {
+            exception = wrapped;
+        }
+        return exception;
+    }
 
     // The hint only mentions --detailed-stacktrace because filtering is bypassed
     // entirely when --log-level Debug/Trace is set (see TUnitMessageBus.SimplifyStacktrace),

--- a/TUnit.Engine/Reporters/GitHubReporter.cs
+++ b/TUnit.Engine/Reporters/GitHubReporter.cs
@@ -9,6 +9,7 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Constants;
+using TUnit.Engine.Exceptions;
 using TUnit.Engine.Framework;
 using TUnit.Engine.Helpers;
 
@@ -528,9 +529,9 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
         return stateProperty switch
         {
             FailedTestNodeStateProperty failedTestNodeStateProperty =>
-                GetTruncatedExceptionMessage(failedTestNodeStateProperty.Exception) ?? "Test failed",
+                GetTruncatedExceptionMessage(TUnitFailedException.Unwrap(failedTestNodeStateProperty.Exception)) ?? "Test failed",
             ErrorTestNodeStateProperty errorTestNodeStateProperty =>
-                GetTruncatedExceptionMessage(errorTestNodeStateProperty.Exception) ?? "Test failed",
+                GetTruncatedExceptionMessage(TUnitFailedException.Unwrap(errorTestNodeStateProperty.Exception)) ?? "Test failed",
             TimeoutTestNodeStateProperty timeoutTestNodeStateProperty => timeoutTestNodeStateProperty.Explanation,
 #pragma warning disable CS0618 // CancelledTestNodeStateProperty is obsolete
             CancelledTestNodeStateProperty => "Test was cancelled",
@@ -637,8 +638,8 @@ public class GitHubReporter(IExtension extension) : IDataConsumer, ITestHostAppl
 
     private static string GetExceptionTypeName(IProperty? stateProperty) => stateProperty switch
     {
-        FailedTestNodeStateProperty f => f.Exception?.GetType().Name ?? "Unknown",
-        ErrorTestNodeStateProperty e => e.Exception?.GetType().Name ?? "Unknown",
+        FailedTestNodeStateProperty f => TUnitFailedException.Unwrap(f.Exception)?.GetType().Name ?? "Unknown",
+        ErrorTestNodeStateProperty e => TUnitFailedException.Unwrap(e.Exception)?.GetType().Name ?? "Unknown",
         TimeoutTestNodeStateProperty => "Timeout",
         _ => "Unknown"
     };

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -13,6 +13,7 @@ using Microsoft.Testing.Platform.TestHost;
 using TUnit.Core;
 using TUnit.Engine.Configuration;
 using TUnit.Engine.Constants;
+using TUnit.Engine.Exceptions;
 using TUnit.Engine.Framework;
 
 #pragma warning disable TPEXP
@@ -592,6 +593,8 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         {
             return null;
         }
+
+        ex = TUnitFailedException.Unwrap(ex);
 
         return new ReportExceptionData
         {

--- a/TUnit.Engine/Xml/JUnitXmlWriter.cs
+++ b/TUnit.Engine/Xml/JUnitXmlWriter.cs
@@ -5,6 +5,7 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Xml;
 using Microsoft.Testing.Platform.Extensions.Messages;
+using TUnit.Engine.Exceptions;
 
 namespace TUnit.Engine.Xml;
 
@@ -245,7 +246,7 @@ internal static class JUnitXmlWriter
     {
         writer.WriteStartElement("failure");
 
-        var exception = failed.Exception;
+        var exception = TUnitFailedException.Unwrap(failed.Exception);
         if (exception != null)
         {
             writer.WriteAttributeString("message", SanitizeForXml(exception.Message));
@@ -267,7 +268,7 @@ internal static class JUnitXmlWriter
     {
         writer.WriteStartElement("error");
 
-        var exception = error.Exception;
+        var exception = TUnitFailedException.Unwrap(error.Exception);
         if (exception != null)
         {
             writer.WriteAttributeString("message", SanitizeForXml(exception.Message));


### PR DESCRIPTION
## Summary
- GitHub / HTML / JUnit reporters grouped every failure as `TestFailedException` because `SimplifyStacktrace` wraps the real exception in a `TestFailedException` to strip TUnit-internal frames from the console stack trace. Quick diagnosis and Failures by Cause both showed the wrapper type instead of e.g. `InvalidOperationException`.
- Added `WrappedException` property + static `Unwrap` helper on `TUnitFailedException`. `Unwrap` is null-tolerant (`[NotNullIfNotNull]`) and loops to handle wrapper-of-wrapper.
- `GitHubReporter` (`GetExceptionTypeName`, `GetError`), `HtmlReporter.MapException`, and `JUnitXmlWriter` (`WriteFailure`, `WriteError`) now unwrap before reading type / message / stack. MTP's built-in console reporter still receives the wrapper, so filtered stack traces are preserved.

## Test plan
- [x] New test `AfterRunAsync_Unwraps_TestFailedException_For_Grouping` verifies grouping and Quick diagnosis use the inner exception type.
- [x] All 14 existing `GitHubReporterTests` pass.
- [x] All 15 `StackTraceFilterTests` pass (no regression in wrapper behaviour).
- [x] `TUnit.Engine` builds clean across `netstandard2.0;net8.0;net9.0;net10.0`.