### PR TITLE
perf: avoid Cast<object>().FirstOrDefault() iterator alloc in CastHelper (#6029)

### DIFF
--- a/TUnit.Core/Helpers/CastHelper.cs
+++ b/TUnit.Core/Helpers/CastHelper.cs
@@ -160,7 +160,12 @@ public static class CastHelper
         // Unwrap single-element enumerables (but not strings or arrays)
         if (value is not string && !sourceType.IsArray && value is IEnumerable enumerable && !typeof(IEnumerable).IsAssignableFrom(targetType))
         {
-            var firstElement = enumerable.Cast<object>().FirstOrDefault();
+            object? firstElement = null;
+            foreach (var e in enumerable)
+            {
+                firstElement = e;
+                break;
+            }
             if (firstElement != null)
             {
                 // Recursively try to cast the first element

--- a/TUnit.Core/Helpers/CastHelper.cs
+++ b/TUnit.Core/Helpers/CastHelper.cs
@@ -161,9 +161,9 @@ public static class CastHelper
         if (value is not string && !sourceType.IsArray && value is IEnumerable enumerable && !typeof(IEnumerable).IsAssignableFrom(targetType))
         {
             object? firstElement = null;
-            foreach (var e in enumerable)
+            foreach (var item in enumerable)
             {
-                firstElement = e;
+                firstElement = item;
                 break;
             }
             if (firstElement != null)


### PR DESCRIPTION
## Summary
- Replace `enumerable.Cast<object>().FirstOrDefault()` in `CastHelper.TryAotSafeConversion` with a manual `foreach` that breaks after the first element, eliminating the `OfTypeIterator` + closure allocations per argument conversion.
- Hot path: runs on every `[Arguments]` value flowing through the AOT-safe conversion when the source is `IEnumerable` and the target isn't.

Closes #6029

## Test plan
- [x] `dotnet build TUnit.Core/TUnit.Core.csproj -c Release` succeeds across all TFMs.
- [ ] CI green.