### PR TITLE
feat(playwright): add TUnitPlaywrightSettings defaults

### DIFF
--- a/TUnit.Playwright/BrowserFixture.cs
+++ b/TUnit.Playwright/BrowserFixture.cs
@@ -20,7 +20,7 @@ public class BrowserFixture : IAsyncInitializer, IAsyncDisposable
 
     protected virtual BrowserTypeLaunchOptions GetLaunchOptions() => new()
     {
-        Headless = PlaywrightSettingsExtensions.Default.DefaultHeadless,
+        Headless = TUnitPlaywrightSettings.Default.DefaultHeadless,
     };
 
     public virtual async Task InitializeAsync()

--- a/TUnit.Playwright/BrowserFixture.cs
+++ b/TUnit.Playwright/BrowserFixture.cs
@@ -18,7 +18,10 @@ public class BrowserFixture : IAsyncInitializer, IAsyncDisposable
 
     public virtual string BrowserName => Microsoft.Playwright.BrowserType.Chromium;
 
-    protected virtual BrowserTypeLaunchOptions GetLaunchOptions() => new();
+    protected virtual BrowserTypeLaunchOptions GetLaunchOptions() => new()
+    {
+        Headless = PlaywrightSettingsExtensions.Default.DefaultHeadless,
+    };
 
     public virtual async Task InitializeAsync()
     {

--- a/TUnit.Playwright/BrowserTest.cs
+++ b/TUnit.Playwright/BrowserTest.cs
@@ -7,7 +7,7 @@ public class BrowserTest : PlaywrightTest
 {
     public BrowserTest() : this(new BrowserTypeLaunchOptions
     {
-        Headless = PlaywrightSettingsExtensions.Default.DefaultHeadless,
+        Headless = TUnitPlaywrightSettings.Default.DefaultHeadless,
     })
     {
     }

--- a/TUnit.Playwright/BrowserTest.cs
+++ b/TUnit.Playwright/BrowserTest.cs
@@ -5,7 +5,10 @@ namespace TUnit.Playwright;
 
 public class BrowserTest : PlaywrightTest
 {
-    public BrowserTest() : this(new BrowserTypeLaunchOptions())
+    public BrowserTest() : this(new BrowserTypeLaunchOptions
+    {
+        Headless = PlaywrightSettingsExtensions.Default.DefaultHeadless,
+    })
     {
     }
 

--- a/TUnit.Playwright/ContextFixture.cs
+++ b/TUnit.Playwright/ContextFixture.cs
@@ -24,7 +24,11 @@ public class ContextFixture : IAsyncInitializer, IAsyncDisposable
     /// (<c>new BrowserNewContextOptions()</c>).
     /// </summary>
     protected virtual BrowserNewContextOptions GetContextOptions() =>
-        new() { Locale = "en-US", ColorScheme = ColorScheme.Light };
+        new()
+        {
+            Locale = "en-US", ColorScheme = ColorScheme.Light,
+            IgnoreHTTPSErrors = PlaywrightSettingsExtensions.Default.DefaultIgnoreHttpsErrors,
+        };
 
     /// <summary>
     /// When <c>true</c>, seeds the context with W3C trace propagation headers from

--- a/TUnit.Playwright/ContextFixture.cs
+++ b/TUnit.Playwright/ContextFixture.cs
@@ -27,7 +27,7 @@ public class ContextFixture : IAsyncInitializer, IAsyncDisposable
         new()
         {
             Locale = "en-US", ColorScheme = ColorScheme.Light,
-            IgnoreHTTPSErrors = PlaywrightSettingsExtensions.Default.DefaultIgnoreHttpsErrors,
+            IgnoreHTTPSErrors = TUnitPlaywrightSettings.Default.DefaultIgnoreHttpsErrors,
         };
 
     /// <summary>

--- a/TUnit.Playwright/ContextTest.cs
+++ b/TUnit.Playwright/ContextTest.cs
@@ -20,7 +20,7 @@ public class ContextTest : BrowserTest
         return new()
         {
             Locale = "en-US", ColorScheme = ColorScheme.Light,
-            IgnoreHTTPSErrors = PlaywrightSettingsExtensions.Default.DefaultIgnoreHttpsErrors,
+            IgnoreHTTPSErrors = TUnitPlaywrightSettings.Default.DefaultIgnoreHttpsErrors,
         };
     }
 

--- a/TUnit.Playwright/ContextTest.cs
+++ b/TUnit.Playwright/ContextTest.cs
@@ -17,7 +17,11 @@ public class ContextTest : BrowserTest
 
     public virtual BrowserNewContextOptions ContextOptions(TestContext testContext)
     {
-        return new() { Locale = "en-US", ColorScheme = ColorScheme.Light, };
+        return new()
+        {
+            Locale = "en-US", ColorScheme = ColorScheme.Light,
+            IgnoreHTTPSErrors = PlaywrightSettingsExtensions.Default.DefaultIgnoreHttpsErrors,
+        };
     }
 
     [Before(HookType.Test, "", 0)]

--- a/TUnit.Playwright/PlaywrightSettings.cs
+++ b/TUnit.Playwright/PlaywrightSettings.cs
@@ -4,16 +4,20 @@ namespace TUnit.Playwright;
 
 public static class PlaywrightSettingsExtensions
 {
-    internal static readonly TUnitPlaywrightSettings Default = new();
-
     extension(TUnitSettings settings)
     {
-        public TUnitPlaywrightSettings PlaywrightSettings => Default;
+        public TUnitPlaywrightSettings PlaywrightSettings => TUnitPlaywrightSettings.Default;
     }
 }
 
 public class TUnitPlaywrightSettings
 {
-    public bool DefaultHeadless { get; set; }
+    internal static readonly TUnitPlaywrightSettings Default = new();
+
+    internal TUnitPlaywrightSettings()
+    {
+    }
+
+    public bool? DefaultHeadless { get; set; } = null;
     public bool DefaultIgnoreHttpsErrors { get; set; }
 }

--- a/TUnit.Playwright/PlaywrightSettings.cs
+++ b/TUnit.Playwright/PlaywrightSettings.cs
@@ -1,0 +1,19 @@
+using TUnit.Core.Settings;
+
+namespace TUnit.Playwright;
+
+public static class PlaywrightSettingsExtensions
+{
+    internal static readonly TUnitPlaywrightSettings Default = new();
+
+    extension(TUnitSettings settings)
+    {
+        public TUnitPlaywrightSettings PlaywrightSettings => Default;
+    }
+}
+
+public class TUnitPlaywrightSettings
+{
+    public bool DefaultHeadless { get; set; }
+    public bool DefaultIgnoreHttpsErrors { get; set; }
+}

--- a/TUnit.Playwright/PlaywrightSettings.cs
+++ b/TUnit.Playwright/PlaywrightSettings.cs
@@ -19,5 +19,5 @@ public class TUnitPlaywrightSettings
     }
 
     public bool? DefaultHeadless { get; set; } = null;
-    public bool DefaultIgnoreHttpsErrors { get; set; }
+    public bool? DefaultIgnoreHttpsErrors { get; set; } = null;
 }

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -82,6 +82,13 @@ namespace
         public .IPageAssertions Expect(.IPage page) { }
         public virtual . InitializeAsync() { }
     }
