### PR TITLE
feat(mocks): support non-span ref struct out/ref params

### DIFF
--- a/TUnit.Mocks.SourceGenerator/Builders/MockBridgeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockBridgeBuilder.cs
@@ -52,7 +52,7 @@ internal static class MockBridgeBuilder
                 if (!method.IsStaticAbstract) continue;
                 if (!first) writer.AppendLine();
                 first = false;
-                GenerateStaticMethodDim(writer, method, staticEngineTypeName);
+                GenerateStaticMethodDim(writer, method, staticEngineTypeName, model);
             }
 
             // Static abstract properties — provide DIM implementations
@@ -92,7 +92,7 @@ internal static class MockBridgeBuilder
         }
     }
 
-    private static void GenerateStaticMethodDim(CodeWriter writer, MockMemberModel method, string staticEngineTypeName)
+    private static void GenerateStaticMethodDim(CodeWriter writer, MockMemberModel method, string staticEngineTypeName, MockTypeModel model)
     {
         var signatureReturnType = (method.IsVoid && !method.IsAsync) ? "void" : method.ReturnType;
         var paramList = MockImplBuilder.GetParameterList(method);
@@ -103,7 +103,7 @@ internal static class MockBridgeBuilder
 
         using (writer.Block($"static {signatureReturnType} {method.ExplicitInterfaceName}.{EscapeIdentifier(method.Name)}{typeParams}({paramList}){constraints}"))
         {
-            GenerateStaticEngineDispatchBody(writer, method, staticEngineTypeName);
+            GenerateStaticEngineDispatchBody(writer, method, staticEngineTypeName, model);
         }
     }
 
@@ -155,7 +155,7 @@ internal static class MockBridgeBuilder
         writer.CloseBrace();
     }
 
-    private static void GenerateStaticEngineDispatchBody(CodeWriter writer, MockMemberModel method, string staticEngineTypeName)
+    private static void GenerateStaticEngineDispatchBody(CodeWriter writer, MockMemberModel method, string staticEngineTypeName, MockTypeModel model)
     {
         writer.AppendLine($"var __engine = {staticEngineTypeName}.Engine;");
 
@@ -174,7 +174,7 @@ internal static class MockBridgeBuilder
         {
             writer.AppendLine("if (__engine is null) return;");
             writer.AppendLine($"__engine.HandleCall({method.MemberId}, \"{method.Name}\", {argsArray});");
-            MockImplBuilder.EmitOutRefReadback(writer, method);
+            MockImplBuilder.EmitOutRefReadback(writer, method, model);
         }
         else if (method.IsVoid && method.IsAsync)
         {
@@ -190,7 +190,7 @@ internal static class MockBridgeBuilder
             using (writer.Block("try"))
             {
                 writer.AppendLine($"__engine.HandleCall({method.MemberId}, \"{method.Name}\", {argsArray});");
-                MockImplBuilder.EmitOutRefReadback(writer, method);
+                MockImplBuilder.EmitOutRefReadback(writer, method, model);
                 if (method.IsValueTask)
                 {
                     writer.AppendLine("return default(global::System.Threading.Tasks.ValueTask);");
@@ -228,7 +228,7 @@ internal static class MockBridgeBuilder
             using (writer.Block("try"))
             {
                 writer.AppendLine($"var __result = ({method.UnwrappedReturnType})__engine.HandleCallWithReturn<object?>({method.MemberId}, \"{method.Name}\", {argsArray}, null)!;");
-                MockImplBuilder.EmitOutRefReadback(writer, method);
+                MockImplBuilder.EmitOutRefReadback(writer, method, model);
                 if (method.IsValueTask)
                 {
                     writer.AppendLine($"return new global::System.Threading.Tasks.ValueTask<{method.UnwrappedReturnType}>(__result);");
@@ -264,7 +264,7 @@ internal static class MockBridgeBuilder
             using (writer.Block("try"))
             {
                 writer.AppendLine($"var __result = __engine.HandleCallWithReturn<{method.UnwrappedReturnType}>({method.MemberId}, \"{method.Name}\", {argsArray}, {method.UnwrappedSmartDefault});");
-                MockImplBuilder.EmitOutRefReadback(writer, method);
+                MockImplBuilder.EmitOutRefReadback(writer, method, model);
                 if (method.IsValueTask)
                 {
                     writer.AppendLine($"return new global::System.Threading.Tasks.ValueTask<{method.UnwrappedReturnType}>(__result);");
@@ -292,14 +292,14 @@ internal static class MockBridgeBuilder
             // Use object? and cast instead.
             writer.AppendLine("if (__engine is null) return default!;");
             writer.AppendLine($"var __result = __engine.HandleCallWithReturn<object?>({method.MemberId}, \"{method.Name}\", {argsArray}, null);");
-            MockImplBuilder.EmitOutRefReadback(writer, method);
+            MockImplBuilder.EmitOutRefReadback(writer, method, model);
             writer.AppendLine($"return ({method.ReturnType})__result!;");
         }
         else
         {
             writer.AppendLine("if (__engine is null) return default!;");
             writer.AppendLine($"var __result = __engine.HandleCallWithReturn<{method.ReturnType}>({method.MemberId}, \"{method.Name}\", {argsArray}, {method.SmartDefault});");
-            MockImplBuilder.EmitOutRefReadback(writer, method);
+            MockImplBuilder.EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return __result;");
         }
     }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1463,25 +1463,25 @@ internal static class MockImplBuilder
     /// </summary>
     private static void EmitOutRefParamAssignments(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
-        var canInvokeRefStructSetter = !method.IsGenericMethod && model.TypeParameters.Length == 0;
+        var canInvokeRefStructSetter = SupportsClosedRefStructSetter(model, method);
+        string? safeName = null;
+        string? nsPrefix = null;
 
         for (int i = 0; i < method.Parameters.Length; i++)
         {
             var p = method.Parameters[i];
             if (p.Direction != ParameterDirection.Out && p.Direction != ParameterDirection.Ref) continue;
 
-            if (p.IsRefStruct && p.SpanElementType is null)
+            if (p.IsNonSpanRefStruct)
             {
-                // Non-span ref structs can't be stored as object — the setter site instead
-                // accepts a typed delegate; invoke it directly on the out/ref slot.
                 if (!canInvokeRefStructSetter) continue;
-                var delegateFqn = GetOutRefSetterDelegateFqn(model, method, p);
-                var dirKeyword = p.Direction == ParameterDirection.Out ? "out" : "ref";
-                writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i}) && __v{i} is {delegateFqn} __d{i}) __d{i}({dirKeyword} {p.Name});");
+                safeName ??= GetCompositeShortSafeName(model);
+                nsPrefix ??= GetGlobalMockNamespacePrefix(model);
+                var delegateFqn = nsPrefix + GetOutRefSetterDelegateName(safeName, method, p);
+                writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i}) && __v{i} is {delegateFqn} __d{i}) __d{i}({p.Direction.RefKeyword()} {p.Name});");
             }
             else if (p.SpanElementType is not null)
             {
-                // Span types: reconstruct from stored array
                 writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i})) {p.Name} = new {p.FullyQualifiedType}(({p.SpanElementType}[])__v{i}!);");
             }
             else
