### PR TITLE
Add assembly opt-out for TUnit discovery

### DIFF
--- a/TUnit.Core.SourceGenerator.Tests/ExcludeFromTestDiscoveryTests.cs
+++ b/TUnit.Core.SourceGenerator.Tests/ExcludeFromTestDiscoveryTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.CodeGenerators;
+using TUnit.Core.SourceGenerator.Generators;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+internal class ExcludeFromTestDiscoveryTests
+{
+    private const string ExcludedAssemblySource = """
+        using System.Threading.Tasks;
+        using TUnit.Core;
+
+        [assembly: ExcludeFromTestDiscovery]
+
+        namespace TestProject;
+
+        public class ExcludedTests
+        {
+            [Test]
+            public Task Test() => Task.CompletedTask;
+
+            [Before(HookType.Test)]
+            public static void BeforeTest()
+            {
+            }
+
+            [DynamicTestBuilder]
+            public static void Build(DynamicTestBuilderContext context)
+            {
+            }
+        }
+        """;
+
+    [Test]
+    public async Task TestMetadataGenerator_DoesNotGenerateTests_ForExcludedAssembly()
+    {
+        var generatedFiles = await RunGeneratorAsync<TestMetadataGenerator>(ExcludedAssemblySource);
+
+        await Assert.That(generatedFiles).IsEmpty();
+    }
+
+    [Test]
+    public async Task HookMetadataGenerator_DoesNotGenerateHooks_ForExcludedAssembly()
+    {
+        var generatedFiles = await RunGeneratorAsync<HookMetadataGenerator>(ExcludedAssemblySource);
+
+        await Assert.That(generatedFiles).IsEmpty();
+    }
+
+    [Test]
+    public async Task DynamicTestsGenerator_DoesNotGenerateDynamicTests_ForExcludedAssembly()
+    {
+        var generatedFiles = await RunGeneratorAsync<DynamicTestsGenerator>(ExcludedAssemblySource);
+
+        await Assert.That(generatedFiles).IsEmpty();
+    }
+
+    [Test]
+    public async Task InfrastructureGenerator_DoesNotGenerateInfrastructure_ForExcludedAssembly()
+    {
+        var generatedFiles = await RunGeneratorAsync<InfrastructureGenerator>(ExcludedAssemblySource);
+
+        await Assert.That(generatedFiles).IsEmpty();
+    }
+
+    private static async Task<string[]> RunGeneratorAsync<TGenerator>(string source)
+        where TGenerator : IIncrementalGenerator, new()
+    {
+        var generator = new TGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+
+        var compilation = CSharpCompilation.Create(
+                "TestAssembly",
+                [CSharpSyntaxTree.ParseText(source)],
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            )
+            .WithReferences(ReferencesHelper.References);
+
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var newCompilation, out var diagnostics);
+
+        var errors = diagnostics.Where(static d => d.Severity == DiagnosticSeverity.Error).ToList();
+        await Assert.That(errors).IsEmpty()
+            .Because($"Generator errors: {string.Join("\n", errors.Select(static e => e.GetMessage()))}");
+
+        return newCompilation.SyntaxTrees
+            .Select(static tree => tree.GetText().ToString())
+            .Where(text => text != source)
+            .ToArray();
+    }
+}

