### PR TITLE
Preserve specialized chaining after null assertions

### DIFF
--- a/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
+++ b/TUnit.Assertions.Tests/AsyncEnumerableAssertionTests.cs
@@ -149,6 +149,21 @@ public class AsyncEnumerableAssertionTests
             .Or.Contains(99); // First passes, so overall passes
     }
 
+    [Test]
+    public async Task Test_AsyncEnumerable_NullAssertions_Preserve_Chaining()
+    {
+        var items = AsyncRange(1, 5);
+
+        await Assert.That(items)
+            .IsNotNull()
+            .And.Contains(3);
+
+        IAsyncEnumerable<int>? nullItems = null;
+        await Assert.That(nullItems!)
+            .IsNull()
+            .Or.Contains(3);
+    }
+
     // Null handling
     [Test]
     public async Task Test_AsyncEnumerable_Null_Fails()

--- a/TUnit.Assertions.Tests/CollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionAssertionTests.cs
@@ -130,6 +130,28 @@ public class CollectionAssertionTests
     }
 
     [Test]
+    public async Task NullAssertions_IsNotNull_Fails_When_Null_Through_Chain()
+    {
+        List<int>? nullItems = null;
+
+        await Assert.That(async () =>
+            await Assert.That(nullItems).IsNotNull().And.Contains(1)
+        ).Throws<AssertionException>()
+        .WithMessageContaining("to not be null");
+    }
+
+    [Test]
+    public async Task NullAssertions_IsNull_Fails_When_NotNull_Through_Chain()
+    {
+        var items = new List<int> { 1 };
+
+        await Assert.That(async () =>
+            await Assert.That(items).IsNull().Or.Contains(99)
+        ).Throws<AssertionException>()
+        .WithMessageContaining("to be null");
+    }
+
+    [Test]
     public async Task Count_WithInnerAssertion_Lambda_Collection()
     {
         var items = new List<int> { 1, 2, 3, 4, 5 };

--- a/TUnit.Assertions.Tests/CollectionAssertionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionAssertionTests.cs
@@ -109,6 +109,27 @@ public class CollectionAssertionTests
     }
 
     [Test]
