### PR TITLE
perf(engine): hoist GetParameters and dict-dedup AfterTestDiscovery hooks

### DIFF
--- a/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
+++ b/TUnit.Engine/Discovery/ReflectionHookDiscoveryService.cs
@@ -20,6 +20,7 @@ internal sealed class ReflectionHookDiscoveryService
 {
     private static readonly ConcurrentDictionary<Assembly, bool> _scannedAssemblies = new();
     private static readonly ConcurrentDictionary<string, bool> _registeredMethods = new();
+    private static readonly ConcurrentDictionary<(string Name, Type Type), bool> _registeredAfterTestDiscoveryHooks = new();
     private static readonly ConcurrentDictionary<MethodInfo, string> _methodKeyCache = new();
     // Cache attribute lookups to avoid repeated reflection calls in hot paths
     private static readonly ConcurrentDictionary<MethodInfo, (BeforeAttribute?, AfterAttribute?, BeforeEveryAttribute?, AfterEveryAttribute?)> _attributeCache = new();
@@ -499,12 +500,7 @@ internal sealed class ReflectionHookDiscoveryService
                 // Defence in depth: _registeredMethods.TryAdd above would normally short-circuit
                 // before we reach here, but this guard protects against future refactors that
                 // might bypass the upstream dedup (e.g. a separate registration path).
-                if (!Sources.AfterTestDiscoveryHooks.Any(h =>
-                    {
-                        var m = h.Materialize();
-                        return m.MethodInfo.Name == discoveryMetadata.Name &&
-                               m.MethodInfo.Type == discoveryMetadata.Type;
-                    }))
+                if (_registeredAfterTestDiscoveryHooks.TryAdd((discoveryMetadata.Name, discoveryMetadata.Type), true))
                 {
                     var discoveryHook = new AfterTestDiscoveryHookMethod
                     {
@@ -688,12 +684,7 @@ internal sealed class ReflectionHookDiscoveryService
                 // Defence in depth: _registeredMethods.TryAdd above would normally short-circuit
                 // before we reach here, but this guard protects against future refactors that
                 // might bypass the upstream dedup (e.g. a separate registration path).
-                if (!Sources.AfterTestDiscoveryHooks.Any(h =>
-                    {
-                        var m = h.Materialize();
-                        return m.MethodInfo.Name == discoveryEveryMetadata.Name &&
-                               m.MethodInfo.Type == discoveryEveryMetadata.Type;
-                    }))
+                if (_registeredAfterTestDiscoveryHooks.TryAdd((discoveryEveryMetadata.Name, discoveryEveryMetadata.Type), true))
                 {
                     var discoveryHook = new AfterTestDiscoveryHookMethod
                     {
@@ -890,9 +881,9 @@ internal sealed class ReflectionHookDiscoveryService
 
     private static Func<object, TestContext, CancellationToken, ValueTask> CreateInstanceHookDelegate(Type type, MethodInfo method)
     {
+        var parameters = method.GetParameters();
         return async (instance, context, cancellationToken) =>
         {
-            var parameters = method.GetParameters();
             object?[] args;
 
             if (parameters.Length == 0)
@@ -934,9 +925,9 @@ internal sealed class ReflectionHookDiscoveryService
 
     private static Func<T, CancellationToken, ValueTask> CreateHookDelegate<T>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type, MethodInfo method)
     {
+        var parameters = method.GetParameters();
         return async (context, cancellationToken) =>
         {
-            var parameters = method.GetParameters();
             object?[] args;
             object? instance = method.IsStatic ? null : Activator.CreateInstance(type);
 


### PR DESCRIPTION
## Summary

Two perf wins in `ReflectionHookDiscoveryService` (reflection-mode hook discovery, runs once per assembly + every hook invocation).

### 1. Hoist `method.GetParameters()` out of hot hook closures

`CreateInstanceHookDelegate` and `CreateHookDelegate<T>` previously called `method.GetParameters()` inside the returned async lambda, allocating a fresh `ParameterInfo[]` every Before/After hook invocation. The `ParameterInfo[]` for a given `MethodInfo` is immutable for the lifetime of the closure — moved the call outside the lambda so it runs once at delegate-factory time and is captured by closure thereafter.

Impact: in a 1000-test run with 2 before + 2 after hooks per test that drops 4000 `ParameterInfo[]` allocations from the hot path.

### 2. O(1) dedup for `AfterTestDiscovery` defense-in-depth guard

The two registration sites for `AfterTestDiscovery` hooks did a `Sources.AfterTestDiscoveryHooks.Any(h => h.Materialize() == ...)` scan as a defense-in-depth dedup behind the primary `_registeredMethods` guard. Each `.Materialize()` forced lazy hook materialization purely to compare its name/type.

Replaced with a `ConcurrentDictionary<(string Name, Type Type), bool>` TryAdd, mirroring the existing `_registeredMethods` pattern. Same semantics, O(1), no materialization side effects.

## Test plan

- [x] `dotnet build TUnit.Engine -c Release` clean across netstandard2.0, net8.0, net9.0, net10.0
- [ ] CI: full reflection-mode test pass on Linux/Windows
- [ ] No behavior change — only allocation/algorithm reductions