### PR TITLE
perf: use TryAdd in TestDependencyResolver dependency dedupe

### DIFF
--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -110,10 +110,7 @@ internal sealed class TestDependencyResolver
                         continue;
                     }
 
-                    if (!uniqueDependencies.ContainsKey(dep.Test))
-                    {
-                        uniqueDependencies[dep.Test] = dep;
-                    }
+                    uniqueDependencies.TryAdd(dep.Test, dep);
                 }
 
                 test.Dependencies = uniqueDependencies.Values.ToArray();

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -255,10 +255,7 @@ internal sealed class TestDependencyResolver
                     continue;
                 }
 
-                if (!uniqueDependencies.ContainsKey(dep.Test))
-                {
-                    uniqueDependencies[dep.Test] = dep;
-                }
+                uniqueDependencies.TryAdd(dep.Test, dep);
             }
 
             test.Dependencies = uniqueDependencies.Values.ToArray();


### PR DESCRIPTION
## Summary

- Replace `ContainsKey` + indexer with `Dictionary.TryAdd` in `TestDependencyResolver.ResolveDependenciesForTest` to drop the double hash lookup per dependency.
- Behavior is unchanged: both forms skip when the key already exists; `TryAdd` is available on all TFMs TUnit targets.

Closes #6042