### PR TITLE
feat(playwright): expose default Context/Launch options on settings

### DIFF
--- a/TUnit.Playwright/BrowserFixture.cs
+++ b/TUnit.Playwright/BrowserFixture.cs
@@ -18,10 +18,8 @@ public class BrowserFixture : IAsyncInitializer, IAsyncDisposable
 
     public virtual string BrowserName => Microsoft.Playwright.BrowserType.Chromium;
 
-    protected virtual BrowserTypeLaunchOptions GetLaunchOptions() => new()
-    {
-        Headless = TUnitPlaywrightSettings.Default.DefaultHeadless,
-    };
+    protected virtual BrowserTypeLaunchOptions GetLaunchOptions() =>
+        TUnitPlaywrightSettings.Default.DefaultBrowserTypeLaunchOptions ?? new BrowserTypeLaunchOptions();
 
     public virtual async Task InitializeAsync()
     {

--- a/TUnit.Playwright/BrowserTest.cs
+++ b/TUnit.Playwright/BrowserTest.cs
@@ -5,10 +5,7 @@ namespace TUnit.Playwright;
 
 public class BrowserTest : PlaywrightTest
 {
-    public BrowserTest() : this(new BrowserTypeLaunchOptions
-    {
-        Headless = TUnitPlaywrightSettings.Default.DefaultHeadless,
-    })
+    public BrowserTest() : this(TUnitPlaywrightSettings.Default.DefaultBrowserTypeLaunchOptions ?? new BrowserTypeLaunchOptions())
     {
     }
 

--- a/TUnit.Playwright/ContextFixture.cs
+++ b/TUnit.Playwright/ContextFixture.cs
@@ -24,10 +24,9 @@ public class ContextFixture : IAsyncInitializer, IAsyncDisposable
     /// (<c>new BrowserNewContextOptions()</c>).
     /// </summary>
     protected virtual BrowserNewContextOptions GetContextOptions() =>
-        new()
+        TUnitPlaywrightSettings.Default.DefaultBrowserNewContextOptions ?? new BrowserNewContextOptions
         {
             Locale = "en-US", ColorScheme = ColorScheme.Light,
-            IgnoreHTTPSErrors = TUnitPlaywrightSettings.Default.DefaultIgnoreHttpsErrors,
         };
 
     /// <summary>

--- a/TUnit.Playwright/ContextTest.cs
+++ b/TUnit.Playwright/ContextTest.cs
@@ -17,10 +17,9 @@ public class ContextTest : BrowserTest
 
     public virtual BrowserNewContextOptions ContextOptions(TestContext testContext)
     {
-        return new()
+        return TUnitPlaywrightSettings.Default.DefaultBrowserNewContextOptions ?? new BrowserNewContextOptions
         {
             Locale = "en-US", ColorScheme = ColorScheme.Light,
-            IgnoreHTTPSErrors = TUnitPlaywrightSettings.Default.DefaultIgnoreHttpsErrors,
         };
     }
 

--- a/TUnit.Playwright/PlaywrightSettings.cs
+++ b/TUnit.Playwright/PlaywrightSettings.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using TUnit.Core.Settings;
 
 namespace TUnit.Playwright;
@@ -18,6 +19,16 @@ public class TUnitPlaywrightSettings
     {
     }
 
-    public bool? DefaultHeadless { get; set; } = null;
-    public bool? DefaultIgnoreHttpsErrors { get; set; } = null;
+    /// <summary>
+    /// Options used when launching the browser for tests inheriting <see cref="BrowserTest"/>
+    /// or <see cref="BrowserFixture"/>. When non-null, this fully replaces the hardcoded defaults.
+    /// </summary>
+    public BrowserTypeLaunchOptions? DefaultBrowserTypeLaunchOptions { get; set; } = null;
+
+    /// <summary>
+    /// Options used when creating a browser context for tests inheriting <see cref="ContextTest"/>
+    /// or <see cref="ContextFixture"/>. When non-null, this fully replaces the hardcoded defaults
+    /// (<c>Locale = "en-US"</c>, <c>ColorScheme = Light</c>).
+    /// </summary>
+    public BrowserNewContextOptions? DefaultBrowserNewContextOptions { get; set; } = null;
 }

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -122,8 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public bool? DefaultHeadless { get; set; }
-        public bool? DefaultIgnoreHttpsErrors { get; set; }
+        public .BrowserNewContextOptions? DefaultBrowserNewContextOptions { get; set; }
+        public .BrowserTypeLaunchOptions? DefaultBrowserTypeLaunchOptions { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -122,8 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public bool? DefaultHeadless { get; set; }
-        public bool? DefaultIgnoreHttpsErrors { get; set; }
+        public .BrowserNewContextOptions? DefaultBrowserNewContextOptions { get; set; }
+        public .BrowserTypeLaunchOptions? DefaultBrowserTypeLaunchOptions { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -122,8 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public bool? DefaultHeadless { get; set; }
-        public bool? DefaultIgnoreHttpsErrors { get; set; }
+        public .BrowserNewContextOptions? DefaultBrowserNewContextOptions { get; set; }
+        public .BrowserTypeLaunchOptions? DefaultBrowserTypeLaunchOptions { get; set; }
     }
     public class WorkerAwareTest : ., .
     {

--- a/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Playwright_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -122,8 +122,8 @@ namespace
     }
     public class TUnitPlaywrightSettings
     {
-        public bool? DefaultHeadless { get; set; }
-        public bool? DefaultIgnoreHttpsErrors { get; set; }
+        public .BrowserNewContextOptions? DefaultBrowserNewContextOptions { get; set; }
+        public .BrowserTypeLaunchOptions? DefaultBrowserTypeLaunchOptions { get; set; }
     }
     public class WorkerAwareTest : ., .
     {


### PR DESCRIPTION
## Summary
- Replace granular `DefaultHeadless` / `DefaultIgnoreHttpsErrors` on `TUnitPlaywrightSettings` with full options objects: `DefaultBrowserNewContextOptions` and `DefaultBrowserTypeLaunchOptions`.
- One extension point now covers every Playwright option without adding a new property each time.
- When a defaults object is set, it fully replaces the hardcoded base defaults (`Locale = "en-US"`, `ColorScheme = Light`); when null, base defaults still apply.

## Breaking changes
- Removes `TUnitPlaywrightSettings.DefaultHeadless`.
- Removes `TUnitPlaywrightSettings.DefaultIgnoreHttpsErrors` (added in #5859, not yet released).

## Test plan
- [x] Public API snapshots regenerated and accepted across net472 / net8.0 / net9.0 / net10.0.
- [ ] CI green.