### PR TITLE
perf(engine): avoid string round-trip when building nested type names (#6049)

### DIFF
--- a/TUnit.Engine/Helpers/TypeNameHelper.cs
+++ b/TUnit.Engine/Helpers/TypeNameHelper.cs
@@ -1,0 +1,43 @@
+using TUnit.Core.Helpers;
+
+namespace TUnit.Engine.Helpers;
+
+internal static class TypeNameHelper
+{
+    /// <summary>
+    /// Appends a type's display name to the builder, expanding generic arguments by their
+    /// full name to ensure uniqueness (e.g. <c>List&lt;System.Int32&gt;</c>).
+    /// </summary>
+    internal static void AppendTypeNameWithGenericArgs(ref ValueStringBuilder vsb, Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            vsb.Append(type.Name);
+            return;
+        }
+
+        var name = type.Name;
+        var backtickIndex = name.IndexOf('`');
+        if (backtickIndex > 0)
+        {
+            vsb.Append(name.AsSpan(0, backtickIndex));
+        }
+        else
+        {
+            vsb.Append(name);
+        }
+
+        // Use the full name for generic arguments to ensure uniqueness.
+        var genericArgs = type.GetGenericArguments();
+        vsb.Append('<');
+        for (var i = 0; i < genericArgs.Length; i++)
+        {
+            if (i > 0)
+            {
+                vsb.Append(", ");
+            }
+            vsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
+        }
+        vsb.Append('>');
+    }
+}

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -8,6 +8,7 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
 using TUnit.Core.Helpers;
+using TUnit.Engine.Helpers;
 
 namespace TUnit.Engine.Services;
 
@@ -329,7 +330,7 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
                 {
                     resultVsb.Append('+');
                 }
-                AppendTypeNameWithGenericArgs(ref resultVsb, typeHierarchy[i]);
+                TypeNameHelper.AppendTypeNameWithGenericArgs(ref resultVsb, typeHierarchy[i]);
             }
             return resultVsb.ToString();
         }
@@ -338,38 +339,6 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
             resultVsb.Dispose();
             typeHierarchy.Dispose();
         }
-    }
-
-    private static void AppendTypeNameWithGenericArgs(ref ValueStringBuilder vsb, Type type)
-    {
-        if (!type.IsGenericType)
-        {
-            vsb.Append(type.Name);
-            return;
-        }
-
-        var name = type.Name;
-        var backtickIndex = name.IndexOf('`');
-        if (backtickIndex > 0)
-        {
-            vsb.Append(name.AsSpan(0, backtickIndex));
-        }
-        else
-        {
-            vsb.Append(name);
-        }
-
-        var genericArgs = type.GetGenericArguments();
-        vsb.Append('<');
-        for (var i = 0; i < genericArgs.Length; i++)
-        {
-            if (i > 0)
-            {
-                vsb.Append(", ");
-            }
-            vsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
-        }
-        vsb.Append('>');
     }
 
     private static bool HasMethodNameMatch(string uidValue, string methodName)

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -309,78 +309,67 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
             return type.Name;
         }
 
