### PR TITLE
fix(aspnetcore): scope correlation processor per-factory to stop cross-factory tag leak

### DIFF
--- a/TUnit.AspNetCore.Core/FactoryScopeStartupFilter.cs
+++ b/TUnit.AspNetCore.Core/FactoryScopeStartupFilter.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using TUnit.OpenTelemetry;
+
+namespace TUnit.AspNetCore;
+
+/// <summary>
+/// Stamps every incoming request's Activity with a baggage entry that identifies
+/// the owning <c>TestWebApplicationFactory</c>. The companion
+/// <see cref="TUnitTestCorrelationProcessor"/> uses that baggage to refuse to tag
+/// activities triggered by a sibling factory's request pipeline.
+/// </summary>
+/// <remarks>
+/// Without this filter, multiple parallel factories that each register a
+/// <c>TracerProvider</c> against the process-global <c>Microsoft.AspNetCore</c>
+/// <see cref="System.Diagnostics.ActivitySource"/> all observe the same Activity
+/// for any one request, and any one factory's processor can stamp the others'
+/// activities — which is what produced the foreign <c>tunit.test.id</c> in the
+/// opt-out exporter on macOS in run 25572055061.
+/// </remarks>
+internal sealed class FactoryScopeStartupFilter : IStartupFilter
+{
+    private readonly CorrelationScope _scope;
+
+    public FactoryScopeStartupFilter(CorrelationScope scope)
+    {
+        _scope = scope;
+    }
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        => app =>
+        {
+            app.Use(async (context, requestNext) =>
+            {
+                var activity = Activity.Current;
+                // Setting baggage on Activity.Current rather than the activity returned by
+                // an OpenTelemetry enricher means the value is available to every processor
+                // observing this activity, including those from sibling factories. They use
+                // it to recognise that the activity is not theirs.
+                activity?.AddBaggage(CorrelationScope.FactoryIdBaggageKey, _scope.FactoryId);
+                await requestNext();
+            });
+            next(app);
+        };
+}

--- a/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
+++ b/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
@@ -21,6 +21,10 @@ namespace TUnit.AspNetCore;
 /// </summary>
 public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint> where TEntryPoint : class
 {
+    // One scope per factory instance. Threaded through the per-factory
+    // TUnitTestCorrelationProcessor so the processor recognises which activities
+    // belong to its own request pipeline vs. a sibling factory's.
+    private readonly CorrelationScope _correlationScope = new();
 
     public WebApplicationFactory<TEntryPoint> GetIsolatedFactory(
         TestContext testContext,
@@ -55,7 +59,7 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
 
                     if (options.AutoConfigureOpenTelemetry)
                     {
-                        AddTUnitOpenTelemetry(services);
+                        AddTUnitOpenTelemetry(services, _correlationScope);
                     }
                 });
 
@@ -97,6 +101,7 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
         builder.ConfigureServices(services =>
         {
             services.AddSingleton<IStartupFilter, PropagatorAlignmentStartupFilter>();
+            services.AddSingleton<IStartupFilter>(_ => new FactoryScopeStartupFilter(_correlationScope));
             services.AddCorrelatedTUnitLogging();
         });
     }
@@ -110,10 +115,10 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
     /// own processor, and the processor's idempotent tagging guard prevents duplicate
     /// <c>tunit.test.id</c> tags across its <c>OnStart</c>/<c>OnEnd</c> hooks.
     /// </summary>
-    private static void AddTUnitOpenTelemetry(IServiceCollection services)
+    private static void AddTUnitOpenTelemetry(IServiceCollection services, CorrelationScope scope)
     {
         services.AddOpenTelemetry().WithTracing(tracing => tracing
-            .AddProcessor(new TUnitTestCorrelationProcessor())
+            .AddProcessor(new TUnitTestCorrelationProcessor(scope))
             .AddAspNetCoreInstrumentation()
             .AddHttpClientInstrumentation());
     }

