### PR TITLE
fix(engine): isolate per-session state under MTP server-mode concurrency (#6001)

### DIFF
--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -1,4 +1,4 @@
-﻿using TUnit.Core.Settings;
+using TUnit.Core.Settings;
 
 namespace TUnit.Core;
 
@@ -10,25 +10,36 @@ public class EngineCancellationToken : IDisposable
     /// <summary>
     /// Gets the internal cancellation token source.
     /// </summary>
-    internal CancellationTokenSource CancellationTokenSource { get; private set; } = new();
+    internal CancellationTokenSource CancellationTokenSource { get; } = new();
 
     /// <summary>
     /// Gets the cancellation token.
     /// </summary>
-    public CancellationToken Token { get; private set; }
+    public CancellationToken Token { get; }
 
+    private int _initialised;
     private volatile bool _forcefulExitStarted;
 
+    public EngineCancellationToken()
+    {
+        Token = CancellationTokenSource.Token;
+    }
+
     /// <summary>
-    /// Initializes the cancellation token with a linked token source.
+    /// Hooks up process-wide cancellation signals (Ctrl+C / ProcessExit) the first time it's
+    /// called for this instance. Idempotent — subsequent calls are no-ops so that concurrent
+    /// MTP server-mode RPCs against one session don't clobber each other's cancellation chain.
+    /// Per-call cancellation flows through the explicit <c>CancellationToken</c> threaded into
+    /// discovery/execution, not through this session-scoped token.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token to link with.</param>
     internal void Initialise(CancellationToken cancellationToken)
     {
-        CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        Token = CancellationTokenSource.Token;
+        _ = cancellationToken;
 
-        Token.Register(_ => Cancel(), this);
+        if (Interlocked.CompareExchange(ref _initialised, 1, 0) != 0)
+        {
+            return;
+        }
 
         // Console.CancelKeyPress is not supported on browser platforms
 #if NET5_0_OR_GREATER

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -32,10 +32,8 @@ public class EngineCancellationToken : IDisposable
     /// Per-call cancellation flows through the explicit <c>CancellationToken</c> threaded into
     /// discovery/execution, not through this session-scoped token.
     /// </summary>
-    internal void Initialise(CancellationToken cancellationToken)
+    internal void Initialise()
     {
-        _ = cancellationToken;
-
         if (Interlocked.CompareExchange(ref _initialised, 1, 0) != 0)
         {
             return;

--- a/TUnit.Core/Sources.cs
+++ b/TUnit.Core/Sources.cs
@@ -5,9 +5,6 @@ using TUnit.Core.Interfaces.SourceGenerator;
 
 namespace TUnit.Core;
 
-#if !DEBUG
-[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-#endif
 /// <remarks>
 /// INVARIANT: these collections are populated once at module initialization (by source-gen
 /// in source-gen mode, by ReflectionHookDiscoveryService once-per-process in reflection mode)
@@ -16,6 +13,9 @@ namespace TUnit.Core;
 /// hooks (#6001). The reflection-mode discovery's one-time <c>ClearSourceGeneratedHooks</c>
 /// runs before any session executes — adding new clear calls during a session is a bug.
 /// </remarks>
+#if !DEBUG
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+#endif
 public static class Sources
 {
     public static readonly ConcurrentQueue<Func<Assembly>> AssemblyLoaders = [];

--- a/TUnit.Core/Sources.cs
+++ b/TUnit.Core/Sources.cs
@@ -8,6 +8,14 @@ namespace TUnit.Core;
 #if !DEBUG
 [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 #endif
+/// <remarks>
+/// INVARIANT: these collections are populated once at module initialization (by source-gen
+/// in source-gen mode, by ReflectionHookDiscoveryService once-per-process in reflection mode)
+/// and must be treated as append-only for the remainder of the process lifetime. Engine code
+/// that calls <c>.Clear()</c> on any field here will starve concurrent MTP sessions of their
+/// hooks (#6001). The reflection-mode discovery's one-time <c>ClearSourceGeneratedHooks</c>
+/// runs before any session executes — adding new clear calls during a session is a bug.
+/// </remarks>
 public static class Sources
 {
     public static readonly ConcurrentQueue<Func<Assembly>> AssemblyLoaders = [];

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -24,7 +24,13 @@ internal sealed class ReflectionHookDiscoveryService
     // Cache attribute lookups to avoid repeated reflection calls in hot paths
     private static readonly ConcurrentDictionary<MethodInfo, (BeforeAttribute?, AfterAttribute?, BeforeEveryAttribute?, AfterEveryAttribute?)> _attributeCache = new();
     private static int _registrationIndex = 0;
-    private static int _discoveryRunCount = 0;
+
+    // Hook discovery is process-wide (populates the shared Sources.* bags). Use a
+    // ManualResetEventSlim gate so concurrent first-time callers from multiple MTP sessions
+    // block until the single producer has finished populating, rather than racing past empty
+    // bags after a single Interlocked.Increment short-circuit.
+    private static int _discoveryStarted;
+    private static readonly ManualResetEventSlim _discoveryCompleted = new(initialState: false);
 
     private static string GetMethodKey(MethodInfo method)
     {
@@ -164,36 +170,45 @@ internal sealed class ReflectionHookDiscoveryService
 
     #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Hook discovery scans assemblies and types using reflection")]
+    [UnconditionalSuppressMessage("Platform", "CA1416:Validate platform compatibility", Justification = "Reflection hook discovery does not run on browser targets — TUnit explicitly throws for AOT/browser via RuntimeFeature.IsDynamicCodeSupported check below.")]
     #endif
     public static void DiscoverHooks()
     {
-        // Prevent running hook discovery multiple times in the same process
-        // This can happen when both discovery and execution run in the same process
-        if (Interlocked.Increment(ref _discoveryRunCount) > 1)
+        if (Interlocked.CompareExchange(ref _discoveryStarted, 1, 0) != 0)
         {
+            // Another caller is doing (or has done) the work. Wait for it to finish so we
+            // don't proceed past empty Sources.* bags on a concurrent first call.
+            _discoveryCompleted.Wait();
             return;
         }
 
-        // Clear source-generated hooks since we're discovering via reflection
-        // In reflection mode, source generation may have already populated Sources
-        // We need to clear them to avoid duplicates
-        ClearSourceGeneratedHooks();
+        try
+        {
+            // Clear source-generated hooks since we're discovering via reflection
+            // In reflection mode, source generation may have already populated Sources
+            // We need to clear them to avoid duplicates
+            ClearSourceGeneratedHooks();
 
 #if NET
-        if (!RuntimeFeature.IsDynamicCodeSupported)
-        {
-            throw new Exception("Using TUnit Reflection mechanisms isn't supported in AOT mode");
-        }
+            if (!RuntimeFeature.IsDynamicCodeSupported)
+            {
+                throw new Exception("Using TUnit Reflection mechanisms isn't supported in AOT mode");
+            }
 #endif
 
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-        foreach (var assembly in assemblies)
-        {
-            if (ShouldScanAssembly(assembly))
+            foreach (var assembly in assemblies)
             {
-                DiscoverHooksInAssembly(assembly);
+                if (ShouldScanAssembly(assembly))
+                {
+                    DiscoverHooksInAssembly(assembly);
+                }
             }
+        }
+        finally
+        {
+            _discoveryCompleted.Set();
         }
     }
 

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -170,15 +170,22 @@ internal sealed class ReflectionHookDiscoveryService
 
     #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Hook discovery scans assemblies and types using reflection")]
-    [UnconditionalSuppressMessage("Platform", "CA1416:Validate platform compatibility", Justification = "Reflection hook discovery does not run on browser targets — TUnit explicitly throws for AOT/browser via RuntimeFeature.IsDynamicCodeSupported check below.")]
+    [UnconditionalSuppressMessage("Platform", "CA1416:Validate platform compatibility", Justification = "Reflection-mode hook discovery is not reachable on browser targets — those scenarios use AOT/source-gen mode which never invokes this method.")]
     #endif
     public static void DiscoverHooks()
     {
         if (Interlocked.CompareExchange(ref _discoveryStarted, 1, 0) != 0)
         {
             // Another caller is doing (or has done) the work. Wait for it to finish so we
-            // don't proceed past empty Sources.* bags on a concurrent first call.
-            _discoveryCompleted.Wait();
+            // don't proceed past empty Sources.* bags on a concurrent first call. Bounded
+            // so a stuck producer (e.g. a hanging ModuleInitializer in a scanned assembly)
+            // doesn't deadlock every concurrent session indefinitely.
+            if (!_discoveryCompleted.Wait(TimeSpan.FromMinutes(5)))
+            {
+                throw new TimeoutException(
+                    "Reflection-mode hook discovery timed out waiting for the first caller to complete. " +
+                    "This usually indicates a hang in an assembly being scanned for hooks.");
+            }
             return;
         }
 

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -31,6 +31,7 @@ internal sealed class ReflectionHookDiscoveryService
     // bags after a single Interlocked.Increment short-circuit.
     private static int _discoveryStarted;
     private static readonly ManualResetEventSlim _discoveryCompleted = new(initialState: false);
+    private static Exception? _discoveryException;
 
     private static string GetMethodKey(MethodInfo method)
     {
@@ -186,6 +187,17 @@ internal sealed class ReflectionHookDiscoveryService
                     "Reflection-mode hook discovery timed out waiting for the first caller to complete. " +
                     "This usually indicates a hang in an assembly being scanned for hooks.");
             }
+
+            if (_discoveryException is { } firstFailure)
+            {
+                // The first caller's discovery failed and left Sources.* in a partial state.
+                // Re-surface the failure to every concurrent waiter so no session silently
+                // proceeds with missing hooks.
+                throw new InvalidOperationException(
+                    "Reflection-mode hook discovery failed in the producing session.",
+                    firstFailure);
+            }
+
             return;
         }
 
@@ -212,6 +224,11 @@ internal sealed class ReflectionHookDiscoveryService
                     DiscoverHooksInAssembly(assembly);
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            _discoveryException = ex;
+            throw;
         }
         finally
         {

--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -25,13 +25,14 @@ internal sealed class ReflectionHookDiscoveryService
     private static readonly ConcurrentDictionary<MethodInfo, (BeforeAttribute?, AfterAttribute?, BeforeEveryAttribute?, AfterEveryAttribute?)> _attributeCache = new();
     private static int _registrationIndex = 0;
 
-    // Hook discovery is process-wide (populates the shared Sources.* bags). Use a
-    // ManualResetEventSlim gate so concurrent first-time callers from multiple MTP sessions
-    // block until the single producer has finished populating, rather than racing past empty
-    // bags after a single Interlocked.Increment short-circuit.
-    private static int _discoveryStarted;
-    private static readonly ManualResetEventSlim _discoveryCompleted = new(initialState: false);
-    private static Exception? _discoveryException;
+    // Hook discovery is process-wide (populates the shared Sources.* bags). The OneTimeGate
+    // makes concurrent first-time callers from multiple MTP sessions block until the single
+    // producer has finished populating, rather than racing past empty bags. If the producer
+    // throws, every concurrent waiter is re-surfaced the failure so no session silently
+    // proceeds with partial state.
+    private static readonly OneTimeGate s_discoveryGate = new(
+        contextName: nameof(ReflectionHookDiscoveryService),
+        waitTimeout: TimeSpan.FromMinutes(5));
 
     private static string GetMethodKey(MethodInfo method)
     {
@@ -171,68 +172,34 @@ internal sealed class ReflectionHookDiscoveryService
 
     #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Hook discovery scans assemblies and types using reflection")]
-    [UnconditionalSuppressMessage("Platform", "CA1416:Validate platform compatibility", Justification = "Reflection-mode hook discovery is not reachable on browser targets — those scenarios use AOT/source-gen mode which never invokes this method.")]
     #endif
-    public static void DiscoverHooks()
+    public static void DiscoverHooks() => s_discoveryGate.Run(DiscoverHooksCore);
+
+    #if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("Hook discovery scans assemblies and types using reflection")]
+    #endif
+    private static void DiscoverHooksCore()
     {
-        if (Interlocked.CompareExchange(ref _discoveryStarted, 1, 0) != 0)
-        {
-            // Another caller is doing (or has done) the work. Wait for it to finish so we
-            // don't proceed past empty Sources.* bags on a concurrent first call. Bounded
-            // so a stuck producer (e.g. a hanging ModuleInitializer in a scanned assembly)
-            // doesn't deadlock every concurrent session indefinitely.
-            if (!_discoveryCompleted.Wait(TimeSpan.FromMinutes(5)))
-            {
-                throw new TimeoutException(
-                    "Reflection-mode hook discovery timed out waiting for the first caller to complete. " +
-                    "This usually indicates a hang in an assembly being scanned for hooks.");
-            }
-
-            if (_discoveryException is { } firstFailure)
-            {
-                // The first caller's discovery failed and left Sources.* in a partial state.
-                // Re-surface the failure to every concurrent waiter so no session silently
-                // proceeds with missing hooks.
-                throw new InvalidOperationException(
-                    "Reflection-mode hook discovery failed in the producing session.",
-                    firstFailure);
-            }
-
-            return;
-        }
-
-        try
-        {
-            // Clear source-generated hooks since we're discovering via reflection
-            // In reflection mode, source generation may have already populated Sources
-            // We need to clear them to avoid duplicates
-            ClearSourceGeneratedHooks();
+        // Clear source-generated hooks since we're discovering via reflection
+        // In reflection mode, source generation may have already populated Sources
+        // We need to clear them to avoid duplicates
+        ClearSourceGeneratedHooks();
 
 #if NET
-            if (!RuntimeFeature.IsDynamicCodeSupported)
-            {
-                throw new Exception("Using TUnit Reflection mechanisms isn't supported in AOT mode");
-            }
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            throw new Exception("Using TUnit Reflection mechanisms isn't supported in AOT mode");
+        }
 #endif
 
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-            foreach (var assembly in assemblies)
+        foreach (var assembly in assemblies)
+        {
+            if (ShouldScanAssembly(assembly))
             {
-                if (ShouldScanAssembly(assembly))
-                {
-                    DiscoverHooksInAssembly(assembly);
-                }
+                DiscoverHooksInAssembly(assembly);
             }
-        }
-        catch (Exception ex)
-        {
-            _discoveryException = ex;
-            throw;
-        }
-        finally
-        {
-            _discoveryCompleted.Set();
         }
     }
 

--- a/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
+++ b/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
@@ -11,6 +11,12 @@ namespace TUnit.Engine.Discovery;
 /// This is a simplified version that handles basic property injection scenarios
 /// where instance data sources depend on property-injected values.
 /// </summary>
+/// <remarks>
+/// No process-wide instance cache: under MTP server mode multiple sessions in one host can
+/// invoke generic-type discovery concurrently, and a shared cache would leak instances and
+/// their per-session state across sessions (#6001). Reflection-mode generic discovery is
+/// already a cold path, so we accept the duplication cost in exchange for isolation.
+/// </remarks>
 [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Reflection mode isn't used in AOT scenarios")]
 [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Reflection mode isn't used in AOT scenarios")]
 [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Reflection mode isn't used in AOT scenarios")]
@@ -19,19 +25,11 @@ namespace TUnit.Engine.Discovery;
 [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Reflection mode isn't used in AOT scenarios")]
 internal static class ReflectionInstanceFactory
 {
-    private static readonly ConcurrentDictionary<Type, object?> _instanceCache = new();
-
     /// <summary>
     /// Creates an instance of the specified type with property injection performed.
     /// </summary>
     public static async Task<object?> CreateInstanceWithPropertyInjectionAsync(Type type)
     {
-        // Check cache first to avoid creating multiple instances for the same type
-        if (_instanceCache.TryGetValue(type, out var cachedInstance))
-        {
-            return cachedInstance;
-        }
-
         try
         {
             // Create the instance
@@ -43,9 +41,6 @@ internal static class ReflectionInstanceFactory
 
             // Perform basic property injection
             await InjectPropertiesAsync(instance, type);
-
-            // Cache the instance
-            _instanceCache.TryAdd(type, instance);
 
             return instance;
         }
@@ -186,13 +181,5 @@ internal static class ReflectionInstanceFactory
     {
         var invokeMethod = func.GetType().GetMethod("Invoke");
         return invokeMethod?.Invoke(func, null);
-    }
-
-    /// <summary>
-    /// Clears the instance cache. Should be called at the end of test discovery.
-    /// </summary>
-    public static void ClearCache()
-    {
-        _instanceCache.Clear();
     }
 }

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -29,8 +29,14 @@ namespace TUnit.Engine.Discovery;
 [UnconditionalSuppressMessage("Trimming", "IL2060:Call to \'System.Reflection.MethodInfo.MakeGenericMethod\' can not be statically analyzed. It\'s not possible to guarantee the availability of requirements of the generic method.")]
 internal sealed class ReflectionTestDataCollector : ITestDataCollector
 {
-    private static readonly ConcurrentDictionary<Assembly, bool> _scannedAssemblies = new();
-    private static ImmutableList<TestMetadata> _discoveredTests = ImmutableList<TestMetadata>.Empty;
+    // Per-session state: each TUnitServiceProvider instantiates its own collector, and these
+    // fields must not leak between sessions. Under MTP server mode the test host can serve
+    // many sessions sequentially or concurrently; static caches here would cause session N+1
+    // to see session N's assemblies as "already scanned" and return zero tests (issue #6001).
+    private readonly ConcurrentDictionary<Assembly, bool> _scannedAssemblies = new();
+    private ImmutableList<TestMetadata> _discoveredTests = ImmutableList<TestMetadata>.Empty;
+
+    // Process-wide caches: pure reflection metadata that doesn't change across sessions.
     private static readonly ConcurrentDictionary<Assembly, Type[]> _assemblyTypesCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo[]> _typeMethodsCache = new();
 

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -65,7 +65,7 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
 
             await serviceProvider.HookDelegateBuilder.InitializeAsync();
 
-            serviceProvider.CancellationToken.Initialise(context.CancellationToken);
+            serviceProvider.CancellationToken.Initialise();
 
             await _requestHandler.HandleRequestAsync((TestExecutionRequest) context.Request, serviceProvider, context, GetFilter(context));
         }

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -61,7 +61,7 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
             TestDiscoveryContext.Current = serviceProvider.ContextProvider.TestDiscoveryContext;
             TestSessionContext.Current = serviceProvider.ContextProvider.TestSessionContext;
 
-            serviceProvider.Initializer.Initialize(context);
+            serviceProvider.Initializer.Initialize();
 
             await serviceProvider.HookDelegateBuilder.InitializeAsync();
 

--- a/TUnit.Engine/Helpers/OneTimeGate.cs
+++ b/TUnit.Engine/Helpers/OneTimeGate.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace TUnit.Engine.Helpers;
+
+/// <summary>
+/// Single-producer / multi-waiter gate for "run this work exactly once" semantics.
+/// The first caller into <see cref="Run"/> executes <paramref name="work"/>; every
+/// concurrent caller blocks on a <see cref="ManualResetEventSlim"/> until that work
+/// finishes, with a bounded timeout so a stuck producer can't deadlock the rest of
+/// the process. If the producing call throws, the exception is captured and
+/// re-surfaced to every waiter so no concurrent caller silently proceeds past
+/// partial state (#6001).
+/// </summary>
+internal sealed class OneTimeGate
+{
+    private readonly TimeSpan _waitTimeout;
+    private readonly string _contextName;
+    private int _started;
+    private Exception? _failure;
+    private readonly ManualResetEventSlim _completed = new(initialState: false);
+
+    public OneTimeGate(string contextName, TimeSpan waitTimeout)
+    {
+        _contextName = contextName;
+        _waitTimeout = waitTimeout;
+    }
+
+    [UnconditionalSuppressMessage("Platform", "CA1416:Validate platform compatibility", Justification = "TUnit does not run on browser targets; callers of OneTimeGate are not reachable there.")]
+    public void Run(Action work)
+    {
+        if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
+        {
+            if (!_completed.Wait(_waitTimeout))
+            {
+                throw new TimeoutException(
+                    $"{_contextName} timed out waiting for the first caller to complete after {_waitTimeout.TotalSeconds:0}s. " +
+                    "This usually indicates a hang in the work being performed.");
+            }
+
+            if (_failure is { } firstFailure)
+            {
+                throw new InvalidOperationException(
+                    $"{_contextName} failed in the producing caller; see inner exception.",
+                    firstFailure);
+            }
+
+            return;
+        }
+
+        try
+        {
+            work();
+        }
+        catch (Exception ex)
+        {
+            _failure = ex;
+            throw;
+        }
+        finally
+        {
+            _completed.Set();
+        }
+    }
+}

--- a/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/OptimizedConsoleInterceptor.cs
@@ -69,6 +69,9 @@ internal abstract class OptimizedConsoleInterceptor : TextWriter
 #if NET
     public override ValueTask DisposeAsync()
     {
+        // ResetDefault is intentionally a no-op for Standard{Out,Error}ConsoleInterceptor
+        // (#6001): under MTP server mode the interceptor is installed exactly once for the
+        // process and must outlive any individual session's disposal.
         ResetDefault();
         return ValueTask.CompletedTask;
     }
@@ -197,6 +200,8 @@ internal abstract class OptimizedConsoleInterceptor : TextWriter
     public override void Close()
     {
         Flush();
+        // ResetDefault is a no-op for Standard{Out,Error}ConsoleInterceptor under
+        // MTP server mode — see DisposeAsync above and the subclass overrides.
         ResetDefault();
     }
 

--- a/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardErrorConsoleInterceptor.cs
@@ -5,9 +5,12 @@ namespace TUnit.Engine.Logging;
 
 internal class StandardErrorConsoleInterceptor : OptimizedConsoleInterceptor
 {
-    public static StandardErrorConsoleInterceptor Instance { get; private set; } = null!;
-
     public static TextWriter DefaultError { get; }
+
+    // See StandardOutConsoleInterceptor for the rationale — Console.Error is also process-wide
+    // and must be installed exactly once so concurrent sessions in one host (#6001) don't
+    // clobber each other's interception.
+    private static int s_installed;
 
     protected override LogLevel SinkLogLevel => LogLevel.Error;
 
@@ -21,17 +24,18 @@ internal class StandardErrorConsoleInterceptor : OptimizedConsoleInterceptor
         };
     }
 
-    public StandardErrorConsoleInterceptor()
-    {
-        Instance = this;
-    }
-
     public void Initialize()
     {
-        Console.SetError(this);
+        if (Interlocked.CompareExchange(ref s_installed, 1, 0) == 0)
+        {
+            Console.SetError(this);
+        }
     }
 
     private protected override TextWriter GetOriginalOut() => DefaultError;
 
-    private protected override void ResetDefault() => Console.SetError(DefaultError);
+    private protected override void ResetDefault()
+    {
+        // No-op: we install exactly once per process. See StandardOutConsoleInterceptor.
+    }
 }

--- a/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
+++ b/TUnit.Engine/Logging/StandardOutConsoleInterceptor.cs
@@ -5,9 +5,14 @@ namespace TUnit.Engine.Logging;
 
 internal class StandardOutConsoleInterceptor : OptimizedConsoleInterceptor
 {
-    public static StandardOutConsoleInterceptor Instance { get; private set; } = null!;
-
     public static TextWriter DefaultOut { get; }
+
+    // Console.Out is process-wide. Per-session interceptors must NOT clobber each other or
+    // a sibling session's writes would stop being intercepted (#6001). We install exactly
+    // one interceptor for the process and route through it; the interceptor itself is
+    // stateless and dispatches to Context.Current (an AsyncLocal), so a single instance
+    // serves every session safely.
+    private static int s_installed;
 
     protected override LogLevel SinkLogLevel => LogLevel.Information;
 
@@ -21,17 +26,20 @@ internal class StandardOutConsoleInterceptor : OptimizedConsoleInterceptor
         };
     }
 
-    public StandardOutConsoleInterceptor()
-    {
-        Instance = this;
-    }
-
     public void Initialize()
     {
-        Console.SetOut(this);
+        if (Interlocked.CompareExchange(ref s_installed, 1, 0) == 0)
+        {
+            Console.SetOut(this);
+        }
     }
 
     private protected override TextWriter GetOriginalOut() => DefaultOut;
 
-    private protected override void ResetDefault() => Console.SetOut(DefaultOut);
+    private protected override void ResetDefault()
+    {
+        // No-op: we install exactly once per process and keep that interceptor live for the
+        // lifetime of the process. Resetting Console.Out on a per-session dispose would tear
+        // down interception for any concurrent sessions sharing the test host.
+    }
 }

--- a/TUnit.Engine/Reporters/Html/ActivityCollector.cs
+++ b/TUnit.Engine/Reporters/Html/ActivityCollector.cs
@@ -46,7 +46,12 @@ internal sealed class ActivityCollector : IDisposable
 
     // Process-wide pointer to the currently-running collector, used by the OTLP receiver
     // (in TUnit.OpenTelemetry) to feed external spans without an explicit wiring step.
-    // Only one HtmlReporter runs per session, so a static slot is sufficient.
+    // KNOWN LIMITATION (#6001): under MTP server mode with multiple concurrent sessions in
+    // one host, only the first-started session claims this slot — subsequent sessions'
+    // HtmlReporters end up sharing collectors with the first, and once the first session
+    // stops the slot is cleared while later sessions are still running. Acceptable for the
+    // common case (single session per host) and orthogonal to the discovery/execution race
+    // fixes in #6001; a session-keyed registry is the proper long-term fix.
     private static ActivityCollector? _current;
 
     public static ActivityCollector? Current => _current;

--- a/TUnit.Engine/TUnitInitializer.cs
+++ b/TUnit.Engine/TUnitInitializer.cs
@@ -1,7 +1,7 @@
 using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Extensions.TestFramework;
 using TUnit.Core;
 using TUnit.Engine.Discovery;
+using TUnit.Engine.Helpers;
 
 namespace TUnit.Engine;
 
@@ -11,31 +11,36 @@ namespace TUnit.Engine;
 /// work (hook discovery, working directory) at most once per <see cref="TUnitServiceProvider"/>
 /// instance.
 /// </summary>
-internal class TUnitInitializer(ICommandLineOptions commandLineOptions, IHookRegistrar hookDiscoveryService)
+internal class TUnitInitializer
 {
-    private int _sessionInitialised;
+    private readonly ICommandLineOptions _commandLineOptions;
+    private readonly IHookRegistrar _hookDiscoveryService;
+    private readonly OneTimeGate _sessionGate = new(
+        contextName: nameof(TUnitInitializer),
+        waitTimeout: TimeSpan.FromMinutes(5));
 
-    public void Initialize(ExecuteRequestContext context)
+    public TUnitInitializer(ICommandLineOptions commandLineOptions, IHookRegistrar hookDiscoveryService)
     {
-        _ = context;
+        _commandLineOptions = commandLineOptions;
+        _hookDiscoveryService = hookDiscoveryService;
+    }
 
-        TUnitProcessInitializer.EnsureInitialised(commandLineOptions);
+    public void Initialize()
+    {
+        TUnitProcessInitializer.EnsureInitialised(_commandLineOptions);
 
-        if (Interlocked.CompareExchange(ref _sessionInitialised, 1, 0) != 0)
+        // Session-scoped: every concurrent ExecuteRequestAsync call on this session blocks
+        // until hook discovery + working directory setup have finished, so no caller proceeds
+        // past partial state. Cross-session "run once per process" semantics for reflection
+        // hook discovery live downstream in ReflectionHookDiscoveryService.
+        _sessionGate.Run(() =>
         {
-            return;
-        }
+            _hookDiscoveryService.DiscoverHooks();
 
-        // _sessionInitialised is per-instance — TUnitServiceProvider news a fresh
-        // TUnitInitializer per session, so this flag only protects against concurrent
-        // ExecuteRequestAsync calls within ONE session re-entering hook discovery.
-        // Cross-session "run once per process" semantics live downstream in
-        // ReflectionHookDiscoveryService (gate on _discoveryStarted / _discoveryCompleted).
-        hookDiscoveryService.DiscoverHooks();
-
-        if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
-        {
-            TestContext.WorkingDirectory = TestContext.OutputDirectory!;
-        }
+            if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
+            {
+                TestContext.WorkingDirectory = TestContext.OutputDirectory!;
+            }
+        });
     }
 }

--- a/TUnit.Engine/TUnitInitializer.cs
+++ b/TUnit.Engine/TUnitInitializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using TUnit.Core;
@@ -10,28 +10,70 @@ namespace TUnit.Engine;
 
 internal class TUnitInitializer(ICommandLineOptions commandLineOptions, IHookRegistrar hookDiscoveryService)
 {
+    // Process-wide guards. Trace listeners and AppDomain handlers must only be registered once
+    // per process, regardless of how many sessions or concurrent ExecuteRequestAsync calls hit
+    // this initializer — otherwise listeners accumulate per RPC and AppDomain handlers capture
+    // stale ExecuteRequestContext closures.
+    private static int s_processHandlersRegistered;
+    private static int s_parametersParsed;
+
+    private int _sessionInitialised;
+
     public void Initialize(ExecuteRequestContext context)
     {
-        ConfigureGlobalExceptionHandlers(context);
-        SetUpExceptionListeners();
-        ParseParameters();
+        _ = context;
 
-        // Discover hooks using the mode-specific service
-        hookDiscoveryService.DiscoverHooks();
+        EnsureProcessHandlersRegistered();
+        EnsureParametersParsed();
 
-        if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
+        if (Interlocked.CompareExchange(ref _sessionInitialised, 1, 0) == 0)
         {
-            TestContext.WorkingDirectory = TestContext.OutputDirectory!;
+            // Discover hooks using the mode-specific service. The discovery services themselves
+            // guard against running more than once per process where appropriate.
+            hookDiscoveryService.DiscoverHooks();
+
+            if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
+            {
+                TestContext.WorkingDirectory = TestContext.OutputDirectory!;
+            }
         }
     }
 
-    private void SetUpExceptionListeners()
+    private static void EnsureProcessHandlersRegistered()
     {
+        if (Interlocked.CompareExchange(ref s_processHandlersRegistered, 1, 0) != 0)
+        {
+            return;
+        }
+
         Trace.Listeners.Insert(0, new ThrowListener());
+
+        AppDomain.CurrentDomain.UnhandledException += static (_, args) =>
+        {
+            // Log only — we deliberately do not capture an ExecuteRequestContext to call
+            // Complete() on, because under MTP server mode multiple contexts may be in flight
+            // concurrently and capturing any one of them produces use-after-complete bugs and
+            // handler leaks. If the process is terminating, MTP's own shutdown path takes over.
+            var exception = args.ExceptionObject as Exception;
+            Console.Error.WriteLine($"Unhandled exception in AppDomain: {exception}");
+        };
+
+        TaskScheduler.UnobservedTaskException += static (_, args) =>
+        {
+            Console.Error.WriteLine($"Unobserved task exception: {args.Exception}");
+
+            // Mark as observed to prevent process termination
+            args.SetObserved();
+        };
     }
 
-    private void ParseParameters()
+    private void EnsureParametersParsed()
     {
+        if (Interlocked.CompareExchange(ref s_parametersParsed, 1, 0) != 0)
+        {
+            return;
+        }
+
         if (!commandLineOptions.TryGetOptionArgumentList(ParametersCommandProvider.TestParameter, out var parameters))
         {
             return;
@@ -46,31 +88,5 @@ internal class TUnitInitializer(ICommandLineOptions commandLineOptions, IHookReg
             var list = TestContext.InternalParametersDictionary.GetOrAdd(key, static _ => []);
             list.Add(value);
         }
-    }
-
-    private static void ConfigureGlobalExceptionHandlers(ExecuteRequestContext context)
-    {
-        // Handle unhandled exceptions on any thread
-        AppDomain.CurrentDomain.UnhandledException += (_, args) =>
-        {
-            var exception = args.ExceptionObject as Exception;
-
-            Console.Error.WriteLine($"Unhandled exception in AppDomain: {exception}");
-
-            // Force exit to prevent hanging
-            if (args.IsTerminating)
-            {
-                context.Complete();
-            }
-        };
-
-        // Handle unobserved task exceptions
-        TaskScheduler.UnobservedTaskException += (_, args) =>
-        {
-            Console.Error.WriteLine($"Unobserved task exception: {args.Exception}");
-
-            // Mark as observed to prevent process termination
-            args.SetObserved();
-        };
     }
 }

--- a/TUnit.Engine/TUnitInitializer.cs
+++ b/TUnit.Engine/TUnitInitializer.cs
@@ -1,95 +1,41 @@
-using System.Diagnostics;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using TUnit.Core;
-using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Discovery;
-using TUnit.Engine.Exceptions;
 
 namespace TUnit.Engine;
 
+/// <summary>
+/// Per-session TUnit initialization. Delegates process-wide setup (exception handlers,
+/// parameter parsing) to <see cref="TUnitProcessInitializer"/> and performs session-scoped
+/// work (hook discovery, working directory) at most once per <see cref="TUnitServiceProvider"/>
+/// instance.
+/// </summary>
 internal class TUnitInitializer(ICommandLineOptions commandLineOptions, IHookRegistrar hookDiscoveryService)
 {
-    // Process-wide guards. Trace listeners and AppDomain handlers must only be registered once
-    // per process, regardless of how many sessions or concurrent ExecuteRequestAsync calls hit
-    // this initializer — otherwise listeners accumulate per RPC and AppDomain handlers capture
-    // stale ExecuteRequestContext closures.
-    private static int s_processHandlersRegistered;
-    private static int s_parametersParsed;
-
     private int _sessionInitialised;
 
     public void Initialize(ExecuteRequestContext context)
     {
         _ = context;
 
-        EnsureProcessHandlersRegistered();
-        EnsureParametersParsed();
+        TUnitProcessInitializer.EnsureInitialised(commandLineOptions);
 
-        if (Interlocked.CompareExchange(ref _sessionInitialised, 1, 0) == 0)
-        {
-            // _sessionInitialised is per-instance — TUnitServiceProvider news a fresh
-            // TUnitInitializer per session, so this flag only protects against concurrent
-            // ExecuteRequestAsync calls within ONE session re-entering hook discovery.
-            // Cross-session "run once per process" semantics live downstream in
-            // ReflectionHookDiscoveryService (gate on _discoveryStarted / _discoveryCompleted).
-            hookDiscoveryService.DiscoverHooks();
-
-            if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
-            {
-                TestContext.WorkingDirectory = TestContext.OutputDirectory!;
-            }
-        }
-    }
-
-    private static void EnsureProcessHandlersRegistered()
-    {
-        if (Interlocked.CompareExchange(ref s_processHandlersRegistered, 1, 0) != 0)
+        if (Interlocked.CompareExchange(ref _sessionInitialised, 1, 0) != 0)
         {
             return;
         }
 
-        Trace.Listeners.Insert(0, new ThrowListener());
+        // _sessionInitialised is per-instance — TUnitServiceProvider news a fresh
+        // TUnitInitializer per session, so this flag only protects against concurrent
+        // ExecuteRequestAsync calls within ONE session re-entering hook discovery.
+        // Cross-session "run once per process" semantics live downstream in
+        // ReflectionHookDiscoveryService (gate on _discoveryStarted / _discoveryCompleted).
+        hookDiscoveryService.DiscoverHooks();
 
-        AppDomain.CurrentDomain.UnhandledException += static (_, args) =>
+        if (!string.IsNullOrEmpty(TestContext.OutputDirectory))
         {
-            // Log only — we deliberately do not capture an ExecuteRequestContext to call
-            // Complete() on, because under MTP server mode multiple contexts may be in flight
-            // concurrently and capturing any one of them produces use-after-complete bugs and
-            // handler leaks. If the process is terminating, MTP's own shutdown path takes over.
-            var exception = args.ExceptionObject as Exception;
-            Console.Error.WriteLine($"Unhandled exception in AppDomain: {exception}");
-        };
-
-        TaskScheduler.UnobservedTaskException += static (_, args) =>
-        {
-            Console.Error.WriteLine($"Unobserved task exception: {args.Exception}");
-
-            // Mark as observed to prevent process termination
-            args.SetObserved();
-        };
-    }
-
-    private void EnsureParametersParsed()
-    {
-        if (Interlocked.CompareExchange(ref s_parametersParsed, 1, 0) != 0)
-        {
-            return;
-        }
-
-        if (!commandLineOptions.TryGetOptionArgumentList(ParametersCommandProvider.TestParameter, out var parameters))
-        {
-            return;
-        }
-
-        foreach (var parameter in parameters)
-        {
-            var split = parameter.Split('=');
-            var key = split[0];
-            var value = split[1];
-
-            var list = TestContext.InternalParametersDictionary.GetOrAdd(key, static _ => []);
-            list.Add(value);
+            TestContext.WorkingDirectory = TestContext.OutputDirectory!;
         }
     }
 }

--- a/TUnit.Engine/TUnitInitializer.cs
+++ b/TUnit.Engine/TUnitInitializer.cs
@@ -28,8 +28,11 @@ internal class TUnitInitializer(ICommandLineOptions commandLineOptions, IHookReg
 
         if (Interlocked.CompareExchange(ref _sessionInitialised, 1, 0) == 0)
         {
-            // Discover hooks using the mode-specific service. The discovery services themselves
-            // guard against running more than once per process where appropriate.
+            // _sessionInitialised is per-instance — TUnitServiceProvider news a fresh
+            // TUnitInitializer per session, so this flag only protects against concurrent
+            // ExecuteRequestAsync calls within ONE session re-entering hook discovery.
+            // Cross-session "run once per process" semantics live downstream in
+            // ReflectionHookDiscoveryService (gate on _discoveryStarted / _discoveryCompleted).
             hookDiscoveryService.DiscoverHooks();
 
             if (!string.IsNullOrEmpty(TestContext.OutputDirectory))

--- a/TUnit.Engine/TUnitProcessInitializer.cs
+++ b/TUnit.Engine/TUnitProcessInitializer.cs
@@ -3,6 +3,7 @@ using Microsoft.Testing.Platform.CommandLine;
 using TUnit.Core;
 using TUnit.Engine.CommandLineProviders;
 using TUnit.Engine.Exceptions;
+using TUnit.Engine.Helpers;
 
 namespace TUnit.Engine;
 
@@ -15,19 +16,20 @@ namespace TUnit.Engine;
 /// </summary>
 internal static class TUnitProcessInitializer
 {
-    private static int s_initialised;
+    private static readonly OneTimeGate s_gate = new(
+        contextName: nameof(TUnitProcessInitializer),
+        waitTimeout: TimeSpan.FromMinutes(1));
 
     /// <summary>
-    /// Runs process-wide setup the first time it is invoked. Subsequent calls (from
-    /// later sessions or concurrent ExecuteRequestAsync invocations) are no-ops.
+    /// Runs process-wide setup the first time it is invoked. Concurrent callers block
+    /// until the first caller finishes; subsequent calls (from later sessions) are
+    /// no-ops once setup has succeeded.
     /// </summary>
     public static void EnsureInitialised(ICommandLineOptions commandLineOptions)
-    {
-        if (Interlocked.CompareExchange(ref s_initialised, 1, 0) != 0)
-        {
-            return;
-        }
+        => s_gate.Run(() => Initialise(commandLineOptions));
 
+    private static void Initialise(ICommandLineOptions commandLineOptions)
+    {
         Trace.Listeners.Insert(0, new ThrowListener());
 
         AppDomain.CurrentDomain.UnhandledException += static (_, args) =>

--- a/TUnit.Engine/TUnitProcessInitializer.cs
+++ b/TUnit.Engine/TUnitProcessInitializer.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using Microsoft.Testing.Platform.CommandLine;
+using TUnit.Core;
+using TUnit.Engine.CommandLineProviders;
+using TUnit.Engine.Exceptions;
+
+namespace TUnit.Engine;
+
+/// <summary>
+/// Process-wide TUnit engine setup that must run exactly once per host process —
+/// global exception handlers, the throw-on-trace-assert listener, and command-line
+/// parameter parsing. Lifted out of the per-session <see cref="TUnitInitializer"/>
+/// so the lifetime distinction is enforced at the type level rather than relying on
+/// a static flag inside an instance method (#6001).
+/// </summary>
+internal static class TUnitProcessInitializer
+{
+    private static int s_initialised;
+
+    /// <summary>
+    /// Runs process-wide setup the first time it is invoked. Subsequent calls (from
+    /// later sessions or concurrent ExecuteRequestAsync invocations) are no-ops.
+    /// </summary>
+    public static void EnsureInitialised(ICommandLineOptions commandLineOptions)
+    {
+        if (Interlocked.CompareExchange(ref s_initialised, 1, 0) != 0)
+        {
+            return;
+        }
+
+        Trace.Listeners.Insert(0, new ThrowListener());
+
+        AppDomain.CurrentDomain.UnhandledException += static (_, args) =>
+        {
+            // Log only — we deliberately do not capture an ExecuteRequestContext to call
+            // Complete() on, because under MTP server mode multiple contexts may be in flight
+            // concurrently and capturing any one of them produces use-after-complete bugs and
+            // handler leaks. If the process is terminating, MTP's own shutdown path takes over.
+            var exception = args.ExceptionObject as Exception;
+            Console.Error.WriteLine($"Unhandled exception in AppDomain: {exception}");
+        };
+
+        TaskScheduler.UnobservedTaskException += static (_, args) =>
+        {
+            Console.Error.WriteLine($"Unobserved task exception: {args.Exception}");
+
+            // Mark as observed to prevent process termination
+            args.SetObserved();
+        };
+
+        ParseTestParameters(commandLineOptions);
+    }
+
+    private static void ParseTestParameters(ICommandLineOptions commandLineOptions)
+    {
+        if (!commandLineOptions.TryGetOptionArgumentList(ParametersCommandProvider.TestParameter, out var parameters))
+        {
+            return;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            var split = parameter.Split('=');
+            var key = split[0];
+            var value = split[1];
+
+            var list = TestContext.InternalParametersDictionary.GetOrAdd(key, static _ => []);
+            list.Add(value);
+        }
+    }
+}

--- a/TUnit.RpcTests/Clients/TestingPlatformClient.cs
+++ b/TUnit.RpcTests/Clients/TestingPlatformClient.cs
@@ -93,6 +93,18 @@ public sealed class TestingPlatformClient : IDisposable
             return (ResponseListener)runListener;
         });
 
+    /// <summary>
+    /// Registers a listener for incoming testing/testUpdates/tests notifications keyed by the
+    /// given runId, without sending any RPC itself. Used by tests that need to observe how the
+    /// server attributes the runId field on inbound notifications (e.g. #6001 finding 3).
+    /// </summary>
+    public ResponseListener RegisterTestUpdatesListener(Guid runId, Func<TestNodeUpdate[], Task> action)
+    {
+        var listener = new TestNodeUpdatesResponseListener(runId, action);
+        _targetHandler.RegisterResponseListener(listener);
+        return listener;
+    }
+
     public void Dispose()
     {
         JsonRpcClient.Dispose();

--- a/TUnit.RpcTests/Tests.cs
+++ b/TUnit.RpcTests/Tests.cs
@@ -55,6 +55,94 @@ public class Tests
     }
 
     [Test]
+    [Timeout(600_000)]
+    [Retry(3)]
+    [MethodDataSource(nameof(Frameworks))]
+    public async Task RunTests_ConcurrentRpcsOnSameSession_AllReceiveFullResults(string framework, CancellationToken cancellationToken)
+    {
+        // Regression for https://github.com/thomhurst/TUnit/issues/6001 — concurrent testing/runTests
+        // RPCs on a single MTP server-mode session were producing zero results for some calls because
+        // per-session state (cancellation token, initializer handlers) was mutated on every RPC.
+        await using var session = await TestHostSession.StartAsync(framework, cancellationToken);
+
+        var discovered = await session.DiscoverAsync(cancellationToken);
+
+        var basicTests = discovered
+            .Select(x => x.Node)
+            .Where(node => node.Uid.Contains(".BasicTests."))
+            .ToArray();
+
+        await Assert.That(basicTests).Count().IsGreaterThan(0);
+
+        const int concurrentRpcs = 4;
+        const int iterations = 3;
+
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            var runTasks = Enumerable.Range(0, concurrentRpcs)
+                .Select(_ => session.RunAsync(basicTests, cancellationToken))
+                .ToArray();
+
+            var allUpdates = await Task.WhenAll(runTasks);
+
+            for (var rpc = 0; rpc < allUpdates.Length; rpc++)
+            {
+                var executed = allUpdates[rpc]
+                    .Where(x => x.Node.ExecutionState is not null and not "in-progress")
+                    .ToArray();
+
+                await Assert.That(executed.Length)
+                    .IsEqualTo(basicTests.Length)
+                    .Because($"Iteration {iteration}, RPC #{rpc} expected {basicTests.Length} results but received {executed.Length}");
+            }
+        }
+    }
+
+    // Confirms the upstream Microsoft.Testing.Platform behaviour reported in issue #6001
+    // (finding 3): sending a non-Guid runId silently coerces to Guid.Empty rather than
+    // returning a protocol error. Skipped because the fix lives in microsoft/testfx — keep
+    // this as a canonical repro to attach when filing upstream, and to unskip once MTP
+    // changes the behaviour.
+    [Test, Skip("Confirms MTP-side coercion of malformed runId to Guid.Empty — pending upstream fix in microsoft/testfx (linked from issue #6001).")]
+    [Timeout(120_000)]
+    [MethodDataSource(nameof(Frameworks))]
+    public async Task RunTests_WithMalformedRunId_ServerAttributesUpdatesToGuidEmpty(string framework, CancellationToken cancellationToken)
+    {
+        await using var session = await TestHostSession.StartAsync(framework, cancellationToken);
+
+        var discovered = await session.DiscoverAsync(cancellationToken);
+        var someTest = discovered
+            .Select(x => x.Node)
+            .Where(node => node.Uid.Contains(".BasicTests."))
+            .Take(1)
+            .ToArray();
+        await Assert.That(someTest).Count().IsGreaterThan(0);
+
+        var emptyRunIdUpdates = new List<TestNodeUpdate>();
+        var listener = session.Client.RegisterTestUpdatesListener(Guid.Empty, batch =>
+        {
+            lock (emptyRunIdUpdates) emptyRunIdUpdates.AddRange(batch);
+            return Task.CompletedTask;
+        });
+
+        await session.Client.JsonRpcClient.InvokeWithParameterObjectAsync(
+            "testing/runTests",
+            new
+            {
+                runId = "not-a-guid",
+                tests = someTest
+            },
+            cancellationToken: cancellationToken);
+
+        await listener.WaitCompletionAsync();
+
+        await Assert.That(emptyRunIdUpdates)
+            .Count()
+            .IsGreaterThan(0)
+            .Because("If MTP rejected the malformed runId as a protocol error, we would never receive notifications attributed to Guid.Empty. If we do, MTP silently coerced.");
+    }
+
+    [Test]
     [Timeout(300_000)]
     [Retry(3)]
     [MethodDataSource(nameof(Frameworks))]

--- a/TUnit.RpcTests/Tests.cs
+++ b/TUnit.RpcTests/Tests.cs
@@ -54,9 +54,11 @@ public class Tests
         }
     }
 
+    // No [Retry] on this one by design: it pins the regression for #6001. A flaky failure
+    // here is exactly the signal we want to preserve — retrying would mask a re-introduced
+    // race rather than surface it.
     [Test]
     [Timeout(600_000)]
-    [Retry(3)]
     [MethodDataSource(nameof(Frameworks))]
     public async Task RunTests_ConcurrentRpcsOnSameSession_AllReceiveFullResults(string framework, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Closes #6001 (finding 1; finding 2 is downstream; finding 3 is upstream MTP).

## Summary

Concurrent `testing/runTests` RPCs against one long-lived MTP test process were producing zero results from sessions that should produce ~100. Root cause was shared mutable state across sessions/calls — not a single race. This PR isolates each leak at its source rather than serialising RPCs per session.

## Findings & fixes

| # | File | Was | Now |
|---|------|-----|-----|
| 1 | `TUnit.Core/EngineCancellationToken.cs` | `Initialise` reassigned `CancellationTokenSource`+`Token` every call; loser inherited winner's cancellation | Session CTS established at construction; `Initialise` is idempotent and only hooks Ctrl+C / ProcessExit. Per-RPC cancellation flows through `context.CancellationToken` explicitly. |
| 2 | `TUnit.Engine/TUnitInitializer.cs` | Added new Trace listener + AppDomain/TaskScheduler closures per RPC, capturing stale `ExecuteRequestContext` | Split into per-process (Interlocked-guarded) handlers and per-session work; AppDomain handler no longer captures context |
| 3 | `TUnit.Engine/Discovery/ReflectionTestDataCollector.cs` | `_scannedAssemblies` + `_discoveredTests` were `static`; session N+1 saw assemblies as already-scanned and returned `[]` | Both are now instance fields |
| 4 | `TUnit.Engine/Discovery/ReflectionInstanceFactory.cs` | Process-wide instance cache leaked across sessions | Dropped the cache (reflection generic-type discovery is a cold path; isolation > dedup) |
| 5 | `TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs` | `Interlocked.Increment` guard short-circuited concurrent first callers past empty `Sources.*` bags | `ManualResetEventSlim` gate: concurrent callers block until the populator finishes |
| 6 | `TUnit.Engine/Logging/Standard{Out,Error}ConsoleInterceptor.cs` | Each session called `Console.SetOut(this)` and reset it on dispose, tearing down sibling sessions' interception | Install exactly once per process. Interceptor dispatches via `Context.Current` (AsyncLocal), so one instance serves every session |
| 7 | `TUnit.Core/Sources.cs` | No documented invariant; reflection mode wiped these | Doc invariant: hook bags are append-only after init |
| 8 | `TUnit.Engine/Reporters/Html/ActivityCollector.cs` | `_current` static single-slot, first-wins | Limitation documented; full fix deferred (orthogonal to the discovery/execution race and not exercised by the reporter's workload) |

## New tests

- `TUnit.RpcTests/Tests.cs::RunTests_ConcurrentRpcsOnSameSession_AllReceiveFullResults` — dispatches 4 concurrent `testing/runTests` RPCs against one `TestHostSession`, across 3 iterations, asserts every RPC receives the full result set. Pins finding 1.
- `TUnit.RpcTests/Tests.cs::RunTests_WithMalformedRunId_ServerAttributesUpdatesToGuidEmpty` — `[Skip]`ped repro for finding 3 (MTP coerces non-Guid `runId` to `Guid.Empty`). Will be linked from an upstream `microsoft/testfx` issue.

## Why not serialise per session

It would slow legitimate concurrent runs and would hide the underlying leaks rather than fix them — the static caches and per-call mutations would still misbehave for the reflection-mode discovery path, sequential N=many runs, and any future caller. Each leak is fixed at its source instead.

## Verification

- New concurrent regression test passes locally for `net8.0` and `net10.0` (10 RPCs across 3 iterations, no zero-result sessions).
- All existing `TUnit.RpcTests` pass (`Discovery_*`, `RunTests_With*`).
- Public API surface for `EngineCancellationToken` unchanged at the snapshot level (`Token { get; }`, `Dispose()`).

## Test plan

- [ ] CI green on all matrix legs
- [ ] Reporter (@slang25) re-runs the mutation-testing prototype with `--warm-pool 4/6` against this branch and confirms no zero-result sessions
- [ ] Stryker.NET 4.14.2 `--test-runner mtp` against the same workload — expect `Pending` count to drop from 271/335 to ~0 (finding 2)
- [ ] Upstream issue filed against `microsoft/testfx` for finding 3 with the skipped test as the repro