+    public static class PlaywrightSettingsExtensions
+    {
+        extension(. settings)
+        {
+            public .TUnitPlaywrightSettings PlaywrightSettings { get; }
+        }
+    }
     public class PlaywrightSkipAttribute : .SkipAttribute
     {
         public PlaywrightSkipAttribute(params .[] combinations) { }
@@ -112,6 +119,12 @@ namespace
         [.Before(., "", 0)]
         public static . PlaywrightSetup() { }
         public static void SetDefaultExpectTimeout(float timeout) { }
+    }
+    public class TUnitPlaywrightSettings
+    {
+        public TUnitPlaywrightSettings() { }
+        public bool DefaultHeadless { get; set; }
+        public bool DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -122,9 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public TUnitPlaywrightSettings() { }
-        public bool DefaultHeadless { get; set; }
-        public bool DefaultIgnoreHttpsErrors { get; set; }
+        public bool? DefaultHeadless { get; set; }
+        public bool? DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -82,6 +82,13 @@ namespace
         public .IPageAssertions Expect(.IPage page) { }
         public virtual . InitializeAsync() { }
     }
+    public static class PlaywrightSettingsExtensions
+    {
+        extension(. settings)
+        {
+            public .TUnitPlaywrightSettings PlaywrightSettings { get; }
+        }
+    }
     public class PlaywrightSkipAttribute : .SkipAttribute
     {
         public PlaywrightSkipAttribute(params .[] combinations) { }
@@ -112,6 +119,12 @@ namespace
         [.Before(., "", 0)]
         public static . PlaywrightSetup() { }
         public static void SetDefaultExpectTimeout(float timeout) { }
+    }
+    public class TUnitPlaywrightSettings
+    {
+        public TUnitPlaywrightSettings() { }
+        public bool DefaultHeadless { get; set; }
+        public bool DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -122,9 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public TUnitPlaywrightSettings() { }
-        public bool DefaultHeadless { get; set; }
-        public bool DefaultIgnoreHttpsErrors { get; set; }
+        public bool? DefaultHeadless { get; set; }
+        public bool? DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -82,6 +82,13 @@ namespace
         public .IPageAssertions Expect(.IPage page) { }
         public virtual . InitializeAsync() { }
     }
