### PR TITLE
Mocks: structural fix for Mock<T> / mocked-member name collisions

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
@@ -66,6 +66,52 @@ public static class StaticAbstractImpl_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<int> InstanceValue
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 0, "InstanceValue", true, false);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::StaticAbstractImpl>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
@@ -103,6 +103,52 @@ public static class MyService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::MyService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::MyService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::MyService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::MyService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
@@ -49,6 +49,51 @@ file static class ConfigBasePartialMockFactory
 
 public static class ConfigBase_MockMemberExtensions
 {
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::ConfigBase> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::ConfigBase> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ConfigBase>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::ConfigBase> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
@@ -112,6 +112,52 @@ public static class MyService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::MyService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::MyService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::MyService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::MyService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
@@ -99,6 +99,52 @@ namespace TUnit.Mocks.Generated.MyApp
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_name.Matcher };
             return new MyApp_IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Greet", matchers);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState(this global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::MyApp.IGreeter>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension(global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
@@ -78,6 +78,52 @@ public static class MyService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "DoWork", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::MyService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::MyService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::MyService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::MyService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::MyService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
@@ -108,6 +108,52 @@ public static class IRepository_T__MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
         return new IRepository_T__Save_M1_MockCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState<T>(this global::TUnit.Mocks.Mock<global::IRepository<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IRepository<T>>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension<T>(global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
@@ -109,6 +109,52 @@ namespace Sandbox
             public global::TUnit.Mocks.PropertyMockCall<T> Value
                 => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 0, "Value", true, false);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
@@ -86,6 +86,52 @@ namespace Sandbox
             public global::TUnit.Mocks.PropertyMockCall<T> Value
                 => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 0, "Value", true, false);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
@@ -93,6 +93,52 @@ namespace Sandbox
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
             return new Sandbox_IMapper_TIn_TOut__Map_M0_MockCall<TIn, TOut>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Map", matchers);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState<TIn, TOut>(this global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension<TIn, TOut>(global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
@@ -86,6 +86,52 @@ namespace Sandbox
             var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
             return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
@@ -109,6 +109,52 @@ namespace Sandbox
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_config.Matcher };
             return new Sandbox_IService_T__Apply_M1_MockCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Apply", matchers);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState<T>(this global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Sandbox.IService<T>>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
@@ -124,6 +124,52 @@ public static class ICustomCollection_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<int> Count
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 0, "Count", true, false);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::ICustomCollection> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ICustomCollection>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -97,6 +97,52 @@ public static class IDialogReference_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetReturnValueAsync", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDialogReference> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDialogReference> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDialogReference>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDialogReference> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 
@@ -358,6 +404,52 @@ public static class IDialogService_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("OnShow", (object?)new object?[] { arg1, arg2, arg3, arg4 });
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDialogService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDialogService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDialogService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDialogService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
@@ -82,6 +82,52 @@ public static class ITestEnum_T__MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerator<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetEnumerator", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState<T>(this global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ITestEnum<T>>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension<T>(global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
@@ -123,6 +123,52 @@ public static class IReadWriter_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher };
         return new IReadWriter_Write_M2_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Write", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IReadWriter> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IReadWriter> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IReadWriter>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IReadWriter> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
@@ -105,6 +105,52 @@ public static class IPagedResult_T__MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<int> PageSize
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, 0, "PageSize", true, false);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState<T>(this global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IPagedResult<T>>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension<T>(global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -196,6 +196,52 @@ public static class IAsyncService_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_ct.Matcher };
         return new IAsyncService_InitializeAsync_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "InitializeAsync", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IAsyncService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IAsyncService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IAsyncService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
@@ -153,6 +153,52 @@ public static class INotifier_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("ItemAdded", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::INotifier> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::INotifier> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::INotifier>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::INotifier> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
@@ -156,6 +156,52 @@ public static class IConstrained_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 5, "GetStructDisposable", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IConstrained> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IConstrained> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IConstrained> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IConstrained> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IConstrained> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IConstrained> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IConstrained> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IConstrained>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IConstrained> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -134,6 +134,52 @@ public static class IRepository_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
         return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IRepository> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IRepository> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IRepository>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IRepository> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
@@ -112,6 +112,52 @@ public static class IMyService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<global::ClientConfig>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "CreateDefaultConfig", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IMyServiceMockable>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
@@ -162,6 +162,52 @@ public static class IEscapedNames_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<int> @class
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 0, "class", true, false);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IEscapedNames> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IEscapedNames>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -136,6 +136,52 @@ public static class ITest_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { global::TUnit.Mocks.Matchers.AnyMatcher<int>.Instance, global::TUnit.Mocks.Matchers.AnyMatcher<string>.Instance };
         return new ITest_Get_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Get", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::ITest> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ITest> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ITest> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ITest> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ITest> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::ITest> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::ITest> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ITest>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::ITest> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -210,6 +210,52 @@ public static class IService_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("StatusChanged", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
@@ -173,6 +173,52 @@ public static class IDualEvents_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("Second", (object?)new object?[] { sender, value });
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDualEvents> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDualEvents> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDualEvents>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDualEvents> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
@@ -130,6 +130,52 @@ public static class IFoo_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("Something", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFoo>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
@@ -130,6 +130,52 @@ public static class IFoo_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("Something", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFoo>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
@@ -130,6 +130,52 @@ public static class IFoo_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("Something", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFoo>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -260,6 +260,52 @@ public static class IFoo_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<string?> NullableProp
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, 5, "NullableProp", true, true);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFoo>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
@@ -86,6 +86,52 @@ public static class IDeprecatedApi_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "WithDiagnosticId", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDeprecatedApi>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -71,6 +71,52 @@ public static class BaseDialog_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
         return new BaseDialog_Compute_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Compute", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::BaseDialog> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::BaseDialog> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::BaseDialog>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::BaseDialog> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -455,6 +501,52 @@ public static class IDialogService_MockMemberExtensions
     {
         ((global::TUnit.Mocks.IRaisable)global::TUnit.Mocks.MockRegistry.GetEngine(mock).Raisable!).RaiseEvent("Opened", (object?)e);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDialogService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDialogService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDialogService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDialogService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDialogService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
@@ -120,6 +120,52 @@ public static class IDictionary_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { a.Matcher, b.Matcher };
         return new IDictionary_Swap_M1_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Swap", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IDictionary> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IDictionary> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IDictionary> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IDictionary> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IDictionary> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IDictionary> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IDictionary> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IDictionary>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IDictionary> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
@@ -213,6 +213,52 @@ public static class IFormatter_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_template.Matcher, __fa_arg1.Matcher, __fa_arg2.Matcher };
         return new IFormatter_Format_M3_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "Format", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFormatter> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFormatter> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFormatter> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFormatter> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFormatter> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFormatter> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFormatter> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFormatter>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFormatter> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
@@ -105,6 +105,52 @@ public static class IRepository_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<bool> IsOpen
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, 4, "IsOpen", false, true);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IRepository> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IRepository> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IRepository> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IRepository>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IRepository> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
@@ -139,6 +139,52 @@ public static class IBufferProcessor_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetName", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IBufferProcessor> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IBufferProcessor>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
@@ -134,6 +134,52 @@ public static class IServiceFactory_MockMemberExtensions
         public global::TUnit.Mocks.PropertyMockCall<string> ServiceId
             => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 3, "ServiceId", true, true);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IServiceFactoryMockable>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
@@ -110,6 +110,52 @@ public static class IMyService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetConfigProvider", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IMyService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IMyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IMyService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IMyService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IMyService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IMyService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IMyService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IMyService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IMyService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -123,6 +123,52 @@ public static class IFoo_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<(T?, string)>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetPair", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IFoo> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IFoo> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IFoo>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -171,6 +171,48 @@ public static class ICalculator_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Reset", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ICalculator> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ICalculator> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ICalculator> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ICalculator> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::ICalculator> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::ICalculator> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ICalculator>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::ICalculator> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -115,6 +115,52 @@ namespace ExternalLib
             public global::TUnit.Mocks.PropertyMockCall<string> PublicProperty
                 => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 3, "PublicProperty", true, true);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
@@ -75,6 +75,52 @@ namespace ExternalLib
             var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
             return new ExternalLib_ServiceClient_GetValue_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetValue", matchers);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState(this global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension(global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
@@ -108,6 +108,52 @@ namespace ExternalLib
             public global::TUnit.Mocks.PropertyMockCall<string> Reason
                 => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, 3, "Reason", true, true);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -125,6 +125,52 @@ public static class BaseService_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::BaseService> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::BaseService> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::BaseService> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::BaseService> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::BaseService> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::BaseService> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::BaseService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::BaseService>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::BaseService> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
@@ -122,6 +122,52 @@ public static class SelfEquatableSnapshot_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "ToString", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
@@ -91,6 +91,52 @@ public static class IGreeter_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_name.Matcher };
         return new IGreeter_Greet_M0_MockCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Greet", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::IGreeter> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::IGreeter> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::IGreeter> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::IGreeter> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::IGreeter> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::IGreeter> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::IGreeter> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::IGreeter>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::IGreeter> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
@@ -107,6 +107,52 @@ public static class INotifier_MockMemberExtensions
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
         return new global::TUnit.Mocks.MockMethodCall<string>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetStatus", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::INotifier> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::INotifier> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::INotifier> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::INotifier>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::INotifier> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -96,6 +96,52 @@ namespace ExternalLib
             public global::TUnit.Mocks.PropertyMockCall<string> PublicProperty
                 => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, 2, "PublicProperty", true, true);
         }
+
+        #if NET9_0_OR_GREATER
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void Reset(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+            => global::TUnit.Mocks.Mock.Reset(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyAll(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+            => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+            => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+            => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+            => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void SetState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock, string? stateName)
+            => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void InState(this global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService>> configure)
+            => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+        extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
+        {
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+            public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+            {
+                get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+                set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+            }
+        }
+        #endif
     }
 }
 

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -95,6 +95,52 @@ public static class Repository_MockMemberExtensions
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_item.Matcher };
         return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers);
     }
