### PR TITLE
perf: use is T pattern in ReflectionExtensions.HasAttribute fallback (#6060)

### DIFF
--- a/TUnit.Core/Extensions/ReflectionExtensions.cs
+++ b/TUnit.Core/Extensions/ReflectionExtensions.cs
@@ -61,14 +61,26 @@ public static class ReflectionExtensions
                 return member.IsDefined(typeof(T), inherit);
             }
 
-            return provider.GetCustomAttributes(inherit)
-                .Any(x => x.GetType().IsAssignableTo(typeof(T)));
+            foreach (var x in provider.GetCustomAttributes(inherit))
+            {
+                if (x is T)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
         catch (NotSupportedException ex) when (ex.Message.Contains("Generic types are not valid"))
         {
             // Fall back to safe method for .NET Framework
-            return provider.GetCustomAttributesSafe(inherit)
-                .Any(x => x.GetType().IsAssignableTo(typeof(T)));
+            foreach (var x in provider.GetCustomAttributesSafe(inherit))
+            {
+                if (x is T)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -105,7 +117,12 @@ public static class ReflectionExtensions
                 .OfType<T>()
                 .ToArray();
 #else
-        return provider.GetCustomAttributes(typeof(T), inherit).Cast<T>().ToArray();
+        var attrs = provider.GetCustomAttributes(typeof(T), inherit);
+        if (attrs is T[] typed)
+        {
+            return typed;
+        }
+        return Array.ConvertAll(attrs, static a => (T)a);
 #endif
     }
 


### PR DESCRIPTION
## Summary
- `HasAttribute<T>` fallback path previously used `GetCustomAttributes(...).Any(x => x.GetType().IsAssignableTo(typeof(T)))`, allocating an enumerator + delegate and calling `GetType()` per item. Replaced with a `foreach` + `is T` pattern check.
- `GetCustomAttributesSafe<T>` previously used `.Cast<T>().ToArray()` on the result of `GetCustomAttributes(typeof(T), inherit)`. Since reflection already returns a `T[]` boxed as `object[]`, fast-path returns it directly; otherwise `Array.ConvertAll` avoids the iterator overhead.

Closes #6060

## Test plan
- [x] `dotnet build TUnit.Core/TUnit.Core.csproj -c Release` succeeds across netstandard2.0/net8.0/net9.0/net10.0
- [ ] CI green