### PR TITLE
Fix culture-dependent timestamp in HTML test report (#5868)

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -365,7 +365,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         {
             AssemblyName = assemblyName,
             MachineName = Environment.MachineName,
-            Timestamp = FormatTimestamp(DateTimeOffset.UtcNow),
+            Timestamp = DateTimeOffset.UtcNow.ToString("dd MMM yyyy, HH:mm:ss 'UTC'", CultureInfo.InvariantCulture),
             TUnitVersion = tunitVersion,
             OperatingSystem = RuntimeInformation.OSDescription,
             RuntimeVersion = RuntimeInformation.FrameworkDescription,
@@ -413,15 +413,6 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         }
 
         return (commitSha, branch, prNumber, repoSlug);
-    }
-
-    private static string FormatTimestamp(DateTimeOffset value)
-    {
-        // Both 'R' and 'u' are culture-invariant by spec; branching is purely for English-reader aesthetics.
-        var utc = value.ToUniversalTime();
-        return CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en"
-            ? utc.ToString("R")
-            : utc.ToString("u");
     }
 
     private static void AccumulateStatus(ReportSummary summary, ReportTestResult testResult)

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -364,7 +365,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         {
             AssemblyName = assemblyName,
             MachineName = Environment.MachineName,
-            Timestamp = DateTimeOffset.UtcNow.ToString("dd MMM yyyy, HH:mm:ss 'UTC'"),
+            Timestamp = FormatTimestamp(DateTimeOffset.UtcNow),
             TUnitVersion = tunitVersion,
             OperatingSystem = RuntimeInformation.OSDescription,
             RuntimeVersion = RuntimeInformation.FrameworkDescription,
@@ -412,6 +413,15 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
         }
 
         return (commitSha, branch, prNumber, repoSlug);
+    }
+
+    private static string FormatTimestamp(DateTimeOffset value)
+    {
+        // Both 'R' and 'u' are culture-invariant by spec; branching is purely for English-reader aesthetics.
+        var utc = value.ToUniversalTime();
+        return CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en"
+            ? utc.ToString("R")
+            : utc.ToString("u");
     }
 
     private static void AccumulateStatus(ReportSummary summary, ReportTestResult testResult)


### PR DESCRIPTION
## Summary

- Fixes #5868. `HtmlReporter` was rendering the report timestamp with `dd MMM yyyy, HH:mm:ss 'UTC'` and no `IFormatProvider`, so the localized month abbreviation leaked into the output — e.g. `08 5月 2026, 17:40:20 UTC` on Japanese systems.
- Switches to standard format strings (culture-invariant by .NET spec, no `CultureInfo` argument required): `R` (RFC1123) for English UI cultures, `u` (universal sortable ISO) otherwise. Defensive `ToUniversalTime()` so the helper is robust if a future caller passes a non-UTC value.

Output examples:
- English UI: `Sun, 10 May 2026 17:40:20 GMT`
- Any non-English UI: `2026-05-10 17:40:20Z`

Note: `R` emits the literal `GMT` (functionally identical to UTC); the previous output said `UTC`. Minor cosmetic change for the English path.

## Test plan

- [x] `dotnet build TUnit.Engine` clean
- [ ] Manual smoke: run a small project against the HTML reporter with `CultureInfo.CurrentUICulture` set to `ja-JP`, confirm timestamp reads `2026-...Z` (not `5月`)
- [ ] Manual smoke: same with `en-US`, confirm timestamp reads `... GMT`