### PR TITLE
fix(tests): retry trx read to dodge MTP post-exit flush race on Windows

### DIFF
--- a/TUnit.Engine.Tests/TrxAsserter.cs
+++ b/TUnit.Engine.Tests/TrxAsserter.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
+using System.Xml;
 using CliWrap;
 using CliWrap.Buffered;
 using TrxTools.TrxParser;
@@ -12,12 +13,72 @@ public class TrxAsserter
         List<Action<TestRun>> assertions,
         string trxFilename, [CallerArgumentExpression("assertions")] string assertionExpression = "")
     {
-        var trxFile = FileSystemHelpers.FindFile(x => x.Name == trxFilename)?.FullName ?? throw new FileNotFoundException($"Could not find trx file {trxFilename}");
+        var trxFile = await WaitForTrxFile(trxFilename)
+                      ?? throw new FileNotFoundException($"Could not find trx file {trxFilename}");
 
-        var trxFileContents = await File.ReadAllTextAsync(trxFile);
+        var trxFileContents = await ReadTrxWithRetry(trxFile);
 
         var testRun = TrxControl.ReadTrx(new StringReader(trxFileContents));
 
         assertions.ForEach(x => x.Invoke(testRun));
+    }
+
+    // MTP can finish writing the trx after the subprocess returns control, so the file
+    // may be missing or being written when the test reads it. Bounded retries keep the
+    // window small enough to still surface a real "test never produced a trx" failure.
+    private static async Task<string?> WaitForTrxFile(string trxFilename)
+    {
+        int[] backoffsMs = [50, 100, 250, 500, 1000];
+
+        foreach (var delay in backoffsMs)
+        {
+            var found = FileSystemHelpers.FindFile(x => x.Name == trxFilename)?.FullName;
+            if (found is not null)
+            {
+                return found;
+            }
+
+            await Task.Delay(delay);
+        }
+
+        return FileSystemHelpers.FindFile(x => x.Name == trxFilename)?.FullName;
+    }
+
+    // FileShare.ReadWrite lets us read past a still-open MTP write handle on Windows.
+    // Re-reads on XML parse failure since a partial flush would yield truncated XML.
+    private static async Task<string> ReadTrxWithRetry(string path)
+    {
+        int[] backoffsMs = [0, 100, 250, 500];
+
+        Exception? lastError = null;
+        foreach (var delay in backoffsMs)
+        {
+            if (delay > 0)
+            {
+                await Task.Delay(delay);
+            }
+
+            try
+            {
+                using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                var contents = await reader.ReadToEndAsync();
+
+                // Cheap shape check — if the trx is mid-flush we'd see something that
+                // doesn't even parse as XML. Trigger another retry instead of bubbling
+                // a misleading parse error up to the assertion list.
+                using var probeReader = new StringReader(contents);
+                using var xmlReader = XmlReader.Create(probeReader);
+                while (xmlReader.Read()) { }
+
+                return contents;
+            }
+            catch (Exception ex) when (ex is IOException or XmlException)
+            {
+                lastError = ex;
+            }
+        }
+
+        throw new IOException($"Failed to read trx file '{path}' after retries.", lastError);
     }
 }


### PR DESCRIPTION
## Summary

`TUnit.Engine.Tests/TrxAsserter` read the subprocess's trx file the instant `ExecuteBufferedAsync` returned, with no retry and no `FileShare`. On Windows that intermittently failed two ways:

- `Could not find trx file <guid>.trx` — `FindFile` ran before MTP finished writing it ([run 24604906015](https://github.com/thomhurst/TUnit/actions/runs/24604906015))
- `The process cannot access the file because it is being used by another process` — sharing violation while MTP still held a write handle ([run 24532069901](https://github.com/thomhurst/TUnit/actions/runs/24532069901))

Both share a root cause: MTP can flush the trx slightly after the subprocess returns control. `TrxAsserter.AssertTrx` now:

1. Polls for the file with progressive backoff (50/100/250/500/1000 ms) before giving up
2. Reads via `FileShare.ReadWrite` so a still-open MTP write handle doesn't block us
3. Re-reads on `XmlException` (catches a partial flush) up to ~1.85 s

Caps stay short enough to still surface a genuine "test never produced a trx" failure within seconds.

## Test plan

- [x] Local Windows run: `dotnet run --filter ExpectedStateTests/*` passes (Reflection mode; AOT skipped outside CI)
- [ ] `.NET` workflow runs across all three OS legs