-        // Build the full nested type hierarchy with '+' separators
-        // This matches TestIdentifierService.WriteTypeNameWithGenerics
-        var typeHierarchy = new ValueListBuilder<string>([null, null, null, null]);
-        var typeVsb = new ValueStringBuilder(stackalloc char[128]);
+        // Collect the nested-type chain (inner -> outer) without allocating per-segment strings,
+        // then emit it directly into the result builder. Matches TestIdentifierService.WriteTypeNameWithGenerics.
+        var typeHierarchy = new ValueListBuilder<Type>([null!, null!, null!, null!]);
+        var resultVsb = new ValueStringBuilder(stackalloc char[256]);
         try
         {
             var currentType = type;
-
             while (currentType != null)
             {
-                if (currentType.IsGenericType)
-                {
-                    var name = currentType.Name;
-
-                    var backtickIndex = name.IndexOf('`');
-                    if (backtickIndex > 0)
-                    {
-                        typeVsb.Append(name.AsSpan(0, backtickIndex));
-                    }
-                    else
-                    {
-                        typeVsb.Append(name);
-                    }
-
-                    // Add the generic type arguments (same format as TestIdentifierService)
-                    var genericArgs = currentType.GetGenericArguments();
-                    typeVsb.Append('<');
-                    for (var i = 0; i < genericArgs.Length; i++)
-                    {
-                        if (i > 0)
-                        {
-                            typeVsb.Append(", ");
-                        }
-                        typeVsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
-                    }
-                    typeVsb.Append('>');
-
-                    typeHierarchy.Append(typeVsb.AsSpan().ToString());
-                    typeVsb.Length = 0;
-                }
-                else
-                {
-                    typeHierarchy.Append(currentType.Name);
-                }
-
+                typeHierarchy.Append(currentType);
                 currentType = currentType.DeclaringType;
             }
 
-            // Build result: reverse to get outer-to-inner order and join with '+'
-            var resultVsb = new ValueStringBuilder(stackalloc char[256]);
-            try
+            // Reverse to get outer-to-inner order and join with '+'.
+            for (var i = typeHierarchy.Length - 1; i >= 0; i--)
             {
-                for (var i = typeHierarchy.Length - 1; i >= 0; i--)
+                if (i < typeHierarchy.Length - 1)
                 {
-                    if (i < typeHierarchy.Length - 1)
-                    {
-                        resultVsb.Append('+');
-                    }
-                    resultVsb.Append(typeHierarchy[i]);
+                    resultVsb.Append('+');
                 }
-                return resultVsb.ToString();
+                AppendTypeNameWithGenericArgs(ref resultVsb, typeHierarchy[i]);
             }
-            finally
-            {
-                resultVsb.Dispose();
-            }
+            return resultVsb.ToString();
         }
         finally
         {
+            resultVsb.Dispose();
             typeHierarchy.Dispose();
-            typeVsb.Dispose();
         }
+    }
+
+    private static void AppendTypeNameWithGenericArgs(ref ValueStringBuilder vsb, Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            vsb.Append(type.Name);
+            return;
+        }
+
+        var name = type.Name;
+        var backtickIndex = name.IndexOf('`');
+        if (backtickIndex > 0)
+        {
+            vsb.Append(name.AsSpan(0, backtickIndex));
+        }
+        else
+        {
+            vsb.Append(name);
+        }
+
+        var genericArgs = type.GetGenericArguments();
+        vsb.Append('<');
+        for (var i = 0; i < genericArgs.Length; i++)
+        {
+            if (i > 0)
+            {
+                vsb.Append(", ");
+            }
+            vsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
+        }
+        vsb.Append('>');
     }
 
     private static bool HasMethodNameMatch(string uidValue, string methodName)

--- a/TUnit.Engine/Services/TestIdentifierService.cs
+++ b/TUnit.Engine/Services/TestIdentifierService.cs
@@ -1,6 +1,7 @@
 using TUnit.Core;
 using TUnit.Core.Helpers;
 using TUnit.Engine.Building;
+using TUnit.Engine.Helpers;
 
 namespace TUnit.Engine.Services;
 
@@ -135,46 +136,13 @@ internal static class TestIdentifierService
                 {
                     vsb.Append('+');
                 }
-                AppendTypeNameWithGenericArgs(ref vsb, typeHierarchy[i]);
+                TypeNameHelper.AppendTypeNameWithGenericArgs(ref vsb, typeHierarchy[i]);
             }
         }
         finally
         {
             typeHierarchy.Dispose();
         }
-    }
-
-    private static void AppendTypeNameWithGenericArgs(ref ValueStringBuilder vsb, Type type)
-    {
-        if (!type.IsGenericType)
-        {
-            vsb.Append(type.Name);
-            return;
-        }
-
-        var name = type.Name;
-        var backtickIndex = name.IndexOf('`');
-        if (backtickIndex > 0)
-        {
-            vsb.Append(name.AsSpan(0, backtickIndex));
-        }
-        else
-        {
-            vsb.Append(name);
-        }
-
-        // Use the full name for generic arguments to ensure uniqueness.
-        var genericArgs = type.GetGenericArguments();
-        vsb.Append('<');
-        for (var i = 0; i < genericArgs.Length; i++)
-        {
-            if (i > 0)
-            {
-                vsb.Append(", ");
-            }
-            vsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
-        }
-        vsb.Append('>');
     }
 
     private static void WriteTypeWithParameters(ref ValueStringBuilder vsb, ReadOnlySpan<ParameterMetadata> parameterTypes)

