### PR TITLE
perf: replace LINQ Any with foreach in TestGenericTypeResolver (#6044)

### DIFF
--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -205,7 +205,20 @@ internal sealed class TestGenericTypeResolver
         
         // Handle the case where all parameter types are Object
         // This happens when data sources provide untyped data
-        if (parameterTypes.All(t => t == typeof(object)) && methodArguments.Length > 0)
+        var allParametersAreObject = methodArguments.Length > 0;
+        if (allParametersAreObject)
+        {
+            foreach (var t in parameterTypes)
+            {
+                if (t != typeof(object))
+                {
+                    allParametersAreObject = false;
+                    break;
+                }
+            }
+        }
+
+        if (allParametersAreObject)
         {
             // For the AggregateBy test case with 3 generic parameters
             if (genericMethodInfo.ParameterNames.Length == 3 &&

--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -133,7 +133,19 @@ internal sealed class TestGenericTypeResolver
     {
         // Handle the case where some parameter types are Object (placeholders for generic parameters)
         // This happens when data sources provide untyped data or when we have mixed generic/non-generic parameters
-        if (parameterTypes.Any(t => t == typeof(object)) && methodArguments.Length > 0)
+        var hasObjectParameter = false;
+        if (methodArguments.Length > 0)
+        {
+            foreach (var parameterType in parameterTypes)
+            {
+                if (parameterType == typeof(object))
+                {
+                    hasObjectParameter = true;
+                    break;
+                }
+            }
+        }
+        if (hasObjectParameter)
         {
             // Check if this is a simple generic method with one type parameter and mixed parameters
             if (genericMethodInfo.ParameterNames.Length == 1 && parameterTypes.Length >= 1)


### PR DESCRIPTION
## Summary
- Replaces `parameterTypes.Any(t => t == typeof(object))` in `TestGenericTypeResolver.ResolveMethodGenericArguments` with an inline `foreach` scan, removing the per-call delegate and `IEnumerator` allocations on the generic test resolution hot path during discovery.
- Hoists the existing `methodArguments.Length > 0` short-circuit above the scan so the loop is skipped entirely when there are no arguments.

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release`
- [ ] CI green

Closes #6044