### PR TITLE
feat(mocks): add Arg.AnyArgs() shortcut for setup/verify

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -338,6 +338,13 @@ namespace TUnit.Mocks.Generated
             return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
         }
 
+        /// <summary>Configure the mock setup for <c>UpdateDialogAsync</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.AnyArgs _) where TData : class
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<string>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<global::DialogParameters<TData>>.Instance };
+            return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
+        }
+
         public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, parameters.Matcher };
@@ -363,6 +370,13 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
             global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, __fa_parameters.Matcher };
+            return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
+        }
+
+        /// <summary>Configure the mock setup for <c>ShowDialogAsync</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.AnyArgs _) where TDialog : global::IDialogContentComponent
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<object>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<global::DialogParameters>.Instance };
             return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
         }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -338,13 +338,6 @@ namespace TUnit.Mocks.Generated
             return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
         }
 
-        /// <summary>Configure the mock setup for <c>UpdateDialogAsync</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
-        public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.AnyArgs _) where TData : class
-        {
-            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<string>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<global::DialogParameters<TData>>.Instance };
-            return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
-        }
-
         public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, parameters.Matcher };
@@ -370,13 +363,6 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
             global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, __fa_parameters.Matcher };
-            return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
-        }
-
-        /// <summary>Configure the mock setup for <c>ShowDialogAsync</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
-        public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.AnyArgs _) where TDialog : global::IDialogContentComponent
-        {
-            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<object>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<global::DialogParameters>.Instance };
             return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
         }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
@@ -155,6 +155,13 @@ namespace TUnit.Mocks.Generated
             return new IEscapedNames_namespace_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "namespace", matchers);
         }
 
+        /// <summary>Configure the mock setup for <c>namespace</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static IEscapedNames_namespace_M3_MockCall @namespace(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance };
+            return new IEscapedNames_namespace_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "namespace", matchers);
+        }
+
         extension(global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
         {
             public global::TUnit.Mocks.PropertyMockCall<int> @class

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -134,6 +134,13 @@ namespace TUnit.Mocks.Generated
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_class.Matcher, __fa_return.Matcher };
             return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
         }
+
+        /// <summary>Configure the mock setup for <c>Get</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static ITest_Get_M1_MockCall Get(this global::TUnit.Mocks.Mock<global::ITest> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<string>.Instance };
+            return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
+        }
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -173,6 +173,13 @@ namespace TUnit.Mocks.Generated
             return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
         }
 
+        /// <summary>Configure the mock setup for <c>GetValue</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static IFoo_GetValue_M1_MockCall GetValue(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<string?>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance };
+            return new IFoo_GetValue_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
+        }
+
         public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.Arg<string> nonNull, global::TUnit.Mocks.Arguments.Arg<string?> nullable, global::TUnit.Mocks.Arguments.Arg<object?> obj)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { nonNull.Matcher, nullable.Matcher, obj.Matcher };
@@ -230,6 +237,13 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<string?> __fa_nullable = nullable;
             global::TUnit.Mocks.Arguments.Arg<object?> __fa_obj = obj;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_nonNull.Matcher, __fa_nullable.Matcher, __fa_obj.Matcher };
+            return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
+        }
+
+        /// <summary>Configure the mock setup for <c>Process</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static IFoo_Process_M2_MockCall Process(this global::TUnit.Mocks.Mock<global::IFoo> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<string>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<string?>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<object?>.Instance };
             return new IFoo_Process_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Process", matchers);
         }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -423,6 +423,13 @@ namespace TUnit.Mocks.Generated
             return new IDialogService_Show_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Show", matchers);
         }
 
+        /// <summary>Configure the mock setup for <c>Show</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static IDialogService_Show_M0_MockCall Show(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<string?>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<string?>.Instance };
+            return new IDialogService_Show_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Show", matchers);
+        }
+
         public static global::TUnit.Mocks.MockMethodCall<string?> ShowPanel<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<TData?> data) where TData : class
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -129,6 +129,13 @@ namespace TUnit.Mocks.Generated
             return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
         }
 