@@ -1490,6 +1490,15 @@ internal static class MockImplBuilder
             }
         }
     }
+
+    /// <summary>
+    /// True when the generator can emit a closed-signature delegate setter for non-span ref
+    /// struct out/ref params. Generic mock types and generic methods are excluded — their
+    /// param types may reference type parameters that aren't fully bound at delegate-decl
+    /// time and would require an <c>allows ref struct</c> constraint (C# 13, net9.0+ runtime).
+    /// </summary>
+    internal static bool SupportsClosedRefStructSetter(MockTypeModel model, MockMemberModel method)
+        => !method.IsGenericMethod && model.TypeParameters.Length == 0;
 
     internal static string EmitArgsArrayVariable(CodeWriter writer, MockMemberModel method)
     {
@@ -1580,34 +1589,17 @@ internal static class MockImplBuilder
         return SanitizeIdentifier(name);
     }
 
-    /// <summary>
-    /// Returns the unqualified name of the generated delegate type used to plumb a non-span
-    /// ref-struct <c>out</c>/<c>ref</c> parameter value across the mock setup/invocation boundary.
-    /// The delegate is declared at namespace scope in the <c>_MockMembers.g.cs</c> file with a
-    /// matching closed signature, and referenced from the impl/bridge readback code by its
-    /// fully-qualified name (see <see cref="GetOutRefSetterDelegateFqn"/>).
-    /// </summary>
+    /// <summary>Unqualified name of the generated delegate type used to plumb a non-span ref-struct out/ref value.</summary>
     public static string GetOutRefSetterDelegateName(MockTypeModel model, MockMemberModel method, MockParameterModel param)
-    {
-        var safeName = GetCompositeShortSafeName(model);
-        var dir = param.Direction == ParameterDirection.Out ? "Out" : "Ref";
-        var paramPart = ToPascalCaseSetter(param.Name);
-        return $"{safeName}_{method.Name}_M{method.MemberId}_{paramPart}_{dir}Setter";
-    }
+        => GetOutRefSetterDelegateName(GetCompositeShortSafeName(model), method, param);
 
-    /// <summary>
-    /// Fully qualified (<c>global::</c>-rooted) reference to the delegate emitted by
-    /// <see cref="GetOutRefSetterDelegateName"/> — suitable for use in any generated file
-    /// that shares the mock namespace.
-    /// </summary>
+    /// <summary>Variant that reuses a precomputed safe name to avoid recomputing it per param.</summary>
+    public static string GetOutRefSetterDelegateName(string safeName, MockMemberModel method, MockParameterModel param)
+        => $"{safeName}_{method.Name}_M{method.MemberId}_{MockMembersBuilder.ToPascalCase(param.Name)}_{param.Direction.PascalLabel()}Setter";
+
+    /// <summary>Fully qualified (<c>global::</c>-rooted) reference to the delegate.</summary>
     public static string GetOutRefSetterDelegateFqn(MockTypeModel model, MockMemberModel method, MockParameterModel param)
         => GetGlobalMockNamespacePrefix(model) + GetOutRefSetterDelegateName(model, method, param);
-
-    private static string ToPascalCaseSetter(string name)
-    {
-        if (name.Length > 0 && name[0] == '@') name = name.Substring(1);
-        return name.Length == 0 ? name : char.ToUpperInvariant(name[0]) + name.Substring(1);
-    }
 
     /// <summary>
     /// Gets a composite short safe name that includes additional interfaces for multi-interface mocks.

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -217,17 +217,17 @@ internal static class MockImplBuilder
             {
                 // Abstract methods: dispatch through engine (wrapped instance can't have abstract methods by definition,
                 // but we still handle it for consistency)
-                GenerateEngineDispatchBody(writer, method);
+                GenerateEngineDispatchBody(writer, method, model);
             }
             else
             {
                 // Virtual/override methods: try engine first, fall back to wrapped instance
-                GenerateWrapMethodBody(writer, method);
+                GenerateWrapMethodBody(writer, method, model);
             }
         }
     }
 
-    private static void GenerateWrapMethodBody(CodeWriter writer, MockMemberModel method)
+    private static void GenerateWrapMethodBody(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         // Initialize out parameters
         foreach (var p in method.Parameters)
@@ -249,7 +249,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -260,7 +260,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             if (method.IsValueTask)
             {
                 writer.AppendLine("return default(global::System.Threading.Tasks.ValueTask);");
@@ -288,7 +288,7 @@ internal static class MockImplBuilder
                 writer.AppendLine("{");
                 writer.IncreaseIndent();
             }
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             if (method.IsValueTask)
             {
                 writer.AppendLine($"return new global::System.Threading.Tasks.ValueTask<{method.UnwrappedReturnType}>(__result);");
@@ -308,11 +308,11 @@ internal static class MockImplBuilder
             writer.IncreaseIndent();
             if (method.SpanReturnElementType is not null)
             {
-                EmitSpanReturnReadback(writer, method);
+                EmitSpanReturnReadback(writer, method, model);
             }
             else
             {
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return default;");
             }
             writer.DecreaseIndent();
@@ -325,7 +325,7 @@ internal static class MockImplBuilder
             writer.AppendLine("{");
             writer.IncreaseIndent();
             writer.AppendLine($"var __result = ({method.ReturnType})__rawResult!;");
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return __result;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -336,7 +336,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, "__result", autoMockFactory)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return __result;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -571,7 +571,7 @@ internal static class MockImplBuilder
                 // Return types are incompatible — dispatch through the engine with a dedicated member id.
                 using (writer.Block($"{signatureReturnType} {method.ExplicitInterfaceName}.{EscapeIdentifier(method.Name)}{typeParams}({paramList}){constraints}"))
                 {
-                    GenerateEngineDispatchBody(writer, method);
+                    GenerateEngineDispatchBody(writer, method, model);
                 }
             }
             return;
