### PR TITLE
perf(engine): cache treenode filter path on TestMetadata

### DIFF
--- a/TUnit.Core/TestMetadata.cs
+++ b/TUnit.Core/TestMetadata.cs
@@ -133,6 +133,14 @@ public abstract class TestMetadata
     /// The delegates encapsulate all mode-specific behavior.
     /// </summary>
     public abstract Func<ExecutableTestCreationContext, TestMetadata, AbstractExecutableTest> CreateExecutableTestFactory { get; }
+
+    /// <summary>
+    /// Cached treenode filter path built from this metadata's assembly/namespace/class/method.
+    /// The path is metadata-scoped (independent of per-test data row), so populating once amortises
+    /// across every test instance derived from this metadata during filter pre-check. Benign race
+    /// on first write — string is deterministic so a torn winner is still correct.
+    /// </summary>
+    internal string? CachedFilterPath { get; set; }
 }
 
 public sealed class GenericTypeInfo

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -448,12 +448,19 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
 
     private static string BuildPathFromMetadata(TestMetadata metadata)
     {
+        if (metadata.CachedFilterPath is { } cached)
+        {
+            return cached;
+        }
+
         var classMetadata = metadata.MethodMetadata.Class;
         var assemblyName = classMetadata.Assembly.Name ?? metadata.TestClassType.Assembly.GetName().Name ?? "*";
         var namespaceName = classMetadata.Namespace ?? "*";
         var className = TestFilterService.GetNestedClassName(classMetadata);
         var methodName = metadata.TestMethodName;
 
-        return $"/{assemblyName}/{namespaceName}/{className}/{methodName}";
+        var path = $"/{assemblyName}/{namespaceName}/{className}/{methodName}";
+        metadata.CachedFilterPath = path;
+        return path;
     }
 }


### PR DESCRIPTION
## Summary

`MetadataFilterMatcher.BuildPathFromMetadata` constructed the `/{assembly}/{namespace}/{class}/{method}` filter path via string interpolation on every metadata-phase pre-filter check. On a 5000-test suite with a `--treenode-filter` active that's 5000 fresh string allocations per discovery pass — and the path is deterministic per metadata, so they're all redundant.

Add `internal string? CachedFilterPath { get; set; }` on `TestMetadata` (mirrors the existing `AbstractExecutableTest.CachedFilterPath` pattern from `TestFilterService.BuildPath`) and populate on first build. Because the path depends only on assembly/namespace/class/method (no per-test-row data), a single cache slot amortises across every test instance derived from this metadata.

Race-safety: benign — two threads racing first-write produce identical deterministic strings; last-writer wins, all readers see a valid value, no CAS needed.

## Test plan

- [x] `dotnet build TUnit.Engine -c Release` clean across netstandard2.0, net8.0, net9.0, net10.0
- [ ] CI: filtered discovery (`--treenode-filter`) still selects the same tests
- [ ] No public API change — field is `internal` (already covered by `[assembly: InternalsVisibleTo("TUnit.Engine")]`)