### PR TITLE
perf(core): avoid string[] alloc in ArgumentFormatter.FormatArguments

### DIFF
--- a/TUnit.Core/Helpers/ArgumentFormatter.cs
+++ b/TUnit.Core/Helpers/ArgumentFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Text;
 
 namespace TUnit.Core.Helpers;
 
@@ -44,12 +45,19 @@ public static class ArgumentFormatter
             if (list.Count == 0)
                 return string.Empty;
 
-            var formatted = new string[list.Count];
+            if (list.Count == 1)
+                return FormatDefault(list[0]);
+
+            var builder = new StringBuilder();
             for (int i = 0; i < list.Count; i++)
             {
-                formatted[i] = FormatDefault(list[i]);
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+                builder.Append(FormatDefault(list[i]));
             }
-            return string.Join(", ", formatted);
+            return builder.ToString();
         }
 
         var elements = new List<string>();

--- a/TUnit.Core/Helpers/ArgumentFormatter.cs
+++ b/TUnit.Core/Helpers/ArgumentFormatter.cs
@@ -60,13 +60,18 @@ public static class ArgumentFormatter
             return builder.ToString();
         }
 
-        var elements = new List<string>();
+        // Non-IList fallback (rare: callers normally pass object?[]). Build directly into a
+        // StringBuilder rather than allocating an intermediate List<string> + string.Join.
+        var fallbackBuilder = new StringBuilder();
         foreach (var arg in arguments)
         {
-            elements.Add(FormatDefault(arg));
+            if (fallbackBuilder.Length > 0)
+            {
+                fallbackBuilder.Append(", ");
+            }
+            fallbackBuilder.Append(FormatDefault(arg));
         }
-
-        return elements.Count == 0 ? string.Empty : string.Join(", ", elements);
+        return fallbackBuilder.ToString();
     }
 
     private static string FormatDefault(object? o)
@@ -148,12 +153,24 @@ public static class ArgumentFormatter
     private static string FormatTuple(object tuple)
     {
         var elements = TupleHelper.UnwrapTuple(tuple);
-        var formatted = new string[elements.Length];
+
+        if (elements.Length == 0)
+            return "()";
+
+        if (elements.Length == 1)
+            return $"({FormatDefault(elements[0])})";
+
+        var builder = new StringBuilder("(");
         for (int i = 0; i < elements.Length; i++)
         {
-            formatted[i] = FormatDefault(elements[i]);
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+            builder.Append(FormatDefault(elements[i]));
         }
-        return $"({string.Join(", ", formatted)})";
+        builder.Append(')');
+        return builder.ToString();
     }
 
     private static string FormatEnumerable(IEnumerable enumerable)

--- a/TUnit.Core/Helpers/ArgumentFormatter.cs
+++ b/TUnit.Core/Helpers/ArgumentFormatter.cs
@@ -61,8 +61,7 @@ public static class ArgumentFormatter
             return builder.ToString();
         }
 
-        // Non-IList fallback (rare: callers normally pass object?[]). Build directly into a
-        // StringBuilder rather than allocating an intermediate List<string> + string.Join.
+        // Non-IList fallback — rare in practice; callers normally pass object?[].
         var fallbackBuilder = new StringBuilder();
         foreach (var arg in arguments)
         {
@@ -161,7 +160,9 @@ public static class ArgumentFormatter
         if (elements.Length == 1)
             return $"({FormatDefault(elements[0])})";
 
-        var builder = new StringBuilder("(");
+        // ~16 chars per element + parentheses avoids resizing for typical tuple sizes.
+        var builder = new StringBuilder(elements.Length * 16 + 2);
+        builder.Append('(');
         for (int i = 0; i < elements.Length; i++)
         {
             if (i > 0)

--- a/TUnit.Core/Helpers/ArgumentFormatter.cs
+++ b/TUnit.Core/Helpers/ArgumentFormatter.cs
@@ -48,7 +48,8 @@ public static class ArgumentFormatter
             if (list.Count == 1)
                 return FormatDefault(list[0]);
 
-            var builder = new StringBuilder();
+            // ~16 chars per formatted arg avoids the internal buffer resizing for typical counts.
+            var builder = new StringBuilder(list.Count * 16);
             for (int i = 0; i < list.Count; i++)
             {
                 if (i > 0)


### PR DESCRIPTION
Avoids the intermediate `string[]` allocation in `ArgumentFormatter.FormatArguments` (TUnit.Core/Helpers/ArgumentFormatter.cs).

## Change
- Build the comma-joined argument display directly into a `StringBuilder` instead of allocating a temporary `string[]` and calling `string.Join`.
- Short-circuit the single-argument case to return `FormatDefault` directly, skipping both the array and the builder (the common case for a single parameterized test argument).

## Why
This is a hot path: it runs per parameterized test argument display. The previous code allocated an N-length `string[]` plus the join's internal buffer; the new code allocates just the builder and final string, and nothing extra for the single-arg case.

## Compatibility
- Works on all TFMs (netstandard2.0;net8.0;net9.0;net10.0) — `StringBuilder` requires no API gating.
- AOT-safe; no reflection added.
- Behavior identical: same `", "` separator and same `FormatDefault` output ordering.

Build: `TUnit.Core` compiles clean across all four TFMs (0 warnings, 0 errors).

Closes #6033