### PR TITLE
ci(docs): add link-check automation and tighten Docusaurus strictness

### DIFF
--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           args: >-
             --config ./docs/lychee.toml
-            --base https://tunit.dev
+            --base-url https://tunit.dev
             --no-progress
             'docs/build/**/*.html'
           fail: true

--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages-test.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -30,3 +30,20 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test build website
         run: yarn build
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: docs/.lycheecache
+          key: lychee-html-${{ hashFiles('docs/docs/**/*.md', 'docs/docs/**/*.mdx', 'docs/lychee.toml') }}
+          restore-keys: lychee-html-
+
+      - name: Check links in built HTML
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config ./docs/lychee.toml
+            --no-progress
+            'docs/build/**/*.html'
+          fail: true
+          workingDirectory: ${{ github.workspace }}

--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
-          path: docs/.lycheecache
+          path: .lycheecache
           key: lychee-html-${{ hashFiles('docs/docs/**/*.md', 'docs/docs/**/*.mdx', 'docs/lychee.toml') }}
           restore-keys: lychee-html-
 

--- a/.github/workflows/deploy-pages-test.yml
+++ b/.github/workflows/deploy-pages-test.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           args: >-
             --config ./docs/lychee.toml
+            --base https://tunit.dev
             --no-progress
             'docs/build/**/*.html'
           fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'docs/docs/**'
+      - 'docs/docusaurus.config.ts'
+      - 'docs/sidebars.ts'
       - 'docs/lychee.toml'
       - '.github/workflows/link-check.yml'
   push:
@@ -13,6 +15,8 @@ on:
       - main
     paths:
       - 'docs/docs/**'
+      - 'docs/docusaurus.config.ts'
+      - 'docs/sidebars.ts'
       - 'docs/lychee.toml'
       - '.github/workflows/link-check.yml'
   workflow_dispatch:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,49 @@
+name: Documentation Link Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/docs/**'
+      - 'docs/lychee.toml'
+      - '.github/workflows/link-check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/docs/**'
+      - 'docs/lychee.toml'
+      - '.github/workflows/link-check.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-links:
+    name: Check links in Markdown sources
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-markdown-${{ hashFiles('docs/docs/**/*.md', 'docs/docs/**/*.mdx', 'docs/lychee.toml') }}
+          restore-keys: lychee-markdown-
+
+      - name: Run lychee on Markdown sources
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config ./docs/lychee.toml
+            --no-progress
+            'docs/docs/**/*.md'
+            'docs/docs/**/*.mdx'
+          fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           args: >-
             --config ./docs/lychee.toml
+            --base https://tunit.dev
             --no-progress
             'docs/docs/**/*.md'
             'docs/docs/**/*.mdx'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           args: >-
             --config ./docs/lychee.toml
-            --base https://tunit.dev
+            --base-url https://tunit.dev
             --no-progress
             'docs/docs/**/*.md'
             'docs/docs/**/*.mdx'

--- a/docs/docs/examples/aspire.md
+++ b/docs/docs/examples/aspire.md
@@ -1,6 +1,6 @@
 # Aspire Integration Testing
 
-TUnit provides first-class support for [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/overview) integration testing through the `TUnit.Aspire` package. This package eliminates the boilerplate of managing an Aspire distributed application in tests, handling the full lifecycle (build, start, wait for resources, stop, dispose) automatically.
+TUnit provides first-class support for [.NET Aspire](https://aspire.dev/get-started/what-is-aspire/) integration testing through the `TUnit.Aspire` package. This package eliminates the boilerplate of managing an Aspire distributed application in tests, handling the full lifecycle (build, start, wait for resources, stop, dispose) automatically.
 
 ## Installation
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
   deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -85,7 +86,7 @@ const config: Config = {
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownLinks: 'throw',
     },
   },
   themes: ['@docusaurus/theme-mermaid'],

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -8,15 +8,25 @@ retry_wait_time = 5
 timeout = 20
 user_agent = "Mozilla/5.0 (compatible; lychee-tunit-docs)"
 
-# 429 = rate-limited; the link is fine, just throttled. 200/206 are accepted by default.
-accept = [429]
+# Lychee's `accept` REPLACES defaults rather than extending — must list 200/206 explicitly.
+# 429 = rate-limited; the link is fine, just throttled.
+accept = [200, 206, 429]
 
 cache = true
 max_cache_age = "1d"
 