+    public static class PlaywrightSettingsExtensions
+    {
+        extension(. settings)
+        {
+            public .TUnitPlaywrightSettings PlaywrightSettings { get; }
+        }
+    }
     public class PlaywrightSkipAttribute : .SkipAttribute
     {
         public PlaywrightSkipAttribute(params .[] combinations) { }
@@ -112,6 +119,12 @@ namespace
         [.Before(., "", 0)]
         public static . PlaywrightSetup() { }
         public static void SetDefaultExpectTimeout(float timeout) { }
+    }
+    public class TUnitPlaywrightSettings
+    {
+        public TUnitPlaywrightSettings() { }
+        public bool DefaultHeadless { get; set; }
+        public bool DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -122,9 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public TUnitPlaywrightSettings() { }
-        public bool DefaultHeadless { get; set; }
-        public bool DefaultIgnoreHttpsErrors { get; set; }
+        public bool? DefaultHeadless { get; set; }
+        public bool? DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -82,6 +82,13 @@ namespace
         public .IPageAssertions Expect(.IPage page) { }
         public virtual . InitializeAsync() { }
     }
+    public static class PlaywrightSettingsExtensions
+    {
+        extension(. settings)
+        {
+            public .TUnitPlaywrightSettings PlaywrightSettings { get; }
+        }
+    }
     public class PlaywrightSkipAttribute : .SkipAttribute
     {
         public PlaywrightSkipAttribute(params .[] combinations) { }
@@ -112,6 +119,12 @@ namespace
         [.Before(., "", 0)]
         public static . PlaywrightSetup() { }
         public static void SetDefaultExpectTimeout(float timeout) { }
+    }
+    public class TUnitPlaywrightSettings
+    {
+        public TUnitPlaywrightSettings() { }
+        public bool DefaultHeadless { get; set; }
+        public bool DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -122,9 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public TUnitPlaywrightSettings() { }
-        public bool DefaultHeadless { get; set; }
-        public bool DefaultIgnoreHttpsErrors { get; set; }
+        public bool? DefaultHeadless { get; set; }
+        public bool? DefaultIgnoreHttpsErrors { get; set; }
     }
     public class WorkerAwareTest : ., .
     {


### PR DESCRIPTION
## Summary
- Add `TUnitPlaywrightSettings` with `DefaultHeadless` and `DefaultIgnoreHttpsErrors` knobs, exposed via a `TUnitSettings.PlaywrightSettings` extension property
- Wire defaults into `BrowserFixture.GetLaunchOptions`, `BrowserTest` ctor, `ContextFixture.GetContextOptions`, and `ContextTest.ContextOptions`

## Test plan
- [ ] `dotnet build TUnit.Playwright`
- [ ] Verify Playwright sample tests still launch with expected headless/HTTPS behavior