### PR TITLE
Fix chained mock setup behavior

### DIFF
--- a/TUnit.Mocks.Tests/BehaviorCompositionRegressionTests.cs
+++ b/TUnit.Mocks.Tests/BehaviorCompositionRegressionTests.cs
@@ -36,10 +36,10 @@ public class BehaviorCompositionRegressionTests
     {
         var mock = ICalculator.Mock();
         var captured = 0;
-        var setup = new MethodSetup(0, [AnyMatcher<int>.Instance, AnyMatcher<int>.Instance], nameof(ICalculator.Add));
-        setup.AddBehavior(new FallbackThrowingTypedSideEffectBehavior((a, b) => captured = a + b));
-        setup.AddBehavior(new CustomReturnBehavior<int>(99));
-        MockRegistry.GetEngine(mock).AddSetup(setup);
+
+        mock.Add(Arg.Any<int>(), Arg.Any<int>())
+            .Callback((int a, int b) => captured = a + b)
+            .Returns(99);
 
         var result = mock.Object.Add(4, 5);
 
@@ -119,17 +119,4 @@ public class BehaviorCompositionRegressionTests
         public object? Execute() => value;
     }
 
-    private sealed class FallbackThrowingTypedSideEffectBehavior(Action<int, int> callback) : IBehavior, ITypedBehavior<int, int>, ISideEffectBehavior
-    {
-        public object? Execute(object?[] arguments)
-        {
-            throw new InvalidOperationException("Composite behavior used object[] dispatch.");
-        }
-
-        public object? Execute(int arg1, int arg2)
-        {
-            callback(arg1, arg2);
-            return null;
-        }
-    }
 }