@@ -579,7 +579,7 @@ internal static class MockImplBuilder
 
         using (writer.Block($"public {signatureReturnType} {EscapeIdentifier(method.Name)}{typeParams}({paramList}){constraints}"))
         {
-            GenerateEngineDispatchBody(writer, method);
+            GenerateEngineDispatchBody(writer, method, model);
         }
     }
 
@@ -599,17 +599,17 @@ internal static class MockImplBuilder
             if (method.IsAbstractMember)
             {
                 // Abstract methods: same as interface methods - dispatch through engine
-                GenerateEngineDispatchBody(writer, method);
+                GenerateEngineDispatchBody(writer, method, model);
             }
             else
             {
                 // Virtual/override methods: try engine first, fall back to base
-                GeneratePartialMethodBody(writer, method);
+                GeneratePartialMethodBody(writer, method, model);
             }
         }
     }
 
-    private static void GeneratePartialMethodBody(CodeWriter writer, MockMemberModel method)
+    private static void GeneratePartialMethodBody(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         // Initialize out parameters
         foreach (var p in method.Parameters)
@@ -632,7 +632,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -644,7 +644,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             EmitRawReturnCheck(writer, method);
             if (method.IsValueTask)
             {
@@ -674,7 +674,7 @@ internal static class MockImplBuilder
                 writer.AppendLine("{");
                 writer.IncreaseIndent();
             }
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             EmitRawReturnCheck(writer, method);
             if (method.IsValueTask)
             {
@@ -696,11 +696,11 @@ internal static class MockImplBuilder
             writer.IncreaseIndent();
             if (method.SpanReturnElementType is not null)
             {
-                EmitSpanReturnReadback(writer, method);
+                EmitSpanReturnReadback(writer, method, model);
             }
             else
             {
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return default;");
             }
             writer.DecreaseIndent();
@@ -713,7 +713,7 @@ internal static class MockImplBuilder
             writer.AppendLine("{");
             writer.IncreaseIndent();
             writer.AppendLine($"var __result = ({method.ReturnType})__rawResult!;");
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return __result;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -725,7 +725,7 @@ internal static class MockImplBuilder
             writer.AppendLine($"if ({EmitTryHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, "__result", autoMockFactory)})");
             writer.AppendLine("{");
             writer.IncreaseIndent();
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
             writer.AppendLine("return __result;");
             writer.DecreaseIndent();
             writer.AppendLine("}");
@@ -733,7 +733,7 @@ internal static class MockImplBuilder
         }
     }
 
-    private static void GenerateEngineDispatchBody(CodeWriter writer, MockMemberModel method)
+    private static void GenerateEngineDispatchBody(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         // Initialize out parameters
         foreach (var p in method.Parameters)
@@ -754,7 +754,7 @@ internal static class MockImplBuilder
         {
             // Pure void method
             writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)};");
-            EmitOutRefReadback(writer, method);
+            EmitOutRefReadback(writer, method, model);
         }
         else if (method.IsVoid && method.IsAsync)
         {
@@ -762,7 +762,7 @@ internal static class MockImplBuilder
             using (writer.Block("try"))
             {
                 writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)};");
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 EmitRawReturnCheck(writer, method);
                 if (method.IsValueTask)
                 {
@@ -800,7 +800,7 @@ internal static class MockImplBuilder
                 {
                     writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, unwrappedArg, method.MemberId, method.Name, unwrappedDefault, autoMockFactory)};");
                 }
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 EmitRawReturnCheck(writer, method);
                 if (method.IsValueTask)
                 {
@@ -832,11 +832,11 @@ internal static class MockImplBuilder
             if (method.SpanReturnElementType is not null)
             {
                 // Span return: read back out/ref params AND extract return value from OutRefContext index -1
-                EmitSpanReturnReadback(writer, method);
+                EmitSpanReturnReadback(writer, method, model);
             }
             else
             {
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return default;");
             }
         }
@@ -847,7 +847,7 @@ internal static class MockImplBuilder
             if (hasOutRef)
             {
                 writer.AppendLine($"var __result = ({method.ReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, "object?", method.MemberId, method.Name, "null")}!;");
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return __result;");
             }
             else
@@ -861,7 +861,7 @@ internal static class MockImplBuilder
             if (hasOutRef)
             {
                 writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, autoMockFactory)};");
-                EmitOutRefReadback(writer, method);
+                EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return __result;");
             }
             else
@@ -1413,14 +1413,14 @@ internal static class MockImplBuilder
     /// <summary>
     /// Emits code to read back out/ref parameter values from OutRefContext after an engine call.
     /// </summary>
-    internal static void EmitOutRefReadback(CodeWriter writer, MockMemberModel method)
+    internal static void EmitOutRefReadback(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         if (!HasOutRefParams(method)) return;
 
         writer.AppendLine("var __outRef = global::TUnit.Mocks.Setup.OutRefContext.Consume();");
         using (writer.Block("if (__outRef is not null)"))
         {
-            EmitOutRefParamAssignments(writer, method);
+            EmitOutRefParamAssignments(writer, method, model);
         }
     }
 
@@ -1446,12 +1446,12 @@ internal static class MockImplBuilder
     /// read back out/ref params, extract span return value, and return.
     /// Always ends with "return default;" as fallback.
     /// </summary>
