### PR TITLE
perf(engine): avoid closure allocation in AfterHookPairTracker.GetOrCreateAfterAssemblyTask (#6041)

### DIFF
--- a/TUnit.Engine/Services/AfterHookPairTracker.cs
+++ b/TUnit.Engine/Services/AfterHookPairTracker.cs
@@ -155,6 +155,12 @@ internal sealed class AfterHookPairTracker
     /// </summary>
     public ValueTask<List<Exception>> GetOrCreateAfterAssemblyTask(Assembly assembly, Func<Assembly, ValueTask<List<Exception>>> taskFactory)
     {
+        // Lock-free fast path avoids allocating a closure on the common cache-hit case.
+        if (_afterAssemblyTasks.TryGetValue(assembly, out var existingTask))
+        {
+            return new ValueTask<List<Exception>>(existingTask);
+        }
+
         var task = _afterAssemblyTasks.GetOrAdd(assembly, a => taskFactory(a).AsTask());
         return new ValueTask<List<Exception>>(task);
     }


### PR DESCRIPTION
## Summary
- Add a lock-free `TryGetValue` fast path before `GetOrAdd` in `GetOrCreateAfterAssemblyTask` so cache hits no longer allocate a closure capturing `taskFactory`.
- Mirrors the existing pattern already used by `GetOrCreateAfterClassTask` in the same type.

Closes #6041

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` passes.
- [ ] Existing TUnit.Engine tests cover After hook caching behavior.