--- a/TUnit.Mocks.Tests/BehaviorCompositionRegressionTests.cs
+++ b/TUnit.Mocks.Tests/BehaviorCompositionRegressionTests.cs
@@ -1,0 +1,135 @@
+using TUnit.Mocks.Arguments;
+using TUnit.Mocks.Matchers;
+using TUnit.Mocks.Setup;
+using TUnit.Mocks.Setup.Behaviors;
+
+namespace TUnit.Mocks.Tests;
+
+public interface IStatefulCommand
+{
+    int Run(int value);
+    void Crash(int value);
+    void Ping();
+}
+
+public class BehaviorCompositionRegressionTests
+{
+    [Test]
+    public async Task Public_SideEffect_Behavior_Does_Not_Replace_Configured_Return()
+    {
+        var mock = ICalculator.Mock();
+        var sideEffectCount = 0;
+        var setup = new MethodSetup(0, [AnyMatcher<int>.Instance, AnyMatcher<int>.Instance], nameof(ICalculator.Add));
+        setup.AddBehavior(new CustomReturnBehavior<int>(42));
+        setup.AddBehavior(new CustomSideEffectBehavior(() => sideEffectCount++));
+        MockRegistry.GetEngine(mock).AddSetup(setup);
+
+        var result = mock.Object.Add(1, 2);
+
+        await Assert.That(typeof(ISideEffectBehavior).IsPublic).IsTrue();
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(sideEffectCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Composite_Behavior_Uses_Typed_Dispatch_For_Chained_Behaviors()
+    {
+        var mock = ICalculator.Mock();
+        var captured = 0;
+        var setup = new MethodSetup(0, [AnyMatcher<int>.Instance, AnyMatcher<int>.Instance], nameof(ICalculator.Add));
+        setup.AddBehavior(new FallbackThrowingTypedSideEffectBehavior((a, b) => captured = a + b));
+        setup.AddBehavior(new CustomReturnBehavior<int>(99));
+        MockRegistry.GetEngine(mock).AddSetup(setup);
+
+        var result = mock.Object.Add(4, 5);
+
+        await Assert.That(result).IsEqualTo(99);
+        await Assert.That(captured).IsEqualTo(9);
+    }
+
+    [Test]
+    public async Task TransitionsTo_Chains_With_Typed_Callback_And_Returns()
+    {
+        var mock = IStatefulCommand.Mock();
+        var captured = 0;
+        Mock.SetState(mock, "ready");
+
+        Mock.InState(mock, "ready", m =>
+        {
+            m.Run(Arg.Any<int>())
+                .TransitionsTo("done")
+                .Callback((int value) => captured = value)
+                .Returns(123);
+        });
+
+        var result = mock.Object.Run(456);
+
+        await Assert.That(result).IsEqualTo(123);
+        await Assert.That(captured).IsEqualTo(456);
+        await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsEqualTo("done");
+    }
+
+    [Test]
+    public async Task TransitionsTo_Does_Not_Advance_State_When_Behavior_Throws()
+    {
+        var mock = IStatefulCommand.Mock();
+        var captured = 0;
+        Mock.SetState(mock, "ready");
+
+        Mock.InState(mock, "ready", m =>
+        {
+            m.Crash(Arg.Any<int>())
+                .TransitionsTo("failed")
+                .Callback((int value) => captured = value)
+                .Throws(new InvalidOperationException("boom"));
+        });
+
+        var exception = Assert.Throws<InvalidOperationException>(() => mock.Object.Crash(7));
+
+        await Assert.That(exception.Message).IsEqualTo("boom");
+        await Assert.That(captured).IsEqualTo(7);
+        await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsEqualTo("ready");
+    }
+
+    [Test]
+    public async Task TransitionsTo_Works_Without_Required_State()
+    {
+        var mock = IStatefulCommand.Mock();
+
+        mock.Ping().TransitionsTo("pinged");
+
+        mock.Object.Ping();
+
+        await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsEqualTo("pinged");
+    }
+
+    private sealed class CustomSideEffectBehavior(Action callback) : IBehavior, ISideEffectBehavior
+    {
+        public object? Execute(object?[] arguments)
+        {
+            callback();
+            return null;
+        }
+    }
+
+    private sealed class CustomReturnBehavior<T>(T value) : IBehavior, IArgumentFreeBehavior
+    {
+        public object? Execute(object?[] arguments) => Execute();
+
+        public object? Execute() => value;
+    }
+
+    private sealed class FallbackThrowingTypedSideEffectBehavior(Action<int, int> callback) : IBehavior, ITypedBehavior<int, int>, ISideEffectBehavior
+    {
+        public object? Execute(object?[] arguments)
+        {
+            throw new InvalidOperationException("Composite behavior used object[] dispatch.");
+        }
+
+        public object? Execute(int arg1, int arg2)
+        {
+            callback(arg1, arg2);
+            return null;
+        }
+    }
+}

--- a/TUnit.Mocks.Tests/Issue5972Tests.cs
+++ b/TUnit.Mocks.Tests/Issue5972Tests.cs
@@ -1,0 +1,28 @@
+using TUnit.Mocks;
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks.Tests;
+
+public interface IIssue5972Service
+{
+    int GetInt(int i);
+}
+
+public class Issue5972Tests
+{
+    [Test]
+    public async Task Callback_Chained_Before_Returns_Still_Returns_Configured_Value()
+    {
+        var mock = IIssue5972Service.Mock();
+        var capture = 0;
+
+        mock.GetInt(Any())
+            .Callback((int i) => capture = i)
+            .Returns(42);
+
+        var result = mock.Object.GetInt(123);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(capture).IsEqualTo(123);
+    }
+}

--- a/TUnit.Mocks.Tests/MixedBehaviorRegressionTests.cs
+++ b/TUnit.Mocks.Tests/MixedBehaviorRegressionTests.cs
@@ -1,0 +1,243 @@
+using TUnit.Mocks;
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks.Tests;
+
+public class MixedBehaviorRegressionTests
+{
+    [Test]
+    public async Task Multiple_Callbacks_And_Return_Run_In_One_Repeating_Behavior()
+    {
+        var observations = new List<string>();
+        var mock = ICalculator.Mock();
+
+        mock.Add(Any(), Any())
+            .Callback((int a, int b) => observations.Add($"typed:{a}:{b}"))
+            .Callback(() => observations.Add("plain"))
+            .Returns(42);
+
+        await Assert.That(mock.Object.Add(1, 2)).IsEqualTo(42);
+        await Assert.That(mock.Object.Add(3, 4)).IsEqualTo(42);
+
+        await Assert.That(observations).Count().IsEqualTo(4);
+        await Assert.That(observations[0]).IsEqualTo("typed:1:2");
+        await Assert.That(observations[1]).IsEqualTo("plain");
+        await Assert.That(observations[2]).IsEqualTo("typed:3:4");
+        await Assert.That(observations[3]).IsEqualTo("plain");
+    }
+
+    [Test]
+    public async Task Return_Callback_And_Computed_Return_Use_Last_Return_While_Running_Side_Effects()
+    {
+        var captured = new List<int>();
+        var tailCallbackCount = 0;
+        var mock = ICalculator.Mock();
+
+        mock.Add(Any(), Any())
+            .Returns(1)
+            .Callback((int a, int b) => captured.Add(a + b))
+            .Returns((int a, int b) => a * b)
+            .Callback(() => tailCallbackCount++);
+
+        await Assert.That(mock.Object.Add(3, 4)).IsEqualTo(12);
+
+        await Assert.That(captured).Count().IsEqualTo(1);
+        await Assert.That(captured[0]).IsEqualTo(7);
+        await Assert.That(tailCallbackCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Callback_Then_Throws_Then_Returns_Sequences_Composite_Steps()
+    {
+        var observations = new List<string>();
+        var mock = ICalculator.Mock();
+
+        mock.Add(Any(), Any())
+            .Callback((int a, int b) => observations.Add($"first:{a + b}"))
+            .Throws(new InvalidOperationException("first step failed"))
+            .Then()
+            .Callback((int a, int b) => observations.Add($"second:{a + b}"))
+            .Returns(99);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => mock.Object.Add(1, 2));
+        await Assert.That(exception.Message).IsEqualTo("first step failed");
+        await Assert.That(observations).Count().IsEqualTo(1);
+        await Assert.That(observations[0]).IsEqualTo("first:3");
+
+        await Assert.That(mock.Object.Add(4, 5)).IsEqualTo(99);
+        await Assert.That(observations).Count().IsEqualTo(2);
+        await Assert.That(observations[1]).IsEqualTo("second:9");
+    }
+
+    [Test]
+    public async Task Throw_Before_Callback_Does_Not_Run_Later_Callback_In_Same_Behavior()
+    {
+        var laterCallbackRan = false;
+        var mock = ICalculator.Mock();
+
+        mock.Add(Any(), Any())
+            .Throws(new InvalidOperationException("boom"))
+            .Callback(() => laterCallbackRan = true)
+            .Then()
+            .Returns(7);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => mock.Object.Add(1, 1));
+        await Assert.That(exception.Message).IsEqualTo("boom");
+        await Assert.That(laterCallbackRan).IsFalse();
+        await Assert.That(mock.Object.Add(1, 1)).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Explicit_Then_Separates_Mixed_Steps_And_Last_Step_Repeats()
+    {
+        var observations = new List<string>();
+        var mock = IGreeter.Mock();
+
+        mock.Greet(Any())
+            .Callback((string name) => observations.Add($"first:{name}"))
+            .Returns((string name) => name.ToUpperInvariant())
+            .Then()
+            .Callback((string name) => observations.Add($"second:{name}"))
+            .Returns("fallback");
+
+        await Assert.That(mock.Object.Greet("alice")).IsEqualTo("ALICE");
+        await Assert.That(mock.Object.Greet("bob")).IsEqualTo("fallback");
+        await Assert.That(mock.Object.Greet("cara")).IsEqualTo("fallback");
+
+        await Assert.That(observations).Count().IsEqualTo(3);
+        await Assert.That(observations[0]).IsEqualTo("first:alice");
+        await Assert.That(observations[1]).IsEqualTo("second:bob");
+        await Assert.That(observations[2]).IsEqualTo("second:cara");
+    }
+
+    [Test]
+    public async Task Separate_Setups_Stay_Independent_When_Each_Setup_Has_Mixed_Behaviors()
+    {
+        var observations = new List<string>();
+        var mock = ICalculator.Mock();
+
+        mock.Add(Any(), Any())
+            .Callback(() => observations.Add("first setup"))
+            .Returns(1);
+
+        mock.Add(Any(), Any())
+            .Callback(() => observations.Add("second setup"))
+            .Returns(2);
+
+        await Assert.That(mock.Object.Add(10, 20)).IsEqualTo(2);
+
+        await Assert.That(observations).Count().IsEqualTo(1);
+        await Assert.That(observations[0]).IsEqualTo("second setup");
+    }
+
+    [Test]
+    public async Task Async_Task_Callback_And_ReturnsAsync_Run_In_One_Repeating_Behavior()
+    {
+        var capturedKeys = new List<string>();
+        var mock = IAsyncService.Mock();
+
+        mock.GetNameAsync(Any())
+            .Callback((string key) => capturedKeys.Add(key))
+            .ReturnsAsync((string key) => Task.FromResult($"value:{key}"));
+
+        await Assert.That(await mock.Object.GetNameAsync("one")).IsEqualTo("value:one");
+        await Assert.That(await mock.Object.GetNameAsync("two")).IsEqualTo("value:two");
+
+        await Assert.That(capturedKeys).Count().IsEqualTo(2);
+        await Assert.That(capturedKeys[0]).IsEqualTo("one");
+        await Assert.That(capturedKeys[1]).IsEqualTo("two");
+    }
+
+    [Test]
+    public async Task Async_ValueTask_Mixed_Sequence_Preserves_Callbacks_And_Returns()
+    {
+        var capturedInputs = new List<int>();
+        var mock = IAsyncService.Mock();
+
+        mock.ComputeValueTaskAsync(Any())
+            .Callback((int input) => capturedInputs.Add(input))
+            .ReturnsAsync((int input) => new ValueTask<int>(input + 1))
+            .Then()
+            .Callback((int input) => capturedInputs.Add(input * 10))
+            .Returns(500);
+
+        await Assert.That(await mock.Object.ComputeValueTaskAsync(4)).IsEqualTo(5);
+        await Assert.That(await mock.Object.ComputeValueTaskAsync(4)).IsEqualTo(500);
+        await Assert.That(await mock.Object.ComputeValueTaskAsync(2)).IsEqualTo(500);
+
+        await Assert.That(capturedInputs).Count().IsEqualTo(3);
+        await Assert.That(capturedInputs[0]).IsEqualTo(4);
+        await Assert.That(capturedInputs[1]).IsEqualTo(40);
+        await Assert.That(capturedInputs[2]).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task Out_Parameter_Callback_Return_And_Assignment_All_Apply()
+    {
+        string? capturedKey = null;
+        var mock = IDictionary.Mock();
+
+        mock.TryGet(Any())
+            .Callback((string key) => capturedKey = key)
+            .Returns(true)
+            .SetsOutValue("configured");
+
+        var result = mock.Object.TryGet("key", out var value);
+
+        await Assert.That(result).IsTrue();
+        await Assert.That(value).IsEqualTo("configured");
+        await Assert.That(capturedKey).IsEqualTo("key");
+    }
+
+    [Test]
+    public async Task Event_Raise_Callback_And_Return_All_Apply()
+    {
+        var ids = new List<int>();
+        string? raisedStatus = null;
+        var mock = IProcessService.Mock();
+        mock.Object.StatusChanged += (_, status) => raisedStatus = status;
+
+        mock.Process(Any())
+            .Callback((int id) => ids.Add(id))
+            .Returns(true)
+            .RaisesStatusChanged("done");
+
+        var result = mock.Object.Process(123);
+
+        await Assert.That(result).IsTrue();
+        await Assert.That(ids).Count().IsEqualTo(1);
+        await Assert.That(ids[0]).IsEqualTo(123);
+        await Assert.That(raisedStatus).IsEqualTo("done");
+    }
+
+    [Test]
+    public async Task State_Transition_Callback_And_Returns_All_Apply()
+    {
+        var observations = new List<string>();
+        var mock = IConnection.Mock();
+        Mock.SetState(mock, "disconnected");
+
+        Mock.InState(mock, "disconnected", m =>
+        {
+            m.Connect()
+                .Callback(() => observations.Add("connect"))
+                .TransitionsTo("connected");
+        });
+
+        Mock.InState(mock, "connected", m =>
+        {
+            m.GetStatus()
+                .TransitionsTo("checked")
+                .Callback(() => observations.Add("status"))
+                .Returns("ONLINE");
+        });
+
+        mock.Object.Connect();
+
+        await Assert.That(mock.Object.GetStatus()).IsEqualTo("ONLINE");
+        await Assert.That(observations).Count().IsEqualTo(2);
+        await Assert.That(observations[0]).IsEqualTo("connect");
+        await Assert.That(observations[1]).IsEqualTo("status");
+        await Assert.That(MockRegistry.GetEngine(mock).CurrentState).IsEqualTo("checked");
+    }
+}

--- a/TUnit.Mocks/MockEngine.Typed.cs
+++ b/TUnit.Mocks/MockEngine.Typed.cs
@@ -20,35 +20,35 @@ public sealed partial class MockEngine<T> where T : class
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1>(IBehavior b, in ArgumentStore<T1> store, T1 a1)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1> tb ? tb.Execute(a1) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1) : b is ITypedBehavior<T1> tb ? tb.Execute(a1) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2>(IBehavior b, in ArgumentStore<T1, T2> store, T1 a1, T2 a2)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2> tb ? tb.Execute(a1, a2) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2) : b is ITypedBehavior<T1, T2> tb ? tb.Execute(a1, a2) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3>(IBehavior b, in ArgumentStore<T1, T2, T3> store, T1 a1, T2 a2, T3 a3)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3> tb ? tb.Execute(a1, a2, a3) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3) : b is ITypedBehavior<T1, T2, T3> tb ? tb.Execute(a1, a2, a3) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4>(IBehavior b, in ArgumentStore<T1, T2, T3, T4> store, T1 a1, T2 a2, T3 a3, T4 a4)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3, T4> tb ? tb.Execute(a1, a2, a3, a4) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4) : b is ITypedBehavior<T1, T2, T3, T4> tb ? tb.Execute(a1, a2, a3, a4) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3, T4, T5> tb ? tb.Execute(a1, a2, a3, a4, a5) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5) : b is ITypedBehavior<T1, T2, T3, T4, T5> tb ? tb.Execute(a1, a2, a3, a4, a5) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3, T4, T5, T6> tb ? tb.Execute(a1, a2, a3, a4, a5, a6) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6> tb ? tb.Execute(a1, a2, a3, a4, a5, a6) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6, T7>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6, T7> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6, T7, T8>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6, T7, T8> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b.Execute(store.ToArray());
     // ──────────────────────────────────────────────────────────────────────
     //  Arity 1
     // ──────────────────────────────────────────────────────────────────────