-    private static void EmitSpanReturnReadback(CodeWriter writer, MockMemberModel method)
+    private static void EmitSpanReturnReadback(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         writer.AppendLine("var __outRef = global::TUnit.Mocks.Setup.OutRefContext.Consume();");
         using (writer.Block("if (__outRef is not null)"))
         {
-            EmitOutRefParamAssignments(writer, method);
+            EmitOutRefParamAssignments(writer, method, model);
             writer.AppendLine($"if (__outRef.TryGetValue(global::TUnit.Mocks.Setup.OutRefContext.SpanReturnValueIndex, out var __spanRet)) return new {method.ReturnType}(({method.SpanReturnElementType}[])__spanRet!);");
         }
         writer.AppendLine("return default;");
@@ -1461,23 +1461,32 @@ internal static class MockImplBuilder
     /// Emits individual out/ref parameter assignments from the __outRef dictionary.
     /// Shared by <see cref="EmitOutRefReadback"/> and <see cref="EmitSpanReturnReadback"/>.
     /// </summary>
-    private static void EmitOutRefParamAssignments(CodeWriter writer, MockMemberModel method)
+    private static void EmitOutRefParamAssignments(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
+        var canInvokeRefStructSetter = !method.IsGenericMethod && model.TypeParameters.Length == 0;
+
         for (int i = 0; i < method.Parameters.Length; i++)
         {
             var p = method.Parameters[i];
-            if (p.IsRefStruct && p.SpanElementType is null) continue; // non-span ref structs can't be cast from object
-            if (p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref)
+            if (p.Direction != ParameterDirection.Out && p.Direction != ParameterDirection.Ref) continue;
+
+            if (p.IsRefStruct && p.SpanElementType is null)
             {
-                if (p.SpanElementType is not null)
-                {
-                    // Span types: reconstruct from stored array
-                    writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i})) {p.Name} = new {p.FullyQualifiedType}(({p.SpanElementType}[])__v{i}!);");
-                }
-                else
-                {
-                    writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i})) {p.Name} = ({p.FullyQualifiedType})__v{i}!;");
-                }
+                // Non-span ref structs can't be stored as object — the setter site instead
+                // accepts a typed delegate; invoke it directly on the out/ref slot.
+                if (!canInvokeRefStructSetter) continue;
+                var delegateFqn = GetOutRefSetterDelegateFqn(model, method, p);
+                var dirKeyword = p.Direction == ParameterDirection.Out ? "out" : "ref";
+                writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i}) && __v{i} is {delegateFqn} __d{i}) __d{i}({dirKeyword} {p.Name});");
+            }
+            else if (p.SpanElementType is not null)
+            {
+                // Span types: reconstruct from stored array
+                writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i})) {p.Name} = new {p.FullyQualifiedType}(({p.SpanElementType}[])__v{i}!);");
+            }
+            else
+            {
+                writer.AppendLine($"if (__outRef.TryGetValue({i}, out var __v{i})) {p.Name} = ({p.FullyQualifiedType})__v{i}!;");
             }
         }
     }
@@ -1569,6 +1578,35 @@ internal static class MockImplBuilder
             name = name.Replace("global::" + model.Namespace + ".", "");
 
         return SanitizeIdentifier(name);
+    }
+
+    /// <summary>
+    /// Returns the unqualified name of the generated delegate type used to plumb a non-span
+    /// ref-struct <c>out</c>/<c>ref</c> parameter value across the mock setup/invocation boundary.
+    /// The delegate is declared at namespace scope in the <c>_MockMembers.g.cs</c> file with a
+    /// matching closed signature, and referenced from the impl/bridge readback code by its
+    /// fully-qualified name (see <see cref="GetOutRefSetterDelegateFqn"/>).
+    /// </summary>
+    public static string GetOutRefSetterDelegateName(MockTypeModel model, MockMemberModel method, MockParameterModel param)
+    {
+        var safeName = GetCompositeShortSafeName(model);
+        var dir = param.Direction == ParameterDirection.Out ? "Out" : "Ref";
+        var paramPart = ToPascalCaseSetter(param.Name);
+        return $"{safeName}_{method.Name}_M{method.MemberId}_{paramPart}_{dir}Setter";
+    }
+
+    /// <summary>
+    /// Fully qualified (<c>global::</c>-rooted) reference to the delegate emitted by
+    /// <see cref="GetOutRefSetterDelegateName"/> — suitable for use in any generated file
+    /// that shares the mock namespace.
+    /// </summary>
+    public static string GetOutRefSetterDelegateFqn(MockTypeModel model, MockMemberModel method, MockParameterModel param)
+        => GetGlobalMockNamespacePrefix(model) + GetOutRefSetterDelegateName(model, method, param);
+
+    private static string ToPascalCaseSetter(string name)
+    {
+        if (name.Length > 0 && name[0] == '@') name = name.Substring(1);
+        return name.Length == 0 ? name : char.ToUpperInvariant(name[0]) + name.Substring(1);
     }
 
     /// <summary>

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -126,11 +126,33 @@ internal static class MockMembersBuilder
                 if (method.ExplicitInterfaceName is not null && !method.IsStaticAbstract) continue;
                 if (!ShouldGenerateTypedWrapper(method, hasEvents)) continue;
                 writer.AppendLine();
+                EmitNonSpanRefStructSetterDelegates(writer, model, method);
                 GenerateUnifiedSealedClass(writer, method, safeName, instanceEventArray, model.Visibility, model);
             }
         }
 
         return writer.ToString();
+    }
+
+    /// <summary>
+    /// Emits namespace-scoped delegate types for non-span ref struct out/ref parameters.
+    /// These cannot be boxed into the <see cref="System.Collections.Generic.Dictionary{Int32, Object}"/>
+    /// used by <c>OutRefContext</c>, so the typed setter accepts a delegate instead and the
+    /// generated mock implementation invokes the delegate on the actual <c>out</c>/<c>ref</c> slot.
+    /// </summary>
+    private static void EmitNonSpanRefStructSetterDelegates(CodeWriter writer, MockTypeModel model, MockMemberModel method)
+    {
+        if (method.IsGenericMethod || model.TypeParameters.Length > 0) return;
+
+        foreach (var param in method.Parameters)
+        {
+            if (param.Direction != ParameterDirection.Out && param.Direction != ParameterDirection.Ref) continue;
+            if (!param.IsRefStruct || param.SpanElementType is not null) continue;
+
+            var name = MockImplBuilder.GetOutRefSetterDelegateName(model, method, param);
+            var dir = param.Direction == ParameterDirection.Out ? "out" : "ref";
+            writer.AppendLine($"{model.Visibility} delegate void {name}({dir} {param.FullyQualifiedType} value);");
+        }
     }
 
     private static void EmitOutParamDefaults(CodeWriter writer, MockMemberModel method)
