### PR TITLE
feat(assertions): add CancellationToken overload to WaitsFor and Eventually

### DIFF
--- a/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
+++ b/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
@@ -425,7 +425,6 @@ public class WaitsForAssertionTests
 
         stopwatch.Stop();
 
-        // External cancel must abort the loop well before the 30s internal timeout.
         await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
     }
 
@@ -447,7 +446,7 @@ public class WaitsForAssertionTests
     public async Task WaitsFor_Honours_PreCancelled_Token_Before_First_Poll()
     {
         using var cts = new CancellationTokenSource();
-        await cts.CancelAsync();
+        cts.Cancel();
 
         var stopwatch = Stopwatch.StartNew();
 
@@ -461,16 +460,12 @@ public class WaitsForAssertionTests
 
         stopwatch.Stop();
 
-        // Pre-cancelled token must exit the loop on the first iteration, well before any
-        // poll sleep would matter; the 5s internal timeout must not have elapsed.
         await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
     }
 
     [Test]
     public async Task Eventually_PropagatesExternalCancellation_Before_Internal_Timeout()
     {
-        // Alias symmetry: the same cancellation contract holds for Eventually as for
-        // WaitsFor, since Eventually forwards to WaitsFor.
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
@@ -492,9 +487,6 @@ public class WaitsForAssertionTests
     [Test]
     public async Task WaitsFor_Propagates_OCE_When_Predicate_Observes_Supplied_Token()
     {
-        // When the predicate itself observes the supplied token and throws after the
-        // token is cancelled, the cancellation must propagate out of the polling loop
-        // instead of being swallowed-and-retried until the internal timeout elapses.
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
@@ -516,7 +508,6 @@ public class WaitsForAssertionTests
 
         stopwatch.Stop();
 
-        // Propagation should occur within roughly the cancel delay plus one poll interval.
         await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
     }
 

--- a/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
+++ b/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
@@ -407,6 +407,119 @@ public class WaitsForAssertionTests
         await Assert.That(entity.IsReady).IsEqualTo(true);
     }
 
