### PR TITLE
perf(engine): skip tracked object graph rediscovery

### DIFF
--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -250,7 +250,9 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
             var tasks = new List<Task>(objectsAtLevel.Count);
             foreach (var obj in objectsAtLevel)
             {
-                tasks.Add(InitializeTrackedObjectWithSpanAsync(obj, testContext, cancellationToken));
+                // Tracked objects were discovered before execution and are already
+                // ordered deepest-first, so nested graph traversal would be redundant.
+                tasks.Add(InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken));
             }
 
             if (tasks.Count > 0)
@@ -264,16 +266,6 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
         // GetSharedType returns null → defaults to per-test scope automatically.
         var classInstance = testContext.Metadata.TestDetails.ClassInstance;
         await InitializeObjectWithSpanAsync(classInstance, testContext, cancellationToken);
-    }
-
-    /// <summary>
-    /// Initializes a tracked object, wrapped in a scope-aware OpenTelemetry span.
-    /// Nested object graph discovery is skipped because tracked objects are already initialized
-    /// deepest-first from <see cref="TestContext.TrackedObjects"/>.
-    /// </summary>
-    private Task InitializeTrackedObjectWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
-    {
-        return InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken);
     }
 
     /// <summary>

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -252,7 +252,7 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
             {
                 // Tracked objects were discovered before execution and are already
                 // ordered deepest-first, so nested graph traversal would be redundant.
-                tasks.Add(InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken));
+                tasks.Add(InitializeObjectWithSpanAsync(obj, testContext, cancellationToken, includeNestedObjects: false));
             }
 
             if (tasks.Count > 0)
@@ -272,18 +272,17 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
     /// Initializes an object and its nested objects, wrapped in a scope-aware OpenTelemetry span.
     /// Used for objects outside the tracked graph, such as the test class instance.
     /// </summary>
-    private async Task InitializeObjectWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
+    private async Task InitializeObjectWithSpanAsync(
+        object obj,
+        TestContext testContext,
+        CancellationToken cancellationToken,
+        bool includeNestedObjects = true)
     {
-        await InitializeNestedObjectsForExecutionAsync(obj, cancellationToken);
-        await InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken);
-    }
+        if (includeNestedObjects)
+        {
+            await InitializeNestedObjectsForExecutionAsync(obj, cancellationToken);
+        }
 
-    /// <summary>
-    /// Initializes only the supplied object, wrapped in a scope-aware OpenTelemetry span.
-    /// Callers that use this directly must initialize nested dependencies first.
-    /// </summary>
-    private async Task InitializeObjectOnlyWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
-    {
 #if NET
         var sharedType = TraceScopeRegistry.GetSharedType(obj);
         var activitySource = TUnitActivitySource.GetSourceForSharedType(sharedType);

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -308,6 +308,7 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
             await ObjectInitializer.InitializeAsync(obj, cancellationToken);
         }
 #else
+        _ = testContext;
         await ObjectInitializer.InitializeAsync(obj, cancellationToken);
 #endif
     }

--- a/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -250,7 +250,7 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
             var tasks = new List<Task>(objectsAtLevel.Count);
             foreach (var obj in objectsAtLevel)
             {
-                tasks.Add(InitializeObjectWithSpanAsync(obj, testContext, cancellationToken));
+                tasks.Add(InitializeTrackedObjectWithSpanAsync(obj, testContext, cancellationToken));
             }
 
             if (tasks.Count > 0)
@@ -267,13 +267,31 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
     }
 
     /// <summary>
+    /// Initializes a tracked object, wrapped in a scope-aware OpenTelemetry span.
+    /// Nested object graph discovery is skipped because tracked objects are already initialized
+    /// deepest-first from <see cref="TestContext.TrackedObjects"/>.
+    /// </summary>
+    private Task InitializeTrackedObjectWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
+    {
+        return InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken);
+    }
+
+    /// <summary>
     /// Initializes an object and its nested objects, wrapped in a scope-aware OpenTelemetry span.
+    /// Used for objects outside the tracked graph, such as the test class instance.
     /// </summary>
     private async Task InitializeObjectWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
     {
-        // First initialize nested objects depth-first
         await InitializeNestedObjectsForExecutionAsync(obj, cancellationToken);
+        await InitializeObjectOnlyWithSpanAsync(obj, testContext, cancellationToken);
+    }
 
+    /// <summary>
+    /// Initializes only the supplied object, wrapped in a scope-aware OpenTelemetry span.
+    /// Callers that use this directly must initialize nested dependencies first.
+    /// </summary>
+    private async Task InitializeObjectOnlyWithSpanAsync(object obj, TestContext testContext, CancellationToken cancellationToken)
+    {
 #if NET
         var sharedType = TraceScopeRegistry.GetSharedType(obj);
         var activitySource = TUnitActivitySource.GetSourceForSharedType(sharedType);


### PR DESCRIPTION
## Summary

- skip nested object graph rediscovery when initializing objects already present in `TestContext.TrackedObjects`
- keep nested discovery for the test class instance and standalone `InitializeObjectForExecutionAsync` paths
- preserve existing OpenTelemetry span behavior through a shared object-only initialization helper

Closes #5718.

## Verification

- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/InheritedDataSourceTests/*"`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/InheritedDataSourceTests/*" --reflection`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/CombinedDataSourceTests/CombinedDataSource_WithNestedPropertyInjectionAndMultipleIAsyncInitializers*"`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/CombinedDataSourceTests/CombinedDataSource_WithNestedPropertyInjectionAndMultipleIAsyncInitializers*" --reflection`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/ParallelPropertyInjectionTests/*"`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net10.0 -- --treenode-filter "/*/*/ParallelPropertyInjectionTests/*" --reflection`
- `dotnet test TUnit.TestProject\TUnit.TestProject.csproj -c Release -f net8.0 -p:TargetFrameworks=net8.0 -- --treenode-filter "/*/*/InheritedDataSourceTests/*"`
- `git diff --check`

Existing unrelated analyzer warnings were emitted during the retargeted net8.0 build.