@@ -158,10 +180,10 @@ internal static class MockMembersBuilder
         var matchableParams = method.Parameters.Where(p => p.Direction != ParameterDirection.Out && !p.IsRefStruct).ToList();
         if (matchableParams.Count == 0)
         {
-            // Include span-type ref struct out/ref params (supported via array conversion)
+            // Include span-type ref struct out/ref params (array conversion path) and
+            // non-span ref struct out/ref params (delegate-setter path).
             var hasOutRefParams = method.Parameters.Any(p =>
-                (!p.IsRefStruct || p.SpanElementType is not null) &&
-                (p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref));
+                p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref);
             // Span return types need a typed wrapper for the generated Returns(SpanType) method
             var hasSpanReturn = method.SpanReturnElementType is not null;
             return hasEvents || hasOutRefParams || hasSpanReturn;
@@ -227,18 +249,18 @@ internal static class MockMembersBuilder
         // Ref struct returns use the void wrapper (can't use ref structs as generic type args)
         if (method.IsVoid || method.IsRefStructReturn)
         {
-            GenerateVoidUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, visibility, matchableParams, events, method.Parameters, hasRefStructParams, allNonOutParams, method.SpanReturnElementType, method.ReturnType,
+            GenerateVoidUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, visibility, matchableParams, events, method.Parameters, hasRefStructParams, allNonOutParams, model, method, method.SpanReturnElementType, method.ReturnType,
                 isAsync: method.IsAsync, isValueTask: method.IsValueTask);
         }
         else if (method.IsReturnTypeStaticAbstractInterface)
         {
             // Static-abstract interface returns can't be used as generic type args (CS8920)
             // Use object? to preserve .Returns() capability
-            GenerateReturnUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, matchableParams, "object?", events, method.Parameters, hasRefStructParams, allNonOutParams, visibility);
+            GenerateReturnUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, matchableParams, "object?", events, method.Parameters, hasRefStructParams, allNonOutParams, visibility, model, method);
         }
         else
         {
-            GenerateReturnUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, matchableParams, setupReturnType, events, method.Parameters, hasRefStructParams, allNonOutParams, visibility,
+            GenerateReturnUnifiedClass(writer, wrapperName, wrapperTypeName, typeConstraints, matchableParams, setupReturnType, events, method.Parameters, hasRefStructParams, allNonOutParams, visibility, model, method,
                 isAsync: method.IsAsync, isValueTask: method.IsValueTask, fullReturnType: method.ReturnType);
         }
     }
@@ -246,7 +268,7 @@ internal static class MockMembersBuilder
     private static void GenerateReturnUnifiedClass(CodeWriter writer, string wrapperCtorName, string wrapperTypeName, string typeConstraints,
         List<MockParameterModel> nonOutParams, string returnType, EquatableArray<MockEventModel> events,
         EquatableArray<MockParameterModel> allParameters, bool hasRefStructParams, List<MockParameterModel> allNonOutParams,
-        string visibility,
+        string visibility, MockTypeModel model, MockMemberModel method,
         bool isAsync = false, bool isValueTask = false, string? fullReturnType = null)
     {
         var builderType = $"global::TUnit.Mocks.Setup.MethodSetupBuilder<{returnType}>";
@@ -325,7 +347,7 @@ internal static class MockMembersBuilder
             if (hasOutRef)
             {
                 writer.AppendLine();
-                GenerateTypedOutRefMethods(writer, allParameters, wrapperTypeName);
+                GenerateTypedOutRefMethods(writer, allParameters, wrapperTypeName, model, method);
             }
 
             // Typed event raises
@@ -356,6 +378,7 @@ internal static class MockMembersBuilder
     private static void GenerateVoidUnifiedClass(CodeWriter writer, string wrapperCtorName, string wrapperTypeName, string typeConstraints, string visibility,
         List<MockParameterModel> nonOutParams, EquatableArray<MockEventModel> events,
         EquatableArray<MockParameterModel> allParameters, bool hasRefStructParams, List<MockParameterModel> allNonOutParams,
+        MockTypeModel model, MockMemberModel method,
         string? spanReturnElementType = null, string? spanReturnType = null,
         bool isAsync = false, bool isValueTask = false)
     {
@@ -450,7 +473,7 @@ internal static class MockMembersBuilder
             if (hasOutRef)
             {
                 writer.AppendLine();
-                GenerateTypedOutRefMethods(writer, allParameters, wrapperTypeName);
+                GenerateTypedOutRefMethods(writer, allParameters, wrapperTypeName, model, method);
             }
 
             // Typed event raises
@@ -597,8 +620,10 @@ internal static class MockMembersBuilder
         }
     }
 