+
+    #if NET9_0_OR_GREATER
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void Reset(this global::TUnit.Mocks.Mock<global::Repository> mock)
+        => global::TUnit.Mocks.Mock.Reset(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyAll(this global::TUnit.Mocks.Mock<global::Repository> mock)
+        => global::TUnit.Mocks.Mock.VerifyAll(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void VerifyNoOtherCalls(this global::TUnit.Mocks.Mock<global::Repository> mock)
+        => global::TUnit.Mocks.Mock.VerifyNoOtherCalls(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetupAllProperties(this global::TUnit.Mocks.Mock<global::Repository> mock)
+        => global::TUnit.Mocks.Mock.SetupAllProperties(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static global::TUnit.Mocks.Diagnostics.MockDiagnostics GetDiagnostics(this global::TUnit.Mocks.Mock<global::Repository> mock)
+        => global::TUnit.Mocks.Mock.GetDiagnostics(mock);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void SetState(this global::TUnit.Mocks.Mock<global::Repository> mock, string? stateName)
+        => global::TUnit.Mocks.Mock.SetState(mock, stateName);
+
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static void InState(this global::TUnit.Mocks.Mock<global::Repository> mock, string stateName, global::System.Action<global::TUnit.Mocks.Mock<global::Repository>> configure)
+        => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);
+
+    extension(global::TUnit.Mocks.Mock<global::Repository> mock)
+    {
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
+
+        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
+        {
+            get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
+            set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);
+        }
+    }
+    #endif
 }
 
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using TUnit.Mocks.SourceGenerator.Models;
 using static TUnit.Mocks.SourceGenerator.IdentifierEscaping;
 
@@ -16,6 +17,9 @@ internal static class MockMembersBuilder
 {
     private const int MaxTypedParams = 8;
     private const int MaxFuncOverloadParams = 4;
+
+    private const string PriorityMinusOneAttribute =
+        "[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]";
 
     // Closed, structural collision set. Framework operations on Mock<T> live on the
     // IMockControl<T> explicit interface — they are NOT instance members on Mock<T> and
@@ -197,31 +201,40 @@ internal static class MockMembersBuilder
 
     private static string GetSafeMemberName(string name, MockTypeModel model)
     {
-        if (ObjectMemberDisambiguations.TryGetValue(name, out var renamed))
+        // Only escalate when we've actually renamed away from `name`. A passthrough name IS the
+        // user member's own name; comparing it against the user-name set always self-collides.
+        if (ObjectMemberDisambiguations.TryGetValue(name, out var disambiguated))
         {
-            return EscapeIdentifier(EscalateUntilUnique(renamed, model));
+            return EscapeIdentifier(EscalateUntilUnique(disambiguated, GetUserMemberNames(model)));
         }
         if (MockMemberNames.Contains(name))
         {
-            return EscapeIdentifier(EscalateUntilUnique(name + "_", model));
+            return EscapeIdentifier(EscalateUntilUnique(name + "_", GetUserMemberNames(model)));
         }
         return EscapeIdentifier(name);
     }
 
-    // Iteratively append "_" until the candidate name does not collide with any other
-    // member of the mocked type (and its base interfaces). Guards against the
-    // "Object" + "Object_" trailing-underscore overflow case raised in discussion #4981.
-    private static string EscalateUntilUnique(string candidate, MockTypeModel model)
+    // Iteratively append "_" until the candidate doesn't collide with another member of the
+    // mocked type. Guards against the "Object" + "Object_" trailing-underscore overflow from
+    // discussion #4981.
+    private static string EscalateUntilUnique(string candidate, HashSet<string> userMemberNames)
     {
-        var userNames = GetUserMemberNames(model);
-        while (userNames.Contains(candidate))
+        while (userMemberNames.Contains(candidate))
         {
             candidate += "_";
         }
         return candidate;
     }
 
+    // Cached per MockTypeModel instance via ConditionalWeakTable. Build() and its many helpers
+    // call GetUserMemberNames repeatedly across one generator pass; computing once and reusing
+    // avoids ~N HashSet allocations per emitted type.
+    private static readonly ConditionalWeakTable<MockTypeModel, HashSet<string>> _userMemberNamesCache = new();
+
     private static HashSet<string> GetUserMemberNames(MockTypeModel model)
+        => _userMemberNamesCache.GetValue(model, BuildUserMemberNames);
+
+    private static HashSet<string> BuildUserMemberNames(MockTypeModel model)
     {
         var set = new HashSet<string>(System.StringComparer.Ordinal);
         foreach (var m in model.Methods) set.Add(m.Name);
@@ -1268,7 +1281,7 @@ internal static class MockMembersBuilder
             if (!first) writer.AppendLine();
             first = false;
             var paramList = string.IsNullOrEmpty(parms) ? receiverParam : $"{receiverParam}, {parms}";
-            writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+            writer.AppendLine(PriorityMinusOneAttribute);
             writer.AppendLine($"public static {ret} {name}{typeParams}({paramList}){constraints}");
             writer.AppendLine($"    => global::TUnit.Mocks.Mock.{name}(mock{fwd});");
         }
@@ -1278,7 +1291,7 @@ internal static class MockMembersBuilder
         {
             if (!first) writer.AppendLine();
             first = false;
-            writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+            writer.AppendLine(PriorityMinusOneAttribute);
             writer.AppendLine($"public static void InState{typeParams}({receiverParam}, string stateName, global::System.Action<global::TUnit.Mocks.Mock<{mockableType}>> configure){constraints}");
             writer.AppendLine($"    => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);");
         }
@@ -1296,21 +1309,21 @@ internal static class MockMembersBuilder
                 bool firstProp = true;
                 if (hasInvocations)
                 {
-                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);");
                     firstProp = false;
                 }
                 if (hasBehavior)
                 {
                     if (!firstProp) writer.AppendLine();
-                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);");
                     firstProp = false;
                 }
                 if (hasDefaultValueProvider)
                 {
                     if (!firstProp) writer.AppendLine();
-                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    writer.AppendLine(PriorityMinusOneAttribute);
                     using (writer.Block("public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider"))
                     {
                         writer.AppendLine("get => global::TUnit.Mocks.Mock.DefaultValueProvider(mock);");

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -1267,14 +1267,22 @@ internal static class MockMembersBuilder
     {
         var userNames = GetUserMemberNames(model);
 
+        // Cache one Contains() per polyfill name and reuse for both the early-return guard and
+        // the emission below. Each `emitX` is true when the corresponding polyfill SHOULD emit
+        // (i.e. user doesn't already declare that name).
+        var emitMethods = MethodPolyfills.Where(p => !userNames.Contains(p.Name)).ToArray();
+        var emitInState = !userNames.Contains("InState");
+        var emitInvocations = !userNames.Contains("Invocations");
+        var emitBehavior = !userNames.Contains("Behavior");
+        var emitDefaultValueProvider = !userNames.Contains("DefaultValueProvider");
+
         // Skip entirely when every polyfill name collides with a user member — keeps callers
         // from emitting a stray blank line before an empty #if/#endif block.
-        var anyMethod = MethodPolyfills.Any(p => !userNames.Contains(p.Name))
-            || !userNames.Contains("InState");
-        var anyProperty = !userNames.Contains("Invocations")
-            || !userNames.Contains("Behavior")
-            || !userNames.Contains("DefaultValueProvider");
-        if (!anyMethod && !anyProperty) return;
+        if (emitMethods.Length == 0 && !emitInState
+            && !emitInvocations && !emitBehavior && !emitDefaultValueProvider)
+        {
+            return;
+        }
 
         var mockableType = MockImplBuilder.GetMockableTypeName(model);
         var typeParams = MockImplBuilder.GetTypeParameterList(model);
@@ -1285,9 +1293,8 @@ internal static class MockMembersBuilder
 
         bool first = true;
 
-        foreach (var (name, ret, parms, fwd) in MethodPolyfills)
+        foreach (var (name, ret, parms, fwd) in emitMethods)
         {
-            if (userNames.Contains(name)) continue;
             if (!first) writer.AppendLine();
             first = false;
             var paramList = string.IsNullOrEmpty(parms) ? receiverParam : $"{receiverParam}, {parms}";
@@ -1297,7 +1304,7 @@ internal static class MockMembersBuilder
         }
 
         // InState takes an Action<Mock<T>> — emit separately so the generic argument is correct.
-        if (!userNames.Contains("InState"))
+        if (emitInState)
         {
             if (!first) writer.AppendLine();
             first = false;
@@ -1306,31 +1313,28 @@ internal static class MockMembersBuilder
             writer.AppendLine($"    => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);");
         }
 
-        // Property polyfills — emit only if at least one is reachable. Uses C# 14 extension
-        // block syntax so users can write mock.Invocations rather than mock.Invocations().
-        bool hasInvocations = !userNames.Contains("Invocations");
-        bool hasBehavior = !userNames.Contains("Behavior");
-        bool hasDefaultValueProvider = !userNames.Contains("DefaultValueProvider");
-        if (hasInvocations || hasBehavior || hasDefaultValueProvider)
+        // Property polyfills via C# 14 extension block so users write mock.Invocations rather
+        // than mock.Invocations().
+        if (emitInvocations || emitBehavior || emitDefaultValueProvider)
         {
             if (!first) writer.AppendLine();
             using (writer.Block($"extension{typeParams}(global::TUnit.Mocks.Mock<{mockableType}> mock){constraints}"))
             {
                 bool firstProp = true;
-                if (hasInvocations)
+                if (emitInvocations)
                 {
                     writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);");
                     firstProp = false;
                 }
-                if (hasBehavior)
+                if (emitBehavior)
                 {
                     if (!firstProp) writer.AppendLine();
                     writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);");
                     firstProp = false;
                 }
-                if (hasDefaultValueProvider)
+                if (emitDefaultValueProvider)
                 {
                     if (!firstProp) writer.AppendLine();
                     writer.AppendLine(PriorityMinusOneAttribute);

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -132,8 +132,7 @@ internal static class MockMembersBuilder
                 // setup/verify extensions. When the mocked interface already declares a member of
                 // that name, we skip the corresponding polyfill to avoid a CS0111 duplicate — the
                 // framework operation is still reachable via the static helper (Mock.Reset(m), …).
-                if (!firstMember) writer.AppendLine();
-                GenerateMockControlPolyfills(writer, model);
+                GenerateMockControlPolyfills(writer, model, isFirstMember: firstMember);
             }
 
             // Generate unified sealed classes for qualifying methods
@@ -1263,7 +1262,7 @@ internal static class MockMembersBuilder
         ("SetState", "void", "string? stateName", ", stateName"),
     };
 
-    private static void GenerateMockControlPolyfills(CodeWriter writer, MockTypeModel model)
+    private static void GenerateMockControlPolyfills(CodeWriter writer, MockTypeModel model, bool isFirstMember)
     {
         var userNames = GetUserMemberNames(model);
 
@@ -1276,8 +1275,8 @@ internal static class MockMembersBuilder
         var emitBehavior = !userNames.Contains("Behavior");
         var emitDefaultValueProvider = !userNames.Contains("DefaultValueProvider");
 
-        // Skip entirely when every polyfill name collides with a user member — keeps callers
-        // from emitting a stray blank line before an empty #if/#endif block.
+        // Skip entirely when every polyfill name collides with a user member — keeps the
+        // separator blank line (below) and the surrounding #if/#endif from being emitted.
         if (emitMethods.Length == 0 && !emitInState
             && !emitInvocations && !emitBehavior && !emitDefaultValueProvider)
         {
@@ -1289,6 +1288,7 @@ internal static class MockMembersBuilder
         var constraints = MockImplBuilder.GetConstraintClauses(model);
         var receiverParam = $"this global::TUnit.Mocks.Mock<{mockableType}> mock";
 
+        if (!isFirstMember) writer.AppendLine();
         writer.AppendLine("#if NET9_0_OR_GREATER");
 
         bool first = true;

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -17,11 +17,15 @@ internal static class MockMembersBuilder
     private const int MaxTypedParams = 8;
     private const int MaxFuncOverloadParams = 4;
 
-    // Two distinct shadowing problems below — different fixes because the kinds collide differently.
+    // Closed, structural collision set. Framework operations on Mock<T> live on the
+    // IMockControl<T> explicit interface — they are NOT instance members on Mock<T> and
+    // therefore cannot shadow generated extensions. The only names that can ever collide
+    // are the four below: "Object" (the one deliberately-public instance property kept
+    // for ergonomics) plus the three inherited object instance methods.
 
-    // "Object" clashes with the Mock<T>.Object PROPERTY (member-kind collision: property vs.
-    // generated method/property). A trailing underscore is enough since nothing on object
-    // is named "Object_".
+    // "Object" clashes with the Mock<T>.Object PROPERTY. Trailing underscore is the
+    // primary rename; if the user interface declares the suffixed form too, the iterative
+    // suffix in GetSafeMemberName escalates (_, __, ___, …).
     private static readonly HashSet<string> MockMemberNames = new(System.StringComparer.Ordinal)
     {
         "Object",
@@ -116,6 +120,16 @@ internal static class MockMembersBuilder
                     firstMember = false;
                     GenerateRaiseExtensionMethods(writer, model);
                 }
+
+                // net9.0+ ergonomic polyfills: restore instance-style mock.Reset() /
+                // mock.VerifyAll() / mock.Invocations etc. for users via low-priority extensions
+                // emitted into THIS static class. [OverloadResolutionPriority] only ranks within a
+                // single containing type, so the polyfills must live alongside the generated
+                // setup/verify extensions. When the mocked interface already declares a member of
+                // that name, we skip the corresponding polyfill to avoid a CS0111 duplicate — the
+                // framework operation is still reachable via the static helper (Mock.Reset(m), …).
+                if (!firstMember) writer.AppendLine();
+                GenerateMockControlPolyfills(writer, model);
             }
 
             // Generate unified sealed classes for qualifying methods
@@ -181,11 +195,39 @@ internal static class MockMembersBuilder
     private static string GetWrapperName(string safeName, MockMemberModel method)
         => $"{safeName}_{method.Name}_M{method.MemberId}_MockCall";
 
-    private static string GetSafeMemberName(string name)
+    private static string GetSafeMemberName(string name, MockTypeModel model)
     {
         if (ObjectMemberDisambiguations.TryGetValue(name, out var renamed))
-            return renamed;
-        return EscapeIdentifier(MockMemberNames.Contains(name) ? name + "_" : name);
+        {
+            return EscapeIdentifier(EscalateUntilUnique(renamed, model));
+        }
+        if (MockMemberNames.Contains(name))
+        {
+            return EscapeIdentifier(EscalateUntilUnique(name + "_", model));
+        }
+        return EscapeIdentifier(name);
+    }
+
+    // Iteratively append "_" until the candidate name does not collide with any other
+    // member of the mocked type (and its base interfaces). Guards against the
+    // "Object" + "Object_" trailing-underscore overflow case raised in discussion #4981.
+    private static string EscalateUntilUnique(string candidate, MockTypeModel model)
+    {
+        var userNames = GetUserMemberNames(model);
+        while (userNames.Contains(candidate))
+        {
+            candidate += "_";
+        }
+        return candidate;
+    }
+
+    private static HashSet<string> GetUserMemberNames(MockTypeModel model)
+    {
+        var set = new HashSet<string>(System.StringComparer.Ordinal);
+        foreach (var m in model.Methods) set.Add(m.Name);
+        foreach (var p in model.Properties) set.Add(p.Name);
+        foreach (var e in model.Events) set.Add(e.Name);
+        return set;
     }
 
     private static string GetCombinedTypeParameterList(MockTypeModel model, MockMemberModel method)
@@ -836,7 +878,7 @@ internal static class MockMembersBuilder
             ? MockImplBuilder.GetConstraintClauses(method)
             : GetCombinedConstraintClauses(model, method);
 
-        var safeMemberName = GetSafeMemberName(method.Name);
+        var safeMemberName = GetSafeMemberName(method.Name, model);
         var fullParamList = captureModelTypeParameters
             ? paramList
             : BuildExtensionMethodParameterList(model, paramList);
@@ -950,7 +992,7 @@ internal static class MockMembersBuilder
             ? MockImplBuilder.GetConstraintClauses(method)
             : GetCombinedConstraintClauses(model, method);
 
-        var safeMemberName = GetSafeMemberName(method.Name);
+        var safeMemberName = GetSafeMemberName(method.Name, model);
         var paramListInner = "global::TUnit.Mocks.Arguments.AnyArgs _";
         var fullParamList = captureModelTypeParameters
             ? paramListInner
@@ -1062,7 +1104,7 @@ internal static class MockMembersBuilder
             ? MockImplBuilder.GetConstraintClauses(method)
             : GetCombinedConstraintClauses(model, method);
 
-        var safeMemberName = GetSafeMemberName(method.Name);
+        var safeMemberName = GetSafeMemberName(method.Name, model);
         var fullParamList = captureModelTypeParameters
             ? paramList
             : BuildExtensionMethodParameterList(model, paramList);
@@ -1139,7 +1181,7 @@ internal static class MockMembersBuilder
                 var hasGetter = prop.HasGetter ? "true" : "false";
                 var hasSetter = prop.HasSetter ? "true" : "false";
 
-                var safePropName = GetSafeMemberName(prop.Name);
+                var safePropName = GetSafeMemberName(prop.Name, model);
 
                 writer.AppendLine($"public global::TUnit.Mocks.PropertyMockCall<{prop.ReturnType}> {safePropName}");
                 writer.AppendLine($"    => new(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {getterMemberId}, {setterMemberId}, \"{prop.Name}\", {hasGetter}, {hasSetter});");
@@ -1193,6 +1235,92 @@ internal static class MockMembersBuilder
                 writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {indexer.SetterMemberId}, \"set_Item\", matchers);");
             }
         }
