### PR TITLE
perf(engine): skip execution ledger for independent tests

### DIFF
--- a/TUnit.Core/AbstractExecutableTest.cs
+++ b/TUnit.Core/AbstractExecutableTest.cs
@@ -30,6 +30,11 @@ public abstract class AbstractExecutableTest
     // avoiding a per-test scan over ParallelConstraints in the hot path.
     internal bool RequiresGlobalNotInParallelLock { get; set; }
 
+    // Set by the scheduler for tests that either have dependencies or are the target of
+    // another test's dependency. These tests can be reached from both the scheduler and
+    // dependency recursion, so TestRunner must keep using its execution dedup ledger.
+    internal bool RequiresExecutionDedup { get; set; }
+
     public required TestContext Context
     {
         get;

--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -145,7 +145,7 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
     {
         try
         {
-            await _testRunner.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
+            await _testRunner.ExecuteTestWithoutExecutionTaskAsync(test, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -48,6 +48,8 @@ public sealed class TestRunner
     private readonly ConcurrentDictionary<string, TaskCompletionSource<bool>> _executingTests = new();
     private Exception? _firstFailFastException;
 
+    internal int ExecutingTestsCount => _executingTests.Count;
+
     public ValueTask ExecuteTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         if (!test.RequiresExecutionDedup)

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -42,13 +42,28 @@ public sealed class TestRunner
         _notInParallelLock = notInParallelLock;
     }
 
-    // Dedup ledger for re-entrant ExecuteTestAsync calls (dependency recursion, scheduler races).
-    // Entries are intentionally retained for the session: a late dependency lookup must still
-    // observe the in-flight or completed TCS. Session-scoped lifetime bounds growth to O(test count).
+    // Dedup ledger for tests involved in dependency relationships. Entries are intentionally
+    // retained for the session: a late dependency lookup must still observe the in-flight or
+    // completed TCS. Session-scoped lifetime bounds growth to O(test count).
     private readonly ConcurrentDictionary<string, TaskCompletionSource<bool>> _executingTests = new();
     private Exception? _firstFailFastException;
 
     public ValueTask ExecuteTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    {
+        if (!test.RequiresExecutionDedup)
+        {
+            if (test.ExecutionTask is { } executionTask)
+            {
+                return new ValueTask(executionTask);
+            }
+
+            return ExecuteTestInternalAsync(test, cancellationToken);
+        }
+
+        return ExecuteTestWithDependenciesAsync(test, cancellationToken);
+    }
+
+    private ValueTask ExecuteTestWithDependenciesAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         if (_executingTests.TryGetValue(test.TestId, out var existingTcs))
         {

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -54,11 +54,6 @@ public sealed class TestRunner
     {
         if (!test.RequiresExecutionDedup)
         {
-            if (test.ExecutionTask is { } executionTask)
-            {
-                return new ValueTask(executionTask);
-            }
-
             return ExecuteTestInternalAsync(test, cancellationToken);
         }
 
@@ -71,7 +66,7 @@ public sealed class TestRunner
         {
             return new ValueTask(existingTcs.Task);
         }
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         existingTcs = _executingTests.GetOrAdd(test.TestId, tcs);
 
         if (existingTcs != tcs)

--- a/TUnit.Engine/Scheduling/TestRunner.cs
+++ b/TUnit.Engine/Scheduling/TestRunner.cs
@@ -54,6 +54,21 @@ public sealed class TestRunner
     {
         if (!test.RequiresExecutionDedup)
         {
+            if (test.ExecutionTask is { } executionTask)
+            {
+                return new ValueTask(executionTask);
+            }
+
+            return ExecuteTestInternalAsync(test, cancellationToken);
+        }
+
+        return ExecuteTestWithDependenciesAsync(test, cancellationToken);
+    }
+
+    internal ValueTask ExecuteTestWithoutExecutionTaskAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    {
+        if (!test.RequiresExecutionDedup)
+        {
             return ExecuteTestInternalAsync(test, cancellationToken);
         }
 
@@ -66,6 +81,8 @@ public sealed class TestRunner
         {
             return new ValueTask(existingTcs.Task);
         }
+        // Continuations may re-enter scheduling paths; keep them off the thread
+        // that publishes ledger completion.
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         existingTcs = _executingTests.GetOrAdd(test.TestId, tcs);
 

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -144,6 +144,8 @@ internal sealed class TestScheduler : ITestScheduler
         // Group tests by their parallel constraints
         var groupedTests = await _groupingService.GroupTestsByConstraintsAsync(executableTests).ConfigureAwait(false);
 
+        MarkDependencyRelatedTestsForExecutionDedup(executableTests);
+
         // Suites with no global [NotInParallel] tests skip the runtime exclusion
         // lock entirely. Once enabled, the flag is monotonic — dynamic batches
         // that introduce NIP later (see ExecuteDynamicBatchAsync) keep it on.
@@ -317,8 +319,27 @@ internal sealed class TestScheduler : ITestScheduler
         // tests with [NotInParallel(key)], [ParallelGroup(...)] etc. honour their constraints
         // instead of being silently dropped.
         var groupedDynamicTests = await _groupingService.GroupTestsByConstraintsAsync(dynamicTests.ToArray()).ConfigureAwait(false);
+        MarkDependencyRelatedTestsForExecutionDedup(dynamicTests);
         MarkGlobalNotInParallelTests(groupedDynamicTests);
         await ExecuteAllPhasesAsync(groupedDynamicTests, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void MarkDependencyRelatedTestsForExecutionDedup(IEnumerable<AbstractExecutableTest> tests)
+    {
+        foreach (var test in tests)
+        {
+            if (test.Dependencies.Length == 0)
+            {
+                continue;
+            }
+
+            test.RequiresExecutionDedup = true;
+
+            foreach (var dependency in test.Dependencies)
+            {
+                dependency.Test.RequiresExecutionDedup = true;
+            }
+        }
     }
 
     private void MarkGlobalNotInParallelTests(GroupedTests grouped)

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -458,9 +458,14 @@ internal sealed class TestScheduler : ITestScheduler
 
     private async ValueTask ExecuteScheduledTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
-        // Scheduler grouping partitions each batch, so each test reaches this path once.
-        // Dependency recursion is the re-entrant path and those tests are marked for the
-        // TestRunner dedup ledger before scheduling begins.
+        if (!test.RequiresExecutionDedup)
+        {
+            await _testRunner.ExecuteTestAsync(test, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // Dependency recursion is the re-entrant path. Only those tests reuse the
+        // scheduler task slot; independent tests may also use it for constraint wrappers.
         test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
         await test.ExecutionTask.ConfigureAwait(false);
     }

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -324,8 +324,11 @@ internal sealed class TestScheduler : ITestScheduler
         await ExecuteAllPhasesAsync(groupedDynamicTests, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void MarkDependencyRelatedTestsForExecutionDedup(IEnumerable<AbstractExecutableTest> tests)
+    internal static void MarkDependencyRelatedTestsForExecutionDedup(IEnumerable<AbstractExecutableTest> tests)
     {
+        HashSet<AbstractExecutableTest>? visitedDependencyTargets = null;
+        Stack<AbstractExecutableTest>? pendingDependencyTargets = null;
+
         foreach (var test in tests)
         {
             if (test.Dependencies.Length == 0)
@@ -335,9 +338,29 @@ internal sealed class TestScheduler : ITestScheduler
 
             test.RequiresExecutionDedup = true;
 
+            visitedDependencyTargets ??= [];
+            pendingDependencyTargets ??= [];
+
             foreach (var dependency in test.Dependencies)
             {
-                dependency.Test.RequiresExecutionDedup = true;
+                pendingDependencyTargets.Push(dependency.Test);
+            }
+
+            while (pendingDependencyTargets.Count > 0)
+            {
+                var dependencyTarget = pendingDependencyTargets.Pop();
+
+                if (!visitedDependencyTargets.Add(dependencyTarget))
+                {
+                    continue;
+                }
+
+                dependencyTarget.RequiresExecutionDedup = true;
+
+                foreach (var nestedDependency in dependencyTarget.Dependencies)
+                {
+                    pendingDependencyTargets.Push(nestedDependency.Test);
+                }
             }
         }
     }
@@ -383,8 +406,7 @@ internal sealed class TestScheduler : ITestScheduler
     {
         foreach (var test in tests)
         {
-            test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
-            await test.ExecutionTask.ConfigureAwait(false);
+            await ExecuteScheduledTestAsync(test, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -402,8 +424,7 @@ internal sealed class TestScheduler : ITestScheduler
             },
             async (test, ct) =>
             {
-                test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, ct).AsTask();
-                await test.ExecutionTask.ConfigureAwait(false);
+                await ExecuteScheduledTestAsync(test, ct).ConfigureAwait(false);
             }
         );
     }
@@ -423,8 +444,7 @@ internal sealed class TestScheduler : ITestScheduler
                 await globalSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
-                    await test.ExecutionTask.ConfigureAwait(false);
+                    await ExecuteScheduledTestAsync(test, cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -435,6 +455,15 @@ internal sealed class TestScheduler : ITestScheduler
         await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 #endif
+
+    private async ValueTask ExecuteScheduledTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    {
+        // Scheduler grouping partitions each batch, so each test reaches this path once.
+        // Dependency recursion is the re-entrant path and those tests are marked for the
+        // TestRunner dedup ledger before scheduling begins.
+        test.ExecutionTask ??= _testRunner.ExecuteTestAsync(test, cancellationToken).AsTask();
+        await test.ExecutionTask.ConfigureAwait(false);
+    }
 
     // The cancellation token is forwarded only so WaitForTasksWithFailFastHandling can
     // distinguish a fail-fast cancellation from a normal task fault when both phases run.

--- a/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -339,6 +339,8 @@ internal sealed class TestScheduler : ITestScheduler
             test.RequiresExecutionDedup = true;
 
             visitedDependencyTargets ??= [];
+            // Shared across roots so a common dependency target is marked once even
+            // when multiple scheduled tests reference it.
             pendingDependencyTargets ??= [];
 
             foreach (var dependency in test.Dependencies)

--- a/TUnit.UnitTests/TestRunnerTests.cs
+++ b/TUnit.UnitTests/TestRunnerTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using TUnit.Core;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Scheduling;
@@ -17,7 +15,7 @@ public class TestRunnerTests
 
         await runner.ExecuteTestAsync(test, CancellationToken.None);
 
-        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(0);
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(0);
         await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
     }
 
@@ -36,7 +34,7 @@ public class TestRunnerTests
         existingExecution.SetResult();
         await execution;
 
-        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(0);
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(0);
         await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(0);
     }
 
@@ -44,23 +42,25 @@ public class TestRunnerTests
     public async Task ExecuteTestAsync_WithDependencies_UsesExecutingTestsLedger()
     {
         var runner = CreateRunner(out _);
-        var dependency = CreateTest("dependency", requiresExecutionDedup: true);
+        var dependency = CreateTest("dependency");
         var test = CreateTest("with-dependencies", [dependency]);
+        TestScheduler.MarkDependencyRelatedTestsForExecutionDedup([test]);
 
         await runner.ExecuteTestAsync(test, CancellationToken.None);
 
-        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(2);
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(2);
     }
 
     [Test]
     public async Task ExecuteTestAsync_WithNoDependenciesButDependencyTarget_UsesExecutingTestsLedger()
     {
         var runner = CreateRunner(out var coordinator);
-        var test = CreateTest("dependency-target", requiresExecutionDedup: true);
+        var test = CreateTest("dependency-target");
+        test.RequiresExecutionDedup = true;
 
         await runner.ExecuteTestAsync(test, CancellationToken.None);
 
-        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(1);
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(1);
         await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
     }
 
@@ -68,8 +68,9 @@ public class TestRunnerTests
     public async Task ExecuteTestAsync_WithDependencies_DeduplicatesConcurrentAttempts()
     {
         var runner = CreateRunner(out var coordinator);
-        var dependency = CreateTest("dependency", requiresExecutionDedup: true);
+        var dependency = CreateTest("dependency");
         var test = CreateTest("with-dependencies", [dependency]);
+        TestScheduler.MarkDependencyRelatedTestsForExecutionDedup([test]);
         var releaseExecution = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         coordinator.SetExecutionTask(test, releaseExecution.Task);
@@ -81,7 +82,21 @@ public class TestRunnerTests
         await Task.WhenAll(first.AsTask(), second.AsTask());
 
         await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
-        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(2);
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task MarkDependencyRelatedTestsForExecutionDedup_MarksTransitiveDependencyTargetsOutsideBatch()
+    {
+        var leaf = CreateTest("leaf");
+        var middle = CreateTest("middle", [leaf]);
+        var root = CreateTest("root", [middle]);
+
+        TestScheduler.MarkDependencyRelatedTestsForExecutionDedup([root]);
+
+        await Assert.That(root.RequiresExecutionDedup).IsTrue();
+        await Assert.That(middle.RequiresExecutionDedup).IsTrue();
+        await Assert.That(leaf.RequiresExecutionDedup).IsTrue();
     }
 
     private static TestRunner CreateRunner(out FakeTestCoordinator coordinator)
@@ -101,8 +116,7 @@ public class TestRunnerTests
 
     private static AbstractExecutableTest CreateTest(
         string testId,
-        AbstractExecutableTest[]? dependencies = null,
-        bool requiresExecutionDedup = false)
+        AbstractExecutableTest[]? dependencies = null)
     {
         var metadata = CreateMetadata(testId);
         var beforeDiscoveryContext = new BeforeTestDiscoveryContext { TestFilter = null };
@@ -138,13 +152,6 @@ public class TestRunnerTests
                 Metadata = TestDependency.FromMethodName(dependency.Metadata.TestMethodName)
             }).ToArray() ?? []
         };
-
-        test.RequiresExecutionDedup = requiresExecutionDedup || test.Dependencies.Length > 0;
-
-        foreach (var dependency in test.Dependencies)
-        {
-            dependency.Test.RequiresExecutionDedup = true;
-        }
 
         return test;
     }
@@ -189,13 +196,6 @@ public class TestRunnerTests
             ClassDataSources = [],
             PropertyDataSources = []
         };
-    }
-
-    private static int GetExecutingTestsCount(TestRunner runner)
-    {
-        var field = typeof(TestRunner).GetField("_executingTests", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var executingTests = (ConcurrentDictionary<string, TaskCompletionSource<bool>>)field.GetValue(runner)!;
-        return executingTests.Count;
     }
 
     private sealed class StubExecutableTest : AbstractExecutableTest

--- a/TUnit.UnitTests/TestRunnerTests.cs
+++ b/TUnit.UnitTests/TestRunnerTests.cs
@@ -20,7 +20,7 @@ public class TestRunnerTests
     }
 
     [Test]
-    public async Task ExecuteTestAsync_WithNoDependenciesAndExistingExecutionTask_AwaitsExistingTask()
+    public async Task ExecuteTestAsync_WithNoDependenciesAndExistingExecutionTask_IgnoresSchedulerTask()
     {
         var runner = CreateRunner(out var coordinator);
         var test = CreateTest("existing-execution-task");
@@ -29,13 +29,10 @@ public class TestRunnerTests
 
         var execution = runner.ExecuteTestAsync(test, CancellationToken.None);
 
-        await Assert.That(execution.IsCompleted).IsFalse();
-
-        existingExecution.SetResult();
         await execution;
 
         await Assert.That(runner.ExecutingTestsCount).IsEqualTo(0);
-        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(0);
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
     }
 
     [Test]

--- a/TUnit.UnitTests/TestRunnerTests.cs
+++ b/TUnit.UnitTests/TestRunnerTests.cs
@@ -20,7 +20,7 @@ public class TestRunnerTests
     }
 
     [Test]
-    public async Task ExecuteTestAsync_WithNoDependenciesAndExistingExecutionTask_IgnoresSchedulerTask()
+    public async Task ExecuteTestAsync_WithNoDependenciesAndExistingExecutionTask_AwaitsExistingTask()
     {
         var runner = CreateRunner(out var coordinator);
         var test = CreateTest("existing-execution-task");
@@ -29,7 +29,24 @@ public class TestRunnerTests
 
         var execution = runner.ExecuteTestAsync(test, CancellationToken.None);
 
+        await Assert.That(execution.IsCompleted).IsFalse();
+
+        existingExecution.SetResult();
         await execution;
+
+        await Assert.That(runner.ExecutingTestsCount).IsEqualTo(0);
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ExecuteTestWithoutExecutionTaskAsync_WithNoDependenciesAndExistingExecutionTask_ExecutesTest()
+    {
+        var runner = CreateRunner(out var coordinator);
+        var test = CreateTest("scheduler-wrapper");
+        var existingExecution = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        test.ExecutionTask = existingExecution.Task;
+
+        await runner.ExecuteTestWithoutExecutionTaskAsync(test, CancellationToken.None);
 
         await Assert.That(runner.ExecutingTestsCount).IsEqualTo(0);
         await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);

--- a/TUnit.UnitTests/TestRunnerTests.cs
+++ b/TUnit.UnitTests/TestRunnerTests.cs
@@ -216,7 +216,12 @@ public class TestRunnerTests
     {
         public override Task<object> CreateInstanceAsync() => Task.FromResult<object>(new object());
 
-        public override Task InvokeTestAsync(object instance, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task InvokeTestAsync(object instance, CancellationToken cancellationToken)
+        {
+            _ = instance;
+            _ = cancellationToken;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeTestCoordinator : ITestCoordinator
@@ -243,6 +248,8 @@ public class TestRunnerTests
 
         public ValueTask ExecuteTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
         {
+            _ = cancellationToken;
+
             Task? executionTask;
             lock (_lock)
             {
@@ -268,23 +275,60 @@ public class TestRunnerTests
 
     private sealed class FakeMessageBus : ITUnitMessageBus
     {
-        public ValueTask Discovered(TestContext testContext) => default;
+        public ValueTask Discovered(TestContext testContext)
+        {
+            _ = testContext;
+            return default;
+        }
 
-        public ValueTask InProgress(TestContext testContext) => default;
+        public ValueTask InProgress(TestContext testContext)
+        {
+            _ = testContext;
+            return default;
+        }
 
-        public ValueTask Passed(TestContext testContext, DateTimeOffset start) => default;
+        public ValueTask Passed(TestContext testContext, DateTimeOffset start)
+        {
+            _ = testContext;
+            _ = start;
+            return default;
+        }
 
-        public ValueTask Failed(TestContext testContext, Exception exception, DateTimeOffset start) => default;
+        public ValueTask Failed(TestContext testContext, Exception exception, DateTimeOffset start)
+        {
+            _ = testContext;
+            _ = exception;
+            _ = start;
+            return default;
+        }
 
-        public ValueTask Skipped(TestContext testContext, string reason) => default;
+        public ValueTask Skipped(TestContext testContext, string reason)
+        {
+            _ = testContext;
+            _ = reason;
+            return default;
+        }
 
-        public ValueTask Cancelled(TestContext testContext, DateTimeOffset start) => default;
+        public ValueTask Cancelled(TestContext testContext, DateTimeOffset start)
+        {
+            _ = testContext;
+            _ = start;
+            return default;
+        }
 
-        public ValueTask SessionArtifact(Artifact artifact) => default;
+        public ValueTask SessionArtifact(Artifact artifact)
+        {
+            _ = artifact;
+            return default;
+        }
     }
 
     private sealed class FakeServiceProvider : IServiceProvider
     {
-        public object? GetService(Type serviceType) => null;
+        public object? GetService(Type serviceType)
+        {
+            _ = serviceType;
+            return null;
+        }
     }
 }

--- a/TUnit.UnitTests/TestRunnerTests.cs
+++ b/TUnit.UnitTests/TestRunnerTests.cs
@@ -1,0 +1,276 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using TUnit.Core;
+using TUnit.Engine.Interfaces;
+using TUnit.Engine.Scheduling;
+using TUnit.Engine.Services.TestExecution;
+
+namespace TUnit.UnitTests;
+
+public class TestRunnerTests
+{
+    [Test]
+    public async Task ExecuteTestAsync_WithNoDependencies_DoesNotUseExecutingTestsLedger()
+    {
+        var runner = CreateRunner(out var coordinator);
+        var test = CreateTest("no-dependencies");
+
+        await runner.ExecuteTestAsync(test, CancellationToken.None);
+
+        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(0);
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteTestAsync_WithNoDependenciesAndExistingExecutionTask_AwaitsExistingTask()
+    {
+        var runner = CreateRunner(out var coordinator);
+        var test = CreateTest("existing-execution-task");
+        var existingExecution = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        test.ExecutionTask = existingExecution.Task;
+
+        var execution = runner.ExecuteTestAsync(test, CancellationToken.None);
+
+        await Assert.That(execution.IsCompleted).IsFalse();
+
+        existingExecution.SetResult();
+        await execution;
+
+        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(0);
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ExecuteTestAsync_WithDependencies_UsesExecutingTestsLedger()
+    {
+        var runner = CreateRunner(out _);
+        var dependency = CreateTest("dependency", requiresExecutionDedup: true);
+        var test = CreateTest("with-dependencies", [dependency]);
+
+        await runner.ExecuteTestAsync(test, CancellationToken.None);
+
+        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ExecuteTestAsync_WithNoDependenciesButDependencyTarget_UsesExecutingTestsLedger()
+    {
+        var runner = CreateRunner(out var coordinator);
+        var test = CreateTest("dependency-target", requiresExecutionDedup: true);
+
+        await runner.ExecuteTestAsync(test, CancellationToken.None);
+
+        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(1);
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteTestAsync_WithDependencies_DeduplicatesConcurrentAttempts()
+    {
+        var runner = CreateRunner(out var coordinator);
+        var dependency = CreateTest("dependency", requiresExecutionDedup: true);
+        var test = CreateTest("with-dependencies", [dependency]);
+        var releaseExecution = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        coordinator.SetExecutionTask(test, releaseExecution.Task);
+
+        var first = runner.ExecuteTestAsync(test, CancellationToken.None);
+        var second = runner.ExecuteTestAsync(test, CancellationToken.None);
+
+        releaseExecution.SetResult();
+        await Task.WhenAll(first.AsTask(), second.AsTask());
+
+        await Assert.That(coordinator.GetCallCount(test)).IsEqualTo(1);
+        await Assert.That(GetExecutingTestsCount(runner)).IsEqualTo(2);
+    }
+
+    private static TestRunner CreateRunner(out FakeTestCoordinator coordinator)
+    {
+        coordinator = new FakeTestCoordinator();
+
+        return new TestRunner(
+            coordinator,
+            new FakeMessageBus(),
+            isFailFastEnabled: false,
+            new CancellationTokenSource(),
+            logger: null!,
+            new TestStateManager(),
+            new ParallelLimitLockProvider(),
+            new NotInParallelLock());
+    }
+
+    private static AbstractExecutableTest CreateTest(
+        string testId,
+        AbstractExecutableTest[]? dependencies = null,
+        bool requiresExecutionDedup = false)
+    {
+        var metadata = CreateMetadata(testId);
+        var beforeDiscoveryContext = new BeforeTestDiscoveryContext { TestFilter = null };
+        var discoveryContext = new TestDiscoveryContext(beforeDiscoveryContext) { TestFilter = null };
+        var sessionContext = new TestSessionContext(discoveryContext)
+        {
+            Id = Guid.NewGuid().ToString(),
+            TestFilter = null
+        };
+        var assemblyContext = new AssemblyHookContext(sessionContext)
+        {
+            Assembly = typeof(TestRunnerTests).Assembly
+        };
+        var classContext = new ClassHookContext(assemblyContext)
+        {
+            ClassType = typeof(TestRunnerTests)
+        };
+        var builderContext = new TestBuilderContext
+        {
+            TestMetadata = metadata.MethodMetadata
+        };
+        var context = new TestContext(testId, new FakeServiceProvider(), classContext, builderContext, CancellationToken.None);
+
+        var test = new StubExecutableTest
+        {
+            TestId = testId,
+            Metadata = metadata,
+            Arguments = [],
+            Context = context,
+            Dependencies = dependencies?.Select(dependency => new ResolvedDependency
+            {
+                Test = dependency,
+                Metadata = TestDependency.FromMethodName(dependency.Metadata.TestMethodName)
+            }).ToArray() ?? []
+        };
+
+        test.RequiresExecutionDedup = requiresExecutionDedup || test.Dependencies.Length > 0;
+
+        foreach (var dependency in test.Dependencies)
+        {
+            dependency.Test.RequiresExecutionDedup = true;
+        }
+
+        return test;
+    }
+
+    private static TestMetadata<TestRunnerTests> CreateMetadata(string testId)
+    {
+        var classMetadata = new ClassMetadata
+        {
+            Type = typeof(TestRunnerTests),
+            TypeInfo = new ConcreteType(typeof(TestRunnerTests)),
+            Name = nameof(TestRunnerTests),
+            Namespace = typeof(TestRunnerTests).Namespace ?? string.Empty,
+            Assembly = new AssemblyMetadata
+            {
+                Name = typeof(TestRunnerTests).Assembly.GetName().Name ?? string.Empty
+            },
+            Parent = null,
+            Parameters = [],
+            Properties = []
+        };
+
+        return new TestMetadata<TestRunnerTests>
+        {
+            TestClassType = typeof(TestRunnerTests),
+            TestMethodName = testId,
+            TestName = testId,
+            FilePath = "Unknown",
+            LineNumber = 0,
+            AttributeFactory = () => [],
+            MethodMetadata = new MethodMetadata
+            {
+                Type = typeof(TestRunnerTests),
+                TypeInfo = new ConcreteType(typeof(TestRunnerTests)),
+                Name = testId,
+                GenericTypeCount = 0,
+                ReturnType = typeof(void),
+                ReturnTypeInfo = new ConcreteType(typeof(void)),
+                Parameters = [],
+                Class = classMetadata
+            },
+            DataSources = [],
+            ClassDataSources = [],
+            PropertyDataSources = []
+        };
+    }
+
+    private static int GetExecutingTestsCount(TestRunner runner)
+    {
+        var field = typeof(TestRunner).GetField("_executingTests", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var executingTests = (ConcurrentDictionary<string, TaskCompletionSource<bool>>)field.GetValue(runner)!;
+        return executingTests.Count;
+    }
+
+    private sealed class StubExecutableTest : AbstractExecutableTest
+    {
+        public override Task<object> CreateInstanceAsync() => Task.FromResult<object>(new object());
+
+        public override Task InvokeTestAsync(object instance, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class FakeTestCoordinator : ITestCoordinator
+    {
+        private readonly Lock _lock = new();
+        private readonly Dictionary<string, int> _callCounts = [];
+        private readonly Dictionary<string, Task> _executionTasks = [];
+
+        public int GetCallCount(AbstractExecutableTest test)
+        {
+            lock (_lock)
+            {
+                return _callCounts.GetValueOrDefault(test.TestId);
+            }
+        }
+
+        public void SetExecutionTask(AbstractExecutableTest test, Task executionTask)
+        {
+            lock (_lock)
+            {
+                _executionTasks[test.TestId] = executionTask;
+            }
+        }
+
+        public ValueTask ExecuteTestAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+        {
+            Task? executionTask;
+            lock (_lock)
+            {
+                _callCounts[test.TestId] = _callCounts.GetValueOrDefault(test.TestId) + 1;
+                _executionTasks.TryGetValue(test.TestId, out executionTask);
+            }
+
+            if (executionTask is not null)
+            {
+                return CompleteAfterAsync(test, executionTask);
+            }
+
+            test.SetResult(TestState.Passed);
+            return default;
+        }
+
+        private static async ValueTask CompleteAfterAsync(AbstractExecutableTest test, Task executionTask)
+        {
+            await executionTask.ConfigureAwait(false);
+            test.SetResult(TestState.Passed);
+        }
+    }
+
+    private sealed class FakeMessageBus : ITUnitMessageBus
+    {
+        public ValueTask Discovered(TestContext testContext) => default;
+
+        public ValueTask InProgress(TestContext testContext) => default;
+
+        public ValueTask Passed(TestContext testContext, DateTimeOffset start) => default;
+
+        public ValueTask Failed(TestContext testContext, Exception exception, DateTimeOffset start) => default;
+
+        public ValueTask Skipped(TestContext testContext, string reason) => default;
+
+        public ValueTask Cancelled(TestContext testContext, DateTimeOffset start) => default;
+
+        public ValueTask SessionArtifact(Artifact artifact) => default;
+    }
+
+    private sealed class FakeServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}


### PR DESCRIPTION
## Summary

- avoid allocating/using the per-test execution TCS ledger for tests that are not in a dependency relationship
- mark tests with dependencies and dependency targets so scheduler/dependency recursion races keep the existing dedup behavior
- preserve scheduler task reuse for an independent test that already has an `ExecutionTask`

Closes #5716.

## Verification

- `dotnet test TUnit.UnitTests\TUnit.UnitTests.csproj -c Release -- --treenode-filter "/*/*/TestRunnerTests/*"`
  - net8.0, net9.0, net10.0 all passed; 15 total targeted cases
- `git diff --check`

Existing unrelated analyzer/nullability warnings were emitted by the test project.