+        /// <summary>Configure the mock setup for <c>Add</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static ICalculator_Add_M0_MockCall Add(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance };
+            return new ICalculator_Add_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Add", matchers);
+        }
+
         public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.Arg<int> a, global::TUnit.Mocks.Arguments.Arg<int> b)
         {
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, b.Matcher };
@@ -154,6 +161,13 @@ namespace TUnit.Mocks.Generated
             global::TUnit.Mocks.Arguments.Arg<int> __fa_a = a;
             global::TUnit.Mocks.Arguments.Arg<int> __fa_b = b;
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_a.Matcher, __fa_b.Matcher };
+            return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
+        }
+
+        /// <summary>Configure the mock setup for <c>Subtract</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>
+        public static ICalculator_Subtract_M1_MockCall Subtract(this global::TUnit.Mocks.Mock<global::ICalculator> mock, global::TUnit.Mocks.Arguments.AnyArgs _)
+        {
+            var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance };
             return new ICalculator_Subtract_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Subtract", matchers);
         }
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -676,6 +676,8 @@ internal static class MockMembersBuilder
             EmitMemberMethodBody(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: false, receiverIsThis: false);
             EmitFuncOverloads(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: false, receiverIsThis: false);
         }
+
+        EmitAnyArgsOverload(writer, method, model, safeName, captureModelTypeParameters: false, receiverIsThis: false);
     }
 
     private static void GenerateGenericMethodExtensionBlock(CodeWriter writer, MockMemberModel method, MockTypeModel model, string safeName)
@@ -716,6 +718,8 @@ internal static class MockMembersBuilder
             EmitMemberMethodBody(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: true, receiverIsThis: false);
             EmitFuncOverloads(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: true, receiverIsThis: false);
         }
+
+        EmitAnyArgsOverload(writer, method, model, safeName, captureModelTypeParameters: true, receiverIsThis: false);
     }
 
     internal static void GenerateGenericMethodMembersForWrapper(CodeWriter writer, MockMemberModel method, MockTypeModel model, string safeName)
@@ -735,6 +739,8 @@ internal static class MockMembersBuilder
             EmitMemberMethodBody(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: true, receiverIsThis: true);
             EmitFuncOverloads(writer, method, model, safeName, includeRefStructArgs: false, captureModelTypeParameters: true, receiverIsThis: true);
         }
+
+        EmitAnyArgsOverload(writer, method, model, safeName, captureModelTypeParameters: true, receiverIsThis: true);
     }
 
     /// <summary>
@@ -869,23 +875,98 @@ internal static class MockMembersBuilder
                 writer.AppendLine($"var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] {{ {matcherArgs} }};");
             }
 