--- a/TUnit.Mocks/MockEngine.Typed.cs
+++ b/TUnit.Mocks/MockEngine.Typed.cs
@@ -9,49 +9,37 @@ namespace TUnit.Mocks;
 
 public sealed partial class MockEngine<T> where T : class
 {
-    // ── ARITY COUPLING (1–8) ──────────────────────────────────────────────
-    //  Behavior execution helpers — check IArgumentFreeBehavior, then
-    //  ITypedBehavior<T...>, then fall back to store.ToArray().
-    //  If you add an arity (e.g. T9), you MUST also update:
-    //    - ITypedBehavior<T1...T9> and TypedCallbackBehavior in TypedCallbackBehavior.cs
-    //    - Callback<T1...T9> in MethodSetupBuilder.cs and VoidMethodSetupBuilder.cs
-    //    - MaxTypedParams in MockMembersBuilder.cs (source generator)
-    // ──────────────────────────────────────────────────────────────────────
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1>(IBehavior b, in ArgumentStore<T1> store, T1 a1)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1) : b is ITypedBehavior<T1> tb ? tb.Execute(a1) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1) : b is ITypedBehavior<T1> tb ? tb.Execute(a1) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2>(IBehavior b, in ArgumentStore<T1, T2> store, T1 a1, T2 a2)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2) : b is ITypedBehavior<T1, T2> tb ? tb.Execute(a1, a2) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2) : b is ITypedBehavior<T1, T2> tb ? tb.Execute(a1, a2) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3>(IBehavior b, in ArgumentStore<T1, T2, T3> store, T1 a1, T2 a2, T3 a3)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3) : b is ITypedBehavior<T1, T2, T3> tb ? tb.Execute(a1, a2, a3) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3) : b is ITypedBehavior<T1, T2, T3> tb ? tb.Execute(a1, a2, a3) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4>(IBehavior b, in ArgumentStore<T1, T2, T3, T4> store, T1 a1, T2 a2, T3 a3, T4 a4)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4) : b is ITypedBehavior<T1, T2, T3, T4> tb ? tb.Execute(a1, a2, a3, a4) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3, a4) : b is ITypedBehavior<T1, T2, T3, T4> tb ? tb.Execute(a1, a2, a3, a4) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5) : b is ITypedBehavior<T1, T2, T3, T4, T5> tb ? tb.Execute(a1, a2, a3, a4, a5) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5) : b is ITypedBehavior<T1, T2, T3, T4, T5> tb ? tb.Execute(a1, a2, a3, a4, a5) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6> tb ? tb.Execute(a1, a2, a3, a4, a5, a6) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6> tb ? tb.Execute(a1, a2, a3, a4, a5, a6) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6, T7>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6, T7> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7) : b.Execute(store.ToArray());
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7) : b.Execute(store.ToArray());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static object? ExecuteBehavior<T1, T2, T3, T4, T5, T6, T7, T8>(IBehavior b, in ArgumentStore<T1, T2, T3, T4, T5, T6, T7, T8> store, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8)
-        => b is IArgumentFreeBehavior af ? af.Execute() : b is CompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b.Execute(store.ToArray());
-    // ──────────────────────────────────────────────────────────────────────
-    //  Arity 1
-    // ──────────────────────────────────────────────────────────────────────
+        => b is IArgumentFreeBehavior af ? af.Execute() : b is ICompositeBehavior cb ? cb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b is ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8> tb ? tb.Execute(a1, a2, a3, a4, a5, a6, a7, a8) : b.Execute(store.ToArray());
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void HandleCall<T1>(int memberId, string memberName, T1 arg1)