+    }
+
+    // Methods polyfilled with instance-style ergonomics on net9.0+. Each entry: (member name,
+    // return type, parameter list excluding `this Mock<T>`, argument list forwarded to the
+    // matching Mock static helper).
+    private static readonly (string Name, string ReturnType, string Parameters, string ForwardArgs)[] MethodPolyfills =
+    {
+        ("Reset", "void", "", ""),
+        ("VerifyAll", "void", "", ""),
+        ("VerifyNoOtherCalls", "void", "", ""),
+        ("SetupAllProperties", "void", "", ""),
+        ("GetDiagnostics", "global::TUnit.Mocks.Diagnostics.MockDiagnostics", "", ""),
+        ("SetState", "void", "string? stateName", ", stateName"),
+    };
+
+    private static void GenerateMockControlPolyfills(CodeWriter writer, MockTypeModel model)
+    {
+        var userNames = GetUserMemberNames(model);
+        var mockableType = MockImplBuilder.GetMockableTypeName(model);
+        var typeParams = MockImplBuilder.GetTypeParameterList(model);
+        var constraints = MockImplBuilder.GetConstraintClauses(model);
+        var receiverParam = $"this global::TUnit.Mocks.Mock<{mockableType}> mock";
+
+        writer.AppendLine("#if NET9_0_OR_GREATER");
+
+        bool first = true;
+
+        foreach (var (name, ret, parms, fwd) in MethodPolyfills)
+        {
+            if (userNames.Contains(name)) continue;
+            if (!first) writer.AppendLine();
+            first = false;
+            var paramList = string.IsNullOrEmpty(parms) ? receiverParam : $"{receiverParam}, {parms}";
+            writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+            writer.AppendLine($"public static {ret} {name}{typeParams}({paramList}){constraints}");
+            writer.AppendLine($"    => global::TUnit.Mocks.Mock.{name}(mock{fwd});");
+        }
+
+        // InState takes an Action<Mock<T>> — emit separately so the generic argument is correct.
+        if (!userNames.Contains("InState"))
+        {
+            if (!first) writer.AppendLine();
+            first = false;
+            writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+            writer.AppendLine($"public static void InState{typeParams}({receiverParam}, string stateName, global::System.Action<global::TUnit.Mocks.Mock<{mockableType}>> configure){constraints}");
+            writer.AppendLine($"    => global::TUnit.Mocks.Mock.InState(mock, stateName, configure);");
+        }
+
+        // Property polyfills — emit only if at least one is reachable. Uses C# 14 extension
+        // block syntax so users can write mock.Invocations rather than mock.Invocations().
+        bool hasInvocations = !userNames.Contains("Invocations");
+        bool hasBehavior = !userNames.Contains("Behavior");
+        bool hasDefaultValueProvider = !userNames.Contains("DefaultValueProvider");
+        if (hasInvocations || hasBehavior || hasDefaultValueProvider)
+        {
+            if (!first) writer.AppendLine();
+            using (writer.Block($"extension{typeParams}(global::TUnit.Mocks.Mock<{mockableType}> mock){constraints}"))
+            {
+                bool firstProp = true;
+                if (hasInvocations)
+                {
+                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    writer.AppendLine("public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);");
+                    firstProp = false;
+                }
+                if (hasBehavior)
+                {
+                    if (!firstProp) writer.AppendLine();
+                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    writer.AppendLine("public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);");
+                    firstProp = false;
+                }
+                if (hasDefaultValueProvider)
+                {
+                    if (!firstProp) writer.AppendLine();
+                    writer.AppendLine("[global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]");
+                    using (writer.Block("public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider"))
+                    {
+                        writer.AppendLine("get => global::TUnit.Mocks.Mock.DefaultValueProvider(mock);");
+                        writer.AppendLine("set => global::TUnit.Mocks.Mock.DefaultValueProvider(mock, value);");
+                    }
+                }
+            }
+        }
+
+        writer.AppendLine("#endif");
     }
 
     private static void GenerateRaiseExtensionMethods(CodeWriter writer, MockTypeModel model)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -1266,6 +1266,16 @@ internal static class MockMembersBuilder
     private static void GenerateMockControlPolyfills(CodeWriter writer, MockTypeModel model)
     {
         var userNames = GetUserMemberNames(model);
+
+        // Skip entirely when every polyfill name collides with a user member — keeps callers
+        // from emitting a stray blank line before an empty #if/#endif block.
+        var anyMethod = MethodPolyfills.Any(p => !userNames.Contains(p.Name))
+            || !userNames.Contains("InState");
+        var anyProperty = !userNames.Contains("Invocations")
+            || !userNames.Contains("Behavior")
+            || !userNames.Contains("DefaultValueProvider");
+        if (!anyMethod && !anyProperty) return;
+
         var mockableType = MockImplBuilder.GetMockableTypeName(model);
         var typeParams = MockImplBuilder.GetTypeParameterList(model);
         var constraints = MockImplBuilder.GetConstraintClauses(model);
@@ -1326,8 +1336,8 @@ internal static class MockMembersBuilder
                     writer.AppendLine(PriorityMinusOneAttribute);
                     using (writer.Block("public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider"))
                     {
-                        writer.AppendLine("get => global::TUnit.Mocks.Mock.DefaultValueProvider(mock);");
-                        writer.AppendLine("set => global::TUnit.Mocks.Mock.DefaultValueProvider(mock, value);");
+                        writer.AppendLine("get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);");
+                        writer.AppendLine("set => global::TUnit.Mocks.Mock.SetDefaultValueProvider(mock, value);");
                     }
                 }
             }

--- a/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
+++ b/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
@@ -211,7 +211,7 @@ public class VerifyAllMessageTests
         // Act — don't call the method
 
         // Assert
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex.Message).Contains("Add(");
         await Assert.That(ex.Message).Contains("never invoked");
     }
@@ -228,7 +228,7 @@ public class VerifyAllMessageTests
         // Act — don't call any methods
 
         // Assert
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex.Message).Contains("Add(");
         await Assert.That(ex.Message).Contains("GetName()");
         await Assert.That(ex.Message).Contains("Log(");
@@ -247,7 +247,7 @@ public class VerifyAllMessageTests
         mock.Object.GetName();
 
         // Assert — no exception
-        mock.VerifyAll();
+        Mock.VerifyAll(mock);
         await Assert.That(true).IsTrue();
     }
 }
@@ -266,7 +266,7 @@ public class InvocationOrderingTests
         mock.Object.GetName();
         mock.Object.Add(3, 4);
 
-        var invocations = mock.Invocations;
+        var invocations = Mock.Invocations(mock);
         await Assert.That(invocations).Count().IsEqualTo(4);
         await Assert.That(invocations[0].MemberName).IsEqualTo("Add");
         await Assert.That(invocations[1].MemberName).IsEqualTo("Log");
@@ -283,7 +283,7 @@ public class InvocationOrderingTests
         mock.Object.GetName();
         mock.Object.Log("msg");
 