+    [Test]
+    public async Task WaitsFor_PropagatesExternalCancellation_Before_Internal_Timeout()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = async () => await Assert.That(() => false)
+            .WaitsFor(
+                assert => assert.IsTrue(),
+                timeout: TimeSpan.FromSeconds(30),
+                cancellationToken: cts.Token);
+
+        await Assert.That(act).Throws<OperationCanceledException>();
+
+        stopwatch.Stop();
+
+        // External cancel must abort the loop well before the 30s internal timeout.
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task WaitsFor_Throws_AssertionException_On_Internal_Timeout_When_Token_Not_Cancelled()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var act = async () => await Assert.That(() => false)
+            .WaitsFor(
+                assert => assert.IsTrue(),
+                timeout: TimeSpan.FromMilliseconds(200),
+                cancellationToken: cts.Token);
+
+        await Assert.That(act).Throws<AssertionException>();
+    }
+
+    [Test]
+    public async Task WaitsFor_Honours_PreCancelled_Token_Before_First_Poll()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = async () => await Assert.That(() => false)
+            .WaitsFor(
+                assert => assert.IsTrue(),
+                timeout: TimeSpan.FromSeconds(5),
+                cancellationToken: cts.Token);
+
+        await Assert.That(act).Throws<OperationCanceledException>();
+
+        stopwatch.Stop();
+
+        // Pre-cancelled token must exit the loop on the first iteration, well before any
+        // poll sleep would matter; the 5s internal timeout must not have elapsed.
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Test]
+    public async Task Eventually_PropagatesExternalCancellation_Before_Internal_Timeout()
+    {
+        // Alias symmetry: the same cancellation contract holds for Eventually as for
+        // WaitsFor, since Eventually forwards to WaitsFor.
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = async () => await Assert.That(() => false)
+            .Eventually(
+                assert => assert.IsTrue(),
+                timeout: TimeSpan.FromSeconds(30),
+                cancellationToken: cts.Token);
+
+        await Assert.That(act).Throws<OperationCanceledException>();
+
+        stopwatch.Stop();
+
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task WaitsFor_Propagates_OCE_When_Predicate_Observes_Supplied_Token()
+    {
+        // When the predicate itself observes the supplied token and throws after the
+        // token is cancelled, the cancellation must propagate out of the polling loop
+        // instead of being swallowed-and-retried until the internal timeout elapses.
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        Func<bool> tokenAwarePredicate = () =>
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            return false;
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+
+        var act = async () => await Assert.That(tokenAwarePredicate)
+            .WaitsFor(
+                assert => assert.IsTrue(),
+                timeout: TimeSpan.FromSeconds(30),
+                cancellationToken: cts.Token);
+
+        await Assert.That(act).Throws<OperationCanceledException>();
+
+        stopwatch.Stop();
+
+        // Propagation should occur within roughly the cancel delay plus one poll interval.
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
+    }
+
     // Helper class for testing complex objects
     private class TestEntity
     {

--- a/TUnit.Assertions/Conditions/WaitsForAssertion.cs
+++ b/TUnit.Assertions/Conditions/WaitsForAssertion.cs
@@ -59,9 +59,6 @@ public class WaitsForAssertion<TValue> : Assertion<TValue>
 
         while (stopwatch.Elapsed < _timeout)
         {
-            // Honour external cancellation between iterations: a pre-cancelled token, or a token
-            // cancelled during the previous Task.Delay, exits the loop without invoking the
-            // predicate. Internal-timeout cancellation falls through to AssertionResult.Failed.
             _cancellationToken.ThrowIfCancellationRequested();
 
             attemptCount++;
@@ -91,13 +88,10 @@ public class WaitsForAssertion<TValue> : Assertion<TValue>
                 }
                 catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
                 {
-                    // External cancellation during the poll sleep. Propagate.
                     throw;
                 }
                 catch (OperationCanceledException)
                 {
-                    // Internal timeout cancelled the linked source. Fall through to the
-                    // standard AssertionResult.Failed path below.
                     break;
                 }
             }

--- a/TUnit.Assertions/Conditions/WaitsForAssertion.cs
+++ b/TUnit.Assertions/Conditions/WaitsForAssertion.cs
@@ -15,17 +15,20 @@ public class WaitsForAssertion<TValue> : Assertion<TValue>
     private readonly Func<IAssertionSource<TValue>, Assertion<TValue>> _assertionBuilder;
     private readonly TimeSpan _timeout;
     private readonly TimeSpan _pollingInterval;
+    private readonly CancellationToken _cancellationToken;
 
     public WaitsForAssertion(
         AssertionContext<TValue> context,
         Func<IAssertionSource<TValue>, Assertion<TValue>> assertionBuilder,
         TimeSpan timeout,
-        TimeSpan? pollingInterval = null)
+        TimeSpan? pollingInterval = null,
+        CancellationToken cancellationToken = default)
         : base(context)
     {
         _assertionBuilder = assertionBuilder ?? throw new ArgumentNullException(nameof(assertionBuilder));
         _timeout = timeout;
         _pollingInterval = pollingInterval ?? TimeSpan.FromMilliseconds(10);
+        _cancellationToken = cancellationToken;
 
         if (_timeout <= TimeSpan.Zero)
         {
@@ -44,10 +47,23 @@ public class WaitsForAssertion<TValue> : Assertion<TValue>
         Exception? lastException = null;
         var attemptCount = 0;
 
-        using var cts = new CancellationTokenSource(_timeout);
+        // Link the supplied cancellation token with an internal timeout source so the polling
+        // loop honours both: external cancellation propagates as OperationCanceledException,
+        // and the internal timeout still produces the standard AssertionResult.Failed path.
+        // When the caller did not supply a cancellable token, the linking step is skipped to
+        // avoid the registration overhead.
+        using var linkedCts = _cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken)
+            : new CancellationTokenSource();
+        linkedCts.CancelAfter(_timeout);
 
         while (stopwatch.Elapsed < _timeout)
         {
+            // Honour external cancellation between iterations: a pre-cancelled token, or a token
+            // cancelled during the previous Task.Delay, exits the loop without invoking the
+            // predicate. Internal-timeout cancellation falls through to AssertionResult.Failed.
+            _cancellationToken.ThrowIfCancellationRequested();
+
             attemptCount++;
 
             try
@@ -71,10 +87,17 @@ public class WaitsForAssertion<TValue> : Assertion<TValue>
 
                 try
                 {
-                    await Task.Delay(_pollingInterval, cts.Token);
+                    await Task.Delay(_pollingInterval, linkedCts.Token);
+                }
+                catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+                {
+                    // External cancellation during the poll sleep. Propagate.
+                    throw;
                 }
                 catch (OperationCanceledException)
                 {
+                    // Internal timeout cancelled the linked source. Fall through to the
+                    // standard AssertionResult.Failed path below.
                     break;
                 }
             }

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -1719,6 +1719,7 @@ public static class AssertionExtensions
     /// <param name="assertionBuilder">A function that builds the assertion to be evaluated on each poll</param>
     /// <param name="timeout">The maximum time to wait for the assertion to pass</param>
     /// <param name="pollingInterval">The interval between polling attempts (defaults to 10ms if not specified)</param>
+    /// <param name="cancellationToken">A token to cancel the polling loop. External cancellation throws <see cref="OperationCanceledException"/>; the internal timeout still produces the standard <see cref="Exceptions.AssertionException"/>.</param>
     /// <param name="timeoutExpression">Captured expression for the timeout parameter</param>
     /// <param name="pollingIntervalExpression">Captured expression for the polling interval parameter</param>
     /// <returns>An assertion that can be awaited or chained with And/Or</returns>
@@ -1727,12 +1728,13 @@ public static class AssertionExtensions
         Func<IAssertionSource<TValue>, Assertion<TValue>> assertionBuilder,
         TimeSpan timeout,
         TimeSpan? pollingInterval = null,
+        CancellationToken cancellationToken = default,
         [CallerArgumentExpression(nameof(timeout))] string? timeoutExpression = null,
         [CallerArgumentExpression(nameof(pollingInterval))] string? pollingIntervalExpression = null)
     {
         var intervalExpr = pollingInterval.HasValue ? $", pollingInterval: {pollingIntervalExpression}" : "";
         source.Context.ExpressionBuilder.Append($".WaitsFor(..., timeout: {timeoutExpression}{intervalExpr})");
-        return new WaitsForAssertion<TValue>(source.Context, assertionBuilder, timeout, pollingInterval);
+        return new WaitsForAssertion<TValue>(source.Context, assertionBuilder, timeout, pollingInterval, cancellationToken);
     }
 
     /// <summary>