--- a/TUnit.OpenTelemetry.Tests/CorrelationProcessorTests.cs
+++ b/TUnit.OpenTelemetry.Tests/CorrelationProcessorTests.cs
@@ -95,6 +95,63 @@ public class CorrelationProcessorTests
     }
 
     [Test]
+    public async Task ScopedProcessor_DoesNotTag_ActivitiesFromOtherFactories()
+    {
+        // Regression for the OptOut_DoesNotTag_AspNetCoreSpans cross-factory leak:
+        // factory A's processor must skip activities that factory B's request pipeline
+        // tagged with B's factory id, even when the TraceRegistry fallback would happily
+        // resolve a TestId from somewhere.
+        using var listener = AttachPermissiveListener("CorrelationProcessorTests.ScopedAlien");
+        var scopeA = new CorrelationScope();
+        var scopeB = new CorrelationScope();
+        var processorA = new TUnitTestCorrelationProcessor(scopeA);
+
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            using var alien = new ActivitySource("CorrelationProcessorTests.ScopedAlien").StartActivity("alien")!;
+            alien.AddBaggage(CorrelationScope.FactoryIdBaggageKey, scopeB.FactoryId);
+            // A trace registry hit would otherwise satisfy the existing fallback path —
+            // include it so the test proves the per-factory guard is what blocks tagging.
+            TraceRegistry.Register(alien.TraceId.ToString(), testNodeUid: "node-x", contextId: "ctx-x");
+
+            processorA.OnEnd(alien);
+
+            await Assert.That(alien.GetTagItem("tunit.test.id")).IsNull();
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    [Test]
+    public async Task ScopedProcessor_Tags_ActivitiesFromOwnFactory()
+    {
+        using var listener = AttachPermissiveListener("CorrelationProcessorTests.ScopedOwn");
+        var scope = new CorrelationScope();
+        var processor = new TUnitTestCorrelationProcessor(scope);
+
+        var previous = Activity.Current;
+        Activity.Current = null;
+        try
+        {
+            using var own = new ActivitySource("CorrelationProcessorTests.ScopedOwn").StartActivity("own")!;
+            own.AddBaggage(CorrelationScope.FactoryIdBaggageKey, scope.FactoryId);
+            TraceRegistry.Register(own.TraceId.ToString(), testNodeUid: "node-y", contextId: "ctx-y");
+
+            processor.OnEnd(own);
+
+            await Assert.That(own.GetTagItem("tunit.test.id")).IsEqualTo("ctx-y");
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    [Test]
     public async Task Processor_NoOp_WhenNoBaggage()
     {
         using var listener = AttachPermissiveListener("CorrelationProcessorTests.NoBaggage");

--- a/TUnit.OpenTelemetry/CorrelationScope.cs
+++ b/TUnit.OpenTelemetry/CorrelationScope.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+
+namespace TUnit.OpenTelemetry;
+
+/// <summary>
+/// Identifies the factory that owns a TracerProvider, so the per-factory
+/// <see cref="TUnitTestCorrelationProcessor"/> can refuse to stamp activities triggered by
+/// a sibling factory's request pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Several <c>WebApplicationFactory</c> instances commonly run in parallel within one
+/// process. Each calls <c>AddAspNetCoreInstrumentation()</c>, which subscribes the
+/// factory's <c>TracerProvider</c> to the process-global <c>Microsoft.AspNetCore</c>
+/// <see cref="System.Diagnostics.ActivitySource"/>. A single Activity created for an
+/// HTTP request is therefore observed by every subscribed processor — and any tag a
+/// processor writes is visible to every exporter, including those of factories that
+/// intentionally opted out of TUnit's correlation. That cross-factory leak is what
+/// produced the foreign <c>tunit.test.id</c> tag in run 25572055061.
+/// </para>
+/// <para>
+/// The baggage key written by the per-factory request middleware encodes which factory
+/// owns the in-flight request. The processor compares the baggage value to its own
+/// scope's <see cref="FactoryId"/> before tagging.
+/// </para>
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed class CorrelationScope
+{
+    /// <summary>Activity baggage key carrying the owning factory's id.</summary>
+    public const string FactoryIdBaggageKey = "tunit.factory.id";
+
+    /// <summary>A unique id for the owning factory.</summary>
+    public string FactoryId { get; } = Guid.NewGuid().ToString("N");
+}

--- a/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
+++ b/TUnit.OpenTelemetry/TUnitTestCorrelationProcessor.cs
@@ -30,11 +30,39 @@ namespace TUnit.OpenTelemetry;
 /// (e.g. <c>SimpleExportProcessor</c>) that serialize inside their own <c>OnEnd</c>
 /// only observe the tag if this processor is registered before them.
 /// </para>
+/// <para>
+/// Pass a <see cref="CorrelationScope"/> when the processor is registered against a
+/// per-factory <c>TracerProvider</c>: the processor will then refuse to stamp activities
+/// whose request pipeline carries a different factory's id, preventing the cross-factory
+/// leak that broke <c>OptOut_DoesNotTag_AspNetCoreSpans</c>.
+/// </para>
 /// </remarks>
 public sealed class TUnitTestCorrelationProcessor : BaseProcessor<Activity>
 {
+    private readonly CorrelationScope? _scope;
+
+    public TUnitTestCorrelationProcessor()
+        : this(scope: null)
+    {
+    }
+
+    public TUnitTestCorrelationProcessor(CorrelationScope? scope)
+    {
+        _scope = scope;
+    }
+
     public override void OnStart(Activity activity)
     {
+        // When scoped to a factory, the per-request baggage that identifies the owning
+        // factory is set by middleware running AFTER ActivitySource.StartActivity, so
+        // OnStart can't yet tell whether this activity belongs to us. ASP.NET Core
+        // server activities have no in-process parent in test context anyway —
+        // OnEnd-based tagging covers the meaningful path.
+        if (_scope is not null)
+        {
+            return;
+        }
+
         TryTag(activity);
     }
 
@@ -43,11 +71,26 @@ public sealed class TUnitTestCorrelationProcessor : BaseProcessor<Activity>
         TryTag(activity);
     }
 
-    private static void TryTag(Activity activity)
+    private void TryTag(Activity activity)
     {
         if (activity.GetTagItem(TUnitActivitySource.TagTestId) is not null)
         {
             return;
+        }
+
+        if (_scope is not null)
+        {
+            // A scoped processor only tags activities whose request pipeline tagged
+            // them with this factory's id. Without this guard, factory A's processor
+            // would happily stamp activities triggered by factory B's request — both
+            // factories observe the same Activity object via the process-global
+            // Microsoft.AspNetCore source, and any tag it writes is visible to every
+            // factory's exporter.
+            var factoryId = activity.GetBaggageItem(CorrelationScope.FactoryIdBaggageKey);
+            if (factoryId != _scope.FactoryId)
+            {
+                return;
+            }
         }
 
         var testId = activity.GetBaggageItem(TUnitActivitySource.TagTestId)

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -21,6 +21,12 @@ namespace
         [.After(., "PATH_SCRUBBED", 96, Order=2147483647)]
         public static void Stop() { }
     }
+    public sealed class CorrelationScope
+    {
+        public const string FactoryIdBaggageKey = ".id";
+        public CorrelationScope() { }
+        public string FactoryId { get; }
+    }
     public static class TUnitOpenTelemetry
     {
         public static void Configure(<.TracerProviderBuilder> configure) { }
@@ -28,6 +34,7 @@ namespace
     public sealed class TUnitTestCorrelationProcessor : <.Activity>
     {
         public TUnitTestCorrelationProcessor() { }
+        public TUnitTestCorrelationProcessor(.CorrelationScope? scope) { }
         public override void OnEnd(.Activity activity) { }
         public override void OnStart(.Activity activity) { }
     }

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -21,6 +21,12 @@ namespace
         [.After(., "PATH_SCRUBBED", 96, Order=2147483647)]
         public static void Stop() { }
     }
+    public sealed class CorrelationScope
+    {
+        public const string FactoryIdBaggageKey = ".id";
+        public CorrelationScope() { }
+        public string FactoryId { get; }
+    }
     public static class TUnitOpenTelemetry
     {
         public static void Configure(<.TracerProviderBuilder> configure) { }
@@ -28,6 +34,7 @@ namespace
     public sealed class TUnitTestCorrelationProcessor : <.Activity>
     {
         public TUnitTestCorrelationProcessor() { }
+        public TUnitTestCorrelationProcessor(.CorrelationScope? scope) { }
         public override void OnEnd(.Activity activity) { }
         public override void OnStart(.Activity activity) { }
     }

--- a/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.OpenTelemetry_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -21,6 +21,12 @@ namespace
         [.After(., "PATH_SCRUBBED", 96, Order=2147483647)]
         public static void Stop() { }
     }
+    public sealed class CorrelationScope
+    {
+        public const string FactoryIdBaggageKey = ".id";
+        public CorrelationScope() { }
+        public string FactoryId { get; }
+    }
     public static class TUnitOpenTelemetry
     {
         public static void Configure(<.TracerProviderBuilder> configure) { }
@@ -28,6 +34,7 @@ namespace
     public sealed class TUnitTestCorrelationProcessor : <.Activity>
     {
         public TUnitTestCorrelationProcessor() { }
+        public TUnitTestCorrelationProcessor(.CorrelationScope? scope) { }
         public override void OnEnd(.Activity activity) { }
         public override void OnStart(.Activity activity) { }
     }


### PR DESCRIPTION
## Summary

`OptOut_DoesNotTag_AspNetCoreSpans` failed on macOS in [run 25572055061](https://github.com/thomhurst/TUnit/actions/runs/25572055061) with a foreign GUID stamped into the opt-out exporter's activity.

**Cause.** Every parallel `WebApplicationFactory` that calls `AddAspNetCoreInstrumentation()` subscribes its `TracerProvider` to the process-global `Microsoft.AspNetCore` `ActivitySource`. A single `Activity` per request is observed by every subscribed processor — and any tag any processor writes is visible to every exporter. Factory A's `TUnitTestCorrelationProcessor` was therefore tagging factory B's request activity with factory A's `TestId`, polluting the opt-out exporter. `[NotInParallel]` on the OptOut class doesn't help because the contaminating tests are sibling classes without the constraint.

## Approach: per-factory baggage filter

- Each `TestWebApplicationFactory` now owns a `CorrelationScope` with a unique `FactoryId`.
- A new `FactoryScopeStartupFilter` adds middleware that stamps every incoming request's `Activity` with a baggage entry carrying the owning factory's id.
- `TUnitTestCorrelationProcessor` takes an optional `CorrelationScope` constructor argument. When bound, it tags only activities whose baggage matches its own factory id; activities tagged by a sibling factory's middleware are skipped.
- The parameterless processor constructor and `AutoStart`'s process-wide use are unchanged, so the `TUnit.OpenTelemetry` zero-config package keeps its current behavior.

## Test plan

- [x] All 35 `TUnit.AspNetCore.Tests` pass locally including both `AutoConfigureOpenTelemetryTests` and `AutoConfigureOpenTelemetryOptOutTests`.
- [x] All 5 existing `CorrelationProcessorTests` still pass (parameterless constructor unchanged).
- [x] Two new regression tests added for the scoped path: a scoped processor refuses to tag an activity bearing a different factory's baggage (even when `TraceRegistry` would resolve a `TestId`), and still tags activities that carry its own factory's id.
- [ ] `.NET` workflow runs across all three OS legs.