### PR TITLE
perf(engine): replace Select+ToArray with manual Type[] build (#6043)

### DIFF
--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -44,12 +44,7 @@ internal sealed class TestGenericTypeResolver
         // Otherwise resolve from GenericMethodInfo if the test method is a generic definition
         else if (metadata.GenericMethodInfo != null)
         {
-            var parameters = metadata.MethodMetadata.Parameters;
-            var parameterTypes = new Type[parameters.Length];
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                parameterTypes[i] = parameters[i].Type;
-            }
+            var parameterTypes = Array.ConvertAll(metadata.MethodMetadata.Parameters, p => p.Type);
 
             result.ResolvedMethodGenericArguments = ResolveMethodGenericArguments(
                 metadata.MethodMetadata,

--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -44,11 +44,18 @@ internal sealed class TestGenericTypeResolver
         // Otherwise resolve from GenericMethodInfo if the test method is a generic definition
         else if (metadata.GenericMethodInfo != null)
         {
+            var parameters = metadata.MethodMetadata.Parameters;
+            var parameterTypes = new Type[parameters.Length];
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parameterTypes[i] = parameters[i].Type;
+            }
+
             result.ResolvedMethodGenericArguments = ResolveMethodGenericArguments(
                 metadata.MethodMetadata,
                 metadata.GenericMethodInfo,
                 testData.MethodData,
-                metadata.MethodMetadata.Parameters.Select(p => p.Type).ToArray());
+                parameterTypes);
         }
 
         return result;

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -138,7 +138,13 @@ internal sealed class TestRegistry : ITestRegistry
                 nameof(methodArguments));
         }
 
-        var parameterTypes = methodMetadata.Parameters.Select(p => p.Type).ToArray();
+        var parameters = methodMetadata.Parameters;
+        var parameterTypes = new Type[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameterTypes[i] = parameters[i].Type;
+        }
+
         var methodInfo = methodMetadata.Type.GetMethod(
             methodMetadata.Name,
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -138,12 +138,7 @@ internal sealed class TestRegistry : ITestRegistry
                 nameof(methodArguments));
         }
 
-        var parameters = methodMetadata.Parameters;
-        var parameterTypes = new Type[parameters.Length];
-        for (var i = 0; i < parameters.Length; i++)
-        {
-            parameterTypes[i] = parameters[i].Type;
-        }
+        var parameterTypes = Array.ConvertAll(methodMetadata.Parameters, p => p.Type);
 
         var methodInfo = methodMetadata.Type.GetMethod(
             methodMetadata.Name,


### PR DESCRIPTION
## Summary

- Replaces `methodMetadata.Parameters.Select(p => p.Type).ToArray()` in `TestRegistry.cs` and `TestGenericTypeResolver.cs` with a manual `Type[]` build loop.
- Removes the iterator state machine + delegate allocations on the per-test-registration parameter-type extraction path.

Closes #6043

## Test plan

- [x] `dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` (clean)
- [ ] CI green