### PR TITLE
chore(mocks): promote TUnit.Mocks packages to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ See the [documentation](https://tunit.dev/docs/getting-started/attributes) for m
 | `TUnit.Engine` | Execution engine for test projects |
 | `TUnit.Assertions` | Standalone assertions — works with other test frameworks too |
 | `TUnit.Assertions.Should` | Optional FluentAssertions-style `value.Should().BeEqualTo(...)` syntax over `TUnit.Assertions` (beta) |
+| `TUnit.Mocks` | Source-generated, AOT-compatible mocking framework — works with any test runner |
+| `TUnit.Mocks.Http` | `HttpClient` mocking helpers built on `TUnit.Mocks` |
+| `TUnit.Mocks.Logging` | `ILogger` capture/verification helpers built on `TUnit.Mocks` |
+| `TUnit.AspNetCore` | ASP.NET Core integration — `WebApplicationFactory`-based test fixtures |
+| `TUnit.Aspire` | .NET Aspire integration — distributed app host fixtures with OpenTelemetry capture |
 | `TUnit.Playwright` | Playwright integration with automatic browser lifecycle management |
 
 ## Migrating from xUnit, NUnit, or MSTest?

--- a/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
+++ b/TUnit.Pipeline/Modules/PackTUnitFilesModule.cs
@@ -22,10 +22,6 @@ public class PackTUnitFilesModule : Module<List<PackedProject>>
     // Remove entries from this set once a package is considered stable.
     private static readonly HashSet<string> BetaPackages =
     [
-        "TUnit.Mocks",
-        "TUnit.Mocks.Assertions",
-        "TUnit.Mocks.Http",
-        "TUnit.Mocks.Logging",
         "TUnit.Assertions.Should"
     ];
 

--- a/docs/docs/writing-tests/mocking/http.md
+++ b/docs/docs/writing-tests/mocking/http.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 `TUnit.Mocks.Http` provides `MockHttpHandler` — a drop-in `HttpMessageHandler` replacement for testing code that uses `HttpClient`.
 
 ```bash
-dotnet add package TUnit.Mocks.Http --prerelease
+dotnet add package TUnit.Mocks.Http
 ```
 
 ## Getting Started

--- a/docs/docs/writing-tests/mocking/index.md
+++ b/docs/docs/writing-tests/mocking/index.md
@@ -8,23 +8,19 @@ TUnit.Mocks is a **standalone, source-generated, AOT-compatible** mocking framew
 
 While it integrates seamlessly with TUnit's assertion engine, TUnit.Mocks has **no dependency on the TUnit test framework** and works with any test runner — xUnit, NUnit, MSTest, or no framework at all.
 
-:::note Beta
-TUnit.Mocks is currently in **beta**. The API may change before the stable release.
-:::
-
 ## Installation
 
 Add the NuGet package to your test project:
 
 ```bash
-dotnet add package TUnit.Mocks --prerelease
+dotnet add package TUnit.Mocks
 ```
 
 For HTTP mocking or logging helpers, also add:
 
 ```bash
-dotnet add package TUnit.Mocks.Http --prerelease
-dotnet add package TUnit.Mocks.Logging --prerelease
+dotnet add package TUnit.Mocks.Http
+dotnet add package TUnit.Mocks.Logging
 ```
 
 :::warning C# 14 Required

--- a/docs/docs/writing-tests/mocking/logging.md
+++ b/docs/docs/writing-tests/mocking/logging.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 `TUnit.Mocks.Logging` provides `MockLogger` — a simple `ILogger` implementation that captures log entries for inspection and verification.
 
 ```bash
-dotnet add package TUnit.Mocks.Logging --prerelease
+dotnet add package TUnit.Mocks.Logging
 ```
 
 :::tip No Source Generation Needed


### PR DESCRIPTION
## Summary

- Drops `TUnit.Mocks`, `TUnit.Mocks.Assertions`, `TUnit.Mocks.Http`, `TUnit.Mocks.Logging` from `BetaPackages` in `TUnit.Pipeline/Modules/PackTUnitFilesModule.cs` so the pack module no longer appends `-beta` to the version. `TUnit.Assertions.Should` stays beta.
- Removes the `:::note Beta` admonition from `docs/docs/writing-tests/mocking/index.md` and drops the `--prerelease` flag from the install snippets in `index.md`, `http.md`, and `logging.md`.
- Adds rows for `TUnit.Mocks`, `TUnit.Mocks.Http`, `TUnit.Mocks.Logging`, `TUnit.AspNetCore`, and `TUnit.Aspire` to the Packages table in `README.md` (none of these were previously listed).

## Test plan

- [ ] CI build succeeds
- [ ] Next pack run on `main` produces `TUnit.Mocks*.<semver>.nupkg` with no `-beta` suffix
- [ ] Docs site renders `writing-tests/mocking` pages with no Beta admonition and clean install commands