--- a/TUnit.Mocks/MockEngine.cs
+++ b/TUnit.Mocks/MockEngine.cs
@@ -826,6 +826,14 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
         OutRefContext.Set(matchedSetup?.OutRefAssignments);
         if (matchedSetup is not null)
         {
+            if (matchedSetup.TransitionTarget is not null)
+            {
+                lock (Lock)
+                {
+                    _currentState = matchedSetup.TransitionTarget;
+                }
+            }
+
             RaiseEventsForSetup(matchedSetup);
         }
     }
@@ -938,10 +946,6 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
                 {
                     setup.IncrementInvokeCount();
                     setup.ApplyCaptures(args);
-                    if (setup.TransitionTarget is not null)
-                    {
-                        _currentState = setup.TransitionTarget;
-                    }
                     return (true, setup.GetNextBehavior(), setup);
                 }
             }

--- a/TUnit.Mocks/Setup/Behaviors/CallbackBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CallbackBehavior.cs
@@ -1,6 +1,6 @@
 namespace TUnit.Mocks.Setup.Behaviors;
 
-internal sealed class CallbackBehavior : IBehavior, IArgumentFreeBehavior
+internal sealed class CallbackBehavior : IBehavior, IArgumentFreeBehavior, ISideEffectBehavior
 {
     private readonly Action _callback;
 

--- a/TUnit.Mocks/Setup/Behaviors/CallbackWithArgsBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CallbackWithArgsBehavior.cs
@@ -10,7 +10,7 @@ namespace TUnit.Mocks.Setup.Behaviors;
 /// Future optimization: implement ITypedBehavior&lt;T...&gt; to avoid store.ToArray() when args are needed.
 /// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public sealed class CallbackWithArgsBehavior : IBehavior
+public sealed class CallbackWithArgsBehavior : IBehavior, ISideEffectBehavior
 {
     private readonly Action<object?[]> _callback;
 

--- a/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
@@ -1,0 +1,224 @@
+namespace TUnit.Mocks.Setup.Behaviors;
+
+internal sealed class CompositeBehavior : IBehavior
+{
+    private readonly IBehavior[] _behaviors;
+
+    private CompositeBehavior(IBehavior[] behaviors) => _behaviors = behaviors;
+
+    public static IBehavior Combine(IBehavior first, IBehavior second)
+    {
+        if (first is CompositeBehavior composite)
+        {
+            var combined = new IBehavior[composite._behaviors.Length + 1];
+            composite._behaviors.CopyTo(combined, 0);
+            combined[^1] = second;
+            return new CompositeBehavior(combined);
+        }
+
+        return new CompositeBehavior([first, second]);
+    }
+
+    public object? Execute(object?[] arguments)
+    {
+        object? result = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior is IArgumentFreeBehavior argumentFree
+                ? argumentFree.Execute()
+                : behavior.Execute(arguments);
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1>(T1 arg1)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1> typed => typed.Execute(arg1),
+                _ => behavior.Execute(arguments ??= [arg1])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2>(T1 arg1, T2 arg2)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2> typed => typed.Execute(arg1, arg2),
+                _ => behavior.Execute(arguments ??= [arg1, arg2])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3> typed => typed.Execute(arg1, arg2, arg3),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3, T4> typed => typed.Execute(arg1, arg2, arg3, arg4),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3, arg4])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3, T4, T5> typed => typed.Execute(arg1, arg2, arg3, arg4, arg5),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3, arg4, arg5])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3, T4, T5, T6> typed => typed.Execute(arg1, arg2, arg3, arg4, arg5, arg6),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3, arg4, arg5, arg6])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3, T4, T5, T6, T7> typed => typed.Execute(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3, arg4, arg5, arg6, arg7])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+
+    internal object? Execute<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+    {
+        object? result = null;
+        object?[]? arguments = null;
+
+        foreach (var behavior in _behaviors)
+        {
+            var behaviorResult = behavior switch
+            {
+                IArgumentFreeBehavior argumentFree => argumentFree.Execute(),
+                ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8> typed => typed.Execute(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+                _ => behavior.Execute(arguments ??= [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8])
+            };
+
+            if (behavior is not ISideEffectBehavior)
+            {
+                result = behaviorResult;
+            }
+        }
+
+        return result;
+    }
+}

