### PR TITLE
Fix xUnit Throws migration docs

### DIFF
--- a/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/XUnitMigrationAnalyzerTests.cs
@@ -1488,6 +1488,86 @@ public class XUnitMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task Assert_Throws_Sync_Delegate_Stays_Sync()
+    {
+        await CodeFixer
+            .VerifyCodeFixAsync(
+                """
+                {|#0:using System;
+                using Xunit;
+
+                public class MyClass
+                {
+                    [Fact]
+                    public void MyTest()
+                    {
+                        Assert.Throws<ArgumentException>(() => ThrowException());
+                    }
+
+                    private void ThrowException() => throw new ArgumentException();
+                }|}
+                """,
+                Verifier.Diagnostic(Rules.XunitMigration).WithLocation(0),
+                """
+                using System;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyTest()
+                    {
+                        Assert.Throws<ArgumentException>(() => ThrowException());
+                    }
+
+                    private void ThrowException() => throw new ArgumentException();
+                }
+                """,
+                ConfigureXUnitTest
+            );
+    }
+
+    [Test]
+    public async Task Assert_ThrowsAsync_Async_Delegate_Stays_Async()
+    {
+        await CodeFixer
+            .VerifyCodeFixAsync(
+                """
+                {|#0:using System;
+                using System.Threading.Tasks;
+                using Xunit;
+
+                public class MyClass
+                {
+                    [Fact]
+                    public async Task MyTest()
+                    {
+                        await Assert.ThrowsAsync<ArgumentException>(() => ThrowExceptionAsync());
+                    }
+
+                    private Task ThrowExceptionAsync() => Task.FromException(new ArgumentException());
+                }|}
+                """,
+                Verifier.Diagnostic(Rules.XunitMigration).WithLocation(0),
+                """
+                using System;
+                using System.Threading.Tasks;
+
+                public class MyClass
+                {
+                    [Test]
+                    public async Task MyTest()
+                    {
+                        await Assert.ThrowsAsync<ArgumentException>(() => ThrowExceptionAsync());
+                    }
+
+                    private Task ThrowExceptionAsync() => Task.FromException(new ArgumentException());
+                }
+                """,
+                ConfigureXUnitTest
+            );
+    }
+
+    [Test]
     public async Task Assert_Throws_With_Message_Contains_Can_Be_Converted()
     {
         await CodeFixer

--- a/docs/docs/migration/xunit.md
+++ b/docs/docs/migration/xunit.md
@@ -21,7 +21,7 @@ Migrating from xUnit to TUnit can improve test execution speed. Check the [bench
 | `IAsyncLifetime` | `[Before(Test)]` / `[After(Test)]` |
 | `ITestOutputHelper` | `TestContext` parameter |
 | `Assert.Equal(expected, actual)` | `await Assert.That(actual).IsEqualTo(expected)` |
-| `Assert.Throws<T>(() => ...)` | `await Assert.ThrowsAsync<T>(() => ...)` |
+| `Assert.Throws<T>(() => ...)` | `Assert.Throws<T>(() => ...)` |
 
 ## Automated Migration with Code Fixers
 
@@ -35,7 +35,7 @@ TUnit includes Roslyn analyzers and code fixers that automate most of the migrat
 - `[Trait("key", "value")]` → `[Property("key", "value")]`
 - `Assert.Equal(expected, actual)` → `await Assert.That(actual).IsEqualTo(expected)`
 - `Assert.True(condition)` → `await Assert.That(condition).IsTrue()`
-- `Assert.Throws<T>(...)` → `await Assert.ThrowsAsync<T>(...)`
+- `Assert.Throws<T>(...)` → `Assert.Throws<T>(...)`
 - `Assert.Contains(item, collection)` → `await Assert.That(collection).Contains(item)`
 - Test methods converted to `async Task` with `await` on assertions
 
@@ -1022,9 +1022,9 @@ public async Task Async_Exception_Assertions()
 [Test]
 public async Task Exception_Assertions()
 {
-    await Assert.ThrowsAsync<ArgumentException>(() => ThrowsException());
+    Assert.Throws<ArgumentException>(() => ThrowsException());
 
-    var ex = await Assert.ThrowsAsync<ArgumentException>(() => ThrowsException());
+    var ex = Assert.Throws<ArgumentException>(() => ThrowsException());
     await Assert.That(ex.ParamName).IsEqualTo("paramName");
 }
 
@@ -1036,7 +1036,8 @@ public async Task Async_Exception_Assertions()
 ```
 
 **Key Changes:**
-- Both sync and async use `Assert.ThrowsAsync` in TUnit
+- Sync exception assertions use `Assert.Throws`
+- Async exception assertions use `Assert.ThrowsAsync`
 - Returned exception can be further asserted on
 
 ### Complete Example: Real-World Test Class


### PR DESCRIPTION
## Summary
- update xUnit migration docs so sync `Assert.Throws<T>(Action)` stays sync
- add focused xUnit migration code-fix tests for sync `Throws` and async `ThrowsAsync`

## Verification
- `dotnet exec "C:\Program Files\dotnet\sdk\10.0.203\MSBuild.dll" TUnit.Analyzers.Tests\TUnit.Analyzers.Tests.csproj /t:Build /p:Restore=false /v:minimal`
- `dotnet TUnit.Analyzers.Tests\bin\Debug\net10.0\TUnit.Analyzers.Tests.dll --treenode-filter "/*/*/XUnitMigrationAnalyzerTests/Assert_Throws_Sync_Delegate_Stays_Sync"`
- `dotnet TUnit.Analyzers.Tests\bin\Debug\net10.0\TUnit.Analyzers.Tests.dll --treenode-filter "/*/*/XUnitMigrationAnalyzerTests/Assert_ThrowsAsync_Async_Delegate_Stays_Async"`

Closes #5817