### PR TITLE
fix(core): fill optional params when invoking MethodDataSource via reflection

### DIFF
--- a/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
@@ -324,9 +324,7 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
         }
     }
 
-    // Reflection's MethodBase.Invoke does not auto-fill optional parameters the way a C# call site does.
-    // The source generator emits a direct C# call (compiler fills defaults) but the reflection fallback
-    // — used for [InheritsTests] generic abstract bases (issue #5879) — must build the args array itself.
+    // MethodInfo.Invoke does not auto-fill optional parameters the way a C# call site does.
     private static object?[] BuildInvokeArgs(MethodInfo methodInfo, object?[] suppliedArguments)
     {
         var parameters = methodInfo.GetParameters();

--- a/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
@@ -328,8 +328,9 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
     private static object?[] BuildInvokeArgs(MethodInfo methodInfo, object?[] suppliedArguments)
     {
         var parameters = methodInfo.GetParameters();
-        if (parameters.Length == suppliedArguments.Length)
+        if (parameters.Length <= suppliedArguments.Length)
         {
+            // Exact match passes through; surplus supplied args are left to Invoke to surface as a mismatch.
             return suppliedArguments;
         }
 

--- a/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
@@ -196,7 +196,7 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
                 instance = await GetOrCreateInstanceAsync(dataGeneratorMetadata, targetType);
             }
 
-            methodResult = methodInfo.Invoke(instance, Arguments);
+            methodResult = methodInfo.Invoke(instance, BuildInvokeArgs(methodInfo, Arguments));
         }
         else
         {
@@ -322,6 +322,41 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
                 return await Task.FromResult<object?[]?>(methodResult.ToObjectArrayWithTypes(paramTypes));
             };
         }
+    }
+
+    // Reflection's MethodBase.Invoke does not auto-fill optional parameters the way a C# call site does.
+    // The source generator emits a direct C# call (compiler fills defaults) but the reflection fallback
+    // — used for [InheritsTests] generic abstract bases (issue #5879) — must build the args array itself.
+    private static object?[] BuildInvokeArgs(MethodInfo methodInfo, object?[] suppliedArguments)
+    {
+        var parameters = methodInfo.GetParameters();
+        if (parameters.Length == suppliedArguments.Length)
+        {
+            return suppliedArguments;
+        }
+
+        var args = new object?[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (i < suppliedArguments.Length)
+            {
+                args[i] = suppliedArguments[i];
+            }
+            else if (parameters[i].HasDefaultValue)
+            {
+                args[i] = parameters[i].DefaultValue;
+            }
+            else if (parameters[i].ParameterType == typeof(CancellationToken))
+            {
+                args[i] = CancellationToken.None;
+            }
+            else
+            {
+                // More required params than supplied — fall back so Invoke surfaces the original mismatch.
+                return suppliedArguments;
+            }
+        }
+        return args;
     }
 
     private static Type[]? GetMemberTypes(IMemberMetadata[]? members)

--- a/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
@@ -335,23 +335,21 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
         }
 
         var args = new object?[parameters.Length];
-        for (var i = 0; i < parameters.Length; i++)
+        Array.Copy(suppliedArguments, args, suppliedArguments.Length);
+        for (var i = suppliedArguments.Length; i < parameters.Length; i++)
         {
-            if (i < suppliedArguments.Length)
+            var p = parameters[i];
+            if (p.HasDefaultValue)
             {
-                args[i] = suppliedArguments[i];
+                args[i] = Type.Missing;
             }
-            else if (parameters[i].HasDefaultValue)
-            {
-                args[i] = parameters[i].DefaultValue;
-            }
-            else if (parameters[i].ParameterType == typeof(CancellationToken))
+            else if (p.ParameterType == typeof(CancellationToken))
             {
                 args[i] = CancellationToken.None;
             }
             else
             {
-                // More required params than supplied — fall back so Invoke surfaces the original mismatch.
+                // Required param missing — fall back so Invoke surfaces the original mismatch.
                 return suppliedArguments;
             }
         }

--- a/TUnit.TestProject/Bugs/5879/Repro.cs
+++ b/TUnit.TestProject/Bugs/5879/Repro.cs
@@ -1,0 +1,41 @@
+using System.Runtime.CompilerServices;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._5879;
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/issues/5879.
+///
+/// `[InheritsTests]` derived class extends a generic abstract base whose
+/// `[MethodDataSource]` method has an optional `[EnumeratorCancellation] CancellationToken ct = default`
+/// parameter. Source generation can't emit a `Factory` for this case, so the engine
+/// falls back to <c>MethodDataSourceAttribute.GetDataRowsAsync</c>'s reflection
+/// invoke path. <c>MethodInfo.Invoke</c> does not auto-fill defaults like a C# call
+/// site does, so before the fix the call threw <c>TargetParameterCountException</c>.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+[InheritsTests]
+public class Issue5879Tests : Issue5879AbstractBase<string, string>
+{
+    protected override (string, string) Value => ("test", "test");
+}
+
+public abstract class Issue5879AbstractBase<TInput, TExpected>
+{
+    [Test]
+    [MethodDataSource(nameof(DataSource))]
+    public async ValueTask Reproduce((TInput, TExpected) value)
+    {
+        var (input, expected) = value;
+        await Assert.That(input).IsEquivalentTo(expected);
+    }
+
+    public async IAsyncEnumerable<(TInput, TExpected)> DataSource(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return Value;
+        await Task.CompletedTask;
+    }
+
+    protected abstract (TInput, TExpected) Value { get; }
+}


### PR DESCRIPTION
## Summary

- Closes #5879. `[InheritsTests]` derived class on a generic abstract base + a `[MethodDataSource]` method with an optional parameter (e.g. `[EnumeratorCancellation] CancellationToken ct = default`) threw `TargetParameterCountException` at discovery.
- Root cause: `MethodDataSourceAttribute.GetDataRowsAsync` called `methodInfo.Invoke(instance, Arguments)` with `Arguments == []`; reflection's `Invoke` does not auto-fill defaults like a C# call site. The source-gen `Factory` path emits a direct C# call (compiler fills defaults), but the reflection fallback used for the generic abstract base case did not — so the optional CT parameter triggered the count mismatch.
- Fix: added `BuildInvokeArgs(MethodInfo, object?[])` that pads the supplied args to the method's parameter count, filling missing slots with `ParameterInfo.DefaultValue`, then `CancellationToken.None` for `CancellationToken`-typed params without an explicit default, then falling back to the original array so genuine required-param mismatches still surface the original `TargetParameterCountException`.

## Behaviour parity with source-gen

The source generator emits `DataSource()` (`TestMetadataGenerator.cs:1628`) — the C# compiler then fills `default(CancellationToken)`. The reflection path now matches that exactly (`CancellationToken.None`). Plumbing a build-time CT through `IDataSourceAttribute.GetDataRowsAsync` would be a public-API change and is out of scope for this bug fix.

## Test plan

- [x] Regression test: `TUnit.TestProject/Bugs/5879/Repro.cs` — exact repro from the issue, marked `[EngineTest(ExpectedResult.Pass)]`. Throws `TargetParameterCountException` before the fix; passes after.
- [x] `dotnet test TUnit.TestProject --treenode-filter "/*/*/Issue5879Tests/*"` → 1/1 pass.
- [x] `dotnet test TUnit.UnitTests` → 191/191 pass (no regressions in adjacent paths).