+    public async Task NullAssertions_Preserve_List_Chaining()
+    {
+        var items = new List<int> { 1 };
+
+        await Assert.That(items).IsNotNull().And.ItemAt(0).IsEqualTo(1);
+
+        List<int>? nullItems = null;
+        await Assert.That(nullItems).IsNull().Or.ItemAt(0).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task NullAssertions_Preserve_Dictionary_And_Set_Chaining()
+    {
+        IDictionary<string, int> dictionary = new Dictionary<string, int> { ["one"] = 1 };
+        ISet<int> set = new HashSet<int> { 1 };
+
+        await Assert.That(dictionary).IsNotNull().And.ContainsKey("one");
+        await Assert.That(set).IsNotNull().And.IsSubsetOf([1, 2]);
+    }
+
+    [Test]
     public async Task Count_WithInnerAssertion_Lambda_Collection()
     {
         var items = new List<int> { 1, 2, 3, 4, 5 };

--- a/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
+++ b/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
@@ -43,6 +43,32 @@ public abstract class AsyncEnumerableAssertionConditionBase<TItem> : AsyncEnumer
     protected abstract AssertionResult CheckMaterialized(List<TItem> items);
 }
 
+internal class AsyncEnumerableNullAssertion<TItem> : AsyncEnumerableAssertionBase<TItem>
+{
+    public AsyncEnumerableNullAssertion(AssertionContext<IAsyncEnumerable<TItem>> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<IAsyncEnumerable<TItem>> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class AsyncEnumerableNotNullAssertion<TItem> : AsyncEnumerableAssertionBase<TItem>
+{
+    public AsyncEnumerableNotNullAssertion(AssertionContext<IAsyncEnumerable<TItem>> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<IAsyncEnumerable<TItem>> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
 /// <summary>
 /// Asserts that the async enumerable is empty or not empty.
 /// </summary>

--- a/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
+++ b/TUnit.Assertions/Conditions/AsyncEnumerableAssertions.cs
@@ -43,30 +43,13 @@ public abstract class AsyncEnumerableAssertionConditionBase<TItem> : AsyncEnumer
     protected abstract AssertionResult CheckMaterialized(List<TItem> items);
 }
 
-internal class AsyncEnumerableNullAssertion<TItem> : AsyncEnumerableAssertionBase<TItem>
+internal class AsyncEnumerableNullAssertion<TItem>(AssertionContext<IAsyncEnumerable<TItem>> context, bool expectNull)
+    : AsyncEnumerableAssertionBase<TItem>(context)
 {
-    public AsyncEnumerableNullAssertion(AssertionContext<IAsyncEnumerable<TItem>> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<IAsyncEnumerable<TItem>> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
-}
-
-internal class AsyncEnumerableNotNullAssertion<TItem> : AsyncEnumerableAssertionBase<TItem>
-{
-    public AsyncEnumerableNotNullAssertion(AssertionContext<IAsyncEnumerable<TItem>> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<IAsyncEnumerable<TItem>> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
 /// <summary>

--- a/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
+++ b/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
@@ -18,9 +18,9 @@ internal class CollectionNullAssertion<TCollection, TItem> : CollectionAssertion
     }
 
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull: true);
 
-    protected override string GetExpectation() => "to be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull: true);
 }
 
 /// <summary>
@@ -36,198 +36,86 @@ public class CollectionNotNullAssertion<TCollection, TItem> : CollectionAssertio
     }
 
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
+        => NullCheck.Check(metadata, expectNull: false);
 
-    protected override string GetExpectation() => "to not be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull: false);
 }
 
-internal class ListNullAssertion<TList, TItem> : ListAssertionBase<TList, TItem>
+internal class ListNullAssertion<TList, TItem>(AssertionContext<TList> context, bool expectNull)
+    : ListAssertionBase<TList, TItem>(context)
     where TList : IList<TItem>
 {
-    public ListNullAssertion(AssertionContext<TList> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
-internal class ListNotNullAssertion<TList, TItem> : ListAssertionBase<TList, TItem>
-    where TList : IList<TItem>
-{
-    public ListNotNullAssertion(AssertionContext<TList> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
-}
-
-internal class ReadOnlyListNullAssertion<TList, TItem> : ReadOnlyListAssertionBase<TList, TItem>
+internal class ReadOnlyListNullAssertion<TList, TItem>(AssertionContext<TList> context, bool expectNull)
+    : ReadOnlyListAssertionBase<TList, TItem>(context)
     where TList : IReadOnlyList<TItem>
 {
-    public ReadOnlyListNullAssertion(AssertionContext<TList> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
-internal class ReadOnlyListNotNullAssertion<TList, TItem> : ReadOnlyListAssertionBase<TList, TItem>
-    where TList : IReadOnlyList<TItem>
-{
-    public ReadOnlyListNotNullAssertion(AssertionContext<TList> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
-}
-
-internal class DictionaryNullAssertion<TDictionary, TKey, TValue> : DictionaryAssertionBase<TDictionary, TKey, TValue>
+internal class DictionaryNullAssertion<TDictionary, TKey, TValue>(AssertionContext<TDictionary> context, bool expectNull)
+    : DictionaryAssertionBase<TDictionary, TKey, TValue>(context)
     where TDictionary : IReadOnlyDictionary<TKey, TValue>
     where TKey : notnull
 {
-    public DictionaryNullAssertion(AssertionContext<TDictionary> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
-internal class DictionaryNotNullAssertion<TDictionary, TKey, TValue> : DictionaryAssertionBase<TDictionary, TKey, TValue>
-    where TDictionary : IReadOnlyDictionary<TKey, TValue>
-    where TKey : notnull
-{
-    public DictionaryNotNullAssertion(AssertionContext<TDictionary> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
-}
-
-internal class MutableDictionaryNullAssertion<TDictionary, TKey, TValue> : MutableDictionaryAssertionBase<TDictionary, TKey, TValue>
+internal class MutableDictionaryNullAssertion<TDictionary, TKey, TValue>(AssertionContext<TDictionary> context, bool expectNull)
+    : MutableDictionaryAssertionBase<TDictionary, TKey, TValue>(context)
     where TDictionary : IDictionary<TKey, TValue>
     where TKey : notnull
 {
-    public MutableDictionaryNullAssertion(AssertionContext<TDictionary> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
-internal class MutableDictionaryNotNullAssertion<TDictionary, TKey, TValue> : MutableDictionaryAssertionBase<TDictionary, TKey, TValue>
-    where TDictionary : IDictionary<TKey, TValue>
-    where TKey : notnull
-{
-    public MutableDictionaryNotNullAssertion(AssertionContext<TDictionary> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
-}
-
-internal class SetNullAssertion<TSet, TItem> : SetAssertionBase<TSet, TItem>
+internal class SetNullAssertion<TSet, TItem>(
+    AssertionContext<TSet> context,
+    Func<TSet, ISetAdapter<TItem>> adapterFactory,
+    bool expectNull)
+    : SetAssertionBase<TSet, TItem>(context)
     where TSet : IEnumerable<TItem>
 {
-    private readonly Func<TSet, ISetAdapter<TItem>> _adapterFactory;
-
-    public SetNullAssertion(
-        AssertionContext<TSet> context,
-        Func<TSet, ISetAdapter<TItem>> adapterFactory)
-        : base(context)
-    {
-        _adapterFactory = adapterFactory;
-    }
-
-    protected override ISetAdapter<TItem> CreateSetAdapter(TSet value) => _adapterFactory(value);
+    // adapterFactory is never invoked on the null-check path (the set is never materialized),
+    // but SetAssertionBase requires CreateSetAdapter, so it must be supplied.
+    protected override ISetAdapter<TItem> CreateSetAdapter(TSet value) => adapterFactory(value);
 
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TSet> metadata)
-        => NullCheck.CheckIsNull(metadata);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => "to be null";
-}
-
-internal class SetNotNullAssertion<TSet, TItem> : SetAssertionBase<TSet, TItem>
-    where TSet : IEnumerable<TItem>
-{
-    private readonly Func<TSet, ISetAdapter<TItem>> _adapterFactory;
-
-    public SetNotNullAssertion(
-        AssertionContext<TSet> context,
-        Func<TSet, ISetAdapter<TItem>> adapterFactory)
-        : base(context)
-    {
-        _adapterFactory = adapterFactory;
-    }
-
-    protected override ISetAdapter<TItem> CreateSetAdapter(TSet value) => _adapterFactory(value);
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TSet> metadata)
-        => NullCheck.CheckIsNotNull(metadata);
-
-    protected override string GetExpectation() => "to not be null";
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
 internal static class NullCheck
 {
-    public static Task<AssertionResult> CheckIsNull<TValue>(EvaluationMetadata<TValue> metadata)
+    public static Task<AssertionResult> Check<TValue>(EvaluationMetadata<TValue> metadata, bool expectNull)
     {
         if (metadata.Exception != null)
         {
             return Task.FromResult(AssertionResult.Failed($"threw {metadata.Exception.GetType().Name}", metadata.Exception));
         }
 
-        if (metadata.Value is null)
+        if (expectNull ? metadata.Value is null : metadata.Value is not null)
         {
             return AssertionResult._passedTask;
         }
 
-        return Task.FromResult(AssertionResult.Failed("value is not null"));
+        return Task.FromResult(AssertionResult.Failed(expectNull ? "value is not null" : "value is null"));
     }
 
-    public static Task<AssertionResult> CheckIsNotNull<TValue>(EvaluationMetadata<TValue> metadata)
-    {
-        if (metadata.Exception != null)
-        {
-            return Task.FromResult(AssertionResult.Failed($"threw {metadata.Exception.GetType().Name}", metadata.Exception));
-        }
-
-        if (metadata.Value is not null)
-        {
-            return AssertionResult._passedTask;
-        }
-
-        return Task.FromResult(AssertionResult.Failed("value is null"));
-    }
+    public static string Expectation(bool expectNull) => expectNull ? "to be null" : "to not be null";
 }

--- a/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
+++ b/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
@@ -6,39 +6,17 @@ using TUnit.Assertions.Sources;
 namespace TUnit.Assertions.Conditions;
 
 /// <summary>
-/// Asserts that a collection is null, preserving collection type information.
+/// Asserts that a collection is null (or not null), preserving collection type information.
 /// Extends CollectionAssertionBase to ensure .And and .Or return collection-specific continuations.
 /// </summary>
-public class CollectionNullAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
+internal class CollectionNullAssertion<TCollection, TItem>(AssertionContext<TCollection> context, bool expectNull)
+    : CollectionAssertionBase<TCollection, TItem>(context)
     where TCollection : IEnumerable<TItem>
 {
-    public CollectionNullAssertion(AssertionContext<TCollection> context)
-        : base(context)
-    {
-    }
-
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
-        => NullCheck.Check(metadata, expectNull: true);
+        => NullCheck.Check(metadata, expectNull);
 
-    protected override string GetExpectation() => NullCheck.Expectation(expectNull: true);
-}
-
-/// <summary>
-/// Asserts that a collection is not null, preserving collection type information.
-/// Extends CollectionAssertionBase to ensure .And and .Or return collection-specific continuations.
-/// </summary>
-public class CollectionNotNullAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
-    where TCollection : IEnumerable<TItem>
-{
-    public CollectionNotNullAssertion(AssertionContext<TCollection> context)
-        : base(context)
-    {
-    }
-
-    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
-        => NullCheck.Check(metadata, expectNull: false);
-
-    protected override string GetExpectation() => NullCheck.Expectation(expectNull: false);
+    protected override string GetExpectation() => NullCheck.Expectation(expectNull);
 }
 
 internal class ListNullAssertion<TList, TItem>(AssertionContext<TList> context, bool expectNull)

--- a/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
+++ b/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
@@ -1,8 +1,27 @@
 using System.Collections;
+using TUnit.Assertions.Abstractions;
 using TUnit.Assertions.Core;
 using TUnit.Assertions.Sources;
 
 namespace TUnit.Assertions.Conditions;
+
+/// <summary>
+/// Asserts that a collection is null, preserving collection type information.
+/// Extends CollectionAssertionBase to ensure .And and .Or return collection-specific continuations.
+/// </summary>
+internal class CollectionNullAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
+    where TCollection : IEnumerable<TItem>
+{
+    public CollectionNullAssertion(AssertionContext<TCollection> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
 
 /// <summary>
 /// Asserts that a collection is not null, preserving collection type information.
@@ -17,16 +36,198 @@ public class CollectionNotNullAssertion<TCollection, TItem> : CollectionAssertio
     }
 
     protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TCollection> metadata)
-    {
-        var value = metadata.Value;
+        => NullCheck.CheckIsNotNull(metadata);
 
-        if (value != null)
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal class ListNullAssertion<TList, TItem> : ListAssertionBase<TList, TItem>
+    where TList : IList<TItem>
+{
+    public ListNullAssertion(AssertionContext<TList> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class ListNotNullAssertion<TList, TItem> : ListAssertionBase<TList, TItem>
+    where TList : IList<TItem>
+{
+    public ListNotNullAssertion(AssertionContext<TList> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal class ReadOnlyListNullAssertion<TList, TItem> : ReadOnlyListAssertionBase<TList, TItem>
+    where TList : IReadOnlyList<TItem>
+{
+    public ReadOnlyListNullAssertion(AssertionContext<TList> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class ReadOnlyListNotNullAssertion<TList, TItem> : ReadOnlyListAssertionBase<TList, TItem>
+    where TList : IReadOnlyList<TItem>
+{
+    public ReadOnlyListNotNullAssertion(AssertionContext<TList> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TList> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal class DictionaryNullAssertion<TDictionary, TKey, TValue> : DictionaryAssertionBase<TDictionary, TKey, TValue>
+    where TDictionary : IReadOnlyDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    public DictionaryNullAssertion(AssertionContext<TDictionary> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class DictionaryNotNullAssertion<TDictionary, TKey, TValue> : DictionaryAssertionBase<TDictionary, TKey, TValue>
+    where TDictionary : IReadOnlyDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    public DictionaryNotNullAssertion(AssertionContext<TDictionary> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal class MutableDictionaryNullAssertion<TDictionary, TKey, TValue> : MutableDictionaryAssertionBase<TDictionary, TKey, TValue>
+    where TDictionary : IDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    public MutableDictionaryNullAssertion(AssertionContext<TDictionary> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class MutableDictionaryNotNullAssertion<TDictionary, TKey, TValue> : MutableDictionaryAssertionBase<TDictionary, TKey, TValue>
+    where TDictionary : IDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    public MutableDictionaryNotNullAssertion(AssertionContext<TDictionary> context)
+        : base(context)
+    {
+    }
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TDictionary> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal class SetNullAssertion<TSet, TItem> : SetAssertionBase<TSet, TItem>
+    where TSet : IEnumerable<TItem>
+{
+    private readonly Func<TSet, ISetAdapter<TItem>> _adapterFactory;
+
+    public SetNullAssertion(
+        AssertionContext<TSet> context,
+        Func<TSet, ISetAdapter<TItem>> adapterFactory)
+        : base(context)
+    {
+        _adapterFactory = adapterFactory;
+    }
+
+    protected override ISetAdapter<TItem> CreateSetAdapter(TSet value) => _adapterFactory(value);
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TSet> metadata)
+        => NullCheck.CheckIsNull(metadata);
+
+    protected override string GetExpectation() => "to be null";
+}
+
+internal class SetNotNullAssertion<TSet, TItem> : SetAssertionBase<TSet, TItem>
+    where TSet : IEnumerable<TItem>
+{
+    private readonly Func<TSet, ISetAdapter<TItem>> _adapterFactory;
+
+    public SetNotNullAssertion(
+        AssertionContext<TSet> context,
+        Func<TSet, ISetAdapter<TItem>> adapterFactory)
+        : base(context)
+    {
+        _adapterFactory = adapterFactory;
+    }
+
+    protected override ISetAdapter<TItem> CreateSetAdapter(TSet value) => _adapterFactory(value);
+
+    protected override Task<AssertionResult> CheckAsync(EvaluationMetadata<TSet> metadata)
+        => NullCheck.CheckIsNotNull(metadata);
+
+    protected override string GetExpectation() => "to not be null";
+}
+
+internal static class NullCheck
+{
+    public static Task<AssertionResult> CheckIsNull<TValue>(EvaluationMetadata<TValue> metadata)
+    {
+        if (metadata.Exception != null)
+        {
+            return Task.FromResult(AssertionResult.Failed($"threw {metadata.Exception.GetType().Name}", metadata.Exception));
+        }
+
+        if (metadata.Value is null)
+        {
+            return AssertionResult._passedTask;
+        }
+
+        return Task.FromResult(AssertionResult.Failed("value is not null"));
+    }
+
+    public static Task<AssertionResult> CheckIsNotNull<TValue>(EvaluationMetadata<TValue> metadata)
+    {
+        if (metadata.Exception != null)
+        {
+            return Task.FromResult(AssertionResult.Failed($"threw {metadata.Exception.GetType().Name}", metadata.Exception));
+        }
+
+        if (metadata.Value is not null)
         {
             return AssertionResult._passedTask;
         }
 
         return Task.FromResult(AssertionResult.Failed("value is null"));
     }
-
-    protected override string GetExpectation() => "to not be null";
 }

--- a/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
+++ b/TUnit.Assertions/Conditions/CollectionNullAssertion.cs
@@ -9,7 +9,7 @@ namespace TUnit.Assertions.Conditions;
 /// Asserts that a collection is null, preserving collection type information.
 /// Extends CollectionAssertionBase to ensure .And and .Or return collection-specific continuations.
 /// </summary>
-internal class CollectionNullAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
+public class CollectionNullAssertion<TCollection, TItem> : CollectionAssertionBase<TCollection, TItem>
     where TCollection : IEnumerable<TItem>
 {
     public CollectionNullAssertion(AssertionContext<TCollection> context)

--- a/TUnit.Assertions/Conditions/NullAssertion.cs
+++ b/TUnit.Assertions/Conditions/NullAssertion.cs
@@ -20,7 +20,7 @@ public class NotNullAssertion<TValue> : Assertion<TValue>
     {
         if (metadata.Exception != null)
         {
-            return Task.FromResult(AssertionResult.Failed("received null"));
+            return Task.FromResult(AssertionResult.Failed($"threw {metadata.Exception.GetType().Name}", metadata.Exception));
         }
 
         var value = metadata.Value;

--- a/TUnit.Assertions/Extensions/AssertionExtensions.cs
+++ b/TUnit.Assertions/Extensions/AssertionExtensions.cs
@@ -47,22 +47,6 @@ public static class AssertionExtensions
     }
 
     /// <summary>
-    /// Asserts that a collection is not null, preserving collection type information.
-    /// Returns a collection-aware assertion that maintains TItem type for proper chaining.
-    /// This overload enables: Assert.That(collection).IsNotNull().And.Contains(x => predicate).
-    /// </summary>
-    public static CollectionNotNullAssertion<TCollection, TItem> IsNotNull<TCollection, TItem>(
-        this CollectionAssertionBase<TCollection, TItem> source)
-        where TCollection : class, IEnumerable<TItem>
-    {
-        var assertionSource = (IAssertionSource<TCollection>)source;
-        assertionSource.Context.ExpressionBuilder.Append(".IsNotNull()");
-        // Map from TCollection? to TCollection (nullable to non-nullable)
-        var mappedContext = assertionSource.Context.Map((TCollection? v) => v!);
-        return new CollectionNotNullAssertion<TCollection, TItem>(mappedContext);
-    }
-
-    /// <summary>
     /// Alias for IsEqualTo - asserts that the value is equal to the expected value.
     /// Works with assertions, And, and Or continuations!
     /// </summary>

--- a/TUnit.Assertions/Sources/AsyncEnumerableAssertionBase.cs
+++ b/TUnit.Assertions/Sources/AsyncEnumerableAssertionBase.cs
@@ -45,7 +45,7 @@ public abstract class AsyncEnumerableAssertionBase<TItem> : Assertion<IAsyncEnum
     public AsyncEnumerableAssertionBase<TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new AsyncEnumerableNullAssertion<TItem>(Context);
+        return new AsyncEnumerableNullAssertion<TItem>(Context, expectNull: true);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public abstract class AsyncEnumerableAssertionBase<TItem> : Assertion<IAsyncEnum
     public AsyncEnumerableAssertionBase<TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new AsyncEnumerableNotNullAssertion<TItem>(Context);
+        return new AsyncEnumerableNullAssertion<TItem>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/AsyncEnumerableAssertionBase.cs
+++ b/TUnit.Assertions/Sources/AsyncEnumerableAssertionBase.cs
@@ -40,6 +40,24 @@ public abstract class AsyncEnumerableAssertionBase<TItem> : Assertion<IAsyncEnum
     protected override string GetExpectation() => "async enumerable assertion";
 
     /// <summary>
+    /// Asserts that the async enumerable is null while preserving async-enumerable-specific chaining.
+    /// </summary>
+    public AsyncEnumerableAssertionBase<TItem> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new AsyncEnumerableNullAssertion<TItem>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the async enumerable is not null while preserving async-enumerable-specific chaining.
+    /// </summary>
+    public AsyncEnumerableAssertionBase<TItem> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new AsyncEnumerableNotNullAssertion<TItem>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the async enumerable is empty.
     /// Example: await Assert.That(asyncEnumerable).IsEmpty();
     /// </summary>

--- a/TUnit.Assertions/Sources/CollectionAssertionBase.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertionBase.cs
@@ -52,19 +52,19 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     /// <summary>
     /// Asserts that the collection is null while preserving collection-specific chaining.
     /// </summary>
-    public CollectionNullAssertion<TCollection, TItem> IsNull()
+    public CollectionAssertionBase<TCollection, TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new CollectionNullAssertion<TCollection, TItem>(Context);
+        return new CollectionNullAssertion<TCollection, TItem>(Context, expectNull: true);
     }
 
     /// <summary>
     /// Asserts that the collection is not null while preserving collection-specific chaining.
     /// </summary>
-    public CollectionNotNullAssertion<TCollection, TItem> IsNotNull()
+    public CollectionAssertionBase<TCollection, TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new CollectionNotNullAssertion<TCollection, TItem>(Context);
+        return new CollectionNullAssertion<TCollection, TItem>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/CollectionAssertionBase.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertionBase.cs
@@ -44,10 +44,15 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
 
     protected override string GetExpectation() => "collection assertion";
 
+    // Subclasses hide IsNull/IsNotNull with `public new` to narrow the return type to their own
+    // base (e.g. ListAssertionBase). This is the same idiom used by And/Or below; virtual+override
+    // with covariant returns is avoided because covariant returns are not honored at runtime on the
+    // netstandard2.0 target consumed by .NET Framework.
+
     /// <summary>
     /// Asserts that the collection is null while preserving collection-specific chaining.
     /// </summary>
-    public CollectionAssertionBase<TCollection, TItem> IsNull()
+    public CollectionNullAssertion<TCollection, TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
         return new CollectionNullAssertion<TCollection, TItem>(Context);
@@ -56,7 +61,7 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     /// <summary>
     /// Asserts that the collection is not null while preserving collection-specific chaining.
     /// </summary>
-    public CollectionAssertionBase<TCollection, TItem> IsNotNull()
+    public CollectionNotNullAssertion<TCollection, TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
         return new CollectionNotNullAssertion<TCollection, TItem>(Context);

--- a/TUnit.Assertions/Sources/CollectionAssertionBase.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertionBase.cs
@@ -45,6 +45,24 @@ public abstract class CollectionAssertionBase<TCollection, TItem> : Assertion<TC
     protected override string GetExpectation() => "collection assertion";
 
     /// <summary>
+    /// Asserts that the collection is null while preserving collection-specific chaining.
+    /// </summary>
+    public CollectionAssertionBase<TCollection, TItem> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new CollectionNullAssertion<TCollection, TItem>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the collection is not null while preserving collection-specific chaining.
+    /// </summary>
+    public CollectionAssertionBase<TCollection, TItem> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new CollectionNotNullAssertion<TCollection, TItem>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the collection is of the specified type and returns an assertion on the casted value.
     /// This allows chaining additional assertions on the typed value.
     /// Example: await Assert.That((IEnumerable<int>)list).IsTypeOf<List<int>>().And.Count().IsEqualTo(5);

--- a/TUnit.Assertions/Sources/DictionaryAssertionBase.cs
+++ b/TUnit.Assertions/Sources/DictionaryAssertionBase.cs
@@ -41,6 +41,24 @@ public abstract class DictionaryAssertionBase<TDictionary, TKey, TValue> : Colle
     protected override string GetExpectation() => "dictionary assertion";
 
     /// <summary>
+    /// Asserts that the dictionary is null while preserving dictionary-specific chaining.
+    /// </summary>
+    public new DictionaryAssertionBase<TDictionary, TKey, TValue> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new DictionaryNullAssertion<TDictionary, TKey, TValue>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the dictionary is not null while preserving dictionary-specific chaining.
+    /// </summary>
+    public new DictionaryAssertionBase<TDictionary, TKey, TValue> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new DictionaryNotNullAssertion<TDictionary, TKey, TValue>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the dictionary contains the specified key.
     /// This instance method enables calling ContainsKey with proper type inference.
     /// Example: await Assert.That(dictionary).ContainsKey("key1");

--- a/TUnit.Assertions/Sources/DictionaryAssertionBase.cs
+++ b/TUnit.Assertions/Sources/DictionaryAssertionBase.cs
@@ -46,7 +46,7 @@ public abstract class DictionaryAssertionBase<TDictionary, TKey, TValue> : Colle
     public new DictionaryAssertionBase<TDictionary, TKey, TValue> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new DictionaryNullAssertion<TDictionary, TKey, TValue>(Context);
+        return new DictionaryNullAssertion<TDictionary, TKey, TValue>(Context, expectNull: true);
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public abstract class DictionaryAssertionBase<TDictionary, TKey, TValue> : Colle
     public new DictionaryAssertionBase<TDictionary, TKey, TValue> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new DictionaryNotNullAssertion<TDictionary, TKey, TValue>(Context);
+        return new DictionaryNullAssertion<TDictionary, TKey, TValue>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/ListAssertionBase.cs
+++ b/TUnit.Assertions/Sources/ListAssertionBase.cs
@@ -37,7 +37,7 @@ public abstract class ListAssertionBase<TList, TItem> : CollectionAssertionBase<
     public new ListAssertionBase<TList, TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new ListNullAssertion<TList, TItem>(Context);
+        return new ListNullAssertion<TList, TItem>(Context, expectNull: true);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public abstract class ListAssertionBase<TList, TItem> : CollectionAssertionBase<
     public new ListAssertionBase<TList, TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new ListNotNullAssertion<TList, TItem>(Context);
+        return new ListNullAssertion<TList, TItem>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/ListAssertionBase.cs
+++ b/TUnit.Assertions/Sources/ListAssertionBase.cs
@@ -32,6 +32,24 @@ public abstract class ListAssertionBase<TList, TItem> : CollectionAssertionBase<
     }
 
     /// <summary>
+    /// Asserts that the list is null while preserving list-specific chaining.
+    /// </summary>
+    public new ListAssertionBase<TList, TItem> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new ListNullAssertion<TList, TItem>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the list is not null while preserving list-specific chaining.
+    /// </summary>
+    public new ListAssertionBase<TList, TItem> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new ListNotNullAssertion<TList, TItem>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the item at the specified index equals the expected value.
     /// Example: await Assert.That(list).HasItemAt(0, "expected");
     /// </summary>

--- a/TUnit.Assertions/Sources/MutableDictionaryAssertionBase.cs
+++ b/TUnit.Assertions/Sources/MutableDictionaryAssertionBase.cs
@@ -39,6 +39,24 @@ public abstract class MutableDictionaryAssertionBase<TDictionary, TKey, TValue> 
     protected override string GetExpectation() => "dictionary assertion";
 
     /// <summary>
+    /// Asserts that the dictionary is null while preserving mutable-dictionary-specific chaining.
+    /// </summary>
+    public new MutableDictionaryAssertionBase<TDictionary, TKey, TValue> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new MutableDictionaryNullAssertion<TDictionary, TKey, TValue>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the dictionary is not null while preserving mutable-dictionary-specific chaining.
+    /// </summary>
+    public new MutableDictionaryAssertionBase<TDictionary, TKey, TValue> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new MutableDictionaryNotNullAssertion<TDictionary, TKey, TValue>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the dictionary contains the specified key.
     /// Example: await Assert.That(dictionary).ContainsKey("key1");
     /// </summary>

--- a/TUnit.Assertions/Sources/MutableDictionaryAssertionBase.cs
+++ b/TUnit.Assertions/Sources/MutableDictionaryAssertionBase.cs
@@ -44,7 +44,7 @@ public abstract class MutableDictionaryAssertionBase<TDictionary, TKey, TValue> 
     public new MutableDictionaryAssertionBase<TDictionary, TKey, TValue> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new MutableDictionaryNullAssertion<TDictionary, TKey, TValue>(Context);
+        return new MutableDictionaryNullAssertion<TDictionary, TKey, TValue>(Context, expectNull: true);
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public abstract class MutableDictionaryAssertionBase<TDictionary, TKey, TValue> 
     public new MutableDictionaryAssertionBase<TDictionary, TKey, TValue> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new MutableDictionaryNotNullAssertion<TDictionary, TKey, TValue>(Context);
+        return new MutableDictionaryNullAssertion<TDictionary, TKey, TValue>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/ReadOnlyListAssertionBase.cs
+++ b/TUnit.Assertions/Sources/ReadOnlyListAssertionBase.cs
@@ -34,6 +34,24 @@ public abstract class ReadOnlyListAssertionBase<TList, TItem> : CollectionAssert
     }
 
     /// <summary>
+    /// Asserts that the list is null while preserving read-only-list-specific chaining.
+    /// </summary>
+    public new ReadOnlyListAssertionBase<TList, TItem> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new ReadOnlyListNullAssertion<TList, TItem>(Context);
+    }
+
+    /// <summary>
+    /// Asserts that the list is not null while preserving read-only-list-specific chaining.
+    /// </summary>
+    public new ReadOnlyListAssertionBase<TList, TItem> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new ReadOnlyListNotNullAssertion<TList, TItem>(Context);
+    }
+
+    /// <summary>
     /// Asserts that the list has an item at the specified index that equals the expected value.
     /// Example: await Assert.That(list).HasItemAt(0, "first");
     /// </summary>

--- a/TUnit.Assertions/Sources/ReadOnlyListAssertionBase.cs
+++ b/TUnit.Assertions/Sources/ReadOnlyListAssertionBase.cs
@@ -39,7 +39,7 @@ public abstract class ReadOnlyListAssertionBase<TList, TItem> : CollectionAssert
     public new ReadOnlyListAssertionBase<TList, TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new ReadOnlyListNullAssertion<TList, TItem>(Context);
+        return new ReadOnlyListNullAssertion<TList, TItem>(Context, expectNull: true);
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public abstract class ReadOnlyListAssertionBase<TList, TItem> : CollectionAssert
     public new ReadOnlyListAssertionBase<TList, TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new ReadOnlyListNotNullAssertion<TList, TItem>(Context);
+        return new ReadOnlyListNullAssertion<TList, TItem>(Context, expectNull: false);
     }
 
     /// <summary>

--- a/TUnit.Assertions/Sources/SetAssertionBase.cs
+++ b/TUnit.Assertions/Sources/SetAssertionBase.cs
@@ -43,6 +43,24 @@ public abstract class SetAssertionBase<TSet, TItem> : CollectionAssertionBase<TS
 
     protected override string GetExpectation() => "set assertion";
 
+    /// <summary>
+    /// Asserts that the set is null while preserving set-specific chaining.
+    /// </summary>
+    public new SetAssertionBase<TSet, TItem> IsNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNull()");
+        return new SetNullAssertion<TSet, TItem>(Context, CreateSetAdapter);
+    }
+
+    /// <summary>
+    /// Asserts that the set is not null while preserving set-specific chaining.
+    /// </summary>
+    public new SetAssertionBase<TSet, TItem> IsNotNull()
+    {
+        Context.ExpressionBuilder.Append(".IsNotNull()");
+        return new SetNotNullAssertion<TSet, TItem>(Context, CreateSetAdapter);
+    }
+
     // ========================================
     // Set-specific methods
     // ========================================

--- a/TUnit.Assertions/Sources/SetAssertionBase.cs
+++ b/TUnit.Assertions/Sources/SetAssertionBase.cs
@@ -49,7 +49,7 @@ public abstract class SetAssertionBase<TSet, TItem> : CollectionAssertionBase<TS
     public new SetAssertionBase<TSet, TItem> IsNull()
     {
         Context.ExpressionBuilder.Append(".IsNull()");
-        return new SetNullAssertion<TSet, TItem>(Context, CreateSetAdapter);
+        return new SetNullAssertion<TSet, TItem>(Context, CreateSetAdapter, expectNull: true);
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ public abstract class SetAssertionBase<TSet, TItem> : CollectionAssertionBase<TS
     public new SetAssertionBase<TSet, TItem> IsNotNull()
     {
         Context.ExpressionBuilder.Append(".IsNotNull()");
-        return new SetNotNullAssertion<TSet, TItem>(Context, CreateSetAdapter);
+        return new SetNullAssertion<TSet, TItem>(Context, CreateSetAdapter, expectNull: false);
     }
 
     // ========================================

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -915,20 +915,6 @@ namespace .Conditions
     }
     public class CollectionMemberAssertionAdapter<TCollection, TItem> : .<TCollection, TItem>
         where TCollection : .<TItem> { }
-    public class CollectionNotNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNotNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
-    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -922,6 +922,13 @@ namespace .Conditions
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         protected override string GetExpectation() { }
     }
+    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
+        where TCollection : .<TItem>
+    {
+        public CollectionNullAssertion(.<TCollection> context) { }
+        protected override .<.> CheckAsync(.<TCollection> metadata) { }
+        protected override string GetExpectation() { }
+    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }
@@ -2724,8 +2731,6 @@ namespace .Extensions
             where TValue :  class { }
         public static .<TValue> IsNotNull<TValue>(this .<TValue?> source)
             where TValue :  struct { }
-        public static .<TCollection, TItem> IsNotNull<TCollection, TItem>(this .<TCollection, TItem> source)
-            where TCollection :  class, .<TItem> { }
         public static ..IsNotParsableIntoAssertion<T> IsNotParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TValue> IsOfType<TValue>(this .<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..IsParsableIntoAssertion<T> IsParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -6187,7 +6187,9 @@ namespace .Sources
         public .<TExpected, .<TItem>> IsNotAssignableFrom<TExpected>() { }
         public .<TExpected, .<TItem>> IsNotAssignableTo<TExpected>() { }
         public .<TItem> IsNotEmpty() { }
+        public .<TItem> IsNotNull() { }
         public .<.<TItem>, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TItem> IsNull() { }
         public .<.<TItem>, TExpected> IsTypeOf<TExpected>() { }
     }
     public class AsyncEnumerableAssertion<TItem> : .<TItem>
@@ -6258,7 +6260,9 @@ namespace .Sources
         public .<TSource, TCollection> IsNotAssignableFrom<TSource>() { }
         public .<TTarget, TCollection> IsNotAssignableTo<TTarget>() { }
         public .<TCollection, TItem> IsNotEmpty() { }
+        public .<TCollection, TItem> IsNotNull() { }
         public .<TCollection, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TCollection, TItem> IsNull() { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedByDescending<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
@@ -6303,6 +6307,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class DictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6347,6 +6353,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? expression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6418,6 +6426,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class MutableDictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6434,6 +6444,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? indexExpression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6467,6 +6479,8 @@ namespace .Sources
         protected abstract .<TItem> CreateSetAdapter(TSet value);
         public .<TSet, TItem> DoesNotOverlap(.<TItem> other, [.("other")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TSet, TItem> IsNotNull() { }
+        public new .<TSet, TItem> IsNull() { }
         public .<TSet, TItem> IsProperSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsProperSupersetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -905,6 +905,13 @@ namespace .Conditions
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         protected override string GetExpectation() { }
     }
+    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
+        where TCollection : .<TItem>
+    {
+        public CollectionNullAssertion(.<TCollection> context) { }
+        protected override .<.> CheckAsync(.<TCollection> metadata) { }
+        protected override string GetExpectation() { }
+    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }
@@ -2703,8 +2710,6 @@ namespace .Extensions
             where TValue :  class { }
         public static .<TValue> IsNotNull<TValue>(this .<TValue?> source)
             where TValue :  struct { }
-        public static .<TCollection, TItem> IsNotNull<TCollection, TItem>(this .<TCollection, TItem> source)
-            where TCollection :  class, .<TItem> { }
         public static ..IsNotParsableIntoAssertion<T> IsNotParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TValue> IsOfType<TValue>(this .<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..IsParsableIntoAssertion<T> IsParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -6110,7 +6110,9 @@ namespace .Sources
         public .<TExpected, .<TItem>> IsNotAssignableFrom<TExpected>() { }
         public .<TExpected, .<TItem>> IsNotAssignableTo<TExpected>() { }
         public .<TItem> IsNotEmpty() { }
+        public .<TItem> IsNotNull() { }
         public .<.<TItem>, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TItem> IsNull() { }
         public .<.<TItem>, TExpected> IsTypeOf<TExpected>() { }
     }
     public class AsyncEnumerableAssertion<TItem> : .<TItem>
@@ -6180,7 +6182,9 @@ namespace .Sources
         public .<TSource, TCollection> IsNotAssignableFrom<TSource>() { }
         public .<TTarget, TCollection> IsNotAssignableTo<TTarget>() { }
         public .<TCollection, TItem> IsNotEmpty() { }
+        public .<TCollection, TItem> IsNotNull() { }
         public .<TCollection, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TCollection, TItem> IsNull() { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedByDescending<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
@@ -6225,6 +6229,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class DictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6269,6 +6275,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? expression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6340,6 +6348,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class MutableDictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6356,6 +6366,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? indexExpression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6389,6 +6401,8 @@ namespace .Sources
         protected abstract .<TItem> CreateSetAdapter(TSet value);
         public .<TSet, TItem> DoesNotOverlap(.<TItem> other, [.("other")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TSet, TItem> IsNotNull() { }
+        public new .<TSet, TItem> IsNull() { }
         public .<TSet, TItem> IsProperSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsProperSupersetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -898,20 +898,6 @@ namespace .Conditions
     }
     public class CollectionMemberAssertionAdapter<TCollection, TItem> : .<TCollection, TItem>
         where TCollection : .<TItem> { }
-    public class CollectionNotNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNotNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
-    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -915,20 +915,6 @@ namespace .Conditions
     }
     public class CollectionMemberAssertionAdapter<TCollection, TItem> : .<TCollection, TItem>
         where TCollection : .<TItem> { }
-    public class CollectionNotNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNotNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
-    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -922,6 +922,13 @@ namespace .Conditions
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         protected override string GetExpectation() { }
     }
+    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
+        where TCollection : .<TItem>
+    {
+        public CollectionNullAssertion(.<TCollection> context) { }
+        protected override .<.> CheckAsync(.<TCollection> metadata) { }
+        protected override string GetExpectation() { }
+    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }
@@ -2724,8 +2731,6 @@ namespace .Extensions
             where TValue :  class { }
         public static .<TValue> IsNotNull<TValue>(this .<TValue?> source)
             where TValue :  struct { }
-        public static .<TCollection, TItem> IsNotNull<TCollection, TItem>(this .<TCollection, TItem> source)
-            where TCollection :  class, .<TItem> { }
         public static ..IsNotParsableIntoAssertion<T> IsNotParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }
         public static .<TValue> IsOfType<TValue>(this .<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..IsParsableIntoAssertion<T> IsParsableInto<[.(..None | ..PublicMethods | ..Interfaces)]  T>(this .<string> source) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -6187,7 +6187,9 @@ namespace .Sources
         public .<TExpected, .<TItem>> IsNotAssignableFrom<TExpected>() { }
         public .<TExpected, .<TItem>> IsNotAssignableTo<TExpected>() { }
         public .<TItem> IsNotEmpty() { }
+        public .<TItem> IsNotNull() { }
         public .<.<TItem>, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TItem> IsNull() { }
         public .<.<TItem>, TExpected> IsTypeOf<TExpected>() { }
     }
     public class AsyncEnumerableAssertion<TItem> : .<TItem>
@@ -6258,7 +6260,9 @@ namespace .Sources
         public .<TSource, TCollection> IsNotAssignableFrom<TSource>() { }
         public .<TTarget, TCollection> IsNotAssignableTo<TTarget>() { }
         public .<TCollection, TItem> IsNotEmpty() { }
+        public .<TCollection, TItem> IsNotNull() { }
         public .<TCollection, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TCollection, TItem> IsNull() { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedByDescending<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
@@ -6303,6 +6307,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class DictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6347,6 +6353,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? expression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6418,6 +6426,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class MutableDictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>, .<.<TKey, TValue>, .<TKey, TValue>>, .<.<TKey, TValue>, .<TKey, TValue>>
         where TKey :  notnull
@@ -6434,6 +6444,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? indexExpression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -6467,6 +6479,8 @@ namespace .Sources
         protected abstract .<TItem> CreateSetAdapter(TSet value);
         public .<TSet, TItem> DoesNotOverlap(.<TItem> other, [.("other")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TSet, TItem> IsNotNull() { }
+        public new .<TSet, TItem> IsNull() { }
         public .<TSet, TItem> IsProperSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsProperSupersetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -5305,7 +5305,9 @@ namespace .Sources
         public .<TExpected, .<TItem>> IsNotAssignableFrom<TExpected>() { }
         public .<TExpected, .<TItem>> IsNotAssignableTo<TExpected>() { }
         public .<TItem> IsNotEmpty() { }
+        public .<TItem> IsNotNull() { }
         public .<.<TItem>, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TItem> IsNull() { }
         public .<.<TItem>, TExpected> IsTypeOf<TExpected>() { }
     }
     public class AsyncEnumerableAssertion<TItem> : .<TItem>
@@ -5375,7 +5377,9 @@ namespace .Sources
         public .<TSource, TCollection> IsNotAssignableFrom<TSource>() { }
         public .<TTarget, TCollection> IsNotAssignableTo<TTarget>() { }
         public .<TCollection, TItem> IsNotEmpty() { }
+        public .<TCollection, TItem> IsNotNull() { }
         public .<TCollection, TExpected> IsNotTypeOf<TExpected>() { }
+        public .<TCollection, TItem> IsNull() { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedBy<TKey>(<TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
         public .<TCollection, TItem, TKey> IsOrderedByDescending<TKey>(<TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
@@ -5419,6 +5423,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class DictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>
         where TKey :  notnull
@@ -5461,6 +5467,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? expression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -5486,6 +5494,8 @@ namespace .Sources
         public .<TDictionary, TKey, TValue> DoesNotContainKey(TKey expectedKey, [.("expectedKey")] string? expression = null) { }
         public .<TDictionary, TKey, TValue> DoesNotContainValue(TValue expectedValue, [.("expectedValue")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TDictionary, TKey, TValue> IsNotNull() { }
+        public new .<TDictionary, TKey, TValue> IsNull() { }
     }
     public class MutableDictionaryAssertion<TKey, TValue> : .<.<TKey, TValue>, TKey, TValue>
         where TKey :  notnull
@@ -5500,6 +5510,8 @@ namespace .Sources
         public new .<TList, TItem> Or { get; }
         public .<TList, TItem> FirstItem() { }
         public .<TList, TItem> HasItemAt(int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public new .<TList, TItem> IsNotNull() { }
+        public new .<TList, TItem> IsNull() { }
         public .<TList, TItem> ItemAt(int index, [.("index")] string? indexExpression = null) { }
         public .<TList, TItem> LastItem() { }
     }
@@ -5521,6 +5533,8 @@ namespace .Sources
         protected abstract .<TItem> CreateSetAdapter(TSet value);
         public .<TSet, TItem> DoesNotOverlap(.<TItem> other, [.("other")] string? expression = null) { }
         protected override string GetExpectation() { }
+        public new .<TSet, TItem> IsNotNull() { }
+        public new .<TSet, TItem> IsNull() { }
         public .<TSet, TItem> IsProperSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsProperSupersetOf(.<TItem> other, [.("other")] string? expression = null) { }
         public .<TSet, TItem> IsSubsetOf(.<TItem> other, [.("other")] string? expression = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -762,6 +762,13 @@ namespace .Conditions
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         protected override string GetExpectation() { }
     }
+    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
+        where TCollection : .<TItem>
+    {
+        public CollectionNullAssertion(.<TCollection> context) { }
+        protected override .<.> CheckAsync(.<TCollection> metadata) { }
+        protected override string GetExpectation() { }
+    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }
@@ -2429,8 +2436,6 @@ namespace .Extensions
             where TValue :  class { }
         public static .<TValue> IsNotNull<TValue>(this .<TValue?> source)
             where TValue :  struct { }
-        public static .<TCollection, TItem> IsNotNull<TCollection, TItem>(this .<TCollection, TItem> source)
-            where TCollection :  class, .<TItem> { }
         public static ..IsNotParsableIntoAssertion<T> IsNotParsableInto<T>(this .<string> source) { }
         public static .<TValue> IsOfType<TValue>(this .<TValue> source,  expectedType, [.("expectedType")] string? expression = null) { }
         public static ..IsParsableIntoAssertion<T> IsParsableInto<T>(this .<string> source) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -755,20 +755,6 @@ namespace .Conditions
     }
     public class CollectionMemberAssertionAdapter<TCollection, TItem> : .<TCollection, TItem>
         where TCollection : .<TItem> { }
-    public class CollectionNotNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNotNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
-    public class CollectionNullAssertion<TCollection, TItem> : .<TCollection, TItem>
-        where TCollection : .<TItem>
-    {
-        public CollectionNullAssertion(.<TCollection> context) { }
-        protected override .<.> CheckAsync(.<TCollection> metadata) { }
-        protected override string GetExpectation() { }
-    }
     public abstract class ComparerBasedAssertion<TValue, TItem> : .<TValue>
     {
         protected ComparerBasedAssertion(.<TValue> context) { }


### PR DESCRIPTION
## Summary
- Add specialized `IsNull()` / `IsNotNull()` methods for collection, list, read-only list, dictionary, mutable dictionary, set, and async enumerable assertion bases.
- Preserve the domain-specific fluent surface after null checks, e.g. `.IsNotNull().And.ContainsKey(...)` and `.IsNull().Or.ItemAt(...)`.
- Add focused coverage for collection and async enumerable chaining after null assertions.

## Verification
- `dotnet build TUnit.Assertions\TUnit.Assertions.csproj --no-restore -p:NoWarn=CS1591 -clp:ErrorsOnly`
- `dotnet test TUnit.Assertions.Tests\TUnit.Assertions.Tests.csproj --no-restore --treenode-filter "/*/*/AsyncEnumerableAssertionTests/*" --no-progress --output Normal`
- `dotnet test TUnit.Assertions.Tests\TUnit.Assertions.Tests.csproj --no-restore --treenode-filter "/*/*/CollectionAssertionTests/*" --no-progress --output Normal`

## Notes
- I attempted the public API snapshot test, but the local `TUnit.PublicAPI` build is currently blocked by unrelated assembly version conflicts between `99.99.99.0` and `1.45.46.0` project outputs, so no `.received.txt` files were generated.