### PR TITLE
perf(engine): avoid FirstOrDefault iterator alloc in TestGenericTypeResolver

### DIFF
--- a/TUnit.Engine/Services/TestGenericTypeResolver.cs
+++ b/TUnit.Engine/Services/TestGenericTypeResolver.cs
@@ -288,11 +288,17 @@ internal sealed class TestGenericTypeResolver
                         }
                         else if (arg0 is IEnumerable<object> objEnum)
                         {
-                            // Last resort - try to infer from first element
-                            var first = objEnum.FirstOrDefault();
-                            if (first != null)
+                            // Last resort - try to infer from first element.
+                            // foreach avoids the iterator allocation that FirstOrDefault
+                            // incurs on non-list IEnumerable<object> sources.
+                            foreach (var first in objEnum)
                             {
-                                sourceType = first.GetType();
+                                if (first != null)
+                                {
+                                    sourceType = first.GetType();
+                                }
+
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
Replaces `IEnumerable<object>.FirstOrDefault()` with a `foreach`/`break` in the generic-type inference fallback of `TestGenericTypeResolver`.

`FirstOrDefault()` on a non-list `IEnumerable<object>` allocates an enumerator. The `foreach` form takes the first element without that allocation, and behavior is identical (sets `sourceType` from the first non-null element's runtime type).

Same pattern as #6029 (`CastHelper`). No TFM gating; this path runs per generic-type inference during discovery when args are untyped enumerables.

Closes #6045