### PR TITLE
Preserve override accessibility in generated mocks

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
+++ b/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
@@ -729,6 +729,64 @@ public class MockGeneratorTests : SnapshotTestBase
     }
 
     [Test]
+    public void Partial_Mock_Preserves_All_Access_Modifiers_In_Same_Assembly()
+    {
+        var source = """
+            using System;
+            using TUnit.Mocks;
+
+            public class AccessModifierService
+            {
+                public virtual string PublicMethod() => "";
+                protected virtual string ProtectedMethod() => "";
+                internal virtual string InternalMethod() => "";
+                protected internal virtual string ProtectedInternalMethod() => "";
+                private protected virtual string PrivateProtectedMethod() => "";
+
+                public virtual string PublicProperty { get; set; } = "";
+                protected virtual string ProtectedProperty { get; set; } = "";
+                internal virtual string InternalProperty { get; set; } = "";
+                protected internal virtual string ProtectedInternalProperty { get; set; } = "";
+                private protected virtual string PrivateProtectedProperty { get; set; } = "";
+
+                public virtual event EventHandler? PublicEvent;
+                protected virtual event EventHandler? ProtectedEvent;
+                internal virtual event EventHandler? InternalEvent;
+                protected internal virtual event EventHandler? ProtectedInternalEvent;
+                private protected virtual event EventHandler? PrivateProtectedEvent;
+            }
+
+            public class TestUsage
+            {
+                void M()
+                {
+                    var mock = Mock.Of<AccessModifierService>();
+                }
+            }
+            """;
+
+        var generated = GetGeneratedOutput(source);
+
+        AssertContains(generated, "public override string PublicMethod()");
+        AssertContains(generated, "protected override string ProtectedMethod()");
+        AssertContains(generated, "internal override string InternalMethod()");
+        AssertContains(generated, "protected internal override string ProtectedInternalMethod()");
+        AssertContains(generated, "private protected override string PrivateProtectedMethod()");
+
+        AssertContains(generated, "public override string PublicProperty");
+        AssertContains(generated, "protected override string ProtectedProperty");
+        AssertContains(generated, "internal override string InternalProperty");
+        AssertContains(generated, "protected internal override string ProtectedInternalProperty");
+        AssertContains(generated, "private protected override string PrivateProtectedProperty");
+
+        AssertContains(generated, "public override event global::System.EventHandler? PublicEvent");
+        AssertContains(generated, "protected override event global::System.EventHandler? ProtectedEvent");
+        AssertContains(generated, "internal override event global::System.EventHandler? InternalEvent");
+        AssertContains(generated, "protected internal override event global::System.EventHandler? ProtectedInternalEvent");
+        AssertContains(generated, "private protected override event global::System.EventHandler? PrivateProtectedEvent");
+    }
+
+    [Test]
     public Task Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly()
     {
         // Simulate an external assembly with internal, private protected, and public virtual members
@@ -766,6 +824,141 @@ public class MockGeneratorTests : SnapshotTestBase
             """;
 
         return VerifyGeneratorOutput(source, [externalRef]);
+    }
+
+    [Test]
+    public void Partial_Mock_Preserves_Externally_Accessible_Modifier_Combinations_Without_InternalsVisibleTo()
+    {
+        var externalSource = """
+            using System;
+
+            namespace ExternalLib
+            {
+                public class ExternalModifiers
+                {
+                    public virtual string PublicMethod() => "";
+                    protected virtual string ProtectedMethod() => "";
+                    internal virtual string InternalMethod() => "";
+                    protected internal virtual string ProtectedInternalMethod() => "";
+                    private protected virtual string PrivateProtectedMethod() => "";
+
+                    public virtual string PublicProperty { get; set; } = "";
+                    protected virtual string ProtectedProperty { get; set; } = "";
+                    internal virtual string InternalProperty { get; set; } = "";
+                    protected internal virtual string ProtectedInternalProperty { get; set; } = "";
+                    private protected virtual string PrivateProtectedProperty { get; set; } = "";
+
+                    public virtual event EventHandler? PublicEvent;
+                    protected virtual event EventHandler? ProtectedEvent;
+                    internal virtual event EventHandler? InternalEvent;
+                    protected internal virtual event EventHandler? ProtectedInternalEvent;
+                    private protected virtual event EventHandler? PrivateProtectedEvent;
+                }
+            }
+            """;
+
+        var externalRef = CreateExternalAssemblyReference(externalSource);
+        var source = """
+            using TUnit.Mocks;
+            using ExternalLib;
+
+            public class TestUsage
+            {
+                void M()
+                {
+                    var mock = Mock.Of<ExternalModifiers>();
+                }
+            }
+            """;
+
+        var generated = GetGeneratedOutput(source, [externalRef]);
+
+        AssertContains(generated, "public override string PublicMethod()");
+        AssertContains(generated, "protected override string ProtectedMethod()");
+        AssertContains(generated, "protected override string ProtectedInternalMethod()");
+        AssertDoesNotContain(generated, "internal override string InternalMethod()");
+        AssertDoesNotContain(generated, "private protected override string PrivateProtectedMethod()");
+
+        AssertContains(generated, "public override string PublicProperty");
+        AssertContains(generated, "protected override string ProtectedProperty");
+        AssertContains(generated, "protected override string ProtectedInternalProperty");
+        AssertDoesNotContain(generated, "internal override string InternalProperty");
+        AssertDoesNotContain(generated, "private protected override string PrivateProtectedProperty");
+
+        AssertContains(generated, "public override event global::System.EventHandler? PublicEvent");
+        AssertContains(generated, "protected override event global::System.EventHandler? ProtectedEvent");
+        AssertContains(generated, "protected override event global::System.EventHandler? ProtectedInternalEvent");
+        AssertDoesNotContain(generated, "internal override event global::System.EventHandler? InternalEvent");
+        AssertDoesNotContain(generated, "private protected override event global::System.EventHandler? PrivateProtectedEvent");
+    }
+
+    [Test]
+    public void Partial_Mock_Preserves_All_Access_Modifiers_With_InternalsVisibleTo()
+    {
+        var externalSource = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            [assembly: InternalsVisibleTo("TestAssembly")]
+
+            namespace ExternalLib
+            {
+                public class ExternalModifiers
+                {
+                    public virtual string PublicMethod() => "";
+                    protected virtual string ProtectedMethod() => "";
+                    internal virtual string InternalMethod() => "";
+                    protected internal virtual string ProtectedInternalMethod() => "";
+                    private protected virtual string PrivateProtectedMethod() => "";
+
+                    public virtual string PublicProperty { get; set; } = "";
+                    protected virtual string ProtectedProperty { get; set; } = "";
+                    internal virtual string InternalProperty { get; set; } = "";
+                    protected internal virtual string ProtectedInternalProperty { get; set; } = "";
+                    private protected virtual string PrivateProtectedProperty { get; set; } = "";
+
+                    public virtual event EventHandler? PublicEvent;
+                    protected virtual event EventHandler? ProtectedEvent;
+                    internal virtual event EventHandler? InternalEvent;
+                    protected internal virtual event EventHandler? ProtectedInternalEvent;
+                    private protected virtual event EventHandler? PrivateProtectedEvent;
+                }
+            }
+            """;
+
+        var externalRef = CreateExternalAssemblyReference(externalSource);
+        var source = """
+            using TUnit.Mocks;
+            using ExternalLib;
+
+            public class TestUsage
+            {
+                void M()
+                {
+                    var mock = Mock.Of<ExternalModifiers>();
+                }
+            }
+            """;
+
+        var generated = GetGeneratedOutput(source, [externalRef]);
+
+        AssertContains(generated, "public override string PublicMethod()");
+        AssertContains(generated, "protected override string ProtectedMethod()");
+        AssertContains(generated, "internal override string InternalMethod()");
+        AssertContains(generated, "protected internal override string ProtectedInternalMethod()");
+        AssertContains(generated, "private protected override string PrivateProtectedMethod()");
+
+        AssertContains(generated, "public override string PublicProperty");
+        AssertContains(generated, "protected override string ProtectedProperty");
+        AssertContains(generated, "internal override string InternalProperty");
+        AssertContains(generated, "protected internal override string ProtectedInternalProperty");
+        AssertContains(generated, "private protected override string PrivateProtectedProperty");
+
+        AssertContains(generated, "public override event global::System.EventHandler? PublicEvent");
+        AssertContains(generated, "protected override event global::System.EventHandler? ProtectedEvent");
+        AssertContains(generated, "internal override event global::System.EventHandler? InternalEvent");
+        AssertContains(generated, "protected internal override event global::System.EventHandler? ProtectedInternalEvent");
+        AssertContains(generated, "private protected override event global::System.EventHandler? PrivateProtectedEvent");
     }
 
     // Regression for https://github.com/thomhurst/TUnit/issues/5455 — public virtual properties
