### PR TITLE
test: tag tests with [Category] across test projects (demo for #5912)

### DIFF
--- a/TUnit.Assertions.Tests/ArrayAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ArrayAssertionTests.cs
@@ -2,6 +2,7 @@ using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;
 
+[Category("Collections")]
 public class ArrayAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/AssemblyCategories.cs
+++ b/TUnit.Assertions.Tests/AssemblyCategories.cs
@@ -1,0 +1,1 @@
+[assembly: Category("Assertions")]

--- a/TUnit.Assertions.Tests/AssertMultipleTests.cs
+++ b/TUnit.Assertions.Tests/AssertMultipleTests.cs
@@ -2,6 +2,7 @@
 namespace TUnit.Assertions.Tests;
 
 [UnconditionalSuppressMessage("Usage", "TUnitAssertions0005:Assert.That(...) should not be used with a constant value")]
+[Category("Composition")]
 public class AssertMultipleTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/AssertionBuilders/AndAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/AndAssertionTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace TUnit.Assertions.Tests.AssertionBuilders;
 
+[Category("Composition")]
 public sealed class AndAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AssertionBuilders/OrAssertionTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace TUnit.Assertions.Tests.AssertionBuilders;
 
+[Category("Composition")]
 public sealed class OrAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/AssertionGroupTests.cs
+++ b/TUnit.Assertions.Tests/AssertionGroupTests.cs
@@ -1,5 +1,6 @@
 namespace TUnit.Assertions.Tests;
 
+[Category("Composition")]
 public class AssertionGroupTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
@@ -1,6 +1,8 @@
 #if NET5_0_OR_GREATER
 namespace TUnit.Assertions.Tests;
 
+[Category("Async")]
+[Category("Collections")]
 public class AsyncEnumerableAssertionTests
 {
     // IsEmpty tests

--- a/TUnit.Assertions.Tests/AsyncMapTests.cs
+++ b/TUnit.Assertions.Tests/AsyncMapTests.cs
@@ -8,6 +8,8 @@ using TUnit.Assertions.Sources;
 
 namespace TUnit.Assertions.Tests;
 
+[Category("Async")]
+[Category("Composition")]
 public class AsyncMapTests
 {
 #if !NET472

--- a/TUnit.Assertions.Tests/AsyncMemberTests.cs
+++ b/TUnit.Assertions.Tests/AsyncMemberTests.cs
@@ -1,5 +1,6 @@
 namespace TUnit.Assertions.Tests;
 
+[Category("Async")]
 public class AsyncMemberTests
 {
     private sealed class MyObject

--- a/TUnit.Assertions.Tests/BooleanAssertionTests.cs
+++ b/TUnit.Assertions.Tests/BooleanAssertionTests.cs
@@ -3,6 +3,7 @@ using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;
 
+[Category("Primitives")]
 public class BooleanAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/Bugs/Issue5613Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5613Tests.cs
@@ -10,6 +10,7 @@ namespace TUnit.Assertions.Tests.Bugs;
 /// Fix: instance methods on AsyncDelegateAssertion that forward to the
 /// IAssertionSource&lt;Task&gt; interface.
 /// </summary>
+[Category("Regression")]
 public class Issue5613Tests
 {
     [Test]

--- a/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5707Tests.cs
@@ -16,6 +16,7 @@ namespace TUnit.Assertions.Tests.Bugs;
 /// SetAssertion, etc.) so the failure message also keeps the
 /// specialised assertion's expectation rather than a generic wrapper.
 /// </summary>
+[Category("Regression")]
 public class Issue5707Tests
 {
     [Test]

--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -18,6 +18,7 @@ namespace TUnit.Assertions.Tests.Bugs;
 /// adds <c>IsEqualTo&lt;TValue, TOther&gt;</c> overloads that detect a user-defined
 /// implicit operator at runtime and compare the converted values.
 /// </summary>
+[Category("Regression")]
 public class Issue5720Tests
 {
     public sealed record ProductCode(string Value)

--- a/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5765Tests.cs
@@ -2,6 +2,7 @@ using System.Net;
 
 namespace TUnit.Assertions.Tests.Bugs;
 
+[Category("Regression")]
 public class Issue5765Tests
 {
     [Test]

--- a/TUnit.Assertions.Tests/Bugs/Issue5778Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5778Tests.cs
@@ -5,6 +5,8 @@ namespace TUnit.Assertions.Tests.Bugs;
 /// LastItem(...).Satisfies(...) should preserve specialised assertion sources for
 /// collection-like item values instead of exposing only IAssertionSource&lt;TItem&gt;.
 /// </summary>
+[Category("Regression")]
+[Category("Collections")]
 public class Issue5778Tests
 {
     [Test]

--- a/TUnit.Assertions.Tests/CharAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CharAssertionTests.cs
@@ -3,6 +3,7 @@ using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;
 
+[Category("Primitives")]
 public class CharAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/CollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionAssertionTests.cs
@@ -2,6 +2,7 @@ using TUnit.Assertions.Extensions;
 
 namespace TUnit.Assertions.Tests;
 
+[Category("Collections")]
 public class CollectionAssertionTests
 {
     [Test]

--- a/TUnit.Assertions.Tests/CollectionStructuralEquivalenceTests.cs
+++ b/TUnit.Assertions.Tests/CollectionStructuralEquivalenceTests.cs
@@ -6,6 +6,8 @@ namespace TUnit.Assertions.Tests;
 /// <summary>
 /// Tests for issue #3454: Collection IsEquivalentTo should use structural equality for complex objects
 /// </summary>
+[Category("Collections")]
+[Category("Equivalence")]
 public class CollectionStructuralEquivalenceTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/AssemblyCategories.cs
+++ b/TUnit.Mocks.Tests/AssemblyCategories.cs
@@ -1,0 +1,1 @@
+[assembly: Category("Mocks")]

--- a/TUnit.Mocks.Tests/AsyncTests.cs
+++ b/TUnit.Mocks.Tests/AsyncTests.cs
@@ -20,6 +20,7 @@ public interface IAsyncService
 /// Verifies that async methods (Task{T}, ValueTask{T}, Task) can be
 /// configured with unwrapped return types: .Returns(5) instead of .Returns(Task.FromResult(5)).
 /// </summary>
+[Category("Async")]
 public class AsyncTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/AsyncVerificationTests.cs
+++ b/TUnit.Mocks.Tests/AsyncVerificationTests.cs
@@ -3,6 +3,8 @@ using TUnit.Mocks.Assertions;
 
 namespace TUnit.Mocks.Tests;
 
+[Category("Async")]
+[Category("Verification")]
 public class AsyncVerificationTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/EventTests.cs
+++ b/TUnit.Mocks.Tests/EventTests.cs
@@ -23,6 +23,7 @@ public interface IEventService
 /// <summary>
 /// US5 Integration Tests: Event raising.
 /// </summary>
+[TUnit.Core.Category("Events")]
 public class EventTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -27,6 +27,7 @@ public class Order
 /// <summary>
 /// US7 Integration Tests: Generic method support in mock generation.
 /// </summary>
+[Category("Generics")]
 public class GenericTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/Issue5425Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5425Tests.cs
@@ -25,6 +25,7 @@ namespace TUnit.Mocks.Tests;
 // If the source generator stops preserving nullability on event handler types,
 // the generated mock will mismatch these source declarations and this file will
 // fail to compile.
+[Category("Regression")]
 public class Issue5425Tests
 {
     public interface IWithNullableTypeArg

--- a/TUnit.Mocks.Tests/Issue5426Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5426Tests.cs
@@ -7,6 +7,7 @@ namespace TUnit.Mocks.Tests;
 //
 // These tests are *compile-time* regressions: if the source generator emits `public` for any of
 // the types below, this file fails to compile and the test project will not build.
+[Category("Regression")]
 public class Issue5426Tests
 {
     internal interface IInternalDatabaseService

--- a/TUnit.Mocks.Tests/Issue5434Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5434Tests.cs
@@ -8,6 +8,7 @@ namespace TUnit.Mocks.Tests;
 // BlobClient: CS0111 duplicate GenerateSasUri / GenerateUserDelegationSasUri members in generated extensions.
 // TableClient: CS0411 type inference failures for generic methods (GetEntity<T>, GetEntityAsync<T>,
 // GetEntityIfExists<T>, GetEntityIfExistsAsync<T>, Query<T>, QueryAsync<T>) in generated impl factory.
+[Category("Regression")]
 public class Issue5434Tests
 {
     [Test]

--- a/TUnit.Mocks.Tests/Issue5453Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5453Tests.cs
@@ -4,6 +4,7 @@ namespace TUnit.Mocks.Tests;
 // CS9338 / CS0051: a public generic interface closed over an internal type argument
 // (e.g. ILogger<InternalClass>) used to emit a `public` mock wrapper, leaking the
 // internal type through the wrapper's base signature.
+[Category("Regression")]
 public class Issue5453Tests
 {
     internal sealed class InternalConsumer

--- a/TUnit.Mocks.Tests/Issue5455Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5455Tests.cs
@@ -5,6 +5,7 @@ namespace TUnit.Mocks.Tests;
 // Regression: https://github.com/thomhurst/TUnit/issues/5455
 // Azure.Response.IsError is `public virtual bool IsError { get; internal set; }` — the internal
 // setter is invisible to external assemblies, so the generated override must not emit it.
+[Category("Regression")]
 public class Issue5455Tests
 {
     [Test]

--- a/TUnit.Mocks.Tests/Issue5567Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5567Tests.cs
@@ -14,6 +14,7 @@ public interface IIssue5567Enumerable<T> : IEnumerable<T>
     T? GetValue();
 }
 
+[Category("Regression")]
 public class Issue5567Tests
 {
     [Test]

--- a/TUnit.Mocks.Tests/Issue5673Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5673Tests.cs
@@ -7,6 +7,7 @@ namespace TUnit.Mocks.Tests;
 // EntityEntry implements IInfrastructure<InternalEntityEntry> where InternalEntityEntry is
 // internal to EF Core. The generated override for `Instance` referenced that internal type,
 // producing CS0115 "no suitable method found to override" in external assemblies.
+[Category("Regression")]
 public class Issue5673Tests
 {
     [Test]

--- a/TUnit.Mocks.Tests/PerformanceOptimizationTests.cs
+++ b/TUnit.Mocks.Tests/PerformanceOptimizationTests.cs
@@ -12,6 +12,7 @@ namespace TUnit.Mocks.Tests;
 /// - Fast-path verification when no argument matchers are present
 /// - Lock-based call recording thread safety
 /// </summary>
+[Category("Performance")]
 public class PerformanceOptimizationTests
 {
     // ========================================================================

--- a/TUnit.Mocks.Tests/RealWorldScenarioTests.cs
+++ b/TUnit.Mocks.Tests/RealWorldScenarioTests.cs
@@ -136,6 +136,8 @@ public class OrderService
 /// commonly found in production codebases: repository/UoW, DI orchestration,
 /// multi-interface coordination, complex return types, and nullable handling.
 /// </summary>
+[Category("Integration")]
+[Category("RealWorld")]
 public class RealWorldScenarioTests
 {
     // ───────────────────────────────────────────────────────────

--- a/TUnit.Mocks.Tests/SmartDefaultTests.cs
+++ b/TUnit.Mocks.Tests/SmartDefaultTests.cs
@@ -19,6 +19,7 @@ public interface IDefaultsService
 /// <summary>
 /// US6 Integration Tests: Smart defaults — unconfigured methods return sensible defaults based on type.
 /// </summary>
+[Category("SmartDefaults")]
 public class SmartDefaultTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/StrictModeTests.cs
+++ b/TUnit.Mocks.Tests/StrictModeTests.cs
@@ -6,6 +6,7 @@ namespace TUnit.Mocks.Tests;
 /// <summary>
 /// US6 Integration Tests: Strict mode behavior — unconfigured calls throw MockStrictBehaviorException.
 /// </summary>
+[Category("StrictMode")]
 public class StrictModeTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/ThreadSafetyTests.cs
+++ b/TUnit.Mocks.Tests/ThreadSafetyTests.cs
@@ -6,6 +6,8 @@ namespace TUnit.Mocks.Tests;
 /// <summary>
 /// T071 Integration Tests: Thread safety — concurrent mock usage, setup, and verification.
 /// </summary>
+[Category("Concurrency")]
+[Category("ThreadSafety")]
 public class ThreadSafetyTests
 {
     [Test]

--- a/TUnit.Mocks.Tests/VerificationTests.cs
+++ b/TUnit.Mocks.Tests/VerificationTests.cs
@@ -7,6 +7,7 @@ namespace TUnit.Mocks.Tests;
 /// <summary>
 /// US2 Integration Tests: Verification — verify method calls were made with expected arguments and counts.
 /// </summary>
+[Category("Verification")]
 public class VerificationTests
 {
     [Test]

--- a/TUnit.TestProject/AdaptiveParallelismTests.cs
+++ b/TUnit.TestProject/AdaptiveParallelismTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 namespace TUnit.TestProject;
 
+[Category("Parallelism")]
+[Category("Concurrency")]
 public class AdaptiveParallelismTests
 {
     private static int _currentlyRunning;

--- a/TUnit.TestProject/ArgumentsWithClassDataSourceTests.cs
+++ b/TUnit.TestProject/ArgumentsWithClassDataSourceTests.cs
@@ -8,6 +8,7 @@ namespace TUnit.TestProject;
 [Arguments(2)]
 [ClassDataSource(typeof(IntDataSource1))]
 [ClassDataSource(typeof(IntDataSource2))]
+[Category("DataSource")]
 public class ArgumentsWithClassDataSourceTests(int classArg)
 {
     private static readonly ConcurrentBag<string> ExecutedTests =

--- a/TUnit.TestProject/AsyncDataSourceExampleTests.cs
+++ b/TUnit.TestProject/AsyncDataSourceExampleTests.cs
@@ -73,6 +73,8 @@ public class AsyncUntypedDataSource : AsyncUntypedDataSourceGeneratorAttribute
     }
 }
 
+[Category("DataSource")]
+[Category("Async")]
 public class AsyncDataSourceExampleTests
 {
     [Test]

--- a/TUnit.TestProject/AsyncDisposableTests.cs
+++ b/TUnit.TestProject/AsyncDisposableTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace TUnit.TestProject;
 
+[Category("Lifecycle")]
+[Category("Async")]
 public class AsyncDisposableTests : IAsyncDisposable
 {
     [Test]

--- a/TUnit.TestProject/AsyncLocalTest.cs
+++ b/TUnit.TestProject/AsyncLocalTest.cs
@@ -4,6 +4,8 @@ using TUnit.TestProject.Attributes;
 namespace TUnit.TestProject;
 
 [SkipNetFramework("ExecutionContext.Restore is not supported on .NET Framework")]
+[Category("Async")]
+[Category("Context")]
 public class AsyncLocalTest
 {
     private readonly AsyncLocal<string> _asyncLocalValue = new();

--- a/TUnit.TestProject/AutoDataTests.cs
+++ b/TUnit.TestProject/AutoDataTests.cs
@@ -2,6 +2,8 @@
 
 namespace TUnit.TestProject;
 
+[Category("DataSource")]
+[Category("AutoData")]
 public class AutoDataTests
 {
     [AutoData]

--- a/TUnit.TestProject/BasicTests.cs
+++ b/TUnit.TestProject/BasicTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace TUnit.TestProject;
 
+[Category("Smoke")]
 public class BasicTests
 {
     [Test]

--- a/TUnit.TestProject/CanCancelTests.cs
+++ b/TUnit.TestProject/CanCancelTests.cs
@@ -1,5 +1,6 @@
 namespace TUnit.TestProject;
 
+[Category("Cancellation")]
 public class CanCancelTests
 {
     [Test, Explicit]

--- a/TUnit.TestProject/CaptureOutputTests.cs
+++ b/TUnit.TestProject/CaptureOutputTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace TUnit.TestProject;
 
 [Repeat(15)]
+[Category("Output")]
+[Category("Reporting")]
 public class CaptureOutputTests
 {
     private readonly MyClass _myClass = new();

--- a/TUnit.TestProject/ClassDataSourceDrivenTests.cs
+++ b/TUnit.TestProject/ClassDataSourceDrivenTests.cs
@@ -4,6 +4,7 @@ using TUnit.TestProject.Library.Models;
 namespace TUnit.TestProject;
 
 [EngineTest(ExpectedResult.Pass)]
+[Category("DataSource")]
 public class ClassDataSourceDrivenTests
 {
     [Test]

--- a/TUnit.TestProject/ClassHooksExecutionCountTests.cs
+++ b/TUnit.TestProject/ClassHooksExecutionCountTests.cs
@@ -3,6 +3,8 @@
 namespace TUnit.TestProject;
 
 [EngineTest(ExpectedResult.Pass)]
+[Category("Hooks")]
+[Category("Lifecycle")]
 public class ClassHooksExecutionCountTests
 {
     private static int _beforeClassCalls;

--- a/TUnit.TestProject/CustomRetryTests.cs
+++ b/TUnit.TestProject/CustomRetryTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace TUnit.TestProject;
 
 [RetryOperationCancelledException(3)]
+[Category("Retry")]
 public class CustomRetryTests
 {
     public static int ExecutionCount1 { get; private set; }

--- a/TUnit.TestProject/HookExecutionOrderTest.cs
+++ b/TUnit.TestProject/HookExecutionOrderTest.cs
@@ -1,5 +1,7 @@
 namespace TUnit.TestProject;
 
+[Category("Hooks")]
+[Category("Lifecycle")]
 public class HookExecutionOrderTest
 {
     private static readonly List<string> ExecutionOrder = new();

--- a/TUnit.TestProject/HookTimeoutTests.cs
+++ b/TUnit.TestProject/HookTimeoutTests.cs
@@ -4,6 +4,8 @@ namespace TUnit.TestProject;
 /// Tests for hook timeout attribute functionality.
 /// This class tests that [Timeout] attribute on hooks is properly respected.
 /// </summary>
+[Category("Hooks")]
+[Category("Timeout")]
 public class HookTimeoutTests
 {
     /// <summary>

--- a/TUnit.TestProject/KeyedNotInParallelTests.cs
+++ b/TUnit.TestProject/KeyedNotInParallelTests.cs
@@ -5,6 +5,8 @@ namespace TUnit.TestProject;
 
 [EngineTest(ExpectedResult.Pass)]
 [Retry(3)]
+[Category("Parallelism")]
+[Category("Retry")]
 public class KeyedNotInParallelTests
 {
     private static readonly ConcurrentBag<ConstraintDateTimeRange> TestDateTimeRanges = [];

--- a/TUnit.UnitTests/AsyncDataSourceTests.cs
+++ b/TUnit.UnitTests/AsyncDataSourceTests.cs
@@ -1,5 +1,7 @@
 namespace TUnit.UnitTests;
 
+[Category("DataSource")]
+[Category("Async")]
 public class AsyncDataSourceTests
 {
     // Sync data source for comparison

--- a/TUnit.UnitTests/ComplexGenericInheritanceTests.cs
+++ b/TUnit.UnitTests/ComplexGenericInheritanceTests.cs
@@ -2,6 +2,9 @@ using TUnit.Core;
 
 namespace TUnit.UnitTests;
 
+[Category("Discovery")]
+[Category("Generics")]
+[Category("Inheritance")]
 public class ComplexGenericInheritanceTests
 {
     private static TestMetadata<T> CreateTestMetadata<T>(string testId, string methodName) where T : class

--- a/TUnit.UnitTests/ContextThreadSafetyTests.cs
+++ b/TUnit.UnitTests/ContextThreadSafetyTests.cs
@@ -12,6 +12,8 @@ internal class TestableContext : Context
     internal override void SetAsyncLocalContext() { }
 }
 
+[Category("Concurrency")]
+[Category("ThreadSafety")]
 public class ContextThreadSafetyTests
 {
     [Test]

--- a/TUnit.UnitTests/DependencyResolutionFailureTests.cs
+++ b/TUnit.UnitTests/DependencyResolutionFailureTests.cs
@@ -5,6 +5,7 @@ namespace TUnit.UnitTests;
 /// <summary>
 /// Tests to verify that dependency resolution failures don't abort the entire test run
 /// </summary>
+[Category("Discovery")]
 public class DependencyResolutionFailureTests
 {
     [Test]

--- a/TUnit.UnitTests/DependsOnTests.cs
+++ b/TUnit.UnitTests/DependsOnTests.cs
@@ -1,5 +1,7 @@
 namespace TUnit.UnitTests;
 
+[Category("Discovery")]
+[Category("DependsOn")]
 public class DependsOnTests
 {
     private static TestMetadata<T> CreateTestMetadata<T>(string testId, string methodName, int parameterCount = 0, Type[]? parameterTypes = null) where T : class

--- a/TUnit.UnitTests/EmptyDataSourceTests.cs
+++ b/TUnit.UnitTests/EmptyDataSourceTests.cs
@@ -5,6 +5,7 @@ namespace TUnit.UnitTests;
 /// These tests verify that empty data sources behave consistently with NoDataSource by yielding
 /// exactly one empty result, rather than zero results.
 /// </summary>
+[Category("DataSource")]
 public class EmptyDataSourceTests
 {
     /// <summary>

--- a/TUnit.UnitTests/ExpressionHelperTests.cs
+++ b/TUnit.UnitTests/ExpressionHelperTests.cs
@@ -8,6 +8,7 @@ namespace TUnit.UnitTests;
 /// produced by CreateTestVariantInternal for different test method return types.
 /// Regression tests for https://github.com/thomhurst/TUnit/issues/5093
 /// </summary>
+[Category("Internals")]
 public class ExpressionHelperTests
 {
     // Dummy test class used as expression target

--- a/TUnit.UnitTests/GenericTestGenerationTests.cs
+++ b/TUnit.UnitTests/GenericTestGenerationTests.cs
@@ -1,5 +1,7 @@
 namespace TUnit.UnitTests;
 
+[Category("Discovery")]
+[Category("Generics")]
 public class GenericTestGenerationTests
 {
 

--- a/TUnit.UnitTests/GetReadableTypeNameTests.cs
+++ b/TUnit.UnitTests/GetReadableTypeNameTests.cs
@@ -3,6 +3,7 @@ using TUnit.Core;
 
 namespace TUnit.UnitTests;
 
+[Category("Internals")]
 public class GetReadableTypeNameTests
 {
     [Test]

--- a/TUnit.UnitTests/HtmlReporterTruncateOutputTests.cs
+++ b/TUnit.UnitTests/HtmlReporterTruncateOutputTests.cs
@@ -2,6 +2,8 @@ using TUnit.Engine.Reporters.Html;
 
 namespace TUnit.UnitTests;
 
+[Category("Reporting")]
+[Category("Html")]
 public class HtmlReporterTruncateOutputTests
 {
     [Test]

--- a/TUnit.UnitTests/IAsyncEnumerableDocumentationExample.cs
+++ b/TUnit.UnitTests/IAsyncEnumerableDocumentationExample.cs
@@ -40,6 +40,9 @@ public static class AsyncTestDataSources
     }
 }
 
+[Category("Documentation")]
+[Category("Async")]
+[Category("DataSource")]
 public class IAsyncEnumerableDocumentationExample
 {
     [Test]

--- a/TUnit.UnitTests/InheritanceDependencyExample.cs
+++ b/TUnit.UnitTests/InheritanceDependencyExample.cs
@@ -43,6 +43,9 @@ public abstract class DatabaseTestBase
 }
 
 [InheritsTests]
+[Category("Documentation")]
+[Category("Inheritance")]
+[Category("DependsOn")]
 public class UserRepositoryTests : DatabaseTestBase
 {
     [Test]
@@ -60,6 +63,9 @@ public class UserRepositoryTests : DatabaseTestBase
 }
 
 [InheritsTests]
+[Category("Documentation")]
+[Category("Inheritance")]
+[Category("DependsOn")]
 public class ProductRepositoryTests : DatabaseTestBase
 {
     [Test]
@@ -103,6 +109,9 @@ public abstract class RepositoryTestBase<T> where T : class, new()
 }
 
 [InheritsTests]
+[Category("Documentation")]
+[Category("Inheritance")]
+[Category("Generics")]
 public class CustomerRepositoryTests : RepositoryTestBase<Customer>
 {
     [Test]

--- a/TUnit.UnitTests/LogSinkIntegrationTests.cs
+++ b/TUnit.UnitTests/LogSinkIntegrationTests.cs
@@ -6,6 +6,9 @@ namespace TUnit.UnitTests;
 /// Integration tests that verify the end-to-end flow from DefaultLogger through LogSinkRouter to registered sinks.
 /// </summary>
 [NotInParallel]
+[Category("Logging")]
+[Category("Integration")]
+[Property("Owner", "Logging")]
 public class LogSinkIntegrationTests
 {
     private RecordingSink _sink = null!;

--- a/TUnit.UnitTests/LogSinkRouterTests.cs
+++ b/TUnit.UnitTests/LogSinkRouterTests.cs
@@ -3,6 +3,7 @@ using TUnit.Core.Logging;
 namespace TUnit.UnitTests;
 
 [NotInParallel]
+[Category("Logging")]
 public class LogSinkRouterTests
 {
     [Before(Test)]

--- a/TUnit.UnitTests/PropertyDataSourceInjectionTests.cs
+++ b/TUnit.UnitTests/PropertyDataSourceInjectionTests.cs
@@ -4,6 +4,8 @@ using TUnit.Core.Helpers;
 
 namespace TUnit.UnitTests;
 
+[Category("DataSource")]
+[Category("PropertyInjection")]
 public class PropertyDataSourceInjectionTests
 {
     // Property with Arguments attribute

--- a/TUnit.UnitTests/ServiceProviderInfrastructureTests.cs
+++ b/TUnit.UnitTests/ServiceProviderInfrastructureTests.cs
@@ -6,6 +6,7 @@ namespace TUnit.UnitTests;
 /// <summary>
 /// Tests for service provider infrastructure and dependency injection
 /// </summary>
+[Category("Infrastructure")]
 public class ServiceProviderInfrastructureTests
 {
     [Test]

--- a/TUnit.UnitTests/StaticPropertyDataSourceTests.cs
+++ b/TUnit.UnitTests/StaticPropertyDataSourceTests.cs
@@ -2,6 +2,8 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.UnitTests;
 
+[Category("DataSource")]
+[Category("PropertyInjection")]
 public class StaticPropertyDataSourceTests
 {
     // Static property with Arguments attribute

--- a/TUnit.UnitTests/TUnitLoggerFactoryTests.cs
+++ b/TUnit.UnitTests/TUnitLoggerFactoryTests.cs
@@ -3,6 +3,7 @@ using TUnit.Core.Logging;
 namespace TUnit.UnitTests;
 
 [NotInParallel]
+[Category("Logging")]
 public class TUnitLoggerFactoryTests
 {
     [Before(Test)]

--- a/TUnit.UnitTests/TestConstructorTests.cs
+++ b/TUnit.UnitTests/TestConstructorTests.cs
@@ -3,6 +3,8 @@ using TUnit.Core;
 namespace TUnit.UnitTests.TestConstructorTests;
 
 // Test case 1: Single constructor (no change in behavior)
+[Category("Discovery")]
+[Category("Construction")]
 public class SingleConstructorTest
 {
     [Test]

--- a/TUnit.UnitTests/TestIsolationTests.cs
+++ b/TUnit.UnitTests/TestIsolationTests.cs
@@ -3,6 +3,8 @@ using TUnit.Core.Interfaces;
 
 namespace TUnit.UnitTests;
 
+[Category("Isolation")]
+[Category("Concurrency")]
 public class TestIsolationTests
 {
     [Test]

--- a/TUnit.UnitTests/TraceScopeRegistryTests.cs
+++ b/TUnit.UnitTests/TraceScopeRegistryTests.cs
@@ -5,6 +5,8 @@ using TUnit.Core;
 
 namespace TUnit.UnitTests;
 
+[Category("Tracing")]
+[Category("Infrastructure")]
 public class TraceScopeRegistryTests
 {
     [Test]

--- a/TUnit.UnitTests/TypeArrayComparerTests.cs
+++ b/TUnit.UnitTests/TypeArrayComparerTests.cs
@@ -3,6 +3,7 @@ namespace TUnit.UnitTests;
 /// <summary>
 /// Tests for TypeArrayComparer functionality
 /// </summary>
+[Category("Internals")]
 public class TypeArrayComparerTests
 {
     [Test]


### PR DESCRIPTION
## Summary

Demo PR for issue #5912 (filtering by Test Categories / properties). TUnit already supports `[Category]` and `[Property]` attributes that flow into MTP's `TreeNodeFilter` and the HTML report's category pills — this PR populates real-world category data across the test suites so the existing filtering and reporting can actually be exercised.

### What's tagged

- **TUnit.UnitTests** — class-level categories on ~22 classes (DataSource, Async, Logging, Internals, Concurrency, Discovery, Generics, Inheritance, Documentation, Infrastructure, …) plus one `[Property("Owner", "Logging")]` example.
- **TUnit.Mocks.Tests** — assembly-level `[Category(""Mocks"")]` via a new `AssemblyCategories.cs`, plus class-level extras on ~18 classes (Async, Verification, Events, Generics, Regression, Concurrency, Performance, StrictMode, SmartDefaults, RealWorld).
- **TUnit.Assertions.Tests** — assembly-level `[Category(""Assertions"")]`, plus class-level extras on ~16 classes (Collections, Async, Primitives, Composition, Equivalence, Regression).
- **TUnit.TestProject** — class-level categories on ~14 stable classes (Smoke, Parallelism, Concurrency, DataSource, Async, Lifecycle, Output, Reporting, Hooks, Timeout, Retry, Cancellation, Context, AutoData). Skipped intentionally-failing tests so as not to mis-categorize them.

### How to try it

Filter examples:

```bash
dotnet test TUnit.UnitTests --treenode-filter ""/*/*/*/*[Category=Async]""
dotnet test TUnit.Mocks.Tests --treenode-filter ""/*/*/*/*[Category=Regression]""
dotnet test TUnit.Assertions.Tests --treenode-filter ""/*/*/*/*[Category=Collections]""
dotnet test TUnit.Assertions.Tests --treenode-filter ""/*/*/*/*[Category=Assertions]&[Category!=Regression]""
```

HTML report (categories appear as filter pills in the toolbar):

```bash
dotnet test TUnit.UnitTests --report-html
# open the generated report under TestResults/
```

### Notes

- `TUnit.Mocks.Tests/EventTests.cs` uses fully qualified `[TUnit.Core.Category(""Events"")]` because the file already imports `System.ComponentModel` (for `INotifyPropertyChanging`), which would otherwise collide with `System.ComponentModel.CategoryAttribute`.
- All four touched test projects build cleanly (0 errors; warning count unchanged from baseline).

## Test plan

- [ ] `dotnet test TUnit.UnitTests --report-html` and inspect the HTML report — verify the category pills include the new tags and clicking them filters correctly.
- [ ] Repeat for `TUnit.Mocks.Tests` and `TUnit.Assertions.Tests`.
- [ ] Spot-check `--treenode-filter` syntax above narrows the run as expected.
- [ ] Confirm `TUnit.TestProject` behaviour is unchanged (no failing tests gained categories; designed-to-fail tests left alone).

Refs #5912