### PR TITLE
fix(pipeline): timeout + retry InstallPlaywrightModule so a hung download fails fast

### DIFF
--- a/TUnit.Pipeline/Modules/InstallPlaywrightModule.cs
+++ b/TUnit.Pipeline/Modules/InstallPlaywrightModule.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -7,8 +8,22 @@ namespace TUnit.Pipeline.Modules;
 
 public class InstallPlaywrightModule : Module<CommandResult>
 {
-    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) =>
-        await context.Shell.Bash.Command(
+    // Browser download is ~500 MB. 10 minutes is far past the happy-path
+    // (~2 min on a warm runner) but short enough that a hung connection gets
+    // killed and retried instead of burning the module's outer 30-min budget.
+    private static readonly TimeSpan PerAttemptTimeout = TimeSpan.FromMinutes(10);
+
+    protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        .WithRetryCount(2)
+        .Build();
+
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {
+        using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        attemptCts.CancelAfter(PerAttemptTimeout);
+
+        return await context.Shell.Bash.Command(
             new BashCommandOptions("npx playwright install --with-deps"),
-            cancellationToken);
+            attemptCts.Token);
+    }
 }


### PR DESCRIPTION
## Summary

`npx playwright install --with-deps` ran with no per-attempt timeout and no retry. When the network stalled mid-download (~500 MB of browser binaries), the module sat at the outer 30-minute module budget before failing — cascading into `RunPlaywrightTestsModule`, `UploadToNuGetModule`, and `CreateReleaseModule` ([run 25238011861](https://github.com/thomhurst/TUnit/actions/runs/25238011861)).

Adds a 10-minute per-attempt timeout via a linked `CancellationTokenSource` plus the same `ModuleConfiguration.WithRetryCount(2)` pattern already used by `TestNugetPackageModule`. Happy path (~2 min on a warm runner) is unaffected; a hang now fails at 10 min and retries instead of burning the full 30.

## Notes

- The repo has no root `package.json`, so the workflow's `actions/cache@v5` step (`.github/workflows/dotnet.yml:78-88`) keys the cache against `docs/**/package.json` and `Directory.Packages.props` — neither tracks the Playwright version. Cache will hit reliably across PR runs, but a Playwright release will silently invalidate which browsers are needed and trigger a fresh download. Out of scope to fix here.

## Test plan

- [x] `dotnet build TUnit.Pipeline` passes
- [ ] Workflow runs across all three OS legs without regression