-        var invocations = mock.Invocations;
+        var invocations = Mock.Invocations(mock);
         for (int i = 1; i < invocations.Count; i++)
         {
             await Assert.That(invocations[i].SequenceNumber)
@@ -306,7 +306,7 @@ public class AutoTrackPropertyResetTests
     public async Task Reset_Clears_Auto_Tracked_Property_Values()
     {
         var mock = ISettingsService.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
 
         var svc = mock.Object;
         svc.Theme = "dark";
@@ -316,8 +316,8 @@ public class AutoTrackPropertyResetTests
         await Assert.That(svc.FontSize).IsEqualTo(14);
 
         // Reset should clear tracked values
-        mock.Reset();
-        mock.SetupAllProperties();
+        Mock.Reset(mock);
+        Mock.SetupAllProperties(mock);
 
         // After reset + re-enable auto-track, values are back to defaults
         await Assert.That(svc.Theme).IsNotEqualTo("dark");
@@ -374,9 +374,9 @@ public class MockDefaultValueProviderPropertyTests
         var mock = IGreeter.Mock();
         var provider = new FixedStringProvider();
 
-        mock.DefaultValueProvider = provider;
+        Mock.DefaultValueProvider(mock, provider);
 
-        await Assert.That(mock.DefaultValueProvider).IsEqualTo(provider);
+        await Assert.That(Mock.DefaultValueProvider(mock)).IsEqualTo(provider);
     }
 
     [Test]
@@ -399,13 +399,13 @@ public class MockBehaviorPropertyTests
     public async Task Loose_Mock_Has_Loose_Behavior()
     {
         var mock = ICalculator.Mock();
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Loose);
     }
 
     [Test]
     public async Task Strict_Mock_Has_Strict_Behavior()
     {
         var mock = ICalculator.Mock(MockBehavior.Strict);
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
     }
 }

--- a/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
+++ b/TUnit.Mocks.Tests/AdditionalCoverageTests.cs
@@ -374,9 +374,9 @@ public class MockDefaultValueProviderPropertyTests
         var mock = IGreeter.Mock();
         var provider = new FixedStringProvider();
 
-        Mock.DefaultValueProvider(mock, provider);
+        Mock.SetDefaultValueProvider(mock, provider);
 
-        await Assert.That(Mock.DefaultValueProvider(mock)).IsEqualTo(provider);
+        await Assert.That(Mock.GetDefaultValueProvider(mock)).IsEqualTo(provider);
     }
 
     [Test]

--- a/TUnit.Mocks.Tests/AutoTrackPropertyTests.cs
+++ b/TUnit.Mocks.Tests/AutoTrackPropertyTests.cs
@@ -23,7 +23,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — opt in to auto-tracking
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
 
         // Act
         mock.Object.Name = "Alice";
@@ -38,7 +38,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
 
         // Act
         mock.Object.Name = "Bob";
@@ -68,7 +68,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
         mock.Name.Returns("Configured");
 
         // Act — set a tracked value, but explicit setup should win
@@ -83,7 +83,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
 
         // Act — set then overwrite
         mock.Object.Name = "First";
@@ -111,7 +111,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — explicit opt-in enables auto-tracking
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
 
         // Act
         mock.Object.Name = "Alice";
@@ -140,7 +140,7 @@ public class AutoTrackPropertyTests
     {
         // Arrange — strict mode with explicit opt-in
         var mock = IAutoTrackEntity.Mock(MockBehavior.Strict);
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
         mock.Name.Set(Any());
         mock.Name.Returns("");
 
@@ -156,11 +156,11 @@ public class AutoTrackPropertyTests
     {
         // Arrange
         var mock = IAutoTrackEntity.Mock();
-        mock.SetupAllProperties();
+        Mock.SetupAllProperties(mock);
         mock.Object.Name = "Alice";
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — tracked values cleared, but auto-track still active
         await Assert.That(mock.Object.Name).IsEmpty();

--- a/TUnit.Mocks.Tests/BasicMockTests.cs
+++ b/TUnit.Mocks.Tests/BasicMockTests.cs
@@ -160,7 +160,7 @@ public class BasicMockTests
         await Assert.That(calc.Add(1, 1)).IsEqualTo(42);
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — after reset, returns default
         await Assert.That(calc.Add(1, 1)).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
+++ b/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
@@ -28,7 +28,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = IGreeter.Mock();
-        mock.DefaultValueProvider = new CustomProvider();
+        Mock.DefaultValueProvider(mock, new CustomProvider());
 
         IGreeter greeter = mock.Object;
 
@@ -44,7 +44,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = ICalculator.Mock();
-        mock.DefaultValueProvider = new CustomProvider();
+        Mock.DefaultValueProvider(mock, new CustomProvider());
 
         ICalculator calc = mock.Object;
 
@@ -60,7 +60,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = ICalculator.Mock();
-        mock.DefaultValueProvider = new CustomProvider();
+        Mock.DefaultValueProvider(mock, new CustomProvider());
         mock.Add(1, 2).Returns(100);
 
         ICalculator calc = mock.Object;
@@ -92,7 +92,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = IGreeter.Mock();
-        mock.DefaultValueProvider = DefaultValueProvider.Instance;
+        Mock.DefaultValueProvider(mock, DefaultValueProvider.Instance);
 
         IGreeter greeter = mock.Object;
 

--- a/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
+++ b/TUnit.Mocks.Tests/DefaultValueProviderTests.cs
@@ -28,7 +28,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = IGreeter.Mock();
-        Mock.DefaultValueProvider(mock, new CustomProvider());
+        Mock.SetDefaultValueProvider(mock, new CustomProvider());
 
         IGreeter greeter = mock.Object;
 
@@ -44,7 +44,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = ICalculator.Mock();
-        Mock.DefaultValueProvider(mock, new CustomProvider());
+        Mock.SetDefaultValueProvider(mock, new CustomProvider());
 
         ICalculator calc = mock.Object;
 
@@ -60,7 +60,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = ICalculator.Mock();
-        Mock.DefaultValueProvider(mock, new CustomProvider());
+        Mock.SetDefaultValueProvider(mock, new CustomProvider());
         mock.Add(1, 2).Returns(100);
 
         ICalculator calc = mock.Object;
@@ -92,7 +92,7 @@ public class DefaultValueProviderTests
     {
         // Arrange
         var mock = IGreeter.Mock();
-        Mock.DefaultValueProvider(mock, DefaultValueProvider.Instance);
+        Mock.SetDefaultValueProvider(mock, DefaultValueProvider.Instance);
 
         IGreeter greeter = mock.Object;
 

--- a/TUnit.Mocks.Tests/DiagnosticsTests.cs
+++ b/TUnit.Mocks.Tests/DiagnosticsTests.cs
@@ -16,7 +16,7 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(1, 2); // only exercise the first setup
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.TotalSetups).IsEqualTo(2);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(1);
@@ -36,7 +36,7 @@ public class DiagnosticsTests
         _ = calc.Add(1, 2); // matches setup
         _ = calc.Add(5, 5); // no setup match — unmatched
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.UnmatchedCalls).Count().IsEqualTo(1);
         await Assert.That(diag.UnmatchedCalls[0].MemberName).IsEqualTo("Add");
@@ -52,7 +52,7 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(1, 2);
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.TotalSetups).IsEqualTo(1);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(1);
@@ -67,7 +67,7 @@ public class DiagnosticsTests
         mock.Add(1, 2).Returns(3);
         mock.Add(3, 4).Returns(7);
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.TotalSetups).IsEqualTo(2);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);
@@ -80,7 +80,7 @@ public class DiagnosticsTests
         var mock = ICalculator.Mock();
         mock.Add(Any(), Is<int>(x => x > 0)).Returns(1);
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.UnusedSetups).Count().IsEqualTo(1);
         var setup = diag.UnusedSetups[0];
@@ -98,9 +98,9 @@ public class DiagnosticsTests
         ICalculator calc = mock.Object;
         _ = calc.Add(5, 5); // unmatched
 
-        mock.Reset();
+        Mock.Reset(mock);
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.TotalSetups).IsEqualTo(0);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);
@@ -113,7 +113,7 @@ public class DiagnosticsTests
     {
         var mock = ICalculator.Mock();
 
-        var diag = mock.GetDiagnostics();
+        var diag = Mock.GetDiagnostics(mock);
 
         await Assert.That(diag.TotalSetups).IsEqualTo(0);
         await Assert.That(diag.ExercisedSetups).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/EdgeCaseTests.cs
+++ b/TUnit.Mocks.Tests/EdgeCaseTests.cs
@@ -582,7 +582,7 @@ public class ResetReconfigurationTests
         await Assert.That(firstResult).IsEqualTo("A");
 
         // Reset and reconfigure
-        mock.Reset();
+        Mock.Reset(mock);
         mock.GetConfig("key").Returns("B");
 
         // Second phase
@@ -609,7 +609,7 @@ public class ResetReconfigurationTests
         mock.GetConfig("key2").WasCalled(Times.Once);
 
         // Reset — clears call history
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Post-reset: previous calls should not count
         mock.GetConfig("key1").WasNeverCalled();

--- a/TUnit.Mocks.Tests/EventSubscriptionSetupTests.cs
+++ b/TUnit.Mocks.Tests/EventSubscriptionSetupTests.cs
@@ -87,7 +87,7 @@ public class EventSubscriptionSetupTests
         var callbackFired = false;
 
         mock.Events.DataReady.OnSubscribe(() => callbackFired = true);
-        mock.Reset();
+        Mock.Reset(mock);
 
         mock.Object.DataReady += (sender, args) => { };
 

--- a/TUnit.Mocks.Tests/EventSubscriptionVerifyTests.cs
+++ b/TUnit.Mocks.Tests/EventSubscriptionVerifyTests.cs
@@ -83,7 +83,7 @@ public class EventSubscriptionVerifyTests
         mock.Object.OnStringAction += _ => { };
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert
         await Assert.That(mock.Events.OnStringAction.WasSubscribed).IsFalse();

--- a/TUnit.Mocks.Tests/InvocationsTests.cs
+++ b/TUnit.Mocks.Tests/InvocationsTests.cs
@@ -19,7 +19,7 @@ public class InvocationsTests
         svc.GetValue("key2");
         svc.Process(42);
 
-        await Assert.That(mock.Invocations.Count).IsEqualTo(3);
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(3);
     }
 
     [Test]
@@ -32,7 +32,7 @@ public class InvocationsTests
         svc.GetValue("key1");
         svc.Process(99);
 
-        var invocations = mock.Invocations;
+        var invocations = Mock.Invocations(mock);
         await Assert.That(invocations[0].MemberName).IsEqualTo("GetValue");
         await Assert.That(invocations[1].MemberName).IsEqualTo("Process");
     }
@@ -46,14 +46,14 @@ public class InvocationsTests
         var svc = mock.Object;
         svc.GetValue("hello");
 
-        await Assert.That(mock.Invocations[0].Arguments[0]).IsEqualTo("hello");
+        await Assert.That(Mock.Invocations(mock)[0].Arguments[0]).IsEqualTo("hello");
     }
 
     [Test]
     public async Task Invocations_Is_Empty_When_No_Calls_Made()
     {
         var mock = IService.Mock();
-        await Assert.That(mock.Invocations.Count).IsEqualTo(0);
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(0);
     }
 
     [Test]
@@ -65,8 +65,8 @@ public class InvocationsTests
         var svc = mock.Object;
         svc.GetValue("key1");
 
-        mock.Reset();
+        Mock.Reset(mock);
 
-        await Assert.That(mock.Invocations.Count).IsEqualTo(0);
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(0);
     }
 }

--- a/TUnit.Mocks.Tests/MockRepositoryTests.cs
+++ b/TUnit.Mocks.Tests/MockRepositoryTests.cs
@@ -137,8 +137,8 @@ public class MockRepositoryTests
 
         // Assert — setups and history are cleared
         await Assert.That(serviceMock.Object.GetData(1)).IsEmpty(); // no setup, returns smart default