-# Sites that consistently 4xx/5xx automated checks even though the link is correct,
-# plus localhost/loopback.
+# Only check HTTP(S) URLs. File / mailto / etc. are skipped — internal Docusaurus
+# links are validated at build time by `onBrokenLinks: 'throw'` and friends in
+# docusaurus.config.ts, so re-checking them here is duplicate work and produces
+# false positives (e.g. bare paths `mocking/advanced` that Docusaurus rewrites
+# to `.md` but lychee can't).
+scheme = ["https", "http"]
+
 exclude = [
+  # Self-links — validated at build time; new pages in a PR are not yet live and would 404.
+  "^https?://tunit\\.dev/",
+
+  # Bot-hostile sites that 4xx/5xx automated checks even when the link is fine.
   "^https://github\\.com/thomhurst/TUnit/edit/",   # Docusaurus "edit this page" — generated, may 404 on new docs
   "^https://www\\.nuget\\.org/packages/",           # NuGet returns 429/403 to bot UAs
   "^https://stackoverflow\\.com/",                  # Cloudflare bot challenge

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,0 +1,32 @@
+# Lychee link-checker configuration. Used by .github/workflows/link-check.yml
+# and the link-check step in .github/workflows/deploy-pages-test.yml.
+# Docs: https://lychee.cli.rs/usage/config/
+
+max_concurrency = 8
+max_retries = 3
+retry_wait_time = 5
+timeout = 20
+user_agent = "Mozilla/5.0 (compatible; lychee-tunit-docs)"
+
+# 429 = rate-limited; the link is fine, just throttled. 200/206 are accepted by default.
+accept = [429]
+
+cache = true
+max_cache_age = "1d"
+
+# Sites that consistently 4xx/5xx automated checks even though the link is correct,
+# plus localhost/loopback.
+exclude = [
+  "^https://github\\.com/thomhurst/TUnit/edit/",   # Docusaurus "edit this page" — generated, may 404 on new docs
+  "^https://www\\.nuget\\.org/packages/",           # NuGet returns 429/403 to bot UAs
+  "^https://stackoverflow\\.com/",                  # Cloudflare bot challenge
+  "^https://github\\.com/sponsors/",                # often 403 to bots
+  "^https://tluma\\.ai/",                           # third-party widget script, not a doc link
+  "^http://localhost",
+  "^https?://127\\.0\\.0\\.1",
+]
+
+exclude_path = [
+  "docs/node_modules",
+  "docs/.docusaurus",
+]


### PR DESCRIPTION
## Summary

Closes the gap reported in [#5672](https://github.com/thomhurst/TUnit/discussions/5672) — broken/404 links on https://tunit.dev/docs.

- **`.github/workflows/link-check.yml`** (new) — `markdown-links` job runs [lychee](https://lychee.cli.rs/) against `docs/docs/**/*.{md,mdx}` on PRs/pushes that touch docs. Path-filtered so pure C# PRs do not trigger it.
- **`.github/workflows/deploy-pages-test.yml`** — added a "Check links in built HTML" step after the existing `yarn build`, scanning `docs/build/**/*.html`. Reuses the existing build, no duplicate install.
- **`docs/lychee.toml`** (new) — shared lychee config: 1-day cache, retries, `accept = [429]` for rate-limited links, exclusions for sites that block bots (NuGet, Stack Overflow, GitHub sponsors, the Docusaurus "edit this page" template, etc.).
- **`docs/docusaurus.config.ts`** — `onBrokenAnchors: ''throw''` added; `onBrokenMarkdownLinks` flipped from `''warn''` to `''throw''`. Brings parity with the existing `onBrokenLinks: ''throw''` so internal anchor / raw-markdown breakage now fails the build the same way page-link breakage already does. `yarn build` still passes locally.

## Test plan

- [ ] CI: `markdown-links` job runs on this PR (path filter matches because `docs/docs/**` is unchanged here, but the workflow file itself is in the path filter — should still trigger via the `docs/lychee.toml` and workflow paths).
- [ ] CI: `deploy-pages-test` job builds Docusaurus with the tightened config and then runs lychee against the rendered HTML.
- [ ] Confirm both lychee invocations either pass or surface concrete broken links to triage.
- [ ] After merge, the next docs PR that introduces a broken anchor / raw markdown link should fail `deploy-pages-test`, and an external 404 should fail `link-check`.