--- a/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
@@ -25,28 +25,58 @@ internal interface ICompositeBehavior : IBehavior
 
 internal sealed class CompositeBehavior : ICompositeBehavior
 {
-    private readonly IBehavior[] _behaviors;
+    private readonly Lock _lock = new();
+    private readonly List<IBehavior> _behaviors;
+    private IBehavior[]? _snapshot;
 
-    private CompositeBehavior(IBehavior[] behaviors) => _behaviors = behaviors;
+    private CompositeBehavior(IBehavior first, IBehavior second)
+    {
+        _behaviors = [first, second];
+    }
 
     public static IBehavior Combine(IBehavior first, IBehavior second)
     {
         if (first is CompositeBehavior composite)
         {
-            var combined = new IBehavior[composite._behaviors.Length + 1];
-            composite._behaviors.CopyTo(combined, 0);
-            combined[^1] = second;
-            return new CompositeBehavior(combined);
+            composite.Add(second);
+            return composite;
         }
 
-        return new CompositeBehavior([first, second]);
+        return new CompositeBehavior(first, second);
+    }
+
+    private void Add(IBehavior behavior)
+    {
+        lock (_lock)
+        {
+            _behaviors.Add(behavior);
+            Volatile.Write(ref _snapshot, null);
+        }
+    }
+
+    private IBehavior[] GetSnapshot()
+    {
+        if (Volatile.Read(ref _snapshot) is { } snapshot)
+        {
+            return snapshot;
+        }
+
+        lock (_lock)
+        {
+            if (_snapshot is null)
+            {
+                Volatile.Write(ref _snapshot, _behaviors.ToArray());
+            }
+
+            return _snapshot;
+        }
     }
 
     public object? Execute(object?[] arguments)
     {
         object? result = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior is IArgumentFreeBehavior argumentFree
                 ? argumentFree.Execute()
@@ -66,7 +96,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -89,7 +119,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -112,7 +142,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -135,7 +165,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -158,7 +188,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -181,7 +211,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -204,7 +234,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {
@@ -227,7 +257,7 @@ internal sealed class CompositeBehavior : ICompositeBehavior
         object? result = null;
         object?[]? arguments = null;
 
-        foreach (var behavior in _behaviors)
+        foreach (var behavior in GetSnapshot())
         {
             var behaviorResult = behavior switch
             {

--- a/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
@@ -63,12 +63,14 @@ internal sealed class CompositeBehavior : ICompositeBehavior
 
         lock (_lock)
         {
-            if (_snapshot is null)
+            var currentSnapshot = _snapshot;
+            if (currentSnapshot is null)
             {
-                Volatile.Write(ref _snapshot, _behaviors.ToArray());
+                currentSnapshot = _behaviors.ToArray();
+                Volatile.Write(ref _snapshot, currentSnapshot);
             }
 
-            return _snapshot;
+            return currentSnapshot;
         }
     }
 

--- a/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
@@ -1,5 +1,9 @@
 namespace TUnit.Mocks.Setup.Behaviors;
 
+// Arity coupling: if a new typed mock arity is added, update this interface,
+// CompositeBehavior.Execute<T...>, MockEngine.Typed.ExecuteBehavior<T...>,
+// TypedCallbackBehavior, both setup builders, and the source generator's
+// MaxTypedParams together.
 internal interface ICompositeBehavior : IBehavior
 {
     object? Execute<T1>(T1 arg1);

--- a/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/CompositeBehavior.cs
@@ -1,6 +1,25 @@
 namespace TUnit.Mocks.Setup.Behaviors;
 
-internal sealed class CompositeBehavior : IBehavior
+internal interface ICompositeBehavior : IBehavior
+{
+    object? Execute<T1>(T1 arg1);
+
+    object? Execute<T1, T2>(T1 arg1, T2 arg2);
+
+    object? Execute<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3);
+
+    object? Execute<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+
+    object? Execute<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+
+    object? Execute<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+
+    object? Execute<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
+
+    object? Execute<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
+}
+
+internal sealed class CompositeBehavior : ICompositeBehavior
 {
     private readonly IBehavior[] _behaviors;
 
@@ -38,7 +57,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1>(T1 arg1)
+    public object? Execute<T1>(T1 arg1)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -61,7 +80,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2>(T1 arg1, T2 arg2)
+    public object? Execute<T1, T2>(T1 arg1, T2 arg2)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -84,7 +103,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
+    public object? Execute<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -107,7 +126,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    public object? Execute<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -130,7 +149,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    public object? Execute<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -153,7 +172,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+    public object? Execute<T1, T2, T3, T4, T5, T6>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -176,7 +195,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+    public object? Execute<T1, T2, T3, T4, T5, T6, T7>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
     {
         object? result = null;
         object?[]? arguments = null;
@@ -199,7 +218,7 @@ internal sealed class CompositeBehavior : IBehavior
         return result;
     }
 
-    internal object? Execute<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+    public object? Execute<T1, T2, T3, T4, T5, T6, T7, T8>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
     {
         object? result = null;
         object?[]? arguments = null;

--- a/TUnit.Mocks/Setup/Behaviors/IBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/IBehavior.cs
@@ -23,3 +23,9 @@ public interface IArgumentFreeBehavior
 {
     object? Execute();
 }
+
+/// <summary>
+/// Marker interface for behaviors that perform side effects but do not provide the mock return value.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ISideEffectBehavior;

--- a/TUnit.Mocks/Setup/Behaviors/TypedCallbackBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/TypedCallbackBehavior.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace TUnit.Mocks.Setup.Behaviors;
 
 /// <summary>
@@ -7,46 +9,52 @@ namespace TUnit.Mocks.Setup.Behaviors;
 /// (e.g. a TypedComputedReturnBehavior that takes Func&lt;T1, TReturn&gt;).
 /// </summary>
 /// <remarks>
-/// Intentionally internal: the typed dispatch is tightly coupled to the source generator's
-/// knowledge of parameter arity — only generated code knows the concrete types at compile time.
-/// <see cref="IArgumentFreeBehavior"/> is public because any behavior can opt in without type knowledge.
+/// Custom behaviors can implement the matching arity to avoid the object?[] fallback.
 /// </remarks>
-internal interface ITypedBehavior<T1>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1>
 {
     object? Execute(T1 arg1);
 }
 
-internal interface ITypedBehavior<T1, T2>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2>
 {
     object? Execute(T1 arg1, T2 arg2);
 }
 
-internal interface ITypedBehavior<T1, T2, T3>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3);
 }
 
-internal interface ITypedBehavior<T1, T2, T3, T4>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3, T4>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
 }
 
-internal interface ITypedBehavior<T1, T2, T3, T4, T5>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3, T4, T5>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
 }
 
-internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3, T4, T5, T6>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
 }
 
-internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
 }
 
-internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
 }
@@ -59,7 +67,7 @@ internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
 //   - MaxTypedParams in MockMembersBuilder.cs (source generator)
 // ──────────────────────────────────────────────────────────────────────
 
