### PR TITLE
perf: avoid closure allocation in BeforeHookTaskCache.GetOrCreateBeforeAssemblyTask (#6040)

### DIFF
--- a/TUnit.Engine/Services/BeforeHookTaskCache.cs
+++ b/TUnit.Engine/Services/BeforeHookTaskCache.cs
@@ -35,6 +35,12 @@ internal sealed class BeforeHookTaskCache
 
     public ValueTask GetOrCreateBeforeAssemblyTask(Assembly assembly, Func<Assembly, CancellationToken, ValueTask> taskFactory, CancellationToken cancellationToken)
     {
+        // Lock-free fast path avoids allocating a closure on the common cache-hit case.
+        if (_beforeAssemblyTasks.TryGetValue(assembly, out var existingTask))
+        {
+            return new ValueTask(existingTask);
+        }
+
         var task = _beforeAssemblyTasks.GetOrAdd(assembly, a => taskFactory(a, cancellationToken).AsTask());
         return new ValueTask(task);
     }


### PR DESCRIPTION
## Summary
- Mirror the lock-free `TryGetValue` fast path that `GetOrCreateBeforeClassTask` already uses in `GetOrCreateBeforeAssemblyTask`, so the common cache-hit case no longer allocates the `a => taskFactory(a, cancellationToken).AsTask()` closure that captures `taskFactory` + `cancellationToken`.

Closes #6040

## Test plan
- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` succeeds.
- [ ] CI green.