### PR TITLE
fix(html-report): extract categories using MTP Key=name convention

### DIFF
--- a/TUnit.Engine.Tests/HtmlReporterTests.cs
+++ b/TUnit.Engine.Tests/HtmlReporterTests.cs
@@ -262,6 +262,43 @@ public class HtmlReporterTests
         embedded.ShouldContain("\"value\":\"FullExecution\"");
     }
 
+    [Test]
+    public void ExtractTestResult_SortsTestMetadataProperty_Into_Categories_And_CustomProperties()
+    {
+        // Regression: Microsoft.Testing.Platform's VSTestBridge convention emits categories as
+        // TestMetadataProperty(name, "") — the category name lives in Key, Value is empty.
+        // Traits/custom properties use the (key, value) form with a non-empty Value.
+        // Earlier code keyed off IsNullOrEmpty(Key), which inverted both branches and silently
+        // misclassified every category as a custom property — leaving the HTML report's
+        // category-pill UI permanently empty.
+        var node = new TestNode
+        {
+            Uid = new TestNodeUid("extract-1"),
+            DisplayName = "Test",
+            Properties = new PropertyBag(
+                PassedTestNodeStateProperty.CachedInstance,
+                new TestMethodIdentifierProperty(
+                    @namespace: "TestNamespace",
+                    assemblyFullName: "TestAssembly",
+                    typeName: "SampleTests",
+                    methodName: "Test",
+                    parameterTypeFullNames: [],
+                    returnTypeFullName: "System.Void",
+                    methodArity: 0),
+                new TestMetadataProperty("Async", string.Empty),
+                new TestMetadataProperty("Integration", string.Empty),
+                new TestMetadataProperty("Owner", "TeamA"))
+        };
+
+        var result = HtmlReporter.ExtractTestResult("extract-1", node, traceId: null, spanId: null, retryAttempt: 0, additionalTraceIds: null);
+
+        result.Categories.ShouldBe(["Async", "Integration"], ignoreOrder: true);
+        result.CustomProperties.ShouldNotBeNull();
+        result.CustomProperties!.Length.ShouldBe(1);
+        result.CustomProperties[0].Key.ShouldBe("Owner");
+        result.CustomProperties[0].Value.ShouldBe("TeamA");
+    }
+
     private static ReportTestResult CreateTestResultWithStartTime(string displayName, string? startTime) => new()
     {
         Id = displayName,

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -484,7 +484,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             : DateTimeOffset.MaxValue;
     }
 
-    private static ReportTestResult ExtractTestResult(string testId, TestNode testNode, string? traceId, string? spanId, int retryAttempt, string[]? additionalTraceIds)
+    internal static ReportTestResult ExtractTestResult(string testId, TestNode testNode, string? traceId, string? spanId, int retryAttempt, string[]? additionalTraceIds)
     {
         IProperty? stateProperty = null;
         TestMethodIdentifierProperty? testMethodIdentifier = null;
@@ -518,10 +518,13 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
                     stdErr = TruncateOutput(e.StandardError);
                     break;
                 case TestMetadataProperty meta:
-                    if (string.IsNullOrEmpty(meta.Key))
+                    // MTP convention (matches Microsoft.Testing.Extensions.VSTestBridge): categories are
+                    // emitted as TestMetadataProperty(category, "") — name in Key, empty Value. Traits/
+                    // custom properties use (key, value) with a non-empty Value.
+                    if (string.IsNullOrEmpty(meta.Value))
                     {
                         categories ??= [];
-                        categories.Add(meta.Value);
+                        categories.Add(meta.Key);
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Fixes a latent bug in the HTML report where `[Category]` attributes never made it into the report's `categories` array — leaving the category-pill filter UI shipped in #5486 permanently dark.

## Root cause

Two coordinated emissions, one inverted check:

| File | Emits | Result |
|---|---|---|
| `TestExtensions.cs:71` | `new TestMetadataProperty(category)` — single-arg ctor | `Key=""Async""`, `Value=""""` |
| `HtmlReporter.cs:521` | `if (IsNullOrEmpty(meta.Key)) … categories.Add(meta.Value)` | branches to `else`, category lands in `customProperties` |

MTP's single-arg `TestMetadataProperty(string)` constructor stores the argument in `Key` and defaults `Value` to `""""` (verified via reflection on `Microsoft.Testing.Platform.dll` 2.2.3). Microsoft's own `Microsoft.Testing.Extensions.VSTestBridge` uses the same shape — `new TestMetadataProperty(category, string.Empty)` ([ObjectModelConverters.cs lines 72-76](https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs)). So the emitter is right; the extractor's field check is inverted.

Before the fix, decoding the embedded gzipped data blob from a report shows:
```json
""customProperties"":[{""key"":""Async"",""value"":""""},{""key"":""DataSource"",""value"":""""}]
```
After:
```json
""categories"":[""Async"",""DataSource""]
```

`buildCatPills()` (`HtmlReportGenerator.cs:1353`) only renders when `catNames.length > 0`, so with no categories ever populated the `#categoryPills` row stayed `display:none`.

## Fix

Swap the field check — `IsNullOrEmpty(meta.Value)` distinguishes the category shape (name in Key, empty Value) from the trait/property shape (non-empty Value). One-file change.

`TestFilterService` is unaffected — it builds its own `PropertyBag` from `TestDetails.Categories` directly, which is why CLI `--treenode-filter ""/*/*/*/*[Category=X]""` always worked.

## Side-effect: `[Property(""X"", """")]`

A user-defined `[Property(""X"", """")]` (empty value) will now classify as a category named ""X"" rather than a custom property with empty value. This is consistent with the convention (empty value = tag) and matches Microsoft's bridge behaviour.

## Test plan

- [x] New unit test `ExtractTestResult_SortsTestMetadataProperty_Into_Categories_And_CustomProperties` pins the split between the two `TestMetadataProperty` shapes.
- [x] All 14 `HtmlReporterTests` pass locally (`dotnet test --treenode-filter ""/*/*/HtmlReporterTests/*""`).
- [x] Verified end-to-end: ran `TUnit.TestProject` filtered to `CategoryTests` (which uses `[Category(""ClassCategory"")] [Category(""MethodCategory"")]` etc.) and confirmed the decoded report JSON now contains `""categories"":[""ClassCategory2"",""ClassCategory"",""MethodCategory2"",""MethodCategory""]`.
- [ ] (Reviewer) Spot-check a real report in a browser: category pills should appear under the toolbar for any test class with `[Category]`.

Refs #5912 — discovered while investigating why categories weren't filterable from the HTML report despite being well-supported in the code.