### PR TITLE
fix(assertions): skip ref-struct members in IsEquivalentTo (#5841)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Tests5841.cs
+++ b/TUnit.Assertions.Tests/Bugs/Tests5841.cs
@@ -1,0 +1,39 @@
+namespace TUnit.Assertions.Tests.Bugs;
+
+/// <summary>
+/// Regression tests for issue #5841.
+/// IsEquivalentTo must not invoke property/field getters whose return type is a ref struct
+/// (e.g. ReadOnlySpan&lt;T&gt;, reachable via ReadOnlyMemory&lt;T&gt;.Span). Ref structs cannot
+/// be boxed, so RuntimeMethodInfo.Invoke throws NotSupportedException.
+/// </summary>
+public class Tests5841
+{
+    public class HasMemoryProperty
+    {
+        public ReadOnlyMemory<byte> Memory { get; init; }
+    }
+
+    public class HasSpanProperty
+    {
+        public ReadOnlySpan<byte> Span => default;
+        public int Value { get; init; }
+    }
+
+    [Test]
+    public async Task IsEquivalentTo_with_ReadOnlyMemory_property_does_not_invoke_Span_getter()
+    {
+        var a = new HasMemoryProperty { Memory = new byte[] { 1, 2, 3 } };
+        var b = new HasMemoryProperty { Memory = new byte[] { 1, 2, 3 } };
+
+        await Assert.That(a).IsEquivalentTo(b);
+    }
+
+    [Test]
+    public async Task IsEquivalentTo_skips_ref_struct_returning_property()
+    {
+        var a = new HasSpanProperty { Value = 7 };
+        var b = new HasSpanProperty { Value = 7 };
+
+        await Assert.That(a).IsEquivalentTo(b);
+    }
+}

--- a/TUnit.Assertions/Conditions/Helpers/ReflectionHelper.cs
+++ b/TUnit.Assertions/Conditions/Helpers/ReflectionHelper.cs
@@ -35,17 +35,52 @@ internal static class ReflectionHelper
         var members = new List<MemberInfo>();
 
         // Filter out indexed properties (properties with parameters like this[int index])
+        // and members whose type is a ref struct (IsByRefLike). Ref structs cannot be boxed,
+        // so PropertyInfo.GetValue / FieldInfo.GetValue throws NotSupportedException on them.
+        // Common offender: ReadOnlyMemory<T>.Span returns ReadOnlySpan<T>.
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var prop in properties)
         {
-            if (prop.GetIndexParameters().Length == 0 && prop.CanRead && prop.GetMethod?.IsPublic == true)
+            if (prop.GetIndexParameters().Length == 0
+                && prop.CanRead
+                && prop.GetMethod?.IsPublic == true
+                && !IsByRefLike(prop.PropertyType))
             {
                 members.Add(prop);
             }
         }
 
-        members.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.Instance));
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!IsByRefLike(field.FieldType))
+            {
+                members.Add(field);
+            }
+        }
+
         return members.ToArray();
+    }
+
+    private static bool IsByRefLike(Type type)
+    {
+#if NET5_0_OR_GREATER
+        return type.IsByRefLike;
+#else
+        if (!type.IsValueType)
+        {
+            return false;
+        }
+
+        foreach (var attr in type.GetCustomAttributesData())
+        {
+            if (attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- `IsEquivalentTo` blew up with `NotSupportedException` whenever the structural walk reached a property whose getter returned a `ref struct` (e.g. `ReadOnlyMemory<T>.Span` is a `ReadOnlySpan<T>`). `PropertyInfo.GetValue`/`FieldInfo.GetValue` cannot box ref structs.
- Filter members whose type satisfies `IsByRefLike` in `ReflectionHelper.BuildMembersToCompare`. Single point of change covers `StructuralEquivalencyAssertion`, `StructuralEqualityComparer`, and `StructuralDiffHelper` — all route through the cached helper.
- `Type.IsByRefLike` is .NET 5+; netstandard2.0 fallback scans `GetCustomAttributesData()` for `IsByRefLikeAttribute` (cheap because results are cached per-`Type`).

Fixes #5841.

## Test plan
- [x] New regression tests `Tests5841.IsEquivalentTo_with_ReadOnlyMemory_property_does_not_invoke_Span_getter` and `Tests5841.IsEquivalentTo_skips_ref_struct_returning_property` pass on net10.0.
- [x] Existing `IsEquivalentTo_TypeProperty_Tests` (5/5), `CollectionStructuralEquivalenceTests` (20/20), `IgnoringTypeEquivalentTests` (12/12), full `TUnit.Assertions.Tests.Bugs` namespace (231/231), and `EquivalentAssertionTests` (29/29) all pass.
- [x] `TUnit.Assertions` builds clean across `netstandard2.0;net8.0;net9.0;net10.0`.