@@ -1745,6 +1747,7 @@ public static class AssertionExtensions
     /// <param name="assertionBuilder">A function that builds the assertion to be evaluated on each poll</param>
     /// <param name="timeout">The maximum time to wait for the assertion to pass</param>
     /// <param name="pollingInterval">The interval between polling attempts (defaults to 10ms if not specified)</param>
+    /// <param name="cancellationToken">A token to cancel the polling loop. External cancellation throws <see cref="OperationCanceledException"/>; the internal timeout still produces the standard <see cref="Exceptions.AssertionException"/>.</param>
     /// <param name="timeoutExpression">Captured expression for the timeout parameter</param>
     /// <param name="pollingIntervalExpression">Captured expression for the polling interval parameter</param>
     /// <returns>An assertion that can be awaited or chained with And/Or</returns>
@@ -1753,10 +1756,11 @@ public static class AssertionExtensions
         Func<IAssertionSource<TValue>, Assertion<TValue>> assertionBuilder,
         TimeSpan timeout,
         TimeSpan? pollingInterval = null,
+        CancellationToken cancellationToken = default,
         [CallerArgumentExpression(nameof(timeout))] string? timeoutExpression = null,
         [CallerArgumentExpression(nameof(pollingInterval))] string? pollingIntervalExpression = null)
     {
-        return source.WaitsFor(assertionBuilder, timeout, pollingInterval, timeoutExpression, pollingIntervalExpression);
+        return source.WaitsFor(assertionBuilder, timeout, pollingInterval, cancellationToken, timeoutExpression, pollingIntervalExpression);
     }
 
     private static Action GetActionFromDelegate(DelegateAssertion source)

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2279,7 +2279,7 @@ namespace .Conditions
     public static class ValueTaskAssertionExtensions { }
     public class WaitsForAssertion<TValue> : .<TValue>
     {
-        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default) { }
+        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default) { }
         public override .<TValue?> AssertAsync() { }
         protected override .<.> CheckAsync(.<TValue> metadata) { }
         protected override string GetExpectation() { }
