### PR TITLE
perf(core): replace OfType().FirstOrDefault()/.Any() with foreach in ClassConstructorHelper

### DIFF
--- a/TUnit.Core/Helpers/ClassConstructorHelper.cs
+++ b/TUnit.Core/Helpers/ClassConstructorHelper.cs
@@ -25,7 +25,7 @@ public static class ClassConstructorHelper
         return await TryCreateInstanceWithClassConstructor(
             attributes,
             testClassType,
-            TestBuilderContext.FromTestContext(testContext, attributes.OfType<IDataSourceAttribute>().FirstOrDefault()),
+            TestBuilderContext.FromTestContext(testContext, GetDataSourceAttribute(attributes)),
             testSessionId);
     }
 
@@ -70,7 +70,28 @@ public static class ClassConstructorHelper
     /// </summary>
     public static bool HasClassConstructorAttribute(Attribute[] attributes)
     {
-        return attributes.OfType<ClassConstructorAttribute>().Any();
+        foreach (Attribute attribute in attributes)
+        {
+            if (attribute is ClassConstructorAttribute)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IDataSourceAttribute? GetDataSourceAttribute(IReadOnlyList<Attribute> attributes)
+    {
+        foreach (Attribute attribute in attributes)
+        {
+            if (attribute is IDataSourceAttribute dataSourceAttribute)
+            {
+                return dataSourceAttribute;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Removes `OfTypeIterator<T>` allocations on the per-test-instance construction hot path in `ClassConstructorHelper`.

- `HasClassConstructorAttribute(Attribute[])` now uses `foreach` + `is ClassConstructorAttribute` with early return instead of `OfType<ClassConstructorAttribute>().Any()`.
- The `IDataSourceAttribute` lookup at the start of `TryCreateInstanceWithClassConstructor` now goes through a new private `GetDataSourceAttribute` helper (foreach + pattern match) instead of `OfType<IDataSourceAttribute>().FirstOrDefault()`.

Both mirror the existing private `GetClassConstructorAttribute` helper already in the same file. Behavior is identical (first match / presence check), but each call avoids an iterator allocation and short-circuits on first match.

## Notes
- No TFM gating; applies to all targets (netstandard2.0, net8.0, net9.0, net10.0).
- AOT-safe and dual-mode compatible — no reflection or codegen surface changed.
- Built `TUnit.Core` across all four TFMs: 0 warnings, 0 errors.

Closes #6059