-internal sealed class TypedCallbackBehavior<T1>(Action<T1> callback) : IBehavior, ITypedBehavior<T1>
+internal sealed class TypedCallbackBehavior<T1>(Action<T1> callback) : IBehavior, ITypedBehavior<T1>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -71,7 +79,7 @@ internal sealed class TypedCallbackBehavior<T1>(Action<T1> callback) : IBehavior
     public object? Execute(T1 arg1) { callback(arg1); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2>(Action<T1, T2> callback) : IBehavior, ITypedBehavior<T1, T2>
+internal sealed class TypedCallbackBehavior<T1, T2>(Action<T1, T2> callback) : IBehavior, ITypedBehavior<T1, T2>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -83,7 +91,7 @@ internal sealed class TypedCallbackBehavior<T1, T2>(Action<T1, T2> callback) : I
     public object? Execute(T1 arg1, T2 arg2) { callback(arg1, arg2); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3>(Action<T1, T2, T3> callback) : IBehavior, ITypedBehavior<T1, T2, T3>
+internal sealed class TypedCallbackBehavior<T1, T2, T3>(Action<T1, T2, T3> callback) : IBehavior, ITypedBehavior<T1, T2, T3>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -95,7 +103,7 @@ internal sealed class TypedCallbackBehavior<T1, T2, T3>(Action<T1, T2, T3> callb
     public object? Execute(T1 arg1, T2 arg2, T3 arg3) { callback(arg1, arg2, arg3); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3, T4>(Action<T1, T2, T3, T4> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4>
+internal sealed class TypedCallbackBehavior<T1, T2, T3, T4>(Action<T1, T2, T3, T4> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -107,7 +115,7 @@ internal sealed class TypedCallbackBehavior<T1, T2, T3, T4>(Action<T1, T2, T3, T
     public object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4) { callback(arg1, arg2, arg3, arg4); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5>
+internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -119,7 +127,7 @@ internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5>(Action<T1, T2, T
     public object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { callback(arg1, arg2, arg3, arg4, arg5); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6>
+internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -131,7 +139,7 @@ internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6>(Action<T1, T
     public object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { callback(arg1, arg2, arg3, arg4, arg5, arg6); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>
+internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {
@@ -143,7 +151,7 @@ internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6, T7>(Action<T
     public object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) { callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7); return null; }
 }
 
-internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
+internal sealed class TypedCallbackBehavior<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> callback) : IBehavior, ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>, ISideEffectBehavior
 {
     public object? Execute(object?[] arguments)
     {

--- a/TUnit.Mocks/Setup/Behaviors/TypedCallbackBehavior.cs
+++ b/TUnit.Mocks/Setup/Behaviors/TypedCallbackBehavior.cs
@@ -3,69 +3,56 @@ using System.ComponentModel;
 namespace TUnit.Mocks.Setup.Behaviors;
 
 /// <summary>
-/// Typed behavior dispatch interfaces. ExecuteBehavior checks for these after IArgumentFreeBehavior,
-/// enabling behaviors to receive typed arguments without boxing into object?[].
-/// Currently implemented by TypedCallbackBehavior; extensible for future typed return behaviors
-/// (e.g. a TypedComputedReturnBehavior that takes Func&lt;T1, TReturn&gt;).
+/// Internal typed behavior dispatch interfaces. ExecuteBehavior checks for these after IArgumentFreeBehavior,
+/// enabling built-in behaviors to receive typed arguments without boxing into object?[].
 /// </summary>
-/// <remarks>
-/// Custom behaviors can implement the matching arity to avoid the object?[] fallback.
-/// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1>
+internal interface ITypedBehavior<T1>
 {
     object? Execute(T1 arg1);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2>
+internal interface ITypedBehavior<T1, T2>
 {
     object? Execute(T1 arg1, T2 arg2);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3>
+internal interface ITypedBehavior<T1, T2, T3>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3, T4>
+internal interface ITypedBehavior<T1, T2, T3, T4>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3, T4, T5>
+internal interface ITypedBehavior<T1, T2, T3, T4, T5>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3, T4, T5, T6>
+internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>
+internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
+internal interface ITypedBehavior<T1, T2, T3, T4, T5, T6, T7, T8>
 {
     object? Execute(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
 }
-
-// ── ARITY COUPLING (1–8) ──────────────────────────────────────────────
-// If you add an arity (e.g. T9), you MUST also update:
-//   - ITypedBehavior<T1...T9> above
-//   - ExecuteBehavior<T1...T9> in MockEngine.Typed.cs
-//   - Callback<T1...T9> in MethodSetupBuilder.cs and VoidMethodSetupBuilder.cs
-//   - MaxTypedParams in MockMembersBuilder.cs (source generator)
-// ──────────────────────────────────────────────────────────────────────
 
 internal sealed class TypedCallbackBehavior<T1>(Action<T1> callback) : IBehavior, ITypedBehavior<T1>, ISideEffectBehavior
 {

--- a/TUnit.Mocks/Setup/ISetupChain.cs
+++ b/TUnit.Mocks/Setup/ISetupChain.cs
@@ -3,23 +3,17 @@ namespace TUnit.Mocks.Setup;
 /// <summary>
 /// Setup chain for sequential behavior configuration on methods with a return value.
 /// </summary>
-public interface ISetupChain<TReturn>
+public interface ISetupChain<TReturn> : IMethodSetup<TReturn>
 {
     /// <summary>Chain the next call's behavior.</summary>
     IMethodSetup<TReturn> Then();
-
-    /// <summary>Transition to the named state after this behavior executes.</summary>
-    ISetupChain<TReturn> TransitionsTo(string stateName);
 }
 
 /// <summary>
 /// Setup chain for void method sequential behavior configuration.
 /// </summary>
-public interface IVoidSetupChain
+public interface IVoidSetupChain : IVoidMethodSetup
 {
     /// <summary>Chain the next call's behavior.</summary>
     IVoidMethodSetup Then();
-
-    /// <summary>Transition to the named state after this behavior executes.</summary>
-    IVoidSetupChain TransitionsTo(string stateName);
 }

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -37,7 +37,8 @@ public sealed class MethodSetup
     /// <remarks>See <see cref="_singleBehavior"/> for volatility rationale.</remarks>
     private List<IBehavior>? _behaviors;
     private int _callIndex;
-    private bool _nextBehaviorStartsNewStep = true;
+    /// <summary>True while chained behaviors are being composed into the current invocation step.</summary>
+    private bool _hasOpenBehaviorStep;
 
     public int MemberId { get; }
 
@@ -118,12 +119,14 @@ public sealed class MethodSetup
 
     public void AddBehavior(IBehavior behavior)
     {
+        // Setup mutation is not a hot path; one lock keeps sequential steps and composed
+        // behavior steps consistent without the previous single-behavior CAS fast path.
         lock (BehaviorLock)
         {
-            if (_nextBehaviorStartsNewStep)
+            if (!_hasOpenBehaviorStep)
             {
                 AddBehaviorStep(behavior);
-                _nextBehaviorStartsNewStep = false;
+                _hasOpenBehaviorStep = true;
                 return;
             }
 
@@ -135,7 +138,7 @@ public sealed class MethodSetup
     {
         lock (BehaviorLock)
         {
-            _nextBehaviorStartsNewStep = true;
+            _hasOpenBehaviorStep = false;
         }
     }
 

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -120,7 +120,7 @@ public sealed class MethodSetup
     {
         lock (BehaviorLock)
         {
-            if (_nextBehaviorStartsNewStep || (_singleBehavior is null && _behaviors is null))
+            if (_nextBehaviorStartsNewStep)
             {
                 AddBehaviorStep(behavior);
                 _nextBehaviorStartsNewStep = false;

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -37,6 +37,7 @@ public sealed class MethodSetup
     /// <remarks>See <see cref="_singleBehavior"/> for volatility rationale.</remarks>
     private List<IBehavior>? _behaviors;
     private int _callIndex;
+    private bool _nextBehaviorStartsNewStep = true;
 
     public int MemberId { get; }
 
@@ -117,41 +118,55 @@ public sealed class MethodSetup
 
     public void AddBehavior(IBehavior behavior)
     {
-        // Lock-free fast path: CAS for the common single-behavior case.
-        // Avoids allocating the Lock object entirely when only one behavior is registered.
-        // Safety: Interlocked.CompareExchange is a full memory barrier, so a successful CAS
-        // on _singleBehavior is visible to any subsequent Volatile.Read in AddBehaviorSlow.
-        if (Volatile.Read(ref _behaviors) is null
-            && Interlocked.CompareExchange(ref _singleBehavior, behavior, null) is null)
+        lock (BehaviorLock)
         {
-            // Double-check: if a concurrent AddBehaviorSlow promoted to list between our
-            // _behaviors read and the CAS, fall through to slow path to reconcile.
-            if (Volatile.Read(ref _behaviors) is null)
+            if (_nextBehaviorStartsNewStep || (_singleBehavior is null && _behaviors is null))
             {
+                AddBehaviorStep(behavior);
+                _nextBehaviorStartsNewStep = false;
                 return;
             }
-        }
 
-        AddBehaviorSlow(behavior);
+            AppendToCurrentBehaviorStep(behavior);
+        }
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void AddBehaviorSlow(IBehavior behavior)
+    public void Then()
     {
         lock (BehaviorLock)
         {
-            // Promote to list on second behavior. Write _behaviors before clearing
-            // _singleBehavior so that a lock-free reader in GetNextBehavior that sees
-            // _singleBehavior == null will also see the updated _behaviors reference.
-            if (Volatile.Read(ref _behaviors) is null)
-            {
-                var current = Volatile.Read(ref _singleBehavior);
-                Volatile.Write(ref _behaviors, current is not null ? [current] : []);
-            }
+            _nextBehaviorStartsNewStep = true;
+        }
+    }
 
-            _behaviors!.Add(behavior);
+    private void AddBehaviorStep(IBehavior behavior)
+    {
+        if (_singleBehavior is null && _behaviors is null)
+        {
+            Volatile.Write(ref _singleBehavior, behavior);
+            return;
+        }
+
+        var behaviors = _behaviors;
+        if (behaviors is null)
+        {
+            behaviors = [Volatile.Read(ref _singleBehavior)!];
+            Volatile.Write(ref _behaviors, behaviors);
             Volatile.Write(ref _singleBehavior, null);
         }
+
+        behaviors.Add(behavior);
+    }
+
+    private void AppendToCurrentBehaviorStep(IBehavior behavior)
+    {
+        if (_behaviors is { Count: > 0 } behaviors)
+        {
+            behaviors[^1] = CompositeBehavior.Combine(behaviors[^1], behavior);
+            return;
+        }
+
+        Volatile.Write(ref _singleBehavior, CompositeBehavior.Combine(Volatile.Read(ref _singleBehavior)!, behavior));
     }
 
     public bool Matches(object?[] actualArgs)

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -31,7 +31,7 @@ public sealed class MethodSetup
     /// <summary>Fast path for the common single-behavior case. Avoids list + lock on read.</summary>
     /// <remarks>
     /// Not declared volatile to avoid CS0420 with Interlocked.CompareExchange.
-    /// All accesses use Volatile.Read/Write or Interlocked ops for correct ordering.
+    /// Readers use Volatile.Read where they avoid taking BehaviorLock.
     /// </remarks>
     private IBehavior? _singleBehavior;
     /// <remarks>See <see cref="_singleBehavior"/> for volatility rationale.</remarks>
@@ -143,16 +143,16 @@ public sealed class MethodSetup
     {
         if (_singleBehavior is null && _behaviors is null)
         {
-            Volatile.Write(ref _singleBehavior, behavior);
+            _singleBehavior = behavior;
             return;
         }
 
         var behaviors = _behaviors;
         if (behaviors is null)
         {
-            behaviors = [Volatile.Read(ref _singleBehavior)!];
-            Volatile.Write(ref _behaviors, behaviors);
-            Volatile.Write(ref _singleBehavior, null);
+            behaviors = [_singleBehavior!];
+            _behaviors = behaviors;
+            _singleBehavior = null;
         }
 
         behaviors.Add(behavior);
@@ -166,7 +166,7 @@ public sealed class MethodSetup
             return;
         }
 
-        Volatile.Write(ref _singleBehavior, CompositeBehavior.Combine(Volatile.Read(ref _singleBehavior)!, behavior));
+        _singleBehavior = CompositeBehavior.Combine(_singleBehavior!, behavior);
     }
 
     public bool Matches(object?[] actualArgs)

--- a/TUnit.Mocks/Setup/MethodSetupBuilder.cs
+++ b/TUnit.Mocks/Setup/MethodSetupBuilder.cs
@@ -31,9 +31,14 @@ public sealed class MethodSetupBuilder<TReturn> : IMethodSetup<TReturn>, ISetupC
 
     public ISetupChain<TReturn> ReturnsSequentially(params TReturn[] values)
     {
-        foreach (var value in values)
+        for (var i = 0; i < values.Length; i++)
         {
-            _setup.AddBehavior(new ReturnBehavior<TReturn>(value));
+            if (i > 0)
+            {
+                _setup.Then();
+            }
+
+            _setup.AddBehavior(new ReturnBehavior<TReturn>(values[i]));
         }
 
         return this;
@@ -179,5 +184,9 @@ public sealed class MethodSetupBuilder<TReturn> : IMethodSetup<TReturn>, ISetupC
         return this;
     }
 
-    public IMethodSetup<TReturn> Then() => this;
+    public IMethodSetup<TReturn> Then()
+    {
+        _setup.Then();
+        return this;
+    }
 }

--- a/TUnit.Mocks/Setup/VoidMethodSetupBuilder.cs
+++ b/TUnit.Mocks/Setup/VoidMethodSetupBuilder.cs
@@ -149,5 +149,9 @@ public sealed class VoidMethodSetupBuilder : IVoidMethodSetup, IVoidSetupChain
         return this;
     }
 
-    public IVoidMethodSetup Then() => this;
+    public IVoidMethodSetup Then()
+    {
+        _setup.Then();
+        return this;
+    }
 }

--- a/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
+++ b/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
@@ -205,7 +205,7 @@ public class OtlpReceiverIngestionTests
         var latePostCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var latePost = Task.Run(async () =>
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
             using var client = new HttpClient();
             using var content = new ByteArrayContent(Array.Empty<byte>());
             await client.PostAsync($"http://127.0.0.1:{receiver.Port}/v1/traces", content);
@@ -215,10 +215,8 @@ public class OtlpReceiverIngestionTests
         await receiver.DrainAsync(TimeSpan.FromSeconds(3));
 
         // Asserts the real contract directly: drain returned only after the late POST
-        // had been issued and acknowledged. Wall-clock floors (the previous approach)
-        // failed on macOS arm64 because Task.Delay scheduling jitter could push the
-        // late POST inside the synchronous prefix of DrainAsync, making the elapsed
-        // measurement misrepresent the actual invariant the drain must hold.
+        // had been issued and acknowledged. Keep the delay well inside DrainAsync's
+        // quiet window so busy CI runners do not turn this into a scheduler test.
         await Assert.That(latePostCompleted.Task.IsCompleted).IsTrue();
         await Assert.That(receiver.Diagnostics.TracesRequests).IsEqualTo(1);
 

--- a/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
+++ b/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
@@ -194,33 +194,62 @@ public class OtlpReceiverIngestionTests
     }
 
     [Test]
-    public async Task Receiver_DrainAsync_WaitsForLatePostBeforeReturning()
+    public async Task Receiver_DrainAsync_WaitsForInFlightForwardBeforeReturning()
     {
-        await using var receiver = new OtlpReceiver();
-        receiver.Start();
+        using var upstreamListener = new HttpListener();
+        var upstreamPort = LoopbackHttpListenerFactory.FindFreePort();
+        upstreamListener.Prefixes.Add($"http://127.0.0.1:{upstreamPort}/");
+        upstreamListener.Start();
 
-        // Simulate a SUT exporter that flushes a couple hundred ms after the test logic
-        // would finish — without DrainAsync, AspireFixture would tear down the AppHost
-        // and the late POST would fail / be dropped.
-        var latePostCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var latePost = Task.Run(async () =>
+        var upstreamReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseUpstream = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listenerTask = Task.Run(async () =>
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(50));
-            using var client = new HttpClient();
-            using var content = new ByteArrayContent(Array.Empty<byte>());
-            await client.PostAsync($"http://127.0.0.1:{receiver.Port}/v1/traces", content);
-            latePostCompleted.SetResult(true);
+            var ctx = await upstreamListener.GetContextAsync();
+            upstreamReceived.TrySetResult();
+
+            await releaseUpstream.Task;
+
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentLength64 = 0;
+            ctx.Response.Close();
         });
 
-        await receiver.DrainAsync(TimeSpan.FromSeconds(3));
+        try
+        {
+            await using var receiver = new OtlpReceiver($"http://127.0.0.1:{upstreamPort}");
+            receiver.Start();
 
-        // Asserts the real contract directly: drain returned only after the late POST
-        // had been issued and acknowledged. Keep the delay well inside DrainAsync's
-        // quiet window so busy CI runners do not turn this into a scheduler test.
-        await Assert.That(latePostCompleted.Task.IsCompleted).IsTrue();
-        await Assert.That(receiver.Diagnostics.TracesRequests).IsEqualTo(1);
+            using var client = new HttpClient();
+            using var content = new ByteArrayContent(Array.Empty<byte>());
+            content.Headers.ContentType = new("application/x-protobuf");
+            var response = await client.PostAsync($"http://127.0.0.1:{receiver.Port}/v1/traces", content);
 
-        await latePost;
+            await Assert.That(response.IsSuccessStatusCode).IsTrue();
+            await upstreamReceived.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            var drainTask = receiver.DrainAsync(TimeSpan.FromSeconds(3));
+            var completedBeforeUpstreamReleased = await Task.WhenAny(
+                drainTask,
+                Task.Delay(TimeSpan.FromMilliseconds(750))) == drainTask;
+
+            await Assert.That(completedBeforeUpstreamReleased).IsFalse();
+
+            releaseUpstream.TrySetResult();
+
+            await drainTask.WaitAsync(TimeSpan.FromSeconds(2));
+            await listenerTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+            await Assert.That(receiver.Diagnostics.TracesRequests).IsEqualTo(1);
+            await Assert.That(receiver.Diagnostics.UpstreamForwardSuccess).IsEqualTo(1);
+            await Assert.That(receiver.Diagnostics.UpstreamForwardFailures).IsEqualTo(0);
+        }
+        finally
+        {
+            releaseUpstream.TrySetResult();
+            upstreamListener.Stop();
+            try { await listenerTask; } catch { }
+        }
     }
 
     [Test]

--- a/docs/docs/writing-tests/mocking/setup.md
+++ b/docs/docs/writing-tests/mocking/setup.md
@@ -63,6 +63,19 @@ mock.GetValue(Any())
 // 1st: "first", 2nd: "second", 3rd+: "third" (last value repeats)
 ```
 
+Chained setup behaviors without `.Then()` run together as a single invocation step.
+When multiple return behaviors are chained in one step, the last return wins:
+
+```csharp
+mock.GetValue(Any())
+    .Returns("first")
+    .Returns("second");
+// Every call returns "second"
+```
+
+Use `.Then()` or `.ReturnsSequentially(...)` when each return should apply to a
+different invocation.
+
 ### Void Methods
 
 Void methods support `Callback` and `Throws` (but not `Returns`):


### PR DESCRIPTION
## Summary
- combine chained mock behaviors so callbacks and returns execute in the same invocation step
- keep explicit `Then()` and `ReturnsSequentially(...)` as sequential behavior boundaries
- preserve typed dispatch and custom side-effect behavior semantics in composites
- apply state transitions after successful behavior execution

## Tests
- `dotnet test .\TUnit.Mocks.Tests\TUnit.Mocks.Tests.csproj`

Closes #5972