--- a/TUnit.Core.SourceGenerator.Tests/ExcludeFromTestDiscoveryTests.cs
+++ b/TUnit.Core.SourceGenerator.Tests/ExcludeFromTestDiscoveryTests.cs
@@ -32,6 +32,22 @@ internal class ExcludeFromTestDiscoveryTests
         }
         """;
 
+    private const string EntryAssemblyExclusionSource = """
+        using System.Threading.Tasks;
+        using ExternalTests;
+        using TUnit.Core;
+
+        [assembly: ExcludeFromTestDiscovery(typeof(Marker))]
+
+        namespace TestProject;
+
+        public class EntryTests
+        {
+            [Test]
+            public Task Test() => Task.CompletedTask;
+        }
+        """;
+
     [Test]
     public async Task TestMetadataGenerator_DoesNotGenerateTests_ForExcludedAssembly()
     {
@@ -64,7 +80,43 @@ internal class ExcludeFromTestDiscoveryTests
         await Assert.That(generatedFiles).IsEmpty();
     }
 
+    [Test]
+    public async Task TestMetadataGenerator_GeneratesEntryAssemblyTests_WhenReferencedAssemblyIsExcluded()
+    {
+        var externalReference = CreateReference("ExternalTests", "namespace ExternalTests; public class Marker { }");
+
+        var generatedFiles = await RunGeneratorAsync<TestMetadataGenerator>(
+            EntryAssemblyExclusionSource,
+            [externalReference]);
+
+        await Assert.That(generatedFiles).IsNotEmpty();
+        await Assert.That(generatedFiles.Any(static file => file.Contains("EntryTests"))).IsTrue();
+    }
+
+    [Test]
+    public async Task InfrastructureGenerator_RegistersExcludedAssemblyName_WithoutReferencingMarkerType()
+    {
+        var externalReference = CreateReference("ExternalTests", "namespace ExternalTests; public class Marker { }");
+
+        var generatedFiles = await RunGeneratorAsync<InfrastructureGenerator>(
+            EntryAssemblyExclusionSource,
+            [externalReference]);
+
+        var infrastructureFile = generatedFiles.Single(static file => file.Contains("TUnitInfrastructure"));
+
+        await Assert.That(infrastructureFile).Contains("""ExcludeAssemblyFromDiscovery("ExternalTests")""");
+        await Assert.That(infrastructureFile).DoesNotContain("typeof(global::ExternalTests.Marker)");
+    }
+
     private static async Task<string[]> RunGeneratorAsync<TGenerator>(string source)
+        where TGenerator : IIncrementalGenerator, new()
+    {
+        return await RunGeneratorAsync<TGenerator>(source, []);
+    }
+
+    private static async Task<string[]> RunGeneratorAsync<TGenerator>(
+        string source,
+        PortableExecutableReference[] additionalReferences)
         where TGenerator : IIncrementalGenerator, new()
     {
         var generator = new TGenerator();
@@ -75,7 +127,8 @@ internal class ExcludeFromTestDiscoveryTests
                 [CSharpSyntaxTree.ParseText(source)],
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
             )
-            .WithReferences(ReferencesHelper.References);
+            .WithReferences(ReferencesHelper.References)
+            .AddReferences(additionalReferences);
 
         driver.RunGeneratorsAndUpdateCompilation(compilation, out var newCompilation, out var diagnostics);
 
@@ -87,5 +140,26 @@ internal class ExcludeFromTestDiscoveryTests
             .Select(static tree => tree.GetText().ToString())
             .Where(text => text != source)
             .ToArray();
+    }
+
+    private static PortableExecutableReference CreateReference(string assemblyName, string source)
+    {
+        var compilation = CSharpCompilation.Create(
+                assemblyName,
+                [CSharpSyntaxTree.ParseText(source)],
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            )
+            .WithReferences(ReferencesHelper.References);
+
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                $"Failed to create test reference: {string.Join(Environment.NewLine, result.Diagnostics)}");
+        }
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
     }
 }

--- a/TUnit.Core.SourceGenerator/CodeGenerators/DynamicTestsGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/DynamicTestsGenerator.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using TUnit.Core.SourceGenerator.Helpers;
 using TUnit.Core.SourceGenerator.Models.Extracted;
 
 namespace TUnit.Core.SourceGenerator.CodeGenerators;
@@ -44,6 +45,11 @@ public class DynamicTestsGenerator : IIncrementalGenerator
     /// </summary>
     private static DynamicTestModel? ExtractDynamicTestModel(GeneratorAttributeSyntaxContext context)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
         if (context.TargetSymbol is not IMethodSymbol methodSymbol)
         {
             return null;

--- a/TUnit.Core.SourceGenerator/CodeGenerators/DynamicTestsGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/DynamicTestsGenerator.cs
@@ -45,7 +45,7 @@ public class DynamicTestsGenerator : IIncrementalGenerator
     /// </summary>
     private static DynamicTestModel? ExtractDynamicTestModel(GeneratorAttributeSyntaxContext context)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(context.SemanticModel.Compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(context.SemanticModel.Compilation))
         {
             return null;
         }

--- a/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
@@ -68,12 +68,13 @@ public class InfrastructureGenerator : IIncrementalGenerator
     /// </summary>
     private static AssemblyInfoModel ExtractAssemblyInfo(Compilation compilation)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(compilation))
         {
             return new AssemblyInfoModel
             {
                 AssemblyName = compilation.Assembly.Name,
                 TypesToReference = new EquatableArray<string>([]),
+                ExcludedAssemblyNames = new EquatableArray<string>([]),
                 IsExcludedFromTestDiscovery = true
             };
         }
@@ -129,6 +130,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
         {
             AssemblyName = compilation.Assembly.Name,
             TypesToReference = new EquatableArray<string>([.. assembliesToLoad]),
+            ExcludedAssemblyNames = AssemblyDiscoveryExclusion.GetExcludedAssemblyNames(compilation),
             IsExcludedFromTestDiscovery = false
         };
     }
@@ -200,7 +202,8 @@ public class InfrastructureGenerator : IIncrementalGenerator
 
     private static bool ShouldLoadAssembly(IAssemblySymbol assembly, Compilation compilation)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(assembly, compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(assembly, compilation) ||
+            AssemblyDiscoveryExclusion.IsExcludedByCurrentAssembly(assembly, compilation))
         {
             return false;
         }
@@ -400,6 +403,22 @@ public class InfrastructureGenerator : IIncrementalGenerator
                 sourceBuilder.AppendLine("}");
                 sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip source registrar */ }");
                 sourceBuilder.AppendLine();
+
+                foreach (var excludedAssemblyName in model.ExcludedAssemblyNames)
+                {
+                    sourceBuilder.AppendLine("try");
+                    sourceBuilder.AppendLine("{");
+                    sourceBuilder.Indent();
+                    sourceBuilder.AppendLine($"global::TUnit.Core.SourceRegistrar.ExcludeAssemblyFromDiscovery(\"{excludedAssemblyName.Replace("\\", "\\\\").Replace("\"", "\\\"")}\");");
+                    sourceBuilder.Unindent();
+                    sourceBuilder.AppendLine("}");
+                    sourceBuilder.AppendLine("catch { /* TUnit.Core not available - skip excluded assembly registration */ }");
+                }
+
+                if (model.ExcludedAssemblyNames.Length > 0)
+                {
+                    sourceBuilder.AppendLine();
+                }
 
                 // Logging is optional - wrap separately so it doesn't prevent other work
                 sourceBuilder.AppendLine("try");

--- a/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/InfrastructureGenerator.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using TUnit.Core.SourceGenerator.CodeGenerators.Equality;
+using TUnit.Core.SourceGenerator.Helpers;
 using TUnit.Core.SourceGenerator.Models;
 using TUnit.Core.SourceGenerator.Models.Extracted;
 
@@ -52,7 +53,7 @@ public class InfrastructureGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(assemblyInfoProvider, (sourceContext, data) =>
         {
             var (assemblyInfo, isEnabled) = data;
-            if (!isEnabled)
+            if (!isEnabled || assemblyInfo.IsExcludedFromTestDiscovery)
             {
                 return;
             }
@@ -67,6 +68,16 @@ public class InfrastructureGenerator : IIncrementalGenerator
     /// </summary>
     private static AssemblyInfoModel ExtractAssemblyInfo(Compilation compilation)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(compilation))
+        {
+            return new AssemblyInfoModel
+            {
+                AssemblyName = compilation.Assembly.Name,
+                TypesToReference = new EquatableArray<string>([]),
+                IsExcludedFromTestDiscovery = true
+            };
+        }
+
         var assembliesToLoad = new List<string>();
 
         // Find TUnit.Core assembly - only assemblies referencing this can contain tests
@@ -117,7 +128,8 @@ public class InfrastructureGenerator : IIncrementalGenerator
         return new AssemblyInfoModel
         {
             AssemblyName = compilation.Assembly.Name,
-            TypesToReference = new EquatableArray<string>([.. assembliesToLoad])
+            TypesToReference = new EquatableArray<string>([.. assembliesToLoad]),
+            IsExcludedFromTestDiscovery = false
         };
     }
 
@@ -188,6 +200,11 @@ public class InfrastructureGenerator : IIncrementalGenerator
 
     private static bool ShouldLoadAssembly(IAssemblySymbol assembly, Compilation compilation)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(assembly, compilation))
+        {
+            return false;
+        }
+
         // Skip system assemblies
         if (IsSystemAssembly(assembly))
         {

--- a/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TUnit.Core.SourceGenerator.CodeGenerators.Helpers;
 using TUnit.Core.SourceGenerator.Extensions;
+using TUnit.Core.SourceGenerator.Helpers;
 using TUnit.Core.SourceGenerator.Models;
 using TUnit.Core.SourceGenerator.Models.Extracted;
 using TUnit.Core.SourceGenerator.Utilities;
@@ -95,6 +96,11 @@ public class HookMetadataGenerator : IIncrementalGenerator
     /// </summary>
     private static HookModel? ExtractHookModel(GeneratorAttributeSyntaxContext context, string hookKind)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
         if (context.TargetSymbol is not IMethodSymbol methodSymbol)
         {
             return null;

--- a/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/HookMetadataGenerator.cs
@@ -96,7 +96,7 @@ public class HookMetadataGenerator : IIncrementalGenerator
     /// </summary>
     private static HookModel? ExtractHookModel(GeneratorAttributeSyntaxContext context, string hookKind)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(context.SemanticModel.Compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(context.SemanticModel.Compilation))
         {
             return null;
         }

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -110,6 +110,11 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static InheritsTestsClassMetadata? GetInheritsTestsClassMetadata(GeneratorAttributeSyntaxContext context, CompilationContext compilationContext)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(compilationContext.Compilation))
+        {
+            return null;
+        }
+
         var classSyntax = (ClassDeclarationSyntax)context.TargetNode;
 
         if (context.TargetSymbol is not INamedTypeSymbol classSymbol)
@@ -133,6 +138,11 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static TestMethodMetadata? GetTestMethodMetadata(GeneratorAttributeSyntaxContext context, CompilationContext compilationContext)
     {
+        if (AssemblyDiscoveryExclusion.IsExcluded(compilationContext.Compilation))
+        {
+            return null;
+        }
+
         var methodSyntax = (MethodDeclarationSyntax)context.TargetNode;
         var methodSymbol = context.TargetSymbol as IMethodSymbol;
 

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -110,7 +110,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static InheritsTestsClassMetadata? GetInheritsTestsClassMetadata(GeneratorAttributeSyntaxContext context, CompilationContext compilationContext)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(compilationContext.Compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(compilationContext.Compilation))
         {
             return null;
         }
@@ -138,7 +138,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static TestMethodMetadata? GetTestMethodMetadata(GeneratorAttributeSyntaxContext context, CompilationContext compilationContext)
     {
-        if (AssemblyDiscoveryExclusion.IsExcluded(compilationContext.Compilation))
+        if (AssemblyDiscoveryExclusion.IsSelfExcluded(compilationContext.Compilation))
         {
             return null;
         }

--- a/TUnit.Core.SourceGenerator/Helpers/AssemblyDiscoveryExclusion.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/AssemblyDiscoveryExclusion.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+
+namespace TUnit.Core.SourceGenerator.Helpers;
+
+internal static class AssemblyDiscoveryExclusion
+{
+    private const string AttributeMetadataName = "TUnit.Core.ExcludeFromTestDiscoveryAttribute";
+    private const string AttributeFullyQualifiedName = "global::TUnit.Core.ExcludeFromTestDiscoveryAttribute";
+
+    public static bool IsExcluded(Compilation compilation)
+    {
+        return IsExcluded(compilation.Assembly, compilation);
+    }
+
+    public static bool IsExcluded(IAssemblySymbol assembly, Compilation compilation)
+    {
+        var excludeAttributeType = compilation.GetTypeByMetadataName(AttributeMetadataName);
+
+        foreach (var attribute in assembly.GetAttributes())
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null)
+            {
+                continue;
+            }
+
+            if (excludeAttributeType is not null &&
+                SymbolEqualityComparer.Default.Equals(attributeClass, excludeAttributeType))
+            {
+                return true;
+            }
+
+            if (attributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == AttributeFullyQualifiedName ||
+                attributeClass.ToDisplayString() == AttributeMetadataName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/TUnit.Core.SourceGenerator/Helpers/AssemblyDiscoveryExclusion.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/AssemblyDiscoveryExclusion.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using TUnit.Core.SourceGenerator.Models;
 
 namespace TUnit.Core.SourceGenerator.Helpers;
 
@@ -7,36 +8,91 @@ internal static class AssemblyDiscoveryExclusion
     private const string AttributeMetadataName = "TUnit.Core.ExcludeFromTestDiscoveryAttribute";
     private const string AttributeFullyQualifiedName = "global::TUnit.Core.ExcludeFromTestDiscoveryAttribute";
 
-    public static bool IsExcluded(Compilation compilation)
+    public static bool IsSelfExcluded(Compilation compilation)
     {
-        return IsExcluded(compilation.Assembly, compilation);
+        return IsSelfExcluded(compilation.Assembly, compilation);
     }
 
-    public static bool IsExcluded(IAssemblySymbol assembly, Compilation compilation)
+    public static bool IsSelfExcluded(IAssemblySymbol assembly, Compilation compilation)
     {
-        var excludeAttributeType = compilation.GetTypeByMetadataName(AttributeMetadataName);
-
         foreach (var attribute in assembly.GetAttributes())
         {
-            var attributeClass = attribute.AttributeClass;
-            if (attributeClass is null)
-            {
-                continue;
-            }
-
-            if (excludeAttributeType is not null &&
-                SymbolEqualityComparer.Default.Equals(attributeClass, excludeAttributeType))
-            {
-                return true;
-            }
-
-            if (attributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == AttributeFullyQualifiedName ||
-                attributeClass.ToDisplayString() == AttributeMetadataName)
+            if (IsExcludeAttribute(attribute, compilation) && !GetAssemblyMarkerTypes(attribute).Any())
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public static bool IsExcludedByCurrentAssembly(IAssemblySymbol assembly, Compilation compilation)
+    {
+        foreach (var excludedAssemblyName in GetExcludedAssemblyNames(compilation))
+        {
+            if (assembly.Name == excludedAssemblyName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static EquatableArray<string> GetExcludedAssemblyNames(Compilation compilation)
+    {
+        return compilation.Assembly
+            .GetAttributes()
+            .Where(attribute => IsExcludeAttribute(attribute, compilation))
+            .SelectMany(GetAssemblyMarkerTypes)
+            .Select(static type => type.ContainingAssembly.Name)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool IsExcludeAttribute(AttributeData attribute, Compilation compilation)
+    {
+        var attributeClass = attribute.AttributeClass;
+        if (attributeClass is null)
+        {
+            return false;
+        }
+
+        var excludeAttributeType = compilation.GetTypeByMetadataName(AttributeMetadataName);
+        if (excludeAttributeType is not null &&
+            SymbolEqualityComparer.Default.Equals(attributeClass, excludeAttributeType))
+        {
+            return true;
+        }
+
+        return attributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == AttributeFullyQualifiedName ||
+               attributeClass.ToDisplayString() == AttributeMetadataName;
+    }
+
+    private static IEnumerable<ITypeSymbol> GetAssemblyMarkerTypes(AttributeData attribute)
+    {
+        foreach (var argument in attribute.ConstructorArguments)
+        {
+            if (argument.Kind == TypedConstantKind.Type && argument.Value is ITypeSymbol typeSymbol)
+            {
+                yield return typeSymbol;
+                continue;
+            }
+
+            if (argument.Kind != TypedConstantKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var value in argument.Values)
+            {
+                if (value.Kind == TypedConstantKind.Type && value.Value is ITypeSymbol markerType)
+                {
+                    yield return markerType;
+                }
+            }
+        }
     }
 }

--- a/TUnit.Core.SourceGenerator/Models/Extracted/AssemblyInfoModel.cs
+++ b/TUnit.Core.SourceGenerator/Models/Extracted/AssemblyInfoModel.cs
@@ -17,6 +17,8 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
     /// </summary>
     public required EquatableArray<string> TypesToReference { get; init; }
 
+    public required bool IsExcludedFromTestDiscovery { get; init; }
+
     public bool Equals(AssemblyInfoModel? other)
     {
         if (other is null)
@@ -29,7 +31,9 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
             return true;
         }
 
-        return AssemblyName == other.AssemblyName && TypesToReference.Equals(other.TypesToReference);
+        return AssemblyName == other.AssemblyName &&
+               TypesToReference.Equals(other.TypesToReference) &&
+               IsExcludedFromTestDiscovery == other.IsExcludedFromTestDiscovery;
     }
 
     public override bool Equals(object? obj)
@@ -44,6 +48,7 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
             var hash = 17;
             hash = hash * 31 + (AssemblyName?.GetHashCode() ?? 0);
             hash = hash * 31 + TypesToReference.GetHashCode();
+            hash = hash * 31 + IsExcludedFromTestDiscovery.GetHashCode();
             return hash;
         }
     }

--- a/TUnit.Core.SourceGenerator/Models/Extracted/AssemblyInfoModel.cs
+++ b/TUnit.Core.SourceGenerator/Models/Extracted/AssemblyInfoModel.cs
@@ -17,6 +17,8 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
     /// </summary>
     public required EquatableArray<string> TypesToReference { get; init; }
 
+    public required EquatableArray<string> ExcludedAssemblyNames { get; init; }
+
     public required bool IsExcludedFromTestDiscovery { get; init; }
 
     public bool Equals(AssemblyInfoModel? other)
@@ -33,6 +35,7 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
 
         return AssemblyName == other.AssemblyName &&
                TypesToReference.Equals(other.TypesToReference) &&
+               ExcludedAssemblyNames.Equals(other.ExcludedAssemblyNames) &&
                IsExcludedFromTestDiscovery == other.IsExcludedFromTestDiscovery;
     }
 
@@ -48,6 +51,7 @@ public sealed class AssemblyInfoModel : IEquatable<AssemblyInfoModel>
             var hash = 17;
             hash = hash * 31 + (AssemblyName?.GetHashCode() ?? 0);
             hash = hash * 31 + TypesToReference.GetHashCode();
+            hash = hash * 31 + ExcludedAssemblyNames.GetHashCode();
             hash = hash * 31 + IsExcludedFromTestDiscovery.GetHashCode();
             return hash;
         }

--- a/TUnit.Core/Attributes/ExcludeFromTestDiscoveryAttribute.cs
+++ b/TUnit.Core/Attributes/ExcludeFromTestDiscoveryAttribute.cs
@@ -1,18 +1,42 @@
 namespace TUnit.Core;
 
 /// <summary>
-/// Excludes an assembly from TUnit test discovery.
+/// Excludes assemblies from TUnit test discovery.
 /// </summary>
 /// <remarks>
-/// Apply this attribute at assembly level when an assembly references TUnit infrastructure but
-/// should not contribute tests or hooks to a consuming test run.
+/// Apply this attribute to the entry test assembly to exclude referenced assemblies that should
+/// not contribute tests or hooks to that run. Use a marker type from each assembly to exclude.
+/// The parameterless form excludes the assembly it is applied to.
 /// </remarks>
 /// <example>
 /// <code>
 /// using TUnit.Core;
 ///
-/// [assembly: ExcludeFromTestDiscovery]
+/// [assembly: ExcludeFromTestDiscovery(typeof(SharedTestProject.Marker))]
 /// </code>
 /// </example>
-[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-public sealed class ExcludeFromTestDiscoveryAttribute : Attribute;
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+public sealed class ExcludeFromTestDiscoveryAttribute : Attribute
+{
+    /// <summary>
+    /// Excludes the assembly this attribute is applied to from test discovery.
+    /// </summary>
+    public ExcludeFromTestDiscoveryAttribute()
+    {
+        AssemblyMarkerTypes = [];
+    }
+
+    /// <summary>
+    /// Excludes the assemblies containing the supplied marker types from test discovery.
+    /// </summary>
+    /// <param name="assemblyMarkerTypes">Types from assemblies to exclude.</param>
+    public ExcludeFromTestDiscoveryAttribute(params Type[] assemblyMarkerTypes)
+    {
+        AssemblyMarkerTypes = assemblyMarkerTypes;
+    }
+
+    /// <summary>
+    /// Types from assemblies to exclude from test discovery.
+    /// </summary>
+    public Type[] AssemblyMarkerTypes { get; }
+}

--- a/TUnit.Core/Attributes/ExcludeFromTestDiscoveryAttribute.cs
+++ b/TUnit.Core/Attributes/ExcludeFromTestDiscoveryAttribute.cs
@@ -1,0 +1,18 @@
+namespace TUnit.Core;
+
+/// <summary>
+/// Excludes an assembly from TUnit test discovery.
+/// </summary>
+/// <remarks>
+/// Apply this attribute at assembly level when an assembly references TUnit infrastructure but
+/// should not contribute tests or hooks to a consuming test run.
+/// </remarks>
+/// <example>
+/// <code>
+/// using TUnit.Core;
+///
+/// [assembly: ExcludeFromTestDiscovery]
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+public sealed class ExcludeFromTestDiscoveryAttribute : Attribute;

--- a/TUnit.Core/SourceRegistrar.cs
+++ b/TUnit.Core/SourceRegistrar.cs
@@ -16,7 +16,20 @@ namespace TUnit.Core;
 /// </summary>
 public class SourceRegistrar
 {
+    private static readonly ConcurrentDictionary<Assembly, byte> ExcludedAssemblies = new();
+    private static readonly ConcurrentDictionary<string, byte> ExcludedAssemblyNames = new();
+
     public static bool IsEnabled { get; set; }
+
+    public static void ExcludeAssemblyFromDiscovery(string assemblyName)
+    {
+        ExcludedAssemblyNames.TryAdd(assemblyName, 0);
+    }
+
+    public static void ExcludeAssemblyFromDiscovery(Assembly assembly)
+    {
+        ExcludedAssemblies.TryAdd(assembly, 0);
+    }
 
     /// <summary>
     /// Registers an assembly loader.
@@ -40,6 +53,11 @@ public class SourceRegistrar
     /// <param name="testSource">The test source to register.</param>
     public static void RegisterDynamic(IDynamicTestSource testSource)
     {
+        if (IsAssemblyExcludedFromDiscovery(testSource.GetType().Assembly))
+        {
+            return;
+        }
+
         Sources.DynamicTestSources.Enqueue(testSource);
     }
 
@@ -70,6 +88,11 @@ public class SourceRegistrar
     public static int RegisterHook<T>(ConcurrentDictionary<Type, ConcurrentBag<LazyHookEntry<T>>> dictionary, Type key, int registrationIndex, Func<int, T> factory)
         where T : HookMethod
     {
+        if (IsAssemblyExcludedFromDiscovery(key.Assembly))
+        {
+            return 0;
+        }
+
         dictionary.GetOrAdd(key, static _ => new ConcurrentBag<LazyHookEntry<T>>())
             .Add(new LazyHookEntry<T>(registrationIndex, factory));
         return 0;
@@ -84,6 +107,11 @@ public class SourceRegistrar
     public static int RegisterHook<T>(ConcurrentDictionary<Assembly, ConcurrentBag<LazyHookEntry<T>>> dictionary, Assembly key, int registrationIndex, Func<int, T> factory)
         where T : HookMethod
     {
+        if (IsAssemblyExcludedFromDiscovery(key))
+        {
+            return 0;
+        }
+
         dictionary.GetOrAdd(key, static _ => new ConcurrentBag<LazyHookEntry<T>>())
             .Add(new LazyHookEntry<T>(registrationIndex, factory));
         return 0;
@@ -95,9 +123,15 @@ public class SourceRegistrar
     /// module-init cost minimal and to remain AOT compatible.
     /// Returns a dummy value for use as a static field initializer.
     /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static int RegisterHook<T>(ConcurrentBag<LazyHookEntry<T>> bag, int registrationIndex, Func<int, T> factory)
         where T : HookMethod
     {
+        if (IsAssemblyExcludedFromDiscovery(Assembly.GetCallingAssembly()))
+        {
+            return 0;
+        }
+
         bag.Add(new LazyHookEntry<T>(registrationIndex, factory));
         return 0;
     }
@@ -112,6 +146,11 @@ public class SourceRegistrar
     public static int RegisterEntries<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] T>(Func<TestEntry<T>[]> factory) where T : class
     {
         var key = typeof(T);
+
+        if (IsAssemblyExcludedFromDiscovery(key.Assembly))
+        {
+            return 0;
+        }
 
         while (true)
         {
@@ -133,6 +172,112 @@ public class SourceRegistrar
             }
 
             // Another thread added between TryGetValue and TryAdd — retry to merge
+        }
+    }
+
+    internal static bool IsAssemblyExcludedFromDiscovery(Assembly assembly)
+    {
+        if (ExcludedAssemblies.ContainsKey(assembly))
+        {
+            return true;
+        }
+
+        var assemblyName = assembly.GetName().Name;
+        if (assemblyName is not null && ExcludedAssemblyNames.ContainsKey(assemblyName))
+        {
+            return true;
+        }
+
+        if (HasSelfExclusionAttribute(assembly))
+        {
+            return true;
+        }
+
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly is null || ReferenceEquals(entryAssembly, assembly))
+        {
+            return false;
+        }
+
+        return EntryAssemblyExcludes(entryAssembly, assembly);
+    }
+
+    private static bool HasSelfExclusionAttribute(Assembly assembly)
+    {
+        try
+        {
+            foreach (var attribute in CustomAttributeData.GetCustomAttributes(assembly))
+            {
+                if (IsExcludeFromDiscoveryAttribute(attribute) && attribute.ConstructorArguments.Count == 0)
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool EntryAssemblyExcludes(Assembly entryAssembly, Assembly assembly)
+    {
+        try
+        {
+            foreach (var attribute in CustomAttributeData.GetCustomAttributes(entryAssembly))
+            {
+                if (!IsExcludeFromDiscoveryAttribute(attribute))
+                {
+                    continue;
+                }
+
+                foreach (var markerType in GetAssemblyMarkerTypes(attribute))
+                {
+                    if (AssemblyName.ReferenceMatchesDefinition(markerType.Assembly.GetName(), assembly.GetName()))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsExcludeFromDiscoveryAttribute(CustomAttributeData attribute)
+    {
+        return attribute.AttributeType == typeof(ExcludeFromTestDiscoveryAttribute) ||
+               attribute.AttributeType.FullName == typeof(ExcludeFromTestDiscoveryAttribute).FullName;
+    }
+
+    private static IEnumerable<Type> GetAssemblyMarkerTypes(CustomAttributeData attribute)
+    {
+        foreach (var argument in attribute.ConstructorArguments)
+        {
+            if (argument.ArgumentType == typeof(Type) && argument.Value is Type type)
+            {
+                yield return type;
+                continue;
+            }
+
+            if (!argument.ArgumentType.IsArray || argument.Value is not IEnumerable<CustomAttributeTypedArgument> values)
+            {
+                continue;
+            }
+
+            foreach (var value in values)
+            {
+                if (value.Value is Type markerType)
+                {
+                    yield return markerType;
+                }
+            }
         }
     }
 }

--- a/TUnit.Engine/Discovery/AssemblyDiscoveryFilter.cs
+++ b/TUnit.Engine/Discovery/AssemblyDiscoveryFilter.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using TUnit.Core;
+
+namespace TUnit.Engine.Discovery;
+
+internal static class AssemblyDiscoveryFilter
+{
+    public static bool IsExcludedFromTestDiscovery(Assembly assembly)
+    {
+        try
+        {
+            foreach (var attribute in CustomAttributeData.GetCustomAttributes(assembly))
+            {
+                var attributeType = attribute.AttributeType;
+                if (attributeType == typeof(ExcludeFromTestDiscoveryAttribute) ||
+                    attributeType.FullName == typeof(ExcludeFromTestDiscoveryAttribute).FullName)
+                {
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+}

--- a/TUnit.Engine/Discovery/AssemblyDiscoveryFilter.cs
+++ b/TUnit.Engine/Discovery/AssemblyDiscoveryFilter.cs
@@ -5,25 +5,6 @@ namespace TUnit.Engine.Discovery;
 
 internal static class AssemblyDiscoveryFilter
 {
-    public static bool IsExcludedFromTestDiscovery(Assembly assembly)
-    {
-        try
-        {
-            foreach (var attribute in CustomAttributeData.GetCustomAttributes(assembly))
-            {
-                var attributeType = attribute.AttributeType;
-                if (attributeType == typeof(ExcludeFromTestDiscoveryAttribute) ||
-                    attributeType.FullName == typeof(ExcludeFromTestDiscoveryAttribute).FullName)
-                {
-                    return true;
-                }
-            }
-        }
-        catch
-        {
-            return false;
-        }
-
-        return false;
-    }
+    public static bool IsExcludedFromTestDiscovery(Assembly assembly) =>
+        SourceRegistrar.IsAssemblyExcludedFromDiscovery(assembly);
 }

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -237,6 +237,11 @@ internal sealed class ReflectionHookDiscoveryService
             return false;
         }
 
+        if (AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(assembly))
+        {
+            return false;
+        }
+
         var referencedAssemblies = AssemblyReferenceCache.GetReferencedAssemblies(assembly);
         var referencesTUnit = false;
         foreach (var refAssembly in referencedAssemblies)

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -288,6 +288,11 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
             return false;
         }
 
+        if (AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(assembly))
+        {
+            return false;
+        }
+
         try
         {
             var location = assembly.Location;

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -710,10 +710,12 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
-    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    [(.Assembly, AllowMultiple=true, Inherited=false)]
     public sealed class ExcludeFromTestDiscoveryAttribute : 
     {
         public ExcludeFromTestDiscoveryAttribute() { }
+        public ExcludeFromTestDiscoveryAttribute(params [] assemblyMarkerTypes) { }
+        public [] AssemblyMarkerTypes { get; }
     }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
@@ -1304,6 +1306,8 @@ namespace
     {
         public SourceRegistrar() { }
         public static bool IsEnabled { get; set; }
+        public static void ExcludeAssemblyFromDiscovery(.Assembly assembly) { }
+        public static void ExcludeAssemblyFromDiscovery(string assemblyName) { }
         public static void RegisterAssembly(<.Assembly> assemblyLoader) { }
         public static void RegisterDynamic(.IDynamicTestSource testSource) { }
         public static int RegisterEntries<[.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  T>(<.TestEntry<T>[]> factory)

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -710,6 +710,11 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
+    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    public sealed class ExcludeFromTestDiscoveryAttribute : 
+    {
+        public ExcludeFromTestDiscoveryAttribute() { }
+    }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
         public ExcludeOnAttribute(. OperatingSystem) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -710,10 +710,12 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
-    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    [(.Assembly, AllowMultiple=true, Inherited=false)]
     public sealed class ExcludeFromTestDiscoveryAttribute : 
     {
         public ExcludeFromTestDiscoveryAttribute() { }
+        public ExcludeFromTestDiscoveryAttribute(params [] assemblyMarkerTypes) { }
+        public [] AssemblyMarkerTypes { get; }
     }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
@@ -1304,6 +1306,8 @@ namespace
     {
         public SourceRegistrar() { }
         public static bool IsEnabled { get; set; }
+        public static void ExcludeAssemblyFromDiscovery(.Assembly assembly) { }
+        public static void ExcludeAssemblyFromDiscovery(string assemblyName) { }
         public static void RegisterAssembly(<.Assembly> assemblyLoader) { }
         public static void RegisterDynamic(.IDynamicTestSource testSource) { }
         public static int RegisterEntries<[.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  T>(<.TestEntry<T>[]> factory)

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -710,6 +710,11 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
+    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    public sealed class ExcludeFromTestDiscoveryAttribute : 
+    {
+        public ExcludeFromTestDiscoveryAttribute() { }
+    }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
         public ExcludeOnAttribute(. OperatingSystem) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -710,10 +710,12 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
-    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    [(.Assembly, AllowMultiple=true, Inherited=false)]
     public sealed class ExcludeFromTestDiscoveryAttribute : 
     {
         public ExcludeFromTestDiscoveryAttribute() { }
+        public ExcludeFromTestDiscoveryAttribute(params [] assemblyMarkerTypes) { }
+        public [] AssemblyMarkerTypes { get; }
     }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
@@ -1304,6 +1306,8 @@ namespace
     {
         public SourceRegistrar() { }
         public static bool IsEnabled { get; set; }
+        public static void ExcludeAssemblyFromDiscovery(.Assembly assembly) { }
+        public static void ExcludeAssemblyFromDiscovery(string assemblyName) { }
         public static void RegisterAssembly(<.Assembly> assemblyLoader) { }
         public static void RegisterDynamic(.IDynamicTestSource testSource) { }
         public static int RegisterEntries<[.(..None | ..PublicParameterlessConstructor | ..PublicConstructors | ..PublicMethods | ..PublicProperties)]  T>(<.TestEntry<T>[]> factory)

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -710,6 +710,11 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
+    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    public sealed class ExcludeFromTestDiscoveryAttribute : 
+    {
+        public ExcludeFromTestDiscoveryAttribute() { }
+    }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
         public ExcludeOnAttribute(. OperatingSystem) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -686,10 +686,12 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
-    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    [(.Assembly, AllowMultiple=true, Inherited=false)]
     public sealed class ExcludeFromTestDiscoveryAttribute : 
     {
         public ExcludeFromTestDiscoveryAttribute() { }
+        public ExcludeFromTestDiscoveryAttribute(params [] assemblyMarkerTypes) { }
+        public [] AssemblyMarkerTypes { get; }
     }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
@@ -1259,6 +1261,8 @@ namespace
     {
         public SourceRegistrar() { }
         public static bool IsEnabled { get; set; }
+        public static void ExcludeAssemblyFromDiscovery(.Assembly assembly) { }
+        public static void ExcludeAssemblyFromDiscovery(string assemblyName) { }
         public static void RegisterAssembly(<.Assembly> assemblyLoader) { }
         public static void RegisterDynamic(.IDynamicTestSource testSource) { }
         public static int RegisterEntries<T>(<.TestEntry<T>[]> factory)

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -686,6 +686,11 @@ namespace
         public .CancellationToken Token { get; }
         public void Dispose() { }
     }
+    [(.Assembly, AllowMultiple=false, Inherited=false)]
+    public sealed class ExcludeFromTestDiscoveryAttribute : 
+    {
+        public ExcludeFromTestDiscoveryAttribute() { }
+    }
     public sealed class ExcludeOnAttribute : .SkipAttribute
     {
         public ExcludeOnAttribute(. OperatingSystem) { }

--- a/TUnit.UnitTests/AssemblyDiscoveryFilterTests.cs
+++ b/TUnit.UnitTests/AssemblyDiscoveryFilterTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using TUnit.Core;
+using TUnit.Engine.Discovery;
+
+namespace TUnit.UnitTests;
+
+public class AssemblyDiscoveryFilterTests
+{
+    [Test]
+    public async Task IsExcludedFromTestDiscovery_ReturnsTrue_WhenAssemblyHasAttribute()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("TUnit.UnitTests.ExcludedFromDiscovery"),
+            AssemblyBuilderAccess.Run);
+
+        var constructor = typeof(ExcludeFromTestDiscoveryAttribute).GetConstructor(Type.EmptyTypes)!;
+        assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, []));
+
+        await Assert.That(AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(assembly)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsExcludedFromTestDiscovery_ReturnsFalse_WhenAssemblyDoesNotHaveAttribute()
+    {
+        await Assert.That(AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(typeof(AssemblyDiscoveryFilterTests).Assembly)).IsFalse();
+    }
+}

--- a/TUnit.UnitTests/AssemblyDiscoveryFilterTests.cs
+++ b/TUnit.UnitTests/AssemblyDiscoveryFilterTests.cs
@@ -11,11 +11,23 @@ public class AssemblyDiscoveryFilterTests
     public async Task IsExcludedFromTestDiscovery_ReturnsTrue_WhenAssemblyHasAttribute()
     {
         var assembly = AssemblyBuilder.DefineDynamicAssembly(
-            new AssemblyName("TUnit.UnitTests.ExcludedFromDiscovery"),
+            new AssemblyName("TUnit.UnitTests.SelfExcludedFromDiscovery"),
             AssemblyBuilderAccess.Run);
 
         var constructor = typeof(ExcludeFromTestDiscoveryAttribute).GetConstructor(Type.EmptyTypes)!;
         assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, []));
+
+        await Assert.That(AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(assembly)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsExcludedFromTestDiscovery_ReturnsTrue_WhenAssemblyNameWasRegistered()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("TUnit.UnitTests.EntryExcludedFromDiscovery"),
+            AssemblyBuilderAccess.Run);
+
+        SourceRegistrar.ExcludeAssemblyFromDiscovery("TUnit.UnitTests.EntryExcludedFromDiscovery");
 
         await Assert.That(AssemblyDiscoveryFilter.IsExcludedFromTestDiscovery(assembly)).IsTrue();
     }


### PR DESCRIPTION
Closes #5816.

## Summary
- Extend `[assembly: ExcludeFromTestDiscovery]` so an entry test assembly can exclude referenced assemblies with marker types, e.g. `[assembly: ExcludeFromTestDiscovery(typeof(SharedTests.Marker))]`.
- Keep the parameterless form as self-exclusion for an assembly that should never contribute tests or hooks.
- Make source-generated discovery avoid loading entry-excluded assemblies and register excluded assembly names early for AOT/source-gen registration paths.
- Make runtime registration and reflection discovery skip excluded assemblies, including generated tests, hooks, and dynamic test sources.
- Add focused source-generator/runtime coverage and update Core public API snapshots.

## Verification
- `dotnet test TUnit.Core.SourceGenerator.Tests\TUnit.Core.SourceGenerator.Tests.csproj -f net10.0 --no-restore -p:DisableGitVersionTask=true -p:AssemblyVersion=1.43.11.0 -p:Version=1.43.11 -p:FileVersion=1.43.11.0`
- `dotnet test TUnit.UnitTests\TUnit.UnitTests.csproj --no-restore --treenode-filter "/*/*/AssemblyDiscoveryFilterTests/*" -p:DisableGitVersionTask=true`
- `git diff --cached --check`

Note: `dotnet test TUnit.PublicAPI\TUnit.PublicAPI.csproj -f net10.0 --no-restore --treenode-filter "/*/*/Core_Library_Has_No_API_Changes" -p:DisableGitVersionTask=true` still cannot execute locally because `TUnit.PublicAPI` resolves `Microsoft.Testing.Platform` 2.2.2 while the built engine resolves 2.2.3 before test execution. I checked the net10 generated public API output directly with `PublicApiGenerator` and updated the Core snapshots for the expected public API delta.