@@ -877,6 +1070,61 @@ public class MockGeneratorTests : SnapshotTestBase
             """;
 
         return VerifyGeneratorOutput(source, [externalRef]);
+    }
+
+    [Test]
+    public void Wrap_Mock_Preserves_Internal_And_ProtectedInternal_Modifiers_With_InternalsVisibleTo()
+    {
+        var externalSource = """
+            using System;
+            using System.Runtime.CompilerServices;
+
+            [assembly: InternalsVisibleTo("TestAssembly")]
+
+            namespace ExternalLib
+            {
+                public class ExternalWrapTarget
+                {
+                    public virtual string PublicMethod() => "";
+                    internal virtual string InternalMethod() => "";
+                    protected internal virtual string ProtectedInternalMethod() => "";
+
+                    public virtual string PublicProperty { get; set; } = "";
+                    internal virtual string InternalProperty { get; set; } = "";
+                    protected internal virtual string ProtectedInternalProperty { get; set; } = "";
+
+                    public virtual event EventHandler? PublicEvent;
+                    internal virtual event EventHandler? InternalEvent;
+                    protected internal virtual event EventHandler? ProtectedInternalEvent;
+                }
+            }
+            """;
+
+        var externalRef = CreateExternalAssemblyReference(externalSource);
+        var source = """
+            using TUnit.Mocks;
+            using ExternalLib;
+
+            public class TestUsage
+            {
+                void M()
+                {
+                    var mock = Mock.Wrap(new ExternalWrapTarget());
+                }
+            }
+            """;
+
+        var generated = GetGeneratedOutput(source, [externalRef]);
+
+        AssertContains(generated, "public override string PublicMethod()");
+        AssertContains(generated, "internal override string InternalMethod()");
+        AssertContains(generated, "protected internal override string ProtectedInternalMethod()");
+        AssertContains(generated, "public override string PublicProperty");
+        AssertContains(generated, "internal override string InternalProperty");
+        AssertContains(generated, "protected internal override string ProtectedInternalProperty");
+        AssertContains(generated, "public override event global::System.EventHandler? PublicEvent");
+        AssertContains(generated, "internal override event global::System.EventHandler? InternalEvent");
+        AssertContains(generated, "protected internal override event global::System.EventHandler? ProtectedInternalEvent");
     }
 
     [Test]
@@ -1572,5 +1820,24 @@ public class MockGeneratorTests : SnapshotTestBase
             """;
 
         return VerifyGeneratorOutput(source);