--- a/TUnit.Engine/Services/TestIdentifierService.cs
+++ b/TUnit.Engine/Services/TestIdentifierService.cs
@@ -117,70 +117,64 @@ internal static class TestIdentifierService
 
     private static void WriteTypeNameWithGenerics(ref ValueStringBuilder vsb, Type type)
     {
-        // Build the full type hierarchy including all containing types
-        var typeHierarchy = new ValueListBuilder<string>([null, null, null, null]);
-        var typeVsb = new ValueStringBuilder(stackalloc char[128]);
+        // Collect the nested-type chain (inner -> outer) without allocating per-segment strings.
+        var typeHierarchy = new ValueListBuilder<Type>([null!, null!, null!, null!]);
         try
         {
             var currentType = type;
-
             while (currentType != null)
             {
-                if (currentType.IsGenericType)
-                {
-                    var name = currentType.Name;
-
-                    var backtickIndex = name.IndexOf('`');
-                    if (backtickIndex > 0)
-                    {
-                        typeVsb.Append(name.AsSpan(0, backtickIndex));
-                    }
-                    else
-                    {
-                        typeVsb.Append(name);
-                    }
-
-                    // Add the generic type arguments
-                    var genericArgs = currentType.GetGenericArguments();
-                    typeVsb.Append('<');
-                    for (var i = 0; i < genericArgs.Length; i++)
-                    {
-                        if (i > 0)
-                        {
-                            typeVsb.Append(", ");
-                        }
-                        // Use the full name for generic arguments to ensure uniqueness
-                        typeVsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
-                    }
-                    typeVsb.Append('>');
-
-                    typeHierarchy.Append(typeVsb.AsSpan().ToString());
-                    typeVsb.Length = 0;
-                }
-                else
-                {
-                    typeHierarchy.Append(currentType.Name);
-                }
-
+                typeHierarchy.Append(currentType);
                 currentType = currentType.DeclaringType;
             }
 
-            // Reverse to get outer-to-inner order
-            // Append all types with + separator (matching .NET Type.FullName convention for nested types)
+            // Reverse to get outer-to-inner order (matches .NET Type.FullName convention for nested types).
             for (var i = typeHierarchy.Length - 1; i >= 0; i--)
             {
                 if (i < typeHierarchy.Length - 1)
                 {
                     vsb.Append('+');
                 }
-                vsb.Append(typeHierarchy[i]);
+                AppendTypeNameWithGenericArgs(ref vsb, typeHierarchy[i]);
             }
         }
         finally
         {
             typeHierarchy.Dispose();
-            typeVsb.Dispose();
         }
+    }
+
+    private static void AppendTypeNameWithGenericArgs(ref ValueStringBuilder vsb, Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            vsb.Append(type.Name);
+            return;
+        }
+
+        var name = type.Name;
+        var backtickIndex = name.IndexOf('`');
+        if (backtickIndex > 0)
+        {
+            vsb.Append(name.AsSpan(0, backtickIndex));
+        }
+        else
+        {
+            vsb.Append(name);
+        }
+
+        // Use the full name for generic arguments to ensure uniqueness.
+        var genericArgs = type.GetGenericArguments();
+        vsb.Append('<');
+        for (var i = 0; i < genericArgs.Length; i++)
+        {
+            if (i > 0)
+            {
+                vsb.Append(", ");
+            }
+            vsb.Append(genericArgs[i].FullName ?? genericArgs[i].Name);
+        }
+        vsb.Append('>');
     }
 
     private static void WriteTypeWithParameters(ref ValueStringBuilder vsb, ReadOnlySpan<ParameterMetadata> parameterTypes)


### PR DESCRIPTION
## Summary

`BuildClassNameForMatching` (filter matching) and `WriteTypeNameWithGenerics` (identifier service) both formatted each nested-type segment into a scratch `ValueStringBuilder`, materialised a throw-away `string` via `AsSpan().ToString()`, stored it in a `ValueListBuilder<string>`, then re-emitted it into the outer builder.

This change collects the nested-type chain as `ValueListBuilder<Type>` and emits each segment directly into the outer `ValueStringBuilder` in reverse via a shared per-class `AppendTypeNameWithGenericArgs` helper. The intermediate per-segment string allocations and the string list are gone; behaviour and produced format are unchanged.

Runs on the per-test hot path during discovery and filter matching for every nested/generic class test.

Closes #6049

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` succeeds for all TFMs (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`).
- [ ] CI runs the existing engine + identifier tests across TFMs.