-        await Assert.That(serviceMock.Invocations).Count().IsEqualTo(1); // only the new call
-        await Assert.That(loggerMock.Invocations).Count().IsEqualTo(0); // history cleared
+        await Assert.That(Mock.Invocations(serviceMock)).Count().IsEqualTo(1); // only the new call
+        await Assert.That(Mock.Invocations(loggerMock)).Count().IsEqualTo(0); // history cleared
     }
 
     [Test]
@@ -149,7 +149,7 @@ public class MockRepositoryTests
         var mock = repo.Of<IRepoService>();
 
         // Assert — mock inherits strict behavior
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -160,7 +160,7 @@ public class MockRepositoryTests
         var looseMock = repo.Of<IRepoService>(MockBehavior.Loose);
 
         // Assert — specific behavior overrides repository default
-        await Assert.That(looseMock.Behavior).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(Mock.Behavior(looseMock)).IsEqualTo(MockBehavior.Loose);
     }
 
     [Test]
@@ -274,7 +274,7 @@ public class MockRepositoryTests
         var mock = repo.Of<ConcreteService>();
 
         // Assert — partial mock inherits strict behavior from repository
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -285,6 +285,6 @@ public class MockRepositoryTests
         var mock = repo.Of<ConcreteService>(MockBehavior.Loose);
 
         // Assert — behavior overridden
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Loose);
     }
 }

--- a/TUnit.Mocks.Tests/MultipleInterfaceTests.cs
+++ b/TUnit.Mocks.Tests/MultipleInterfaceTests.cs
@@ -114,7 +114,7 @@ public class MultipleInterfaceTests
         ((IMultiDisposable)mock.Object).Dispose();
 
         // Assert — all calls recorded in invocations
-        await Assert.That(mock.Invocations).Count().IsEqualTo(2);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(2);
     }
 
     [Test]
@@ -180,7 +180,7 @@ public class MultipleInterfaceTests
         ((IMultiCloneable)mock.Object).Clone();
 
         // Assert — all 4 calls tracked
-        await Assert.That(mock.Invocations).Count().IsEqualTo(4);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(4);
     }
 
     [Test]
@@ -190,6 +190,6 @@ public class MultipleInterfaceTests
         var mock = Mock.Of<IMultiLogger, IMultiDisposable>(MockBehavior.Strict);
 
         // Assert — strict behavior inherited
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
     }
 }

--- a/TUnit.Mocks.Tests/NameCollisionTests.cs
+++ b/TUnit.Mocks.Tests/NameCollisionTests.cs
@@ -1,0 +1,219 @@
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks.Tests;
+
+/// <summary>
+/// Verifies that source-generated extension members never collide with framework members on
+/// <see cref="Mock{T}"/>. Each interface here defines members whose names match either the
+/// one deliberately-public Mock&lt;T&gt; instance property (<c>Object</c>) or the inherited
+/// <c>object</c> methods (<c>Equals</c>, <c>GetHashCode</c>, <c>ToString</c>). All framework
+/// operations live on <see cref="IMockControl{T}"/> as explicit interface implementations and
+/// are reached via <see cref="Mock"/> static helpers, so members named <c>Reset</c>,
+/// <c>VerifyAll</c>, <c>Invocations</c>, etc. on the mocked interface are reachable as
+/// generated extensions without conflict.
+/// </summary>
+public class NameCollisionTests
+{
+    public interface IFrameworkNameMember
+    {
+        // Names that previously lived as public instance members on Mock<T>. They must
+        // now be reachable as generated setup/verify extensions, not shadowed by Mock<T>.
+        int Reset();
+        int VerifyAll();
+        int VerifyNoOtherCalls();
+        int Invocations();
+        int Behavior();
+        int SetupAllProperties();
+        int GetDiagnostics();
+        int SetState(string s);
+        int InState();
+        int DefaultValueProvider();
+    }
+
+    [Test]
+    public async Task Generated_Extensions_Win_Over_Former_Framework_Member_Names()
+    {
+        var mock = IFrameworkNameMember.Mock();
+
+        mock.Reset().Returns(1);
+        mock.VerifyAll().Returns(2);
+        mock.VerifyNoOtherCalls().Returns(3);
+        mock.Invocations().Returns(4);
+        mock.Behavior().Returns(5);
+        mock.SetupAllProperties().Returns(6);
+        mock.GetDiagnostics().Returns(7);
+        mock.SetState(Any()).Returns(8);
+        mock.InState().Returns(9);
+        mock.DefaultValueProvider().Returns(10);
+
+        var svc = mock.Object;
+        await Assert.That(svc.Reset()).IsEqualTo(1);
+        await Assert.That(svc.VerifyAll()).IsEqualTo(2);
+        await Assert.That(svc.VerifyNoOtherCalls()).IsEqualTo(3);
+        await Assert.That(svc.Invocations()).IsEqualTo(4);
+        await Assert.That(svc.Behavior()).IsEqualTo(5);
+        await Assert.That(svc.SetupAllProperties()).IsEqualTo(6);
+        await Assert.That(svc.GetDiagnostics()).IsEqualTo(7);
+        await Assert.That(svc.SetState("x")).IsEqualTo(8);
+        await Assert.That(svc.InState()).IsEqualTo(9);
+        await Assert.That(svc.DefaultValueProvider()).IsEqualTo(10);
+
+        mock.Reset().WasCalled(Times.Once);
+        mock.SetState("x").WasCalled(Times.Once);
+
+        // Framework operations remain reachable via the static helpers.
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(10);
+        Mock.Reset(mock);
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(0);
+    }
+
+    public interface IObjectCollision
+    {
+        int Object { get; }
+    }
+
+    [Test]
+    public async Task User_Object_Property_Is_Reachable_Via_Renamed_Extension()
+    {
+        var mock = IObjectCollision.Mock();
+        // The Mock<T>.Object property still exists, so the generated extension is renamed.
+        // The single-trailing-underscore form is the primary rename.
+        mock.Object_.Returns(42);
+
+        await Assert.That(mock.Object.Object).IsEqualTo(42);
+    }
+
+    public interface IObjectOverflow
+    {
+        int Object { get; }
+        int Object_ { get; }
+    }
+
+    [Test]
+    public async Task Object_And_Object_Underscore_Both_Reachable_With_Iterative_Suffix()
+    {
+        var mock = IObjectOverflow.Mock();
+        // User's Object property — extension renamed past the user-defined Object_ to Object__.
+        mock.Object__.Returns(7);
+        // User's Object_ property — name doesn't clash with framework, kept as Object_.
+        mock.Object_.Returns(11);
+
+        await Assert.That(mock.Object.Object).IsEqualTo(7);
+        await Assert.That(mock.Object.Object_).IsEqualTo(11);
+    }
+
+    public interface IEqualsCollision
+    {
+        bool Equals(string other);
+        int GetHashCode(int seed);
+        string ToString(string format);
+    }
+
+    [Test]
+    public async Task Inherited_Object_Method_Names_Use_Of_Suffix()
+    {
+        var mock = IEqualsCollision.Mock();
+        mock.EqualsOf(Any()).Returns(true);
+        mock.GetHashCodeOf(Any()).Returns(99);
+        mock.ToStringOf(Any()).Returns("formatted");
+
+        var svc = mock.Object;
+        await Assert.That(svc.Equals("x")).IsTrue();
+        await Assert.That(svc.GetHashCode(5)).IsEqualTo(99);
+        await Assert.That(svc.ToString("D")).IsEqualTo("formatted");
+    }
+
+    public interface IPolyfillSubject
+    {
+        // Plain interface — no member names that overlap with framework operations,
+        // so the net9.0+ generator polyfills emit instance-style ergonomics for
+        // Reset / VerifyAll / Invocations / etc.
+        int GetValue();
+    }
+
+#if NET9_0_OR_GREATER
+    [Test]
+    public async Task Polyfill_Restores_Instance_Style_Mock_Reset_On_Net9_Plus()
+    {
+        var mock = IPolyfillSubject.Mock();
+        mock.GetValue().Returns(7);
+
+        await Assert.That(mock.Object.GetValue()).IsEqualTo(7);
+        await Assert.That(mock.Invocations.Count).IsEqualTo(1);
+
+        mock.Reset();
+
+        await Assert.That(mock.Invocations.Count).IsEqualTo(0);
+        await Assert.That(mock.Object.GetValue()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Polyfill_VerifyAll_And_VerifyNoOtherCalls_Reachable()
+    {
+        var mock = IPolyfillSubject.Mock();
+        mock.GetValue().Returns(1);
+        _ = mock.Object.GetValue();
+
+        // No throw — setup invoked, no unverified calls outside the WasCalled.
+        mock.GetValue().WasCalled();
+        mock.VerifyNoOtherCalls();
+        mock.VerifyAll();
+        await Assert.That(true).IsTrue();
+    }
+
+    [Test]
+    public async Task Polyfill_Property_Getters_And_Setter_Are_Reachable()
+    {
+        var mock = IPolyfillSubject.Mock();
+        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(mock.Invocations).IsNotNull();
+
+        var provider = new NoopDefaults();
+        mock.DefaultValueProvider = provider;
+        await Assert.That(mock.DefaultValueProvider).IsSameReferenceAs(provider);
+    }
+
+    private sealed class NoopDefaults : IDefaultValueProvider
+    {
+        public bool CanProvide(Type type) => false;
+        public object? GetDefaultValue(Type type) => null;
+    }
+
+    [Test]
+    public async Task Polyfill_Skipped_When_User_Member_Collides()
+    {
+        // IFrameworkNameMember.Reset is a user-declared method returning int.
+        // The polyfill must NOT emit a competing void Reset(this Mock<T>) — the user's
+        // generated setup extension is the only mock.Reset(...) form. Reaching the
+        // framework operation requires Mock.Reset(mock).
+        var mock = IFrameworkNameMember.Mock();
+        mock.Reset().Returns(99);
+        await Assert.That(mock.Object.Reset()).IsEqualTo(99);
+
+        // The static helper remains the canonical way to clear setups.
+        Mock.Reset(mock);
+        await Assert.That(Mock.Invocations(mock).Count).IsEqualTo(0);
+    }
+#endif
+
+    public interface IEqualsOfOverflow
+    {
+        bool Equals(string other);
+        bool EqualsOf(string other);
+    }
+
+    [Test]
+    public async Task EqualsOf_Overflow_Escalates_With_Underscore()
+    {
+        var mock = IEqualsOfOverflow.Mock();
+        // User's Equals — primary rename EqualsOf collides with user-defined EqualsOf,
+        // iterative suffix escalates to EqualsOf_.
+        mock.EqualsOf_(Any()).Returns(true);
+        // User's literal EqualsOf — unchanged (only Equals/GetHashCode/ToString are renamed).
+        mock.EqualsOf(Any()).Returns(false);
+
+        var svc = mock.Object;
+        await Assert.That(svc.Equals("x")).IsTrue();
+        await Assert.That(svc.EqualsOf("x")).IsFalse();
+    }
+}

--- a/TUnit.Mocks.Tests/OrderedVerificationTests.cs
+++ b/TUnit.Mocks.Tests/OrderedVerificationTests.cs
@@ -340,7 +340,7 @@ public class OrderedVerificationTests
         });
 
         // This should pass because the calls above were verified in VerifyInOrder
-        mock.VerifyNoOtherCalls();
+        Mock.VerifyNoOtherCalls(mock);
     }
 
     [Test]
@@ -365,7 +365,7 @@ public class OrderedVerificationTests
         // Log("hello") was not verified, so this should fail
         var exception = Assert.Throws<MockVerificationException>(() =>
         {
-            mock.VerifyNoOtherCalls();
+            Mock.VerifyNoOtherCalls(mock);
         });
 
         await Assert.That(exception.Message).Contains("Log(hello)");

