### PR TITLE
perf: replace OrderBy().ToArray() with Array.Sort in ConstraintKeyScheduler

### DIFF
--- a/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
+++ b/TUnit.Engine/Scheduling/ConstraintKeyScheduler.cs
@@ -30,8 +30,18 @@ internal sealed class ConstraintKeyScheduler : IConstraintKeyScheduler
             return;
         }
 
-        // Sort tests by priority
-        var sortedTests = tests.OrderBy(static t => t.Priority).ToArray();
+        // Sort tests by priority. Defensive copy so we don't mutate the caller's array.
+        // Pack (Priority, OriginalIndex) into a long key to preserve OrderBy's stability
+        // (Array.Sort itself is not stable) while using the fast default Int64 comparer.
+        // Replaces `tests.OrderBy(...).ToArray()` which allocates iterator + buffer + array.
+        var sortedTests = new (AbstractExecutableTest Test, IReadOnlyList<string> ConstraintKeys, int Priority)[tests.Length];
+        var sortKeys = new long[tests.Length];
+        for (var i = 0; i < tests.Length; i++)
+        {
+            sortedTests[i] = tests[i];
+            sortKeys[i] = ((long)tests[i].Priority << 32) | (uint)i;
+        }
+        Array.Sort(sortKeys, sortedTests);
 
         // Track which constraint keys are currently in use
         var lockedKeys = new HashSet<string>();


### PR DESCRIPTION
## Summary
- Replaces `tests.OrderBy(static t => t.Priority).ToArray()` in `ConstraintKeyScheduler.ExecuteTestsWithConstraintsAsync` with a defensive-copy + `Array.Sort` over a packed `long` key, eliminating the LINQ iterator + internal buffer + array allocations.
- Preserves `OrderBy`'s stability by packing `(Priority << 32) | OriginalIndex` as the sort key, which keeps tests with identical priorities in their original order (matters because the upstream `List.Sort` in `TestGroupingService` already orders same-priority tests by class/Order).

Closes #6048

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` succeeds across all TFMs.
- [ ] CI green for existing scheduler tests (`KeyedNotInParallel*`, `ConstraintKey*`).