-            if (useTypedWrapper)
+            EmitReturnConstruction(writer, method, model, safeName, useTypedWrapper, setupReturnType);
+        }
+    }
+
+    /// <summary>
+    /// Emits the dispatch tail shared by every setup overload: build a return statement constructing
+    /// the right wrapper / mock-call type given the matchers array already in scope as <c>matchers</c>.
+    /// </summary>
+    private static void EmitReturnConstruction(CodeWriter writer, MockMemberModel method, MockTypeModel model,
+        string safeName, bool useTypedWrapper, string setupReturnType)
+    {
+        if (useTypedWrapper)
+        {
+            var wrapperName = MockImplBuilder.GetGeneratedTypeName(GetWrapperName(safeName, method), model);
+            writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+        }
+        else if (method.IsVoid || method.IsRefStructReturn)
+        {
+            writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+        }
+        else if (method.IsReturnTypeStaticAbstractInterface)
+        {
+            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+        }
+        else
+        {
+            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+        }
+    }
+
+    /// <summary>
+    /// Emits a single-argument shortcut overload that accepts <c>AnyArgs</c> and fills every
+    /// matchable parameter slot with <c>AnyMatcher&lt;T&gt;.Instance</c>. Skipped when the shortcut
+    /// would be ambiguous (the method name is not unique on the model), unhelpful (zero or one
+    /// matchable parameter), or unsafe to mirror at this layer (out / ref / ref-struct params).
+    /// </summary>
+    private static void EmitAnyArgsOverload(CodeWriter writer, MockMemberModel method, MockTypeModel model,
+        string safeName, bool captureModelTypeParameters, bool receiverIsThis)
+    {
+        // Out, ref, and ref-struct params change matcher arity or signature shape; rather than
+        // try to mirror those variations through the AnyArgs path, defer to the explicit form.
+        foreach (var p in method.Parameters)
+        {
+            if (p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref) return;
+            if (p.IsRefStruct) return;
+        }
+
+        // After the early-return loop above, every parameter is matchable.
+        if (method.Parameters.Length < 2) return;
+
+        // Name uniqueness: same set of methods that drive extension-method emission.
+        int sameNameCount = 0;
+        foreach (var m in model.Methods)
+        {
+            if (m.ExplicitInterfaceName is not null && !m.IsStaticAbstract) continue;
+            if (m.Name == method.Name) sameNameCount++;
+        }
+        if (sameNameCount > 1) return;
+
+        var (useTypedWrapper, returnType, setupReturnType) = GetReturnTypeInfo(method, model, safeName);
+
+        var typeParams = captureModelTypeParameters
+            ? MockImplBuilder.GetTypeParameterList(method)
+            : GetCombinedTypeParameterList(model, method);
+        var constraints = captureModelTypeParameters
+            ? MockImplBuilder.GetConstraintClauses(method)
+            : GetCombinedConstraintClauses(model, method);
+
+        var safeMemberName = GetSafeMemberName(method.Name);
+        var paramListInner = "global::TUnit.Mocks.Arguments.AnyArgs _";
+        var fullParamList = captureModelTypeParameters
+            ? paramListInner
+            : BuildExtensionMethodParameterList(model, paramListInner);
+
+        var methodDeclarationPrefix = captureModelTypeParameters ? "public" : "public static";
+
+        writer.AppendLine();
+        writer.AppendLine($"/// <summary>Configure the mock setup for <c>{method.Name}</c> with every argument matched as <c>Any&lt;T&gt;()</c>.</summary>");
+        using (writer.Block($"{methodDeclarationPrefix} {returnType} {safeMemberName}{typeParams}({fullParamList}){constraints}"))
+        {
+            if (receiverIsThis)
             {
-                var wrapperName = MockImplBuilder.GetGeneratedTypeName(GetWrapperName(safeName, method), model);
-                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+                writer.AppendLine("var mock = this;");
             }
-            else if (method.IsVoid || method.IsRefStructReturn)
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
-            else if (method.IsReturnTypeStaticAbstractInterface)
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
-            else
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
+
+            // AnyMatcher<T>.Instance is stateless and shared — unlike Arg.Any<T>(), it skips the
+            // CapturingMatcher wrap, so the AnyArgs path doesn't accumulate captured values per call.
+            var matcherArgs = string.Join(", ", method.Parameters.Select(p =>
+                $"global::TUnit.Mocks.Matchers.AnyMatcher<{p.FullyQualifiedType}>.Instance"));
+            writer.AppendLine($"var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] {{ {matcherArgs} }};");
+
+            EmitReturnConstruction(writer, method, model, safeName, useTypedWrapper, setupReturnType);
         }
     }
 
@@ -1029,24 +1110,7 @@ internal static class MockMembersBuilder
                 writer.AppendLine($"var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] {{ {string.Join(", ", matcherExprs)} }};");
             }
 
-            // Return statement
-            if (useTypedWrapper)
-            {
-                var wrapperName = MockImplBuilder.GetGeneratedTypeName(GetWrapperName(safeName, method), model);
-                writer.AppendLine($"return new {wrapperName}(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
-            else if (method.IsVoid || method.IsRefStructReturn)
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
-            else if (method.IsReturnTypeStaticAbstractInterface)
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
-            else
-            {
-                writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
-            }
+            EmitReturnConstruction(writer, method, model, safeName, useTypedWrapper, setupReturnType);
         }
     }
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -909,11 +909,16 @@ internal static class MockMembersBuilder
     /// Emits a single-argument shortcut overload that accepts <c>AnyArgs</c> and fills every
     /// matchable parameter slot with <c>AnyMatcher&lt;T&gt;.Instance</c>. Skipped when the shortcut
     /// would be ambiguous (the method name is not unique on the model), unhelpful (zero or one