--- a/TUnit.Mocks.Tests/PerformanceOptimizationTests.cs
+++ b/TUnit.Mocks.Tests/PerformanceOptimizationTests.cs
@@ -35,7 +35,7 @@ public class PerformanceOptimizationTests
         calc.Log("msg2");
 
         // Assert — total invocations correct
-        await Assert.That(mock.Invocations).Count().IsEqualTo(6);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(6);
 
         // Verify per-member counts via WasCalled
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(3));
@@ -56,14 +56,14 @@ public class PerformanceOptimizationTests
         calc.Add(3, 4);
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(2));
 
-        mock.Reset();
+        Mock.Reset(mock);
         mock.Add(Any(), Any()).Returns(99);
 
         calc.Add(5, 6);
 
         // Assert — only one call after reset
         mock.Add(Any(), Any()).WasCalled(Times.Once);
-        await Assert.That(mock.Invocations).Count().IsEqualTo(1);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -85,7 +85,7 @@ public class PerformanceOptimizationTests
         // Assert — verify correct counts per member
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(2));
         mock.GetName().WasCalled(Times.Exactly(3));
-        await Assert.That(mock.Invocations).Count().IsEqualTo(5);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(5);
     }
 
     // ========================================================================
@@ -262,7 +262,7 @@ public class PerformanceOptimizationTests
         await Task.WhenAll(addTasks.Concat(nameTasks));
 
         // Assert — all 100 calls recorded
-        await Assert.That(mock.Invocations).Count().IsEqualTo(100);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(100);
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(50));
         mock.GetName().WasCalled(Times.Exactly(50));
     }
@@ -325,7 +325,7 @@ public class PerformanceOptimizationTests
         calc.GetName();
 
         // Assert — VerifyAll should iterate all setups in flat array
-        mock.VerifyAll();
+        Mock.VerifyAll(mock);
         await Assert.That(true).IsTrue();
     }
 
@@ -341,7 +341,7 @@ public class PerformanceOptimizationTests
         calc.Add(1, 2); // Only call Add, not GetName
 
         // Assert — should fail because GetName setup was not invoked
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex).IsNotNull();
     }
 
@@ -360,7 +360,7 @@ public class PerformanceOptimizationTests
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(2));
 
         // Assert — no unverified calls
-        mock.VerifyNoOtherCalls();
+        Mock.VerifyNoOtherCalls(mock);
         await Assert.That(true).IsTrue();
     }
 
@@ -380,7 +380,7 @@ public class PerformanceOptimizationTests
         mock.Add(Any(), Any()).WasCalled(Times.Once);
 
         // Assert — GetName call is unverified
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyNoOtherCalls());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyNoOtherCalls(mock));
         await Assert.That(ex).IsNotNull();
     }
 
@@ -402,13 +402,13 @@ public class PerformanceOptimizationTests
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(3));
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — all counters reset
         mock.Add(Any(), Any()).WasNeverCalled();
         mock.GetName().WasNeverCalled();
         mock.Log(Any()).WasNeverCalled();
-        await Assert.That(mock.Invocations).Count().IsEqualTo(0);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -424,7 +424,7 @@ public class PerformanceOptimizationTests
         await Assert.That(calc.GetName()).IsEqualTo("first");
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
         mock.Add(1, 2).Returns(200);
         mock.GetName().Returns("second");
 
@@ -445,12 +445,12 @@ public class PerformanceOptimizationTests
             calc.Add(1, 2);
             await Assert.That(calc.Add(1, 2)).IsEqualTo(cycle);
             mock.Add(Any(), Any()).WasCalled(Times.Exactly(2));
-            mock.Reset();
+            Mock.Reset(mock);
         }
 
         // Final state: clean
         mock.Add(Any(), Any()).WasNeverCalled();
-        await Assert.That(mock.Invocations).Count().IsEqualTo(0);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(0);
     }
 
     // ========================================================================
@@ -467,7 +467,7 @@ public class PerformanceOptimizationTests
         mock.Add(Any(), Any()).WasNeverCalled();
         mock.GetName().WasNeverCalled();
         mock.Log(Any()).WasNeverCalled();
-        await Assert.That(mock.Invocations).Count().IsEqualTo(0);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(0);
     }
 
     [Test]
@@ -483,7 +483,7 @@ public class PerformanceOptimizationTests
         calc.GetName();
 
         // Assert — all calls recorded even without setups
-        await Assert.That(mock.Invocations).Count().IsEqualTo(3);
+        await Assert.That(Mock.Invocations(mock)).Count().IsEqualTo(3);
         mock.Add(Any(), Any()).WasCalled(Times.Once);
         mock.Log(Any()).WasCalled(Times.Once);
         mock.GetName().WasCalled(Times.Once);

--- a/TUnit.Mocks.Tests/ProtectedMemberTests.cs
+++ b/TUnit.Mocks.Tests/ProtectedMemberTests.cs
@@ -88,7 +88,7 @@ public class ProtectedMemberTests
         mock.Object.ProcessAndFormat(7);
 
         // Assert — both ComputeValue (base call) and FormatResult are recorded
-        await Assert.That(mock.Invocations).Count().IsGreaterThanOrEqualTo(2);
+        await Assert.That(Mock.Invocations(mock)).Count().IsGreaterThanOrEqualTo(2);
     }
 
     [Test]

--- a/TUnit.Mocks.Tests/ResetTests.cs
+++ b/TUnit.Mocks.Tests/ResetTests.cs
@@ -23,7 +23,7 @@ public class ResetTests
         await Assert.That(calc.Add(3, 4)).IsEqualTo(99);
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — after reset, all setups are gone, returns default
         await Assert.That(calc.Add(1, 2)).IsEqualTo(0);
@@ -44,7 +44,7 @@ public class ResetTests
         mock.Add(Any(), Any()).WasCalled(Times.Exactly(3));
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — after reset, call history is cleared
         mock.Add(Any(), Any()).WasNeverCalled();
@@ -62,7 +62,7 @@ public class ResetTests
         await Assert.That(calc.Add(1, 2)).IsEqualTo(42);
 
         // Act — reset and reconfigure with different return value
-        mock.Reset();
+        Mock.Reset(mock);
         mock.Add(1, 2).Returns(100);
 
         // Assert — new setup is in effect
@@ -81,7 +81,7 @@ public class ResetTests
         mock.Add(1, 2).WasCalled(Times.Exactly(2));
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Make one new call
         calc.Add(1, 2);
