### PR TITLE
fix(aspire): route CreateHttpClient through IHttpClientFactory

### DIFF
--- a/TUnit.Aspire.Tests/IntegrationTestFixture.cs
+++ b/TUnit.Aspire.Tests/IntegrationTestFixture.cs
@@ -1,3 +1,6 @@
+using Aspire.Hosting.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace TUnit.Aspire.Tests;
 
 /// <summary>
@@ -10,4 +13,34 @@ public class IntegrationTestFixture : AspireFixture<Projects.TUnit_Aspire_Tests_
     protected override TimeSpan ResourceTimeout => TimeSpan.FromSeconds(120);
 
     protected override ResourceWaitBehavior WaitBehavior => ResourceWaitBehavior.AllRunning;
+
+    protected override void ConfigureBuilder(IDistributedApplicationTestingBuilder builder)
+    {
+        builder.Services.AddSingleton<HttpHandlerInvocationCounter>();
+        builder.Services.AddTransient<CountingDelegatingHandler>();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+            http.AddHttpMessageHandler<CountingDelegatingHandler>());
+    }
+
+    public int HttpHandlerInvocationCount
+        => App.Services.GetRequiredService<HttpHandlerInvocationCounter>().Count;
+}
+
+internal sealed class HttpHandlerInvocationCounter
+{
+    private int _count;
+
+    public int Count => Volatile.Read(ref _count);
+
+    public void Increment() => Interlocked.Increment(ref _count);
+}
+
+internal sealed class CountingDelegatingHandler(HttpHandlerInvocationCounter counter) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        counter.Increment();
+        return base.SendAsync(request, cancellationToken);
+    }
 }

--- a/TUnit.Aspire.Tests/OtlpCorrelationIntegrationTests.cs
+++ b/TUnit.Aspire.Tests/OtlpCorrelationIntegrationTests.cs
@@ -227,6 +227,23 @@ public class OtlpCorrelationIntegrationTests(IntegrationTestFixture fixture)
     }
 
     /// <summary>
+    /// Regression coverage for thomhurst/TUnit#5956 — <c>CreateHttpClient</c> must route through
+    /// the AppHost's <see cref="IHttpClientFactory"/> so that <see cref="DelegatingHandler"/>s
+    /// registered via <c>ConfigureHttpClientDefaults</c> in <c>ConfigureBuilder</c> fire.
+    /// </summary>
+    [Test]
+    public async Task CreateHttpClient_Invokes_Registered_DelegatingHandler()
+    {
+        var before = fixture.HttpHandlerInvocationCount;
+
+        var client = fixture.CreateHttpClient(ServiceName);
+        using var response = await client.GetAsync("/health");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(200);
+        await Assert.That(fixture.HttpHandlerInvocationCount).IsGreaterThan(before);
+    }
+
+    /// <summary>
     /// Polls <see cref="TestContext.GetStandardOutput"/> until it contains the expected marker
     /// or a timeout is reached. The OTLP SDK batches log exports, so there's inherent latency
     /// between when the SUT logs a message and when it arrives at TUnit's OTLP receiver.

--- a/TUnit.Aspire/AspireFixture.cs
+++ b/TUnit.Aspire/AspireFixture.cs
@@ -29,7 +29,6 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
 {
     private DistributedApplication? _app;
     private OtlpReceiver? _otlpReceiver;
-    private SocketsHttpHandler? _httpHandler;
 
     /// <summary>
     /// The running Aspire distributed application.
@@ -39,33 +38,15 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         "App not initialized. Ensure InitializeAsync has completed.");
 
     /// <summary>
-    /// Creates an <see cref="HttpClient"/> for the named resource.
-    /// When <see cref="EnableTelemetryCollection"/> is <c>true</c>, the returned client
-    /// automatically propagates W3C <c>traceparent</c> and <c>baggage</c> headers
-    /// (including <c>tunit.test.id</c>) to the SUT for cross-process correlation.
-    /// Otherwise, delegates to Aspire's default <c>CreateHttpClient</c>.
+    /// Creates an <see cref="HttpClient"/> for the named resource via the AppHost's
+    /// <see cref="IHttpClientFactory"/>, so any <see cref="DelegatingHandler"/> registered
+    /// in <see cref="ConfigureBuilder"/> participates in the pipeline.
     /// </summary>
     /// <param name="resourceName">The name of the resource to connect to.</param>
     /// <param name="endpointName">Optional endpoint name if the resource exposes multiple endpoints.</param>
     /// <returns>An <see cref="HttpClient"/> configured to connect to the resource.</returns>
     public HttpClient CreateHttpClient(string resourceName, string? endpointName = null)
-    {
-        if (!EnableTelemetryCollection)
-        {
-            return App.CreateHttpClient(resourceName, endpointName);
-        }
-
-        _httpHandler ??= new SocketsHttpHandler
-        {
-            // Match Aspire's CreateHttpClient behavior: trust dev certs for HTTPS resources
-            SslOptions = { RemoteCertificateValidationCallback = (_, _, _, _) => true },
-        };
-
-        return new HttpClient(_httpHandler, disposeHandler: false)
-        {
-            BaseAddress = App.GetEndpoint(resourceName, endpointName),
-        };
-    }
+        => App.CreateHttpClient(resourceName, endpointName);
 
     /// <summary>
     /// Gets the connection string for the named resource.
@@ -386,9 +367,6 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             await _otlpReceiver.DisposeAsync();
             _otlpReceiver = null;
         }
-
-        _httpHandler?.Dispose();
-        _httpHandler = null;
 
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## Summary
- Closes #5956. `AspireFixture<TAppHost>.CreateHttpClient` constructed `HttpClient` directly from a cached `SocketsHttpHandler` when `EnableTelemetryCollection` was true, bypassing the AppHost's `IHttpClientFactory`. Any `DelegatingHandler` registered via `ConfigureHttpClientDefaults` or `AddHttpClient` in `ConfigureBuilder` was silently dropped.
- The runtime's built-in `DiagnosticsHandler` propagates `traceparent`/`baggage` on every `HttpClient` regardless of construction path, and Aspire's own `App.CreateHttpClient` already trusts dev certs via the factory's primary handler — so the telemetry branch wasn't doing anything telemetry-specific. Collapse to always delegate to `App.CreateHttpClient`. Dropped the unused `_httpHandler` field and its disposal.
- Added regression coverage in `OtlpCorrelationIntegrationTests`. The shared `IntegrationTestFixture` now registers a `CountingDelegatingHandler` via `ConfigureHttpClientDefaults` and exposes `HttpHandlerInvocationCount` (backed by a DI singleton — no static mutable state).

## Test plan
- [ ] `dotnet build TUnit.Aspire.Tests/TUnit.Aspire.Tests.csproj` passes locally
- [ ] CI Docker integration suite runs `CreateHttpClient_Invokes_Registered_DelegatingHandler` and passes
- [ ] Existing `OtlpCorrelationIntegrationTests` still pass (handler is a pass-through, shouldn't affect OTLP correlation)