@@ -2674,7 +2674,7 @@ namespace .Extensions
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
             "(str).Length().IsGreaterThan(5)")]
         public static ..LengthWrapper HasLength(this .<string> source) { }
@@ -2803,7 +2803,7 @@ namespace .Extensions
         public static .<TException> ThrowsException<TException, TValue>(this .<TValue> source)
             where TException :  { }
         public static .<TValue> ThrowsNothing<TValue>(this .<TValue> source) { }
-        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..WhenParsedIntoAssertion<T> WhenParsedInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TException, TInnerException> WithInnerException<TException, TInnerException>(this .<TException> source)
             where TException : 

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2262,7 +2262,7 @@ namespace .Conditions
     public static class ValueTaskAssertionExtensions { }
     public class WaitsForAssertion<TValue> : .<TValue>
     {
-        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default) { }
+        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default) { }
         public override .<TValue?> AssertAsync() { }
         protected override .<.> CheckAsync(.<TValue> metadata) { }
         protected override string GetExpectation() { }
@@ -2653,7 +2653,7 @@ namespace .Extensions
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
             "(str).Length().IsGreaterThan(5)")]
         public static ..LengthWrapper HasLength(this .<string> source) { }
@@ -2768,7 +2768,7 @@ namespace .Extensions
         public static .<TException> ThrowsException<TException, TValue>(this .<TValue> source)
             where TException :  { }
         public static .<TValue> ThrowsNothing<TValue>(this .<TValue> source) { }
-        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..WhenParsedIntoAssertion<T> WhenParsedInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TException, TInnerException> WithInnerException<TException, TInnerException>(this .<TException> source)
             where TException : 

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2279,7 +2279,7 @@ namespace .Conditions
     public static class ValueTaskAssertionExtensions { }
     public class WaitsForAssertion<TValue> : .<TValue>
     {
-        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default) { }
+        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default) { }
         public override .<TValue?> AssertAsync() { }
         protected override .<.> CheckAsync(.<TValue> metadata) { }
         protected override string GetExpectation() { }
@@ -2674,7 +2674,7 @@ namespace .Extensions
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
             "(str).Length().IsGreaterThan(5)")]
         public static ..LengthWrapper HasLength(this .<string> source) { }
@@ -2803,7 +2803,7 @@ namespace .Extensions
         public static .<TException> ThrowsException<TException, TValue>(this .<TValue> source)
             where TException :  { }
         public static .<TValue> ThrowsNothing<TValue>(this .<TValue> source) { }
-        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..WhenParsedIntoAssertion<T> WhenParsedInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TException, TInnerException> WithInnerException<TException, TInnerException>(this .<TException> source)
             where TException : 

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2032,7 +2032,7 @@ namespace .Conditions
     public static class ValueTaskAssertionExtensions { }
     public class WaitsForAssertion<TValue> : .<TValue>
     {
-        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default) { }
+        public WaitsForAssertion(.<TValue> context, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default) { }
         public override .<TValue?> AssertAsync() { }
         protected override .<.> CheckAsync(.<TValue> metadata) { }
         protected override string GetExpectation() { }
@@ -2389,7 +2389,7 @@ namespace .Extensions
             where TCollection : .<.<TKey, TValue>>
             where TKey :  notnull { }
         public static .<TValue> EqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> Eventually<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length() instead, which provides all numeric assertion methods. Example: Asse" +
             "(str).Length().IsGreaterThan(5)")]
         public static ..LengthWrapper HasLength(this .<string> source) { }
@@ -2482,7 +2482,7 @@ namespace .Extensions
         public static .<TException> ThrowsException<TException, TValue>(this .<TValue> source)
             where TException :  { }
         public static .<TValue> ThrowsNothing<TValue>(this .<TValue> source) { }
