### PR TITLE
fix(mocks-http): auto-prepend `/` to partial endpoint paths (#5838)

### DIFF
--- a/TUnit.Mocks.Http.Tests/MockHttpHandlerTests.cs
+++ b/TUnit.Mocks.Http.Tests/MockHttpHandlerTests.cs
@@ -559,4 +559,50 @@ public class MockHttpHandlerTests
 
         await Assert.That(capturedContentType).IsEqualTo("application/json");
     }
+
+    [Test]
+    public async Task MatchesByPath_AutoPrependsSlashWhenMissing()
+    {
+        using var client = Mock.HttpClient("https://my.domain/");
+        client.Handler.OnPost("my_endpoint").Respond(HttpStatusCode.Accepted);
+
+        var response = await client.PostAsync("my_endpoint", null);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Accepted);
+    }
+
+    [Test]
+    public async Task MatchesByPathPrefix_AutoPrependsSlashWhenMissing()
+    {
+        using var client = Mock.HttpClient("http://localhost");
+        client.Handler.OnRequest(r => r.Method(HttpMethod.Get).PathStartsWith("api/v2"))
+            .Respond(HttpStatusCode.OK);
+
+        var response = await client.GetAsync("/api/v2/anything/here");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task MatchesByPath_KeepsAbsoluteUrlAsIs()
+    {
+        using var client = Mock.HttpClient();
+        client.Handler.OnGet("https://my.domain/foo").Respond(HttpStatusCode.OK);
+
+        var response = await client.GetAsync("https://my.domain/foo");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task MatchesByPath_RegexNotNormalized()
+    {
+        using var client = Mock.HttpClient("http://localhost");
+        client.Handler.OnRequest(r => r.Method(HttpMethod.Get).PathMatches(@"^/api/users/\d+$"))
+            .Respond(HttpStatusCode.OK);
+
+        var response = await client.GetAsync("/api/users/42");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
 }

--- a/TUnit.Mocks.Http/RequestMatcher.cs
+++ b/TUnit.Mocks.Http/RequestMatcher.cs
@@ -39,9 +39,8 @@ public sealed class RequestMatcher
 
     private static string NormalizePath(string value)
     {
-        if (string.IsNullOrEmpty(value)) return value;
-        if (value[0] == '/') return value;
-        if (value.Contains("://", StringComparison.Ordinal)) return value;
+        if (string.IsNullOrEmpty(value) || value[0] == '/') return value;
+        if (Uri.TryCreate(value, UriKind.Absolute, out _)) return value;
         return "/" + value;
     }
 

--- a/TUnit.Mocks.Http/RequestMatcher.cs
+++ b/TUnit.Mocks.Http/RequestMatcher.cs
@@ -26,15 +26,23 @@ public sealed class RequestMatcher
     /// <summary>Match requests to the exact path.</summary>
     public RequestMatcher Path(string path)
     {
-        _exactPath = path;
+        _exactPath = NormalizePath(path);
         return this;
     }
 
     /// <summary>Match requests whose path starts with the specified prefix.</summary>
     public RequestMatcher PathStartsWith(string prefix)
     {
-        _pathPrefix = prefix;
+        _pathPrefix = NormalizePath(prefix);
         return this;
+    }
+
+    private static string NormalizePath(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        if (value[0] == '/') return value;
+        if (value.Contains("://", StringComparison.Ordinal)) return value;
+        return "/" + value;
     }
 
     /// <summary>Match requests whose path matches the regex pattern.</summary>


### PR DESCRIPTION
## Summary
- Normalize partial endpoint paths in `RequestMatcher.Path()` and `PathStartsWith()` so `OnPost("my_endpoint")` matches the same requests as `OnPost("/my_endpoint")`.
- Skip normalization for absolute URLs (containing `://`) and regex patterns (`PathMatches`), preserving existing behaviour.
- Adds 4 regression tests in `MockHttpHandlerTests`.

## Why
Per #5838, the mismatch is silent and easy to overlook: requests resolve to `RequestUri.PathAndQuery` (always rooted with `/`), but the configured path is stored verbatim, so a partial endpoint never matches and falls through to the default 404 (or `HttpRequestException` when `ThrowOnUnmatched`).

## Test plan
- [x] `dotnet test --project TUnit.Mocks.Http.Tests --framework net10.0` — 45/45 passing (4 new).

Closes #5838