-    private static void GenerateTypedOutRefMethods(CodeWriter writer, EquatableArray<MockParameterModel> allParameters, string wrapperName)
+    private static void GenerateTypedOutRefMethods(CodeWriter writer, EquatableArray<MockParameterModel> allParameters, string wrapperName, MockTypeModel model, MockMemberModel method)
     {
+        var canEmitRefStructSetter = !method.IsGenericMethod && model.TypeParameters.Length == 0;
+
         for (int i = 0; i < allParameters.Length; i++)
         {
             var param = allParameters[i];
@@ -607,8 +632,12 @@ internal static class MockMembersBuilder
                 continue;
             }
 
-            // Skip non-span ref structs (can't be boxed)
-            if (param.IsRefStruct && param.SpanElementType is null)
+            // Non-span ref structs can't be boxed: only emit when we can plumb a typed delegate
+            // (closed-signature, declared at namespace scope, referenced from the impl/bridge).
+            // Skip generic mock types and generic methods for now — those would require generic
+            // delegate types with `allows ref struct` constraints (C# 13) which the netstandard2.0
+            // target can't reliably emit.
+            if (param.IsRefStruct && param.SpanElementType is null && !canEmitRefStructSetter)
             {
                 continue;
             }
@@ -622,6 +651,14 @@ internal static class MockMembersBuilder
             {
                 // Span types: convert to array for storage, reconstruct at invocation time
                 writer.AppendLine($"public {wrapperName} {methodName}({param.FullyQualifiedType} {param.Name}) {{ EnsureSetup().SetsOutParameter({i}, {param.Name}.ToArray()); return this; }}");
+            }
+            else if (param.IsRefStruct)
+            {
+                // Non-span ref structs: accept a typed delegate (closed signature) declared at
+                // namespace scope. The delegate itself is a reference type, so the existing
+                // `Dictionary<int, object?>` storage in OutRefContext accepts it unchanged.
+                var delegateFqn = MockImplBuilder.GetOutRefSetterDelegateFqn(model, method, param);
+                writer.AppendLine($"public {wrapperName} {methodName}({delegateFqn} setter) {{ EnsureSetup().SetsOutParameter({i}, setter); return this; }}");
             }
             else
             {

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -124,7 +124,7 @@ internal static class MockMembersBuilder
             foreach (var method in model.Methods)
             {
                 if (method.ExplicitInterfaceName is not null && !method.IsStaticAbstract) continue;
-                if (!ShouldGenerateTypedWrapper(method, hasEvents)) continue;
+                if (!ShouldGenerateTypedWrapper(method, model, hasEvents)) continue;
                 writer.AppendLine();
                 EmitNonSpanRefStructSetterDelegates(writer, model, method);
                 GenerateUnifiedSealedClass(writer, method, safeName, instanceEventArray, model.Visibility, model);
@@ -169,7 +169,7 @@ internal static class MockMembersBuilder
         }
     }
 
-    private static bool ShouldGenerateTypedWrapper(MockMemberModel method, bool hasEvents)
+    private static bool ShouldGenerateTypedWrapper(MockMemberModel method, MockTypeModel model, bool hasEvents)
     {
         if (method.IsGenericMethod) return false;
 
@@ -180,10 +180,13 @@ internal static class MockMembersBuilder
         var matchableParams = method.Parameters.Where(p => p.Direction != ParameterDirection.Out && !p.IsRefStruct).ToList();
         if (matchableParams.Count == 0)
         {
-            // Include span-type ref struct out/ref params (array conversion path) and
-            // non-span ref struct out/ref params (delegate-setter path).
+            // Include out/ref params we can actually plumb: span (array conversion) or non-span
+            // ref struct when the delegate-setter path is available. Don't generate a wrapper
+            // solely for a non-span ref struct out/ref param we'd then have to silently skip.
+            var canEmitRefStructSetter = MockImplBuilder.SupportsClosedRefStructSetter(model, method);
             var hasOutRefParams = method.Parameters.Any(p =>
-                p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref);
+                (p.Direction == ParameterDirection.Out || p.Direction == ParameterDirection.Ref) &&
+                (!p.IsNonSpanRefStruct || canEmitRefStructSetter));
             // Span return types need a typed wrapper for the generated Returns(SpanType) method
             var hasSpanReturn = method.SpanReturnElementType is not null;
             return hasEvents || hasOutRefParams || hasSpanReturn;
@@ -825,7 +828,7 @@ internal static class MockMembersBuilder
             : method.ReturnType;
 
         var hasEvents = model.Events.Any(e => !e.IsStaticAbstract);
-        var useTypedWrapper = ShouldGenerateTypedWrapper(method, hasEvents);
+        var useTypedWrapper = ShouldGenerateTypedWrapper(method, model, hasEvents);
 
         string returnType;
         if (useTypedWrapper)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -135,23 +135,23 @@ internal static class MockMembersBuilder
     }
 
     /// <summary>
-    /// Emits namespace-scoped delegate types for non-span ref struct out/ref parameters.
-    /// These cannot be boxed into the <see cref="System.Collections.Generic.Dictionary{Int32, Object}"/>
-    /// used by <c>OutRefContext</c>, so the typed setter accepts a delegate instead and the
-    /// generated mock implementation invokes the delegate on the actual <c>out</c>/<c>ref</c> slot.
+    /// Emits namespace-scoped delegate types so non-span ref struct out/ref values can travel
+    /// through <c>OutRefContext</c>'s <c>object?</c> dictionary — the delegate is the reference
+    /// type that gets boxed; the ref struct itself never is.
     /// </summary>
     private static void EmitNonSpanRefStructSetterDelegates(CodeWriter writer, MockTypeModel model, MockMemberModel method)
     {
-        if (method.IsGenericMethod || model.TypeParameters.Length > 0) return;
+        if (!MockImplBuilder.SupportsClosedRefStructSetter(model, method)) return;
 
+        string? safeName = null;
         foreach (var param in method.Parameters)
         {
             if (param.Direction != ParameterDirection.Out && param.Direction != ParameterDirection.Ref) continue;
-            if (!param.IsRefStruct || param.SpanElementType is not null) continue;
+            if (!param.IsNonSpanRefStruct) continue;
 
-            var name = MockImplBuilder.GetOutRefSetterDelegateName(model, method, param);
-            var dir = param.Direction == ParameterDirection.Out ? "out" : "ref";
-            writer.AppendLine($"{model.Visibility} delegate void {name}({dir} {param.FullyQualifiedType} value);");
+            safeName ??= MockImplBuilder.GetCompositeShortSafeName(model);
+            var name = MockImplBuilder.GetOutRefSetterDelegateName(safeName, method, param);
+            writer.AppendLine($"{model.Visibility} delegate void {name}({param.Direction.RefKeyword()} {param.FullyQualifiedType} value);");
         }
     }
 
@@ -622,42 +622,29 @@ internal static class MockMembersBuilder
 
     private static void GenerateTypedOutRefMethods(CodeWriter writer, EquatableArray<MockParameterModel> allParameters, string wrapperName, MockTypeModel model, MockMemberModel method)
     {
-        var canEmitRefStructSetter = !method.IsGenericMethod && model.TypeParameters.Length == 0;
+        var canEmitRefStructSetter = MockImplBuilder.SupportsClosedRefStructSetter(model, method);
+        string? safeName = null;
+        string? nsPrefix = null;
 
         for (int i = 0; i < allParameters.Length; i++)
         {
             var param = allParameters[i];
-            if (param.Direction != ParameterDirection.Out && param.Direction != ParameterDirection.Ref)
-            {
-                continue;
-            }
+            if (param.Direction != ParameterDirection.Out && param.Direction != ParameterDirection.Ref) continue;
+            if (param.IsNonSpanRefStruct && !canEmitRefStructSetter) continue;
 
-            // Non-span ref structs can't be boxed: only emit when we can plumb a typed delegate
-            // (closed-signature, declared at namespace scope, referenced from the impl/bridge).
-            // Skip generic mock types and generic methods for now — those would require generic
-            // delegate types with `allows ref struct` constraints (C# 13) which the netstandard2.0
-            // target can't reliably emit.
-            if (param.IsRefStruct && param.SpanElementType is null && !canEmitRefStructSetter)
-            {
-                continue;
-            }
-
-            var prefix = param.Direction == ParameterDirection.Out ? "SetsOut" : "SetsRef";
-            var methodName = prefix + ToPascalCase(param.Name);
-            var dirLabel = param.Direction == ParameterDirection.Out ? "out" : "ref";
+            var methodName = (param.Direction == ParameterDirection.Out ? "SetsOut" : "SetsRef") + ToPascalCase(param.Name);
+            var dirLabel = param.Direction.RefKeyword();
 
             writer.AppendLine($"/// <summary>Sets the '{param.Name}' {dirLabel} parameter to the specified value when this setup matches.</summary>");
             if (param.SpanElementType is not null)
             {
-                // Span types: convert to array for storage, reconstruct at invocation time
                 writer.AppendLine($"public {wrapperName} {methodName}({param.FullyQualifiedType} {param.Name}) {{ EnsureSetup().SetsOutParameter({i}, {param.Name}.ToArray()); return this; }}");
             }
             else if (param.IsRefStruct)
             {
-                // Non-span ref structs: accept a typed delegate (closed signature) declared at
-                // namespace scope. The delegate itself is a reference type, so the existing
-                // `Dictionary<int, object?>` storage in OutRefContext accepts it unchanged.
-                var delegateFqn = MockImplBuilder.GetOutRefSetterDelegateFqn(model, method, param);
+                safeName ??= MockImplBuilder.GetCompositeShortSafeName(model);
+                nsPrefix ??= MockImplBuilder.GetGlobalMockNamespacePrefix(model);
+                var delegateFqn = nsPrefix + MockImplBuilder.GetOutRefSetterDelegateName(safeName, method, param);
                 writer.AppendLine($"public {wrapperName} {methodName}({delegateFqn} setter) {{ EnsureSetup().SetsOutParameter({i}, setter); return this; }}");
             }
             else
@@ -667,7 +654,7 @@ internal static class MockMembersBuilder
         }
     }
 
-    private static string ToPascalCase(string name)
+    internal static string ToPascalCase(string name)
     {
         if (name.StartsWith("@")) name = name[1..];
         return string.IsNullOrEmpty(name) ? name : char.ToUpperInvariant(name[0]) + name[1..];

--- a/TUnit.Mocks.SourceGenerator/Models/MockParameterModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockParameterModel.cs
@@ -19,6 +19,13 @@ internal sealed record MockParameterModel : IEquatable<MockParameterModel>
     /// </summary>
     public string? SpanElementType { get; init; }
 
+    /// <summary>
+    /// True for a ref struct that is not <see cref="Span{T}"/>/<see cref="ReadOnlySpan{T}"/>. Such
+    /// values can't be boxed into <c>OutRefContext</c>, so out/ref params of this kind use the
+    /// delegate-setter path instead of the array-conversion path.
+    /// </summary>
+    public bool IsNonSpanRefStruct => IsRefStruct && SpanElementType is null;
+
     public bool Equals(MockParameterModel? other)
     {
         if (other is null) return false;
@@ -53,4 +60,13 @@ internal enum ParameterDirection
     Out,
     Ref,
     In_Readonly // in keyword
+}
+
+internal static class ParameterDirectionExtensions
+{
+    /// <summary>Lower-case C# keyword for an out/ref direction. Only valid when <paramref name="d"/> is Out or Ref.</summary>
+    public static string RefKeyword(this ParameterDirection d) => d == ParameterDirection.Out ? "out" : "ref";
+
+    /// <summary>Pascal-case label (Out/Ref) used in generated identifier names.</summary>
+    public static string PascalLabel(this ParameterDirection d) => d == ParameterDirection.Out ? "Out" : "Ref";
 }

--- a/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
+++ b/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
@@ -30,12 +30,6 @@ public interface IMixedRefStruct
     void DoMixed(out int count, out Marker marker, ref ReadOnlySpan<byte> buffer);
 }
 
-/// <summary>
-/// Tests for non-span ref struct out/ref parameters. These cannot be boxed for
-/// storage in <c>OutRefContext</c>, so the source generator emits a typed
-/// delegate setter and invokes the delegate on the actual out/ref slot at
-/// invocation time.
-/// </summary>
 public class NonSpanRefStructOutRefTests
 {
     [Test]
@@ -45,6 +39,7 @@ public class NonSpanRefStructOutRefTests
         mock.Produce().SetsOutMarker((out Marker m) => m = new Marker { Value = 42, Tag = 0xAB });
 
         mock.Object.Produce(out var marker);
+        // Hoist before any await — ref structs can't cross an async state-machine boundary.
         var value = marker.Value;
         var tag = marker.Tag;
 

--- a/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
+++ b/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
@@ -30,6 +30,15 @@ public interface IMixedRefStruct
     void DoMixed(out int count, out Marker marker, ref ReadOnlySpan<byte> buffer);
 }
 
+// Generic interface with a non-span ref struct out param — the closed-signature delegate
+// setter can't be emitted here (would need `allows ref struct` on a generic delegate),
+// so SetsOutMarker is intentionally not generated. The fluent wrapper for this method
+// is suppressed entirely (matching pre-feature behavior for this shape).
+public interface IGenericProducer<T>
+{
+    void Produce(out Marker marker);
+}
+
 public class NonSpanRefStructOutRefTests
 {
     [Test]
@@ -116,6 +125,23 @@ public class NonSpanRefStructOutRefTests
     {
         var mock = IMarkerProducer.Mock();
         mock.Produce().Returns();
+
+        mock.Object.Produce(out var marker);
+        var value = marker.Value;
+        var tag = marker.Tag;
+
+        await Assert.That(value).IsEqualTo(0);
+        await Assert.That(tag).IsEqualTo((byte)0);
+    }
+
+    // Pins the generic-mock boundary: the source generator cannot emit a closed-signature
+    // delegate setter for a non-span ref struct out/ref param on a generic mock type
+    // (would require `allows ref struct` on a generic delegate). The mock still works,
+    // the out param just falls through to its default value with no way to override it.
+    [Test]
+    public async Task Out_NonSpanRefStruct_OnGenericMock_LeavesDefault()
+    {
+        var mock = IGenericProducer<int>.Mock();
 
         mock.Object.Produce(out var marker);
         var value = marker.Value;

--- a/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
+++ b/TUnit.Mocks.Tests/NonSpanRefStructOutRefTests.cs
@@ -1,0 +1,134 @@
+#if NET9_0_OR_GREATER
+
+using System.Text;
+using System.Text.Json;
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks.Tests;
+
+// ─── Test ref structs and interfaces ────────────────────────────────────────
+
+public ref struct Marker
+{
+    public int Value;
+    public byte Tag;
+}
+
+public interface IMarkerProducer
+{
+    void Produce(out Marker marker);
+    bool Mutate(int seed, ref Marker marker);
+}
+
+public interface IJsonReaderProducer
+{
+    void GetReader(out Utf8JsonReader reader);
+}
+
+public interface IMixedRefStruct
+{
+    void DoMixed(out int count, out Marker marker, ref ReadOnlySpan<byte> buffer);
+}
+
+/// <summary>
+/// Tests for non-span ref struct out/ref parameters. These cannot be boxed for
+/// storage in <c>OutRefContext</c>, so the source generator emits a typed
+/// delegate setter and invokes the delegate on the actual out/ref slot at
+/// invocation time.
+/// </summary>
+public class NonSpanRefStructOutRefTests
+{
+    [Test]
+    public async Task Out_UserDefinedRefStruct_Assignment()
+    {
+        var mock = IMarkerProducer.Mock();
+        mock.Produce().SetsOutMarker((out Marker m) => m = new Marker { Value = 42, Tag = 0xAB });
+
+        mock.Object.Produce(out var marker);
+        var value = marker.Value;
+        var tag = marker.Tag;
+
+        await Assert.That(value).IsEqualTo(42);
+        await Assert.That(tag).IsEqualTo((byte)0xAB);
+    }
+
+    [Test]
+    public async Task Ref_UserDefinedRefStruct_Mutation_Observed()
+    {
+        var mock = IMarkerProducer.Mock();
+        var input = new Marker { Value = 1, Tag = 0 };
+
+        mock.Mutate(Arg.Any<int>(), RefStructArg<Marker>.Any)
+            .Returns(true)
+            .SetsRefMarker((ref Marker m) =>
+            {
+                m.Value *= 10;
+                m.Tag = 0xFF;
+            });
+
+        var result = mock.Object.Mutate(5, ref input);
+
+        var value = input.Value;
+        var tag = input.Tag;
+        await Assert.That(result).IsTrue();
+        await Assert.That(value).IsEqualTo(10);
+        await Assert.That(tag).IsEqualTo((byte)0xFF);
+    }
+
+    [Test]
+    public async Task Out_Utf8JsonReader_Bcl_RefStruct()
+    {
+        var mock = IJsonReaderProducer.Mock();
+        var payload = Encoding.UTF8.GetBytes("{\"v\":7}");
+
+        mock.GetReader().SetsOutReader((out Utf8JsonReader r) => r = new Utf8JsonReader(payload));
+
+        mock.Object.GetReader(out var reader);
+        var read = reader.Read();
+        var tokenType = reader.TokenType;
+
+        await Assert.That(read).IsTrue();
+        await Assert.That(tokenType).IsEqualTo(JsonTokenType.StartObject);
+    }
+
+    [Test]
+    public async Task Out_Multiple_Mixed_OutInt_OutRefStruct_RefSpan()
+    {
+        var mock = IMixedRefStruct.Mock();
+
+        mock.DoMixed(RefStructArg<ReadOnlySpan<byte>>.Any)
+            .SetsOutCount(99)
+            .SetsOutMarker((out Marker m) => m = new Marker { Value = 7, Tag = 1 })
+            .SetsRefBuffer(new ReadOnlySpan<byte>([4, 5, 6]));
+
+        var buf = new ReadOnlySpan<byte>([1, 2, 3]);
+        mock.Object.DoMixed(out var count, out var marker, ref buf);
+
+        var markerValue = marker.Value;
+        var markerTag = marker.Tag;
+        var bufLen = buf.Length;
+        var b0 = buf[0];
+
+        await Assert.That(count).IsEqualTo(99);
+        await Assert.That(markerValue).IsEqualTo(7);
+        await Assert.That(markerTag).IsEqualTo((byte)1);
+        await Assert.That(bufLen).IsEqualTo(3);
+        await Assert.That(b0).IsEqualTo((byte)4);
+    }
+
+    [Test]
+    public async Task Out_UserDefinedRefStruct_NoSetter_LeavesDefault()
+    {
+        var mock = IMarkerProducer.Mock();
+        mock.Produce().Returns();
+
+        mock.Object.Produce(out var marker);
+        var value = marker.Value;
+        var tag = marker.Tag;
+
+        await Assert.That(value).IsEqualTo(0);
+        await Assert.That(tag).IsEqualTo((byte)0);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Closes the last remaining concrete gap from discussion #4981. Out/ref params whose type is a non-span ref struct (e.g. `Utf8JsonReader`, `Utf8JsonWriter`, user-defined ref structs) were silently dropped from generated setters and read-back — the value can't be boxed into the `OutRefContext` `Dictionary<int, object?>` slot used for span/byval params.
- Source generator now emits a closed-signature delegate type per `(method, param)` at namespace scope, plus a typed `SetsOut{Param}` / `SetsRef{Param}` setter that accepts it. The generated mock impl invokes the delegate directly on the actual out/ref slot, so the ref struct value never round-trips through `object`.
- Span ref-struct params and boxable params continue to use their existing paths unchanged.

Example:

```csharp
public interface IReader { void Read(out Utf8JsonReader reader); }

var mock = IReader.Mock();
mock.Read().SetsOutReader((out Utf8JsonReader r) => r = new Utf8JsonReader(bytes));
mock.Object.Read(out var reader);
reader.Read(); // works
```

## Scope / limitations
- Generic mock types and generic methods stay on the skip path — they'd need an `allows ref struct` constraint on a generic delegate, which can't be cleanly emitted for the `netstandard2.0` library target. Common case (non-generic interface, non-generic method) is what users actually hit.
- Ref struct *return* types are out of scope — discussion didn't ask for them.

## Test plan
- [x] New `NonSpanRefStructOutRefTests.cs`: out `Utf8JsonReader`, ref user-defined ref struct (mutation observed via delegate), mixed `out int + out RefStruct + ref Span<byte>`, no-setter default
- [x] Full `TUnit.Mocks.Tests` suite passes on net10.0 (973/973)
- [x] `TUnit.Mocks.SourceGenerator` + Roslyn44 variant build clean
- [ ] Snapshot tests — local env has a pre-existing `TUnit.Core` version mismatch (Verify.TUnit pinned to 1.43.11.0) that prevents the snapshot test runner from initializing, on `main` as well. CI will be authoritative.

## Related
- Discussion: https://github.com/thomhurst/TUnit/discussions/4981