-        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static .<TValue> WaitsFor<TValue>(this .<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..WhenParsedIntoAssertion<T> WhenParsedInto<T>(this .<string> source) { }
         public static .<TException, TInnerException> WithInnerException<TException, TInnerException>(this .<TException> source)
             where TException : 

--- a/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -293,7 +293,7 @@ namespace .
         public static ..ShouldAssertion<TValue> BeOfType<TValue>(this ..IShouldSource<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..ShouldAssertion<string> BeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
         public static ..ShouldAssertion<TValue> EqualTo<TValue>(this ..IShouldSource<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length().IsEqualTo(expectedLength) instead.")]
         public static ..ShouldAssertion<string> HaveLength(this ..IShouldSource<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static ..ShouldAssertion<TException> HaveMessage<TException>(this ..IShouldSource<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
@@ -313,7 +313,7 @@ namespace .
         public static ..ShouldAssertion<TValue> NotBeNull<TValue>(this ..IShouldSource<TValue> source)
             where TValue :  class { }
         public static ..ShouldAssertion<string> NotBeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
-        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..ShouldAssertion<TException> WithInnerException<TException, TInnerException>(this ..IShouldSource<TException> source)
             where TException : 
             where TInnerException :  { }

--- a/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -293,7 +293,7 @@ namespace .
         public static ..ShouldAssertion<TValue> BeOfType<TValue>(this ..IShouldSource<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..ShouldAssertion<string> BeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
         public static ..ShouldAssertion<TValue> EqualTo<TValue>(this ..IShouldSource<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length().IsEqualTo(expectedLength) instead.")]
         public static ..ShouldAssertion<string> HaveLength(this ..IShouldSource<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static ..ShouldAssertion<TException> HaveMessage<TException>(this ..IShouldSource<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
@@ -313,7 +313,7 @@ namespace .
         public static ..ShouldAssertion<TValue> NotBeNull<TValue>(this ..IShouldSource<TValue> source)
             where TValue :  class { }
         public static ..ShouldAssertion<string> NotBeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
-        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..ShouldAssertion<TException> WithInnerException<TException, TInnerException>(this ..IShouldSource<TException> source)
             where TException : 
             where TInnerException :  { }

--- a/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Should_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -293,7 +293,7 @@ namespace .
         public static ..ShouldAssertion<TValue> BeOfType<TValue>(this ..IShouldSource<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..ShouldAssertion<string> BeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
         public static ..ShouldAssertion<TValue> EqualTo<TValue>(this ..IShouldSource<TValue> source, TValue? expected, [.("expected")] string? expression = null) { }
-        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> Eventually<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         [("Use Length().IsEqualTo(expectedLength) instead.")]
         public static ..ShouldAssertion<string> HaveLength(this ..IShouldSource<string> source, int expectedLength, [.("expectedLength")] string? expression = null) { }
         public static ..ShouldAssertion<TException> HaveMessage<TException>(this ..IShouldSource<TException> source, string expectedMessage, [.("expectedMessage")] string? expression = null)
@@ -313,7 +313,7 @@ namespace .
         public static ..ShouldAssertion<TValue> NotBeNull<TValue>(this ..IShouldSource<TValue> source)
             where TValue :  class { }
         public static ..ShouldAssertion<string> NotBeParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this ..IShouldSource<string> source) { }
-        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
+        public static ..ShouldAssertion<TValue> WaitFor<TValue>(this ..IShouldSource<TValue> source, <.<TValue>, .<TValue>> assertionBuilder,  timeout, ? pollingInterval = default, .CancellationToken cancellationToken = default, [.("timeout")] string? timeoutExpression = null, [.("pollingInterval")] string? pollingIntervalExpression = null) { }
         public static ..ShouldAssertion<TException> WithInnerException<TException, TInnerException>(this ..IShouldSource<TException> source)
             where TException : 
             where TInnerException :  { }


### PR DESCRIPTION
## Description

Adds a `CancellationToken` parameter to `WaitsFor` and `Eventually`. The token is honoured between iterations of the polling loop, and the internal `Task.Delay` is wired through a linked cancellation source so both external cancellation and the internal timeout break the sleep. External cancellation propagates as `OperationCanceledException`; the internal timeout still produces the standard `AssertionException`.

The parameter is defaulted (`CancellationToken cancellationToken = default`), so callers using named arguments compile and behave unchanged.

Implements the locked defaults proposed in #5932:

- Parameter name: `cancellationToken`
- Signature shape: single overload with defaulted CT (not two non-defaulting overloads)
- Pre-cancelled-token shortcut: yes (`ThrowIfCancellationRequested` at the top of each iteration)
- Exception type for external cancellation: plain `OperationCanceledException` (no TUnit wrapper)
- Scope: `WaitsFor` and `Eventually` only (no change to other timeout-bearing assertions)

Any of these defaults can be reversed in review.

### Breaking changes

The new `cancellationToken` parameter is positioned between `pollingInterval` and the `[CallerArgumentExpression]` parameters of `WaitsFor` / `Eventually`, matching the convention used elsewhere in `AssertionExtensions.cs` (real parameters first, compiler-fill diagnostic parameters last).

Impact on callers:

- Named-argument call sites (the form used in every existing test in `WaitsForAssertionTests.cs`): unaffected.
- Positional call sites up to and including `pollingInterval`: unaffected.
- Positional call sites that pass `timeoutExpression` or `pollingIntervalExpression` directly (overriding the compiler's auto-fill; non-standard but legal): CS0029 type mismatch at the 5th positional argument. Resolution is a one-line shift to named arguments.
- Binary callers: any DLL compiled against the prior TUnit needs recompilation; the method signatures changed.

The functional contract for existing callers is preserved: when `cancellationToken` is not passed, the linked CTS short-circuits to a plain timeout-only source and behaviour matches the prior release.

## Related Issue

Fixes #5932

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [x] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [x] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [x] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [x] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [x] All existing tests pass (`dotnet test`)
- [x] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

### Regression tests added

Five new tests in `WaitsForAssertionTests.cs`:

1. `WaitsFor_PropagatesExternalCancellation_Before_Internal_Timeout`: external CT cancels after 100ms, predicate returns false continuously, internal timeout 30s. Asserts `OperationCanceledException` and elapsed time under 1 second.
2. `WaitsFor_Throws_AssertionException_On_Internal_Timeout_When_Token_Not_Cancelled`: CT created but never cancelled, internal timeout 200ms. Asserts `AssertionException` (the existing contract is preserved when CT is unused).
3. `WaitsFor_Honours_PreCancelled_Token_Before_First_Poll`: pre-cancelled CT, would-pass predicate, internal timeout 5s. Asserts `OperationCanceledException` and elapsed under 500ms (proves the loop exits on the first iteration).
4. `Eventually_PropagatesExternalCancellation_Before_Internal_Timeout`: alias-symmetry test confirming the same cancellation contract holds for `Eventually` (which forwards to `WaitsFor`).
5. `WaitsFor_Propagates_OCE_When_Predicate_Observes_Supplied_Token`: predicate calls `cts.Token.ThrowIfCancellationRequested()` after the token is cancelled mid-poll; verifies cancellation propagates within roughly the cancel delay plus one poll interval.

### Implementation

- `WaitsForAssertion<TValue>` constructor takes the token and stores it as a field.
- `CheckAsync` builds a linked CTS when the supplied token is cancellable, otherwise a plain timeout-only CTS. This avoids the linked-registration overhead when no external token is provided.
- Between iterations: `cancellationToken.ThrowIfCancellationRequested()` honours external cancel before each predicate invocation.
- During the poll sleep: `Task.Delay(_pollingInterval, linkedCts.Token)` is wrapped in two `catch (OperationCanceledException)` clauses, the first using a `when (cancellationToken.IsCancellationRequested)` filter to rethrow on external cancel and the second falling through to the existing `AssertionResult.Failed` path on internal timeout.

### Public API snapshot updates

The `TUnit.PublicAPI` test project's `Tests.Assertions_Library_Has_No_API_Changes` snapshots have been regenerated for the four supported TFMs (net472 / net8.0 / net9.0 / net10.0). Each delta is exactly three lines: the `WaitsForAssertion` constructor, the `WaitsFor` extension, and the `Eventually` extension all gain the new defaulted `CancellationToken` parameter.

### Local verification

- Full `TUnit.Assertions.Tests` suite: 2111/2111 pass (existing 2106 + 5 new).
- This change is in `TUnit.Assertions` only; no source-generator emit is affected.