-    /// matchable parameter), or unsafe to mirror at this layer (out / ref / ref-struct params).
+    /// matchable parameter), unable to infer method type parameters, or unsafe to mirror at this
+    /// layer (out / ref / ref-struct params).
     /// </summary>
     private static void EmitAnyArgsOverload(CodeWriter writer, MockMemberModel method, MockTypeModel model,
         string safeName, bool captureModelTypeParameters, bool receiverIsThis)
     {
+        // AnyArgs carries no typed argument information, so generic method type parameters
+        // cannot be inferred at the call site. Defer to the explicit per-parameter overload.
+        if (method.IsGenericMethod) return;
+
         // Out, ref, and ref-struct params change matcher arity or signature shape; rather than
         // try to mirror those variations through the AnyArgs path, defer to the explicit form.
         foreach (var p in method.Parameters)

--- a/TUnit.Mocks.Tests/AnyArgsTests.cs
+++ b/TUnit.Mocks.Tests/AnyArgsTests.cs
@@ -1,0 +1,135 @@
+using TUnit.Mocks;
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks.Tests;
+
+/// <summary>
+/// Test interfaces for the Arg.AnyArgs shortcut. The shortcut emits a single
+/// setup overload that fills every matchable parameter with Any(), so a user
+/// no longer has to write Any() once per parameter.
+/// </summary>
+public interface IFiveParamService
+{
+    int Compute(int a, int b, int c, int d, int e);
+    void Log(string source, string level, string message, int code, bool fatal);
+}
+
+public interface ITwoParamService
+{
+    string Combine(string left, string right);
+}
+
+public interface IOverloadedSumService
+{
+    int Sum(int a, int b);
+    int Sum(int a, int b, int c);
+    void Notify(string message);
+    void Notify(string source, string message);
+}
+
+public class AnyArgsTests
+{
+    [Test]
+    public async Task AnyArgs_Setup_Returns_Value_For_Any_Argument_Combination()
+    {
+        var mock = IFiveParamService.Mock();
+        mock.Compute(AnyArgs()).Returns(42);
+
+        var svc = mock.Object;
+
+        await Assert.That(svc.Compute(0, 0, 0, 0, 0)).IsEqualTo(42);
+        await Assert.That(svc.Compute(1, 2, 3, 4, 5)).IsEqualTo(42);
+        await Assert.That(svc.Compute(-100, int.MaxValue, 0, 7, -1)).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task AnyArgs_Setup_Works_For_Two_Param_Method()
+    {
+        var mock = ITwoParamService.Mock();
+        mock.Combine(AnyArgs()).Returns("OK");
+
+        var svc = mock.Object;
+
+        await Assert.That(svc.Combine("a", "b")).IsEqualTo("OK");
+        await Assert.That(svc.Combine("", "")).IsEqualTo("OK");
+        await Assert.That(svc.Combine(null!, null!)).IsEqualTo("OK");
+    }
+
+    [Test]
+    public async Task AnyArgs_Setup_Works_For_Void_Method()
+    {
+        var mock = IFiveParamService.Mock();
+        mock.Log(AnyArgs()).Throws(new System.InvalidOperationException("boom"));
+
+        var svc = mock.Object;
+
+        await Assert.That(() => svc.Log("a", "b", "c", 0, false))
+            .Throws<System.InvalidOperationException>();
+        await Assert.That(() => svc.Log("x", "y", "z", 99, true))
+            .Throws<System.InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AnyArgs_Verify_Catches_Any_Call()
+    {
+        var mock = IFiveParamService.Mock();
+        var svc = mock.Object;
+
+        svc.Compute(1, 2, 3, 4, 5);
+        svc.Compute(10, 20, 30, 40, 50);
+
+        mock.Compute(AnyArgs()).WasCalled(Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task AnyArgs_Equivalent_To_All_Any_Slots()
+    {
+        var mockA = IFiveParamService.Mock();
+        var mockB = IFiveParamService.Mock();
+
+        mockA.Compute(AnyArgs()).Returns(7);
+        mockB.Compute(Any(), Any(), Any(), Any(), Any()).Returns(7);
+
+        await Assert.That(mockA.Object.Compute(1, 2, 3, 4, 5)).IsEqualTo(7);
+        await Assert.That(mockB.Object.Compute(1, 2, 3, 4, 5)).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task AnyArgs_NotEmitted_For_Overloaded_Method_Names()
+    {
+        var mock = IOverloadedSumService.Mock();
+        mock.Sum(Any(), Any()).Returns(11);
+        mock.Sum(Any(), Any(), Any()).Returns(111);
+
+        var svc = mock.Object;
+
+        await Assert.That(svc.Sum(1, 2)).IsEqualTo(11);
+        await Assert.That(svc.Sum(1, 2, 3)).IsEqualTo(111);
+
+        await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IOverloadedSumService_MockMemberExtensions", "Sum")).IsFalse();
+        await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IOverloadedSumService_MockMemberExtensions", "Notify")).IsFalse();
+    }
+
+    [Test]
+    public async Task AnyArgs_Emitted_For_Unique_Method_Names()
+    {
+        await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IFiveParamService_MockMemberExtensions", "Compute")).IsTrue();
+        await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IFiveParamService_MockMemberExtensions", "Log")).IsTrue();
+    }
+
+    // The generated extension class lives in TUnit.Mocks.Generated and is named
+    // <safe-type-name>_MockMemberExtensions; the AnyArgs overload appears as a 2-param
+    // extension method whose second parameter is typed AnyArgs.
+    private static bool HasAnyArgsOverload(string extensionsTypeName, string methodName)
+    {
+        var extensionsType = typeof(AnyArgsTests).Assembly.GetTypes()
+            .Single(t => t.Name == extensionsTypeName);
+        return extensionsType.GetMethods()
+            .Where(m => m.Name == methodName)
+            .Any(m =>
+            {
+                var ps = m.GetParameters();
+                return ps.Length == 2 && ps[1].ParameterType == typeof(AnyArgs);
+            });
+    }
+}

--- a/TUnit.Mocks.Tests/AnyArgsTests.cs
+++ b/TUnit.Mocks.Tests/AnyArgsTests.cs
@@ -100,6 +100,7 @@ public class AnyArgsTests
     }
 
     [Test]
+    [SkipIfNotDynamicCodeSupported("Inspects generated extension class metadata via reflection; trimmer removes it under PublishTrimmed.")]
     public async Task AnyArgs_NotEmitted_For_Overloaded_Method_Names()
     {
         var mock = IOverloadedSumService.Mock();
@@ -116,6 +117,7 @@ public class AnyArgsTests
     }
 
     [Test]
+    [SkipIfNotDynamicCodeSupported("Inspects generated extension class metadata via reflection; trimmer removes it under PublishTrimmed.")]
     public async Task AnyArgs_Emitted_For_Unique_Method_Names()
     {
         await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IFiveParamService_MockMemberExtensions", "Compute")).IsTrue();
@@ -123,6 +125,7 @@ public class AnyArgsTests
     }
 
     [Test]
+    [SkipIfNotDynamicCodeSupported("Inspects generated extension class metadata via reflection; trimmer removes it under PublishTrimmed.")]
     public async Task AnyArgs_NotEmitted_For_Generic_Methods()
     {
         await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IGenericAnyArgsService_MockMemberExtensions", "Pick")).IsFalse();

--- a/TUnit.Mocks.Tests/AnyArgsTests.cs
+++ b/TUnit.Mocks.Tests/AnyArgsTests.cs
@@ -27,6 +27,11 @@ public interface IOverloadedSumService
     void Notify(string source, string message);
 }
 
+public interface IGenericAnyArgsService
+{
+    T Pick<T>(T left, T right);
+}
+
 public class AnyArgsTests
 {
     [Test]
@@ -117,13 +122,25 @@ public class AnyArgsTests
         await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IFiveParamService_MockMemberExtensions", "Log")).IsTrue();
     }
 
+    [Test]
+    public async Task AnyArgs_NotEmitted_For_Generic_Methods()
+    {
+        await Assert.That(HasAnyArgsOverload("TUnit_Mocks_Tests_IGenericAnyArgsService_MockMemberExtensions", "Pick")).IsFalse();
+    }
+
     // The generated extension class lives in TUnit.Mocks.Generated and is named
     // <safe-type-name>_MockMemberExtensions; the AnyArgs overload appears as a 2-param
-    // extension method whose second parameter is typed AnyArgs.
+    // extension method whose second parameter is typed AnyArgs. Keep these literal class
+    // names in sync with MockImplBuilder.GetSafeName.
     private static bool HasAnyArgsOverload(string extensionsTypeName, string methodName)
     {
         var extensionsType = typeof(AnyArgsTests).Assembly.GetTypes()
-            .Single(t => t.Name == extensionsTypeName);
+            .SingleOrDefault(t => t.Name == extensionsTypeName);
+        if (extensionsType is null)
+        {
+            return false;
+        }
+
         return extensionsType.GetMethods()
             .Where(m => m.Name == methodName)
             .Any(m =>

--- a/TUnit.Mocks.Tests/SkipIfNotDynamicCodeSupportedAttribute.cs
+++ b/TUnit.Mocks.Tests/SkipIfNotDynamicCodeSupportedAttribute.cs
@@ -1,0 +1,20 @@
+using System.Runtime.CompilerServices;
+
+namespace TUnit.Mocks.Tests;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
+public class SkipIfNotDynamicCodeSupportedAttribute : SkipAttribute
+{
+    public SkipIfNotDynamicCodeSupportedAttribute(string reason) : base(reason)
+    {
+    }
+
+    public override Task<bool> ShouldSkip(TestRegisteredContext context)
+    {
+#if NET
+        return Task.FromResult(!RuntimeFeature.IsDynamicCodeSupported);
+#else
+        return Task.FromResult(false);
+#endif
+    }
+}

--- a/TUnit.Mocks/Arguments/AnyArgs.cs
+++ b/TUnit.Mocks/Arguments/AnyArgs.cs
@@ -1,0 +1,19 @@
+namespace TUnit.Mocks.Arguments;
+
+/// <summary>
+/// Sentinel type returned by <see cref="Arg.AnyArgs"/>. Passed to a generated mock setup or
+/// verification overload, it stands in for a complete argument list of <see cref="Arg.Any{T}"/>
+/// matchers — one per parameter — so callers do not have to repeat <c>Any()</c> for each slot.
+/// <para>
+/// The shortcut overload is only generated when the method's name is unique on the mocked type;
+/// for overloaded names it would be ambiguous. In that case use the explicit per-parameter
+/// <see cref="Arg.Any{T}"/> form.
+/// </para>
+/// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+public sealed class AnyArgs
+{
+    internal static readonly AnyArgs Instance = new();
+
+    private AnyArgs() { }
+}

--- a/TUnit.Mocks/Arguments/AnyArgs.cs
+++ b/TUnit.Mocks/Arguments/AnyArgs.cs
@@ -6,14 +6,11 @@ namespace TUnit.Mocks.Arguments;
 /// matchers — one per parameter — so callers do not have to repeat <c>Any()</c> for each slot.
 /// <para>
 /// The shortcut overload is only generated when the method's name is unique on the mocked type;
-/// for overloaded names it would be ambiguous. In that case use the explicit per-parameter
-/// <see cref="Arg.Any{T}"/> form.
+/// for overloaded names, generic methods, or methods with fewer than two matchable parameters,
+/// use the explicit per-parameter <see cref="Arg.Any{T}"/> form.
 /// </para>
 /// </summary>
 [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-public sealed class AnyArgs
+public readonly struct AnyArgs
 {
-    internal static readonly AnyArgs Instance = new();
-
-    private AnyArgs() { }
 }

--- a/TUnit.Mocks/Arguments/Arg.cs
+++ b/TUnit.Mocks/Arguments/Arg.cs
@@ -15,6 +15,13 @@ public static class Arg
     /// <summary>Matches any value — type is inferred from the parameter position.</summary>
     public static AnyArg Any() => AnyArg.Instance;
 
+    /// <summary>
+    /// Shortcut for setting up or verifying a mocked method when every argument should match
+    /// <see cref="Any{T}"/>. Equivalent to passing <c>Any()</c> for each parameter.
+    /// Only available on methods whose name is unique on the mocked type.
+    /// </summary>
+    public static AnyArgs AnyArgs() => Arguments.AnyArgs.Instance;
+
     /// <summary>Matches using exact equality.</summary>
     public static Arg<T> Is<T>(T value) => new(new ExactMatcher<T>(value));
 

--- a/TUnit.Mocks/Arguments/Arg.cs
+++ b/TUnit.Mocks/Arguments/Arg.cs
@@ -18,9 +18,9 @@ public static class Arg
     /// <summary>
     /// Shortcut for setting up or verifying a mocked method when every argument should match
     /// <see cref="Any{T}"/>. Equivalent to passing <c>Any()</c> for each parameter.
-    /// Only available on methods whose name is unique on the mocked type.
+    /// Only available on non-generic methods whose name is unique on the mocked type.
     /// </summary>
-    public static AnyArgs AnyArgs() => Arguments.AnyArgs.Instance;
+    public static AnyArgs AnyArgs() => default;
 
     /// <summary>Matches using exact equality.</summary>
     public static Arg<T> Is<T>(T value) => new(new ExactMatcher<T>(value));

--- a/TUnit.Mocks/Matchers/AnyMatcher.cs
+++ b/TUnit.Mocks/Matchers/AnyMatcher.cs
@@ -17,14 +17,18 @@ internal sealed class AnyMatcher : IArgumentMatcher
 
 /// <summary>
 /// An argument matcher that matches any value of the specified type, including null.
+/// Public for source-generator access; not intended for direct use — call <see cref="Arg.Any{T}"/> instead.
 /// </summary>
-internal sealed class AnyMatcher<T> : IArgumentMatcher<T>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+public sealed class AnyMatcher<T> : IArgumentMatcher<T>
 {
     /// <summary>
     /// Cached singleton — <see cref="AnyMatcher{T}"/> is stateless, so a single instance per closed
     /// generic type avoids a per-call allocation on the common <see cref="Arg.Any{T}"/> path.
     /// </summary>
     public static readonly AnyMatcher<T> Instance = new();
+
+    private AnyMatcher() { }
 
     public bool Matches(T? value) => true;
 

--- a/docs/docs/writing-tests/mocking/argument-matchers.md
+++ b/docs/docs/writing-tests/mocking/argument-matchers.md
@@ -15,6 +15,7 @@ TUnit.Mocks automatically imports the `Arg` class via `global using static`, so 
 | Matcher | Matches |
 |---|---|
 | `Any()` / `Any<T>()` | Any value of type T (including null) |
+| `AnyArgs()` | Shortcut for matching every argument with `Any()` (only on uniquely named methods) |
 | `Is<T>(value)` | Exact equality |
 | `Is<T>(predicate)` | Values satisfying a predicate |
 | Raw value (e.g. `42`, `"hello"`) | Exact equality (implicit conversion) |
@@ -46,6 +47,33 @@ mock.GetUser(Any()).Returns(new User("Default"));
 svc.GetUser(1);    // matches
 svc.GetUser(999);  // matches
 ```
+
+### AnyArgs — match every parameter with one token
+
+When you only care that a method was called and don't want to constrain any of its arguments, repeating `Any()` for each parameter gets noisy:
+
+```csharp
+mock.Compute(Any(), Any(), Any(), Any(), Any()).Returns(42);
+```
+
+`AnyArgs()` is a shortcut that fills every matchable parameter with `Any<T>()` in one token:
+
+```csharp
+mock.Compute(AnyArgs()).Returns(42);
+
+mock.Log(AnyArgs()).Throws<InvalidOperationException>();
+
+// Works for verification too
+mock.Compute(AnyArgs()).WasCalled(Times.Exactly(2));
+```
+
+The two forms are equivalent — `AnyArgs()` simply expands to one `Arg.Any<T>()` per parameter.
+
+:::note When the shortcut is generated
+The `AnyArgs()` overload is only emitted when the method's name is unique on the mocked type. If the type has overloads of the same name (for example `Sum(int, int)` and `Sum(int, int, int)`), the shortcut would be ambiguous, so the generator omits it for those methods — use the explicit per-parameter form instead.
+
+The shortcut is also skipped for methods with `out`, `ref`, or ref-struct parameters, and for methods with fewer than two matchable parameters (where it would save nothing).
+:::
 
 ### Exact Value
 

--- a/docs/docs/writing-tests/mocking/argument-matchers.md
+++ b/docs/docs/writing-tests/mocking/argument-matchers.md
@@ -72,7 +72,7 @@ The two forms are equivalent — `AnyArgs()` simply expands to one `Arg.Any<T>()
 :::note When the shortcut is generated
 The `AnyArgs()` overload is only emitted when the method's name is unique on the mocked type. If the type has overloads of the same name (for example `Sum(int, int)` and `Sum(int, int, int)`), the shortcut would be ambiguous, so the generator omits it for those methods — use the explicit per-parameter form instead.
 
-The shortcut is also skipped for methods with `out`, `ref`, or ref-struct parameters, and for methods with fewer than two matchable parameters (where it would save nothing).
+The shortcut is also skipped for generic methods, methods with `out`, `ref`, or ref-struct parameters, and methods with fewer than two matchable parameters. Generic methods need typed arguments so C# can infer their method type parameters, and single-parameter methods are already as short with `Any()`.
 :::
 
 ### Exact Value


### PR DESCRIPTION
## Summary

- New `Arg.AnyArgs()` shortcut: instead of writing `Any()` once per parameter, callers can match every argument in one token, e.g. `mock.Compute(AnyArgs()).Returns(42)`.
- The shortcut is source-generated as an additional overload alongside the existing typed setup methods. It is only emitted when the method name is unique on the mocked type and the method has no `out`/`ref`/ref-struct parameters; for overloaded names the shortcut would be ambiguous, so callers fall back to the explicit per-parameter form.
- Generated body uses `AnyMatcher<T>.Instance` directly (now `public` + `EditorBrowsable(Never)`) rather than `Arg.Any<T>().Matcher` — skips the `CapturingMatcher<T>` wrap, since `AnyArgs` callers have no `Arg<T>` handle to inspect captures anyway.

Before:
```csharp
mock.Compute(Any(), Any(), Any(), Any(), Any()).Returns(42);
```

After:
```csharp
mock.Compute(AnyArgs()).Returns(42);
```

Also extracts a small `EmitReturnConstruction` helper in `MockMembersBuilder` to deduplicate the wrapper/mock-call dispatch tail across the three setup-emission paths (existing + new).

## Test plan

- [x] Runtime tests in `TUnit.Mocks.Tests/AnyArgsTests.cs` — 7 tests covering: setup returns, void+throws, verification with `WasCalled`, equivalence to all-`Any()` slots, two-param method, reflective check that overloaded names get **no** `AnyArgs` overload, counter-check that uniquely named methods do.
- [x] All 967 `TUnit.Mocks.Tests` pass on net10.0.
- [x] All 49 `TUnit.Mocks.SourceGenerator.Tests` snapshot tests pass; 6 `.verified.txt` snapshots updated to reflect the new emission.
- [x] Docs section added in `docs/docs/writing-tests/mocking/argument-matchers.md`.