+    }
+
+    private static string GetGeneratedOutput(string source, IEnumerable<Microsoft.CodeAnalysis.MetadataReference>? additionalReferences = null)
+        => string.Join(Environment.NewLine, RunGenerator(source, additionalReferences));
+
+    private static void AssertContains(string text, string expected)
+    {
+        if (!text.Contains(expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected generated output to contain: {expected}");
+        }
+    }
+
+    private static void AssertDoesNotContain(string text, string unexpected)
+    {
+        if (text.Contains(unexpected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected generated output not to contain: {unexpected}");
+        }
     }
 }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
@@ -51,7 +51,7 @@ namespace ExternalLib
                 }
                 return base.Reason;
             }
-            set
+            protected set
             {
                 if (!_engine.TryHandleCall(3, "set_Reason", new object?[] { value }))
                 {

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -210,8 +210,7 @@ internal static class MockImplBuilder
         writer.AppendLineIfNotEmpty(method.ObsoleteAttribute);
 
         // C# prohibits restating generic constraints on override methods (CS0460)
-        var accessModifier = method.IsProtected ? "protected" : "public";
-        using (writer.Block($"{accessModifier} override {signatureReturnType} {EscapeIdentifier(method.Name)}{typeParams}({paramList})"))
+        using (writer.Block($"{method.OverrideAccessModifier} override {signatureReturnType} {EscapeIdentifier(method.Name)}{typeParams}({paramList})"))
         {
             if (method.IsAbstractMember)
             {
@@ -346,11 +345,12 @@ internal static class MockImplBuilder
 
     private static void GenerateWrapProperty(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        var accessModifier = prop.IsProtected ? "protected" : "public";
         var autoMockFactory = GetAutoMockFactoryLambda(prop);
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
-        writer.AppendLine($"{accessModifier} override {prop.ReturnType} {EscapeIdentifier(prop.Name)}");
+        writer.AppendLine($"{prop.OverrideAccessModifier} override {prop.ReturnType} {EscapeIdentifier(prop.Name)}");
         writer.OpenBrace();
+        var getterPrefix = AccessorPrefix(prop.GetterAccessModifier);
+        var setterPrefix = AccessorPrefix(prop.SetterAccessModifier);
 
         if (prop.HasGetter)
         {
@@ -359,7 +359,7 @@ internal static class MockImplBuilder
             {
                 if (prop.IsAbstractMember)
                 {
-                    writer.AppendLine("get");
+                    writer.AppendLine($"{getterPrefix}get");
                     writer.OpenBrace();
                     writer.AppendLine($"_engine.HandleCall({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>());");
                     writer.AppendLine("return default;");
@@ -367,7 +367,7 @@ internal static class MockImplBuilder
                 }
                 else
                 {
-                    writer.AppendLine("get");
+                    writer.AppendLine($"{getterPrefix}get");
                     writer.OpenBrace();
                     writer.AppendLine($"if (_engine.TryHandleCall({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>()))");
                     writer.AppendLine("{");
@@ -381,15 +381,15 @@ internal static class MockImplBuilder
             }
             else if (prop.IsAbstractMember && prop.IsReturnTypeStaticAbstractInterface)
             {
-                writer.AppendLine($"get => ({prop.ReturnType})_engine.HandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null)!;");
+                writer.AppendLine($"{getterPrefix}get => ({prop.ReturnType})_engine.HandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null)!;");
             }
             else if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}{FormatAutoMockFactoryArgument(autoMockFactory)});");
+                writer.AppendLine($"{getterPrefix}get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}{FormatAutoMockFactoryArgument(autoMockFactory)});");
             }
             else if (prop.IsReturnTypeStaticAbstractInterface)
             {
-                writer.AppendLine("get");
+                writer.AppendLine($"{getterPrefix}get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null, out var __rawResult))");
                 writer.AppendLine("{");
@@ -402,7 +402,7 @@ internal static class MockImplBuilder
             }
             else
             {
-                writer.AppendLine("get");
+                writer.AppendLine($"{getterPrefix}get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}, out var __result{FormatAutoMockFactoryArgument(autoMockFactory)}))");
                 writer.AppendLine("{");
@@ -424,11 +424,11 @@ internal static class MockImplBuilder
 
             if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs});");
+                writer.AppendLine($"{setterPrefix}set => _engine.HandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs});");
             }
             else
             {
-                writer.AppendLine("set");
+                writer.AppendLine($"{setterPrefix}set");
                 writer.OpenBrace();
                 writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs}))");
                 writer.AppendLine("{");