@@ -102,7 +102,7 @@ public class ResetTests
         await Assert.That(calc.Add(1, 2)).IsEqualTo(3);
 
         // Act — reset clears all setups
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — strict mock throws again for unconfigured calls
         var exception = Assert.Throws<MockStrictBehaviorException>(() =>
@@ -125,7 +125,7 @@ public class ResetTests
         await Assert.That(greeter.Greet("Alice")).IsEqualTo("Hello, Alice!");
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — after reset, returns default (empty string for non-nullable string)
         var result = greeter.Greet("Alice");
@@ -144,7 +144,7 @@ public class ResetTests
         mock.Log(Any()).WasCalled(Times.Exactly(2));
 
         // Act
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Assert — void method call history is cleared
         mock.Log(Any()).WasNeverCalled();
@@ -163,7 +163,7 @@ public class ResetTests
         mock.Add(1, 1).WasCalled(Times.Once);
 
         // Act — reset
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Re-setup with new values
         mock.Add(1, 1).Returns(20);
@@ -188,17 +188,17 @@ public class ResetTests
         // First cycle
         mock.Add(1, 1).Returns(10);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(10);
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Second cycle
         mock.Add(1, 1).Returns(20);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(20);
-        mock.Reset();
+        Mock.Reset(mock);
 
         // Third cycle
         mock.Add(1, 1).Returns(30);
         await Assert.That(calc.Add(1, 1)).IsEqualTo(30);
-        mock.Reset();
+        Mock.Reset(mock);
 
         // After final reset — returns default
         await Assert.That(calc.Add(1, 1)).IsEqualTo(0);

--- a/TUnit.Mocks.Tests/StateMachineTests.cs
+++ b/TUnit.Mocks.Tests/StateMachineTests.cs
@@ -15,14 +15,14 @@ public class StateMachineTests
     public async Task State_Machine_Returns_Different_Values_Per_State()
     {
         var mock = IConnection.Mock();
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
 
-        mock.InState("disconnected", m =>
+        Mock.InState(mock, "disconnected", m =>
         {
             m.GetStatus().Returns("OFFLINE");
         });
 
-        mock.InState("connected", m =>
+        Mock.InState(mock, "connected", m =>
         {
             m.GetStatus().Returns("ONLINE");
         });
@@ -31,10 +31,10 @@ public class StateMachineTests
 
         await Assert.That(conn.GetStatus()).IsEqualTo("OFFLINE");
 
-        mock.SetState("connected");
+        Mock.SetState(mock, "connected");
         await Assert.That(conn.GetStatus()).IsEqualTo("ONLINE");
 
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
         await Assert.That(conn.GetStatus()).IsEqualTo("OFFLINE");
     }
 
@@ -42,15 +42,15 @@ public class StateMachineTests
     public async Task TransitionsTo_Changes_State_After_Call()
     {
         var mock = IConnection.Mock();
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
 
-        mock.InState("disconnected", m =>
+        Mock.InState(mock, "disconnected", m =>
         {
             m.Connect().TransitionsTo("connected");
             m.GetStatus().Returns("OFFLINE");
         });
 
-        mock.InState("connected", m =>
+        Mock.InState(mock, "connected", m =>
         {
             m.Disconnect().TransitionsTo("disconnected");
             m.GetStatus().Returns("ONLINE");
@@ -71,14 +71,14 @@ public class StateMachineTests
     public async Task State_Scoped_Throws()
     {
         var mock = IConnection.Mock();
-        mock.SetState("connected");
+        Mock.SetState(mock, "connected");
 
-        mock.InState("connected", m =>
+        Mock.InState(mock, "connected", m =>
         {
             m.Connect().Throws<InvalidOperationException>();
         });
 
-        mock.InState("disconnected", m =>
+        Mock.InState(mock, "disconnected", m =>
         {
             m.Disconnect().Throws<InvalidOperationException>();
         });
@@ -97,7 +97,7 @@ public class StateMachineTests
     public async Task No_State_Setups_Match_In_Any_State()
     {
         var mock = IConnection.Mock();
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
 
         // Setup without state guard — matches in any state
         mock.GetStatus().Returns("ALWAYS");
@@ -105,10 +105,10 @@ public class StateMachineTests
         IConnection conn = mock.Object;
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
 
-        mock.SetState("connected");
+        Mock.SetState(mock, "connected");
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
 
-        mock.SetState(null);
+        Mock.SetState(mock, null);
         await Assert.That(conn.GetStatus()).IsEqualTo("ALWAYS");
     }
 
@@ -121,7 +121,7 @@ public class StateMachineTests
         mock.GetStatus().Returns("DEFAULT");
 
         // State-scoped setup
-        mock.InState("special", m =>
+        Mock.InState(mock, "special", m =>
         {
             m.GetStatus().Returns("SPECIAL");
         });
@@ -132,11 +132,11 @@ public class StateMachineTests
         await Assert.That(conn.GetStatus()).IsEqualTo("DEFAULT");
 
         // State set — scoped setup wins (last-wins semantics, state-scoped was added later)
-        mock.SetState("special");
+        Mock.SetState(mock, "special");
         await Assert.That(conn.GetStatus()).IsEqualTo("SPECIAL");
 
         // Different state — scoped doesn't match, global wins
-        mock.SetState("other");
+        Mock.SetState(mock, "other");
         await Assert.That(conn.GetStatus()).IsEqualTo("DEFAULT");
     }
 
@@ -144,9 +144,9 @@ public class StateMachineTests
     public async Task Strict_Mode_Throws_For_Unconfigured_Call_In_State()
     {
         var mock = IConnection.Mock(MockBehavior.Strict);
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
 
-        mock.InState("disconnected", m =>
+        Mock.InState(mock, "disconnected", m =>
         {
             m.GetStatus().Returns("OFFLINE");
         });
@@ -163,14 +163,14 @@ public class StateMachineTests
     {
         // Regression test: nested InState calls must save/restore PendingRequiredState
         var mock = IConnection.Mock();
-        mock.SetState("outer");
+        Mock.SetState(mock, "outer");
 
-        mock.InState("outer", m =>
+        Mock.InState(mock, "outer", m =>
         {
             m.GetStatus().Returns("OUTER");
 
             // Nested InState should temporarily switch to "inner" scope
-            mock.InState("inner", m =>
+            Mock.InState(mock, "inner", m =>
             {
                 m.Connect();
             });
@@ -186,7 +186,7 @@ public class StateMachineTests
         conn.Disconnect(); // should not throw (setup registered in outer scope)
 
         // In "inner" state, Connect should work (it was set up in inner scope)
-        mock.SetState("inner");
+        Mock.SetState(mock, "inner");
         conn.Connect(); // should not throw
     }
 
@@ -199,18 +199,18 @@ public class StateMachineTests
         mock.GetStatus().Returns("NO_STATE");
 
         // State-scoped setup — added second, wins when in "connected" state
-        mock.InState("connected", m =>
+        Mock.InState(mock, "connected", m =>
         {
             m.GetStatus().Returns("ONLINE");
         });
 
-        mock.SetState("connected");
+        Mock.SetState(mock, "connected");
 
         IConnection conn = mock.Object;
         await Assert.That(conn.GetStatus()).IsEqualTo("ONLINE");
 
         // Clear state — scoped setup no longer matches, global setup wins
-        mock.SetState(null);
+        Mock.SetState(mock, null);
         await Assert.That(conn.GetStatus()).IsEqualTo("NO_STATE");
     }
 
@@ -218,9 +218,9 @@ public class StateMachineTests
     public async Task Reset_Clears_State()
     {
         var mock = IConnection.Mock();
-        mock.SetState("connected");
+        Mock.SetState(mock, "connected");
 
-        mock.Reset();
+        Mock.Reset(mock);
 
         // After reset, current state should be null
         await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsNull();
@@ -230,9 +230,9 @@ public class StateMachineTests
     public async Task Verify_Works_With_State_Scoped_Setups()
     {
         var mock = IConnection.Mock();
-        mock.SetState("disconnected");
+        Mock.SetState(mock, "disconnected");
 
-        mock.InState("disconnected", m =>
+        Mock.InState(mock, "disconnected", m =>
         {
             m.Connect().TransitionsTo("connected");
         });

--- a/TUnit.Mocks.Tests/StrictModeTests.cs
+++ b/TUnit.Mocks.Tests/StrictModeTests.cs
@@ -65,7 +65,7 @@ public class StrictModeTests
         // Act & Assert — configured void method should not throw
         ICalculator calc = mock.Object;
         calc.Log("expected message");
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
     }
 
     [Test]
@@ -197,6 +197,6 @@ public class StrictModeTests
 
         // Assert
         await Assert.That(result).IsEqualTo(0);
-        await Assert.That(mock.Behavior).IsEqualTo(MockBehavior.Loose);
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Loose);
     }
 }

--- a/TUnit.Mocks.Tests/VerifyAllTests.cs
+++ b/TUnit.Mocks.Tests/VerifyAllTests.cs
@@ -21,7 +21,7 @@ public class VerifyAllTests
         svc.GetValue("key");
         svc.Process(1);
 
-        mock.VerifyAll();
+        Mock.VerifyAll(mock);
         await Assert.That(true).IsTrue();
     }
 
@@ -35,7 +35,7 @@ public class VerifyAllTests
         var svc = mock.Object;
         svc.GetValue("key"); // Only call GetValue, not Process
 
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex.Message).Contains("Process");
     }
 
@@ -45,7 +45,7 @@ public class VerifyAllTests
         var mock = IService.Mock();
         mock.GetValue(Any()).Returns("value");
 
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex.Message).Contains("GetValue");
     }
 
@@ -53,7 +53,7 @@ public class VerifyAllTests
     public async Task VerifyAll_Passes_When_No_Setups_Registered()
     {
         var mock = IService.Mock();
-        mock.VerifyAll(); // No setups = nothing to verify
+        Mock.VerifyAll(mock); // No setups = nothing to verify
         await Assert.That(true).IsTrue();
     }
 
@@ -65,7 +65,7 @@ public class VerifyAllTests
         mock.Process(42);
 
         // Don't call anything
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyAll(mock));
         await Assert.That(ex.Message).Contains("GetValue");
         await Assert.That(ex.Message).Contains("Process");
     }

--- a/TUnit.Mocks.Tests/VerifyNoOtherCallsTests.cs
+++ b/TUnit.Mocks.Tests/VerifyNoOtherCallsTests.cs
@@ -21,7 +21,7 @@ public class VerifyNoOtherCallsTests
         svc.GetValue("key1");
 
         mock.GetValue("key1").WasCalled(Times.Once);
-        mock.VerifyNoOtherCalls();
+        Mock.VerifyNoOtherCalls(mock);
 
         await Assert.That(true).IsTrue();
     }
@@ -39,7 +39,7 @@ public class VerifyNoOtherCallsTests
         // Only verify GetValue, not Process
         mock.GetValue("key1").WasCalled(Times.Once);
 
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyNoOtherCalls());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyNoOtherCalls(mock));
         await Assert.That(ex.Message).Contains("Process(42)");
     }
 
@@ -47,7 +47,7 @@ public class VerifyNoOtherCallsTests
     public async Task VerifyNoOtherCalls_Passes_When_No_Calls_Made()
     {
         var mock = IService.Mock();
-        mock.VerifyNoOtherCalls();
+        Mock.VerifyNoOtherCalls(mock);
         await Assert.That(true).IsTrue();
     }
 
@@ -60,8 +60,8 @@ public class VerifyNoOtherCallsTests
         var svc = mock.Object;
         svc.GetValue("key1");
 
-        mock.Reset();
-        mock.VerifyNoOtherCalls(); // should pass — history cleared
+        Mock.Reset(mock);
+        Mock.VerifyNoOtherCalls(mock); // should pass — history cleared
 
         await Assert.That(true).IsTrue();
     }
@@ -78,7 +78,7 @@ public class VerifyNoOtherCallsTests
         svc.Reset();
 
         // Verify none
-        var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyNoOtherCalls());
+        var ex = Assert.Throws<MockVerificationException>(() => Mock.VerifyNoOtherCalls(mock));
         await Assert.That(ex.Message).Contains("GetValue(a)");
         await Assert.That(ex.Message).Contains("Process(1)");
     }

--- a/TUnit.Mocks/IMockControl.cs
+++ b/TUnit.Mocks/IMockControl.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using TUnit.Mocks.Diagnostics;
+using TUnit.Mocks.Verification;
+
+namespace TUnit.Mocks;
+
+/// <summary>
+/// Strongly-typed framework operations for a <see cref="Mock{T}"/>.
+/// Implemented explicitly on <see cref="Mock{T}"/> so the members never appear as instance candidates
+/// during overload resolution — preventing them from shadowing source-generated extension methods
+/// whose names happen to match. Reach these operations via the static helpers on <see cref="Mock"/>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IMockControl<T> : IMock where T : class
+{
+    /// <summary>The mock object that implements T.</summary>
+    T Object { get; }
+
+    /// <summary>All calls made to this mock, in order.</summary>
+    IReadOnlyList<CallRecord> Invocations { get; }
+
+    /// <summary>The mock behavior (Loose or Strict).</summary>
+    MockBehavior Behavior { get; }
+
+    /// <summary>
+    /// Custom default-value provider consulted before auto-mocking and built-in defaults in loose mode.
+    /// </summary>
+    IDefaultValueProvider? DefaultValueProvider { get; set; }
+
+    /// <summary>
+    /// Enables auto-tracking for all properties. Setters store, getters return.
+    /// Explicit setups take precedence.
+    /// </summary>
+    void SetupAllProperties();
+
+    /// <summary>Returns a diagnostic report of setup coverage and call matching.</summary>
+    MockDiagnostics GetDiagnostics();
+
+    /// <summary>Sets the current state for state-machine mocking. Null clears.</summary>
+    void SetState(string? stateName);
+
+    /// <summary>
+    /// Registers setups scoped to a specific state. Setups created inside <paramref name="configure"/>
+    /// only match when the engine is in <paramref name="stateName"/>.
+    /// </summary>
+    void InState(string stateName, Action<Mock<T>> configure);
+}

--- a/TUnit.Mocks/IMockControl.cs
+++ b/TUnit.Mocks/IMockControl.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using TUnit.Mocks.Diagnostics;
 using TUnit.Mocks.Verification;
 
@@ -8,10 +7,9 @@ namespace TUnit.Mocks;
 /// Strongly-typed framework operations for a <see cref="Mock{T}"/>.
 /// Implemented explicitly on <see cref="Mock{T}"/> so the members never appear as instance candidates
 /// during overload resolution — preventing them from shadowing source-generated extension methods
-/// whose names happen to match. Reach these operations via the static helpers on <see cref="Mock"/>.
+/// whose names happen to match. Reached via the static helpers on <see cref="Mock"/>.
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public interface IMockControl<T> : IMock where T : class
+internal interface IMockControl<T> : IMock where T : class
 {
     /// <summary>The mock object that implements T.</summary>
     T Object { get; }

--- a/TUnit.Mocks/IMockControl.cs
+++ b/TUnit.Mocks/IMockControl.cs
@@ -9,6 +9,14 @@ namespace TUnit.Mocks;
 /// during overload resolution — preventing them from shadowing source-generated extension methods
 /// whose names happen to match. Reached via the static helpers on <see cref="Mock"/>.
 /// </summary>
+/// <remarks>
+/// <see cref="IMock"/> carries the non-generic subset (<see cref="IMock.Reset"/>,
+/// <see cref="IMock.VerifyAll"/>, <see cref="IMock.VerifyNoOtherCalls"/>, <c>ObjectInstance</c>)
+/// because <see cref="MockRepository"/> needs to iterate mocks as a heterogeneous
+/// <see cref="IMock"/>[] for batch operations. The typed members that depend on <c>T</c>
+/// (<see cref="Invocations"/>, <see cref="GetDiagnostics"/>, the typed <see cref="Object"/>,
+/// state-machine helpers) only make sense in the generic shape and live here.
+/// </remarks>
 internal interface IMockControl<T> : IMock where T : class
 {
     /// <summary>The mock object that implements T.</summary>

--- a/TUnit.Mocks/Mock.cs
+++ b/TUnit.Mocks/Mock.cs
@@ -196,11 +196,11 @@ public static class Mock
         => ((IMockControl<T>)mock).Behavior;
 
     /// <summary>Gets the custom default-value provider, or null if none is configured.</summary>
-    public static IDefaultValueProvider? DefaultValueProvider<T>(Mock<T> mock) where T : class
+    public static IDefaultValueProvider? GetDefaultValueProvider<T>(Mock<T> mock) where T : class
         => ((IMockControl<T>)mock).DefaultValueProvider;
 
     /// <summary>Sets the custom default-value provider.</summary>
-    public static void DefaultValueProvider<T>(Mock<T> mock, IDefaultValueProvider? provider) where T : class
+    public static void SetDefaultValueProvider<T>(Mock<T> mock, IDefaultValueProvider? provider) where T : class
         => ((IMockControl<T>)mock).DefaultValueProvider = provider;
 
     /// <summary>Enables auto-tracking for all properties on <paramref name="mock"/>.</summary>

--- a/TUnit.Mocks/Mock.cs
+++ b/TUnit.Mocks/Mock.cs
@@ -1,3 +1,4 @@
+using TUnit.Mocks.Diagnostics;
 using TUnit.Mocks.Verification;
 
 namespace TUnit.Mocks;
@@ -44,7 +45,7 @@ public static class Mock
     public static Mock<T> Of<T>(MockBehavior behavior, IDefaultValueProvider defaultValueProvider) where T : class
     {
         var mock = Of<T>(behavior);
-        mock.DefaultValueProvider = defaultValueProvider;
+        ((IMockControl<T>)mock).DefaultValueProvider = defaultValueProvider;
         return mock;
     }
 
@@ -185,4 +186,55 @@ public static class Mock
     {
         OrderedVerification.Verify(verificationActions);
     }
+
+    /// <summary>All calls made to <paramref name="mock"/>, in order.</summary>
+    public static IReadOnlyList<CallRecord> Invocations<T>(Mock<T> mock) where T : class
+        => ((IMockControl<T>)mock).Invocations;
+
+    /// <summary>The mock behavior (Loose or Strict).</summary>
+    public static MockBehavior Behavior<T>(Mock<T> mock) where T : class
+        => ((IMockControl<T>)mock).Behavior;
+
+    /// <summary>Gets the custom default-value provider, or null if none is configured.</summary>
+    public static IDefaultValueProvider? DefaultValueProvider<T>(Mock<T> mock) where T : class
+        => ((IMockControl<T>)mock).DefaultValueProvider;
+
+    /// <summary>Sets the custom default-value provider.</summary>
+    public static void DefaultValueProvider<T>(Mock<T> mock, IDefaultValueProvider? provider) where T : class
+        => ((IMockControl<T>)mock).DefaultValueProvider = provider;
+
+    /// <summary>Enables auto-tracking for all properties on <paramref name="mock"/>.</summary>
+    public static void SetupAllProperties<T>(Mock<T> mock) where T : class
+        => ((IMockControl<T>)mock).SetupAllProperties();
+
+    /// <summary>Clears all setups and call history on <paramref name="mock"/>.</summary>
+    public static void Reset<T>(Mock<T> mock) where T : class
+        => ((IMock)mock).Reset();
+
+    /// <summary>
+    /// Verifies that every setup registered on <paramref name="mock"/> was invoked at least once.
+    /// </summary>
+    public static void VerifyAll<T>(Mock<T> mock) where T : class
+        => ((IMock)mock).VerifyAll();
+
+    /// <summary>
+    /// Fails if any recorded call on <paramref name="mock"/> was not matched by a prior verification.
+    /// </summary>
+    public static void VerifyNoOtherCalls<T>(Mock<T> mock) where T : class
+        => ((IMock)mock).VerifyNoOtherCalls();
+
+    /// <summary>Returns a diagnostic report of setup coverage and call matching for <paramref name="mock"/>.</summary>
+    public static MockDiagnostics GetDiagnostics<T>(Mock<T> mock) where T : class
+        => ((IMockControl<T>)mock).GetDiagnostics();
+
+    /// <summary>Sets the current state for state-machine mocking on <paramref name="mock"/>. Null clears.</summary>
+    public static void SetState<T>(Mock<T> mock, string? stateName) where T : class
+        => ((IMockControl<T>)mock).SetState(stateName);
+
+    /// <summary>
+    /// Registers setups scoped to <paramref name="stateName"/>. Setups created inside
+    /// <paramref name="configure"/> only match when the engine is in that state.
+    /// </summary>
+    public static void InState<T>(Mock<T> mock, string stateName, Action<Mock<T>> configure) where T : class
+        => ((IMockControl<T>)mock).InState(stateName, configure);
 }

--- a/TUnit.Mocks/MockOfT.cs
+++ b/TUnit.Mocks/MockOfT.cs
@@ -9,7 +9,13 @@ namespace TUnit.Mocks;
 /// Wraps a generated mock implementation. Source-generated extension methods on <c>Mock&lt;T&gt;</c>
 /// provide strongly-typed setup and verification members directly.
 /// </summary>
-public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
+/// <remarks>
+/// Framework operations (Reset, VerifyAll, Invocations, …) live on <see cref="IMockControl{T}"/>
+/// as explicit interface implementations so they never shadow generated extensions whose names
+/// happen to coincide with the mocked interface's members. Access them via <see cref="Mock"/>
+/// static helpers — e.g. <c>Mock.Reset(mock)</c>, <c>Mock.VerifyAll(mock)</c>.
+/// </remarks>
+public class Mock<T> : IMock, IMockControl<T>, IMockEngineAccess<T> where T : class
 {
     private readonly MockEngine<T> _engine;
 
@@ -34,36 +40,23 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <summary>All calls made to this mock, in order.</summary>
-    public IReadOnlyList<CallRecord> Invocations => _engine.GetAllCalls();
+    T IMockControl<T>.Object => Object;
 
-    /// <summary>Returns the mock behavior (Loose or Strict).</summary>
-    public MockBehavior Behavior => _engine.Behavior;
+    IReadOnlyList<CallRecord> IMockControl<T>.Invocations => _engine.GetAllCalls();
 
-    /// <summary>
-    /// Gets or sets the custom default value provider for unconfigured methods in loose mode.
-    /// When set, this provider is consulted before auto-mocking and built-in defaults.
-    /// </summary>
-    public IDefaultValueProvider? DefaultValueProvider
+    MockBehavior IMockControl<T>.Behavior => _engine.Behavior;
+
+    IDefaultValueProvider? IMockControl<T>.DefaultValueProvider
     {
         get => _engine.DefaultValueProvider;
         set => _engine.DefaultValueProvider = value;
     }
 
-    /// <summary>
-    /// Enables auto-tracking for all properties. Property setters store values and getters return them,
-    /// acting like real auto-properties. Explicit setups take precedence over auto-tracked values.
-    /// </summary>
-    public void SetupAllProperties() => _engine.AutoTrackProperties = true;
+    void IMockControl<T>.SetupAllProperties() => _engine.AutoTrackProperties = true;
 
-    /// <summary>Clears all setups and call history.</summary>
-    public void Reset() => _engine.Reset();
+    void IMock.Reset() => _engine.Reset();
 
-    /// <summary>
-    /// Verifies all registered setups were invoked at least once.
-    /// Throws <see cref="MockVerificationException"/> listing uninvoked setups.
-    /// </summary>
-    public void VerifyAll()
+    void IMock.VerifyAll()
     {
         var setups = _engine.GetSetups();
         var uninvoked = new List<string>();
@@ -87,11 +80,7 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <summary>
-    /// Fails if any recorded call was not matched by a prior verification statement.
-    /// Throws <see cref="MockVerificationException"/> listing unverified calls.
-    /// </summary>
-    public void VerifyNoOtherCalls()
+    void IMock.VerifyNoOtherCalls()
     {
         var unverified = _engine.GetUnverifiedCalls();
         if (unverified.Count > 0)
@@ -102,21 +91,11 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <summary>
-    /// Returns a diagnostic report of this mock's setup coverage and call matching.
-    /// </summary>
-    public MockDiagnostics GetDiagnostics() => _engine.GetDiagnostics();
+    MockDiagnostics IMockControl<T>.GetDiagnostics() => _engine.GetDiagnostics();
 
-    /// <summary>
-    /// Sets the current state for state machine mocking. Null clears the state.
-    /// </summary>
-    public void SetState(string? stateName) => _engine.TransitionTo(stateName);
+    void IMockControl<T>.SetState(string? stateName) => _engine.TransitionTo(stateName);
 
-    /// <summary>
-    /// Configures setups scoped to a specific state. All setups registered inside
-    /// the <paramref name="configure"/> action will only match when the engine is in the specified state.
-    /// </summary>
-    public void InState(string stateName, Action<Mock<T>> configure)
+    void IMockControl<T>.InState(string stateName, Action<Mock<T>> configure)
     {
         var previous = _engine.PendingRequiredState;
         _engine.PendingRequiredState = stateName;
@@ -130,15 +109,6 @@ public class Mock<T> : IMock, IMockEngineAccess<T> where T : class
         }
     }
 
-    /// <inheritdoc />
-    void IMock.VerifyAll() => VerifyAll();
-
-    /// <inheritdoc />
-    void IMock.VerifyNoOtherCalls() => VerifyNoOtherCalls();
-
-    /// <inheritdoc />
-    void IMock.Reset() => Reset();
-
-    /// <summary>Implicit conversion to T -- no .Object needed.</summary>
+    /// <summary>Implicit conversion to T — no .Object needed.</summary>
     public static implicit operator T(Mock<T> mock) => mock.Object;
 }


### PR DESCRIPTION
## Summary
- Move framework operations (`Reset`, `VerifyAll`, `Invocations`, …) off `Mock<T>` as instance members onto `IMockControl<T>` explicit interface implementations plus `Mock.X(mock)` static helpers. `Mock<T>` instance surface shrinks to `Object` + constructor + implicit conversion to `T`.
- Collision set is now structurally closed: `{ Object, Equals, GetHashCode, ToString }`. Generator's existing `Object_` / `*Of` renames keep working, with new iterative-suffix escalation when the user interface declares the renamed form (`Object` + `Object_` → generated extension lands on `Object__`).
- On net9.0+ the generator emits low-priority extension polyfills inside the per-type `*_MockMemberExtensions` class so `mock.Reset()`, `mock.VerifyAll()`, `mock.Invocations`, `mock.SetState("x")`, `mock.DefaultValueProvider = …` remain ergonomic. `[OverloadResolutionPriority(-1)]` only ranks within one containing type, so the polyfills must live alongside the generated extensions; they skip emission when the mocked interface declares a member of the same name (no CS0111).

Background: GitHub Discussion [#4981](https://github.com/thomhurst/TUnit/discussions/4981) raised the collision concern. Prior handling covered ~4 names by ad-hoc rename table and would have silently shadowed generator output for ~10 other public `Mock<T>` members. With this change, future framework additions go on `IMockControl<T>` / static `Mock.*` and cannot regress collision safety.

## Breaking changes (TUnit.Mocks is in beta)

- `Mock<T>` no longer exposes `Reset()`, `VerifyAll()`, `VerifyNoOtherCalls()`, `Invocations`, `Behavior`, `DefaultValueProvider`, `SetupAllProperties()`, `GetDiagnostics()`, `SetState()`, `InState()` as instance members.
- **net9.0+ consumers:** code keeps compiling — generator emits ergonomic polyfills as low-priority extensions, so `mock.Reset()` etc. continue to work.
- **net8.0 / netstandard2.0 consumers:** call sites must move to the static helpers (`Mock.Reset(mock)`, `Mock.VerifyAll(mock)`, etc.). `[OverloadResolutionPriority]` isn't available on those targets so the polyfill path can't apply.
- `Mock.DefaultValueProvider` getter/setter overload split into `Mock.GetDefaultValueProvider(mock)` and `Mock.SetDefaultValueProvider(mock, provider)` per .NET naming conventions.

## Test plan
- [x] `NameCollisionTests` (new) exercises every former framework name plus `Object_` / `EqualsOf` overflow paths.
- [x] On net9.0+, polyfill tests verify `mock.Reset()` / `mock.VerifyAll()` / `mock.Invocations` / property setter `mock.DefaultValueProvider = …` route through and that polyfills are skipped when colliding.
- [x] `TUnit.Mocks.Tests` full suite: 977 pass (net10.0), 967 pass (net8.0).
- [x] Full solution `dotnet build TUnit.slnx` succeeds.
- [ ] CI: source-generator snapshot tests (`TUnit.Mocks.SourceGenerator.Tests`) — local runner blocked by an unrelated `Verify.TUnit` / `TUnit.Core` version mismatch; CI will validate.