@@ -593,8 +593,7 @@ internal static class MockImplBuilder
         writer.AppendLineIfNotEmpty(method.ObsoleteAttribute);
 
         // C# prohibits restating generic constraints on override methods (CS0460)
-        var accessModifier = method.IsProtected ? "protected" : "public";
-        using (writer.Block($"{accessModifier} override {signatureReturnType} {EscapeIdentifier(method.Name)}{typeParams}({paramList})"))
+        using (writer.Block($"{method.OverrideAccessModifier} override {signatureReturnType} {EscapeIdentifier(method.Name)}{typeParams}({paramList})"))
         {
             if (method.IsAbstractMember)
             {
@@ -939,11 +938,12 @@ internal static class MockImplBuilder
 
     private static void GeneratePartialProperty(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        var accessModifier = prop.IsProtected ? "protected" : "public";
         var autoMockFactory = GetAutoMockFactoryLambda(prop);
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
-        writer.AppendLine($"{accessModifier} override {prop.ReturnType} {EscapeIdentifier(prop.Name)}");
+        writer.AppendLine($"{prop.OverrideAccessModifier} override {prop.ReturnType} {EscapeIdentifier(prop.Name)}");
         writer.OpenBrace();
+        var getterPrefix = AccessorPrefix(prop.GetterAccessModifier);
+        var setterPrefix = AccessorPrefix(prop.SetterAccessModifier);
 
         if (prop.HasGetter)
         {
@@ -952,7 +952,7 @@ internal static class MockImplBuilder
             {
                 if (prop.IsAbstractMember)
                 {
-                    writer.AppendLine("get");
+                    writer.AppendLine($"{getterPrefix}get");
                     writer.OpenBrace();
                     writer.AppendLine($"_engine.HandleCall({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>());");
                     writer.AppendLine("return default;");
@@ -960,7 +960,7 @@ internal static class MockImplBuilder
                 }
                 else
                 {
-                    writer.AppendLine("get");
+                    writer.AppendLine($"{getterPrefix}get");
                     writer.OpenBrace();
                     writer.AppendLine($"if (_engine.TryHandleCall({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>()))");
                     writer.AppendLine("{");
@@ -974,16 +974,16 @@ internal static class MockImplBuilder
             }
             else if (prop.IsAbstractMember && prop.IsReturnTypeStaticAbstractInterface)
             {
-                writer.AppendLine($"get => ({prop.ReturnType})_engine.HandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null)!;");
+                writer.AppendLine($"{getterPrefix}get => ({prop.ReturnType})_engine.HandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null)!;");
             }
             else if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}{FormatAutoMockFactoryArgument(autoMockFactory)});");
+                writer.AppendLine($"{getterPrefix}get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}{FormatAutoMockFactoryArgument(autoMockFactory)});");
             }
             else if (prop.IsReturnTypeStaticAbstractInterface)
             {
                 // Virtual property getter: try engine, fall back to base (CS8920-safe)
-                writer.AppendLine("get");
+                writer.AppendLine($"{getterPrefix}get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<object?>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), null, out var __rawResult))");
                 writer.AppendLine("{");
@@ -997,7 +997,7 @@ internal static class MockImplBuilder
             else
             {
                 // Virtual property getter: try engine, fall back to base
-                writer.AppendLine("get");
+                writer.AppendLine($"{getterPrefix}get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_{prop.Name}\", global::System.Array.Empty<object?>(), {prop.SmartDefault}, out var __result{FormatAutoMockFactoryArgument(autoMockFactory)}))");
                 writer.AppendLine("{");
@@ -1019,12 +1019,12 @@ internal static class MockImplBuilder
 
             if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs});");
+                writer.AppendLine($"{setterPrefix}set => _engine.HandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs});");
             }
             else
             {
                 // Virtual property setter: try engine, fall back to base
-                writer.AppendLine("set");
+                writer.AppendLine($"{setterPrefix}set");
                 writer.OpenBrace();
                 writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_{prop.Name}\", {setterArgs}))");
                 writer.AppendLine("{");
@@ -1071,12 +1071,13 @@ internal static class MockImplBuilder
 
     private static void GenerateOverrideIndexer(CodeWriter writer, MockMemberModel prop, string fallbackTarget)
     {
-        var accessModifier = prop.IsProtected ? "protected" : "public";
         var paramList = FormatIndexerParameterList(prop);
         var argPassList = string.Join(", ", prop.Parameters.Select(p => p.Name));
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
-        writer.AppendLine($"{accessModifier} override {prop.ReturnType} this[{paramList}]");
+        writer.AppendLine($"{prop.OverrideAccessModifier} override {prop.ReturnType} this[{paramList}]");
         writer.OpenBrace();
+        var getterPrefix = AccessorPrefix(prop.GetterAccessModifier);
+        var setterPrefix = AccessorPrefix(prop.SetterAccessModifier);
 
         if (prop.HasGetter)
         {
@@ -1084,11 +1085,11 @@ internal static class MockImplBuilder
             writer.AppendLineIfNotEmpty(prop.GetterObsoleteAttribute);
             if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
+                writer.AppendLine($"{getterPrefix}get => _engine.HandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault});");
             }
             else
             {
-                writer.AppendLine("get");
+                writer.AppendLine($"{getterPrefix}get");
                 writer.OpenBrace();
                 writer.AppendLine($"if (_engine.TryHandleCallWithReturn<{prop.ReturnType}>({prop.MemberId}, \"get_Item\", {argsArray}, {prop.SmartDefault}, out var __result))");
                 writer.OpenBrace();
@@ -1105,11 +1106,11 @@ internal static class MockImplBuilder
             writer.AppendLineIfNotEmpty(prop.SetterObsoleteAttribute);
             if (prop.IsAbstractMember)
             {
-                writer.AppendLine($"set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
+                writer.AppendLine($"{setterPrefix}set => _engine.HandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs});");
             }
             else
             {
-                writer.AppendLine("set");
+                writer.AppendLine($"{setterPrefix}set");
                 writer.OpenBrace();
                 writer.AppendLine($"if (!_engine.TryHandleCall({prop.SetterMemberId}, \"set_Item\", {setterArgs}))");
                 writer.OpenBrace();
@@ -1124,6 +1125,9 @@ internal static class MockImplBuilder
 
     private static string FormatIndexerParameterList(MockMemberModel indexer)
         => FormatParameterList(indexer.Parameters);
+
+    private static string AccessorPrefix(string accessModifier)
+        => accessModifier.Length == 0 ? "" : accessModifier + " ";
 
     private static string GetIndexerGetterArgsArray(MockMemberModel indexer)
     {
@@ -1181,7 +1185,7 @@ internal static class MockImplBuilder
 
         // Event add/remove accessors with override
         writer.AppendLineIfNotEmpty(evt.ObsoleteAttribute);
-        writer.AppendLine($"public override event {evt.EventHandlerTypeNonNullable}? {EscapeIdentifier(evt.Name)}");
+        writer.AppendLine($"{evt.OverrideAccessModifier} override event {evt.EventHandlerTypeNonNullable}? {EscapeIdentifier(evt.Name)}");
         writer.OpenBrace();
         writer.AppendLine($"add {{ _backing_{evt.Name} += value; _engine.RecordEventSubscription(\"{evt.Name}\", true); }}");
         writer.AppendLine($"remove {{ _backing_{evt.Name} -= value; _engine.RecordEventSubscription(\"{evt.Name}\", false); }}");

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -363,7 +363,7 @@ internal static class MemberDiscovery
                         {
                             if (seenMethods.ContainsKey(key)) continue;
                             seenMethods[key] = (methods.Count, method.ReturnType);
-                            methods.Add(CreateMethodModel(method, ref memberIdCounter, null, compilation: compilation));
+                            methods.Add(CreateMethodModel(method, ref memberIdCounter, null, compilationAssembly: compilationAssembly, compilation: compilation));
                         }
                         else
                         {
@@ -429,7 +429,7 @@ internal static class MemberDiscovery
                         if (evt.IsAbstract || evt.IsVirtual || evt.IsOverride)
                         {
                             if (!seenEvents.Add(key)) continue;
-                            events.Add(CreateEventModel(evt, null));
+                            events.Add(CreateEventModel(evt, null, compilationAssembly: compilationAssembly));
                         }
                         else
                         {
@@ -551,6 +551,43 @@ internal static class MemberDiscovery
         return true;
     }
 
+    private static string GetOverrideAccessModifier(ISymbol member, IAssemblySymbol? compilationAssembly)
+        => member.DeclaredAccessibility switch
+        {
+            Accessibility.Protected => "protected",
+            Accessibility.Internal => "internal",
+            Accessibility.ProtectedAndInternal => "private protected",
+            Accessibility.ProtectedOrInternal => HasInternalAccess(member, compilationAssembly) ? "protected internal" : "protected",
+            _ => "public"
+        };
+
+    private static bool HasInternalAccess(ISymbol member, IAssemblySymbol? compilationAssembly)
+    {
+        if (compilationAssembly is null)
+        {
+            return true;
+        }
+
+        var memberAssembly = member.ContainingAssembly;
+        return memberAssembly is null
+            || SymbolEqualityComparer.Default.Equals(memberAssembly, compilationAssembly)
+            || memberAssembly.GivesAccessTo(compilationAssembly);
+    }
+
+    private static string GetAccessorAccessModifier(
+        IMethodSymbol? accessor,
+        string propertyAccessModifier,
+        IAssemblySymbol? compilationAssembly)
+    {
+        if (accessor is null)
+        {
+            return "";
+        }
+
+        var accessorAccessModifier = GetOverrideAccessModifier(accessor, compilationAssembly);
+        return accessorAccessModifier == propertyAccessModifier ? "" : accessorAccessModifier;
+    }
+
     /// <summary>
     /// Creates a MockMemberModel from a delegate type's Invoke method.
     /// </summary>
@@ -559,7 +596,7 @@ internal static class MemberDiscovery
         return CreateMethodModel(invokeMethod, ref memberIdCounter, null, compilation: compilation);
     }
 
-    private static MockMemberModel CreateMethodModel(IMethodSymbol method, ref int memberIdCounter, string? explicitInterfaceName, string? declaringInterfaceName = null, bool explicitInterfaceCanDelegate = false, Compilation compilation = null!)
+    private static MockMemberModel CreateMethodModel(IMethodSymbol method, ref int memberIdCounter, string? explicitInterfaceName, string? declaringInterfaceName = null, bool explicitInterfaceCanDelegate = false, IAssemblySymbol? compilationAssembly = null, Compilation compilation = null!)
     {
         var returnType = method.ReturnType;
         var isAsync = returnType.IsAsyncReturnType();
@@ -618,8 +655,7 @@ internal static class MemberDiscovery
             UnwrappedSmartDefault = ComputeUnwrappedSmartDefault(returnType, isVoid, isAsync),
             IsAbstractMember = method.IsAbstract,
             IsVirtualMember = method.IsVirtual || method.IsOverride,
-            IsProtected = method.DeclaredAccessibility == Accessibility.Protected
-                       || method.DeclaredAccessibility == Accessibility.ProtectedOrInternal,
+            OverrideAccessModifier = GetOverrideAccessModifier(method, compilationAssembly),
             IsRefStructReturn = returnType.IsRefLikeType,
             AutoMockFactoryMethod = autoMockFactoryMethod,
             IsReturnTypeStaticAbstractInterface = returnTypeHasStaticAbstract,
@@ -666,6 +702,7 @@ internal static class MemberDiscovery
         var getterId = memberIdCounter++;
         var setterId = hasSetter ? memberIdCounter++ : 0;
         var propertyObsolete = GetObsoleteAttributeSyntax(property);
+        var overrideAccessModifier = GetOverrideAccessModifier(property, compilationAssembly);
 
         return new MockMemberModel
         {
@@ -685,8 +722,9 @@ internal static class MemberDiscovery
             SmartDefault = property.Type.GetSmartDefault(property.Type.IsNullableAnnotated()),
             IsAbstractMember = property.IsAbstract,
             IsVirtualMember = property.IsVirtual || property.IsOverride,
-            IsProtected = property.DeclaredAccessibility == Accessibility.Protected
-                       || property.DeclaredAccessibility == Accessibility.ProtectedOrInternal,
+            OverrideAccessModifier = overrideAccessModifier,
+            GetterAccessModifier = GetAccessorAccessModifier(property.GetMethod, overrideAccessModifier, compilationAssembly),
+            SetterAccessModifier = GetAccessorAccessModifier(property.SetMethod, overrideAccessModifier, compilationAssembly),
             IsRefStructReturn = property.Type.IsRefLikeType,
             AutoMockFactoryMethod = GetAutoMockFactoryMethod(property.Type, compilation),
             IsReturnTypeStaticAbstractInterface = IsInterfaceWithStaticAbstractMembers(property.Type),
@@ -755,6 +793,7 @@ internal static class MemberDiscovery
         var getterId = memberIdCounter++;
         var setterId = hasSetter ? memberIdCounter++ : 0;
         var indexerObsolete = GetObsoleteAttributeSyntax(indexer);
+        var overrideAccessModifier = GetOverrideAccessModifier(indexer, compilationAssembly);
 
         return new MockMemberModel
         {
@@ -782,6 +821,9 @@ internal static class MemberDiscovery
             DeclaringInterfaceName = declaringInterfaceName,
             NullableAnnotation = indexer.Type.NullableAnnotation.ToString(),
             SmartDefault = indexer.Type.GetSmartDefault(indexer.Type.IsNullableAnnotated()),
+            OverrideAccessModifier = overrideAccessModifier,
+            GetterAccessModifier = GetAccessorAccessModifier(indexer.GetMethod, overrideAccessModifier, compilationAssembly),
+            SetterAccessModifier = GetAccessorAccessModifier(indexer.SetMethod, overrideAccessModifier, compilationAssembly),
             AutoMockFactoryMethod = GetAutoMockFactoryMethod(indexer.Type, compilation),
             ObsoleteAttribute = indexerObsolete,
             GetterObsoleteAttribute = GetAccessorObsoleteAttributeSyntax(indexerObsolete, indexer.GetMethod),
@@ -822,7 +864,7 @@ internal static class MemberDiscovery
         return $"{globalPrefix}{baseName}MockFactory.CreateAutoMock<{typeArguments}>";
     }
 
-    private static MockEventModel CreateEventModel(IEventSymbol evt, string? explicitInterfaceName, string? declaringInterfaceName = null)
+    private static MockEventModel CreateEventModel(IEventSymbol evt, string? explicitInterfaceName, string? declaringInterfaceName = null, IAssemblySymbol? compilationAssembly = null)
     {
         var eventHandlerType = evt.Type.GetFullyQualifiedNameWithNullability();
 
@@ -882,6 +924,7 @@ internal static class MemberDiscovery
             EventArgsType = eventArgsType,
             ExplicitInterfaceName = explicitInterfaceName,
             DeclaringInterfaceName = declaringInterfaceName,
+            OverrideAccessModifier = GetOverrideAccessModifier(evt, compilationAssembly),
             RaiseParameterList = raiseParameterList,
             ObsoleteAttribute = GetObsoleteAttributeSyntax(evt)
         };

--- a/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
@@ -35,6 +35,7 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
     /// Used by the wrapper type builder for correct explicit interface forwarding.
     /// </summary>
     public string? DeclaringInterfaceName { get; init; }
+    public string OverrideAccessModifier { get; init; } = "public";
     public bool IsStaticAbstract { get; init; }
 
     /// <summary>
@@ -56,6 +57,7 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
             && EventArgsType == other.EventArgsType
             && ExplicitInterfaceName == other.ExplicitInterfaceName
             && DeclaringInterfaceName == other.DeclaringInterfaceName
+            && OverrideAccessModifier == other.OverrideAccessModifier
             && IsStaticAbstract == other.IsStaticAbstract
             && RaiseParameterList == other.RaiseParameterList
             && ObsoleteAttribute == other.ObsoleteAttribute;
@@ -71,6 +73,7 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
             hash = hash * 31 + RaiseParameterList.GetHashCode();
             hash = hash * 31 + (ExplicitInterfaceName?.GetHashCode() ?? 0);
             hash = hash * 31 + (DeclaringInterfaceName?.GetHashCode() ?? 0);
+            hash = hash * 31 + OverrideAccessModifier.GetHashCode();
             hash = hash * 31 + ObsoleteAttribute.GetHashCode();
             return hash;
         }

--- a/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
@@ -41,7 +41,9 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
     public string UnwrappedSmartDefault { get; init; } = "default!";
     public bool IsAbstractMember { get; init; }
     public bool IsVirtualMember { get; init; }
-    public bool IsProtected { get; init; }
+    public string OverrideAccessModifier { get; init; } = "public";
+    public string GetterAccessModifier { get; init; } = "";
+    public string SetterAccessModifier { get; init; } = "";
     public bool IsRefStructReturn { get; init; }
     public bool IsStaticAbstract { get; init; }
     public string? AutoMockFactoryMethod { get; init; }
@@ -120,7 +122,9 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             && UnwrappedSmartDefault == other.UnwrappedSmartDefault
             && IsAbstractMember == other.IsAbstractMember
             && IsVirtualMember == other.IsVirtualMember
-            && IsProtected == other.IsProtected
+            && OverrideAccessModifier == other.OverrideAccessModifier
+            && GetterAccessModifier == other.GetterAccessModifier
+            && SetterAccessModifier == other.SetterAccessModifier
             && IsRefStructReturn == other.IsRefStructReturn
             && IsStaticAbstract == other.IsStaticAbstract
             && AutoMockFactoryMethod == other.AutoMockFactoryMethod
@@ -141,6 +145,9 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             hash = hash * 31 + ReturnType.GetHashCode();
             hash = hash * 31 + Parameters.GetHashCode();
             hash = hash * 31 + IsStaticAbstract.GetHashCode();
+            hash = hash * 31 + OverrideAccessModifier.GetHashCode();
+            hash = hash * 31 + GetterAccessModifier.GetHashCode();
+            hash = hash * 31 + SetterAccessModifier.GetHashCode();
             hash = hash * 31 + (AutoMockFactoryMethod?.GetHashCode() ?? 0);
             hash = hash * 31 + IsReturnTypeStaticAbstractInterface.GetHashCode();
             hash = hash * 31 + (ExplicitInterfaceName?.GetHashCode() ?? 0);


### PR DESCRIPTION
Fixes #5975.

This change preserves the effective accessibility of overridden members when generating partial and wrap mocks, so `protected internal`, `internal`, and `private protected` members emit valid overrides under the right assembly-access conditions.

Validation:
- `dotnet build TUnit.Mocks.SourceGenerator.Tests/TUnit.Mocks.SourceGenerator.Tests.csproj -v:minimal`
- `dotnet test TUnit.Mocks.SourceGenerator.Tests/TUnit.Mocks.SourceGenerator.Tests.csproj --no-build --framework net10.0`