### PR TITLE
perf(core): replace Select+Func factory chain in DataSourceHelpers

### DIFF
--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -59,11 +59,17 @@ public static class DataSourceHelpers
         if (unwrapped.Length > 1)
         {
             // Multiple values from tuple - create a factory for each that returns the specific element
-            return unwrapped.Select((_, index) => new Func<Task<object?>>(() =>
+            var factories = new Func<Task<object?>>[unwrapped.Length];
+            for (var i = 0; i < factories.Length; i++)
             {
-                var freshUnwrapped = UnwrapTupleAot(value);
-                return Task.FromResult<object?>(index < freshUnwrapped.Length ? freshUnwrapped[index] : null);
-            })).ToArray();
+                var index = i;
+                factories[i] = () =>
+                {
+                    var freshUnwrapped = UnwrapTupleAot(value);
+                    return Task.FromResult<object?>(index < freshUnwrapped.Length ? freshUnwrapped[index] : null);
+                };
+            }
+            return factories;
         }
 
         // Single value or not a tuple
@@ -265,12 +271,18 @@ public static class DataSourceHelpers
             // For tuples, return individual factories for each parameter
             if (expectedParameterCount > 0 && unwrapped.Length == expectedParameterCount)
             {
-                return unwrapped.Select((_, index) => new Func<Task<object?>>(() =>
+                var factories = new Func<Task<object?>>[unwrapped.Length];
+                for (var i = 0; i < factories.Length; i++)
                 {
-                    var freshData = InvokeIfFunc(data);
-                    var freshUnwrapped = UnwrapTupleAot(freshData);
-                    return Task.FromResult<object?>(index < freshUnwrapped.Length ? freshUnwrapped[index] : null);
-                })).ToArray();
+                    var index = i;
+                    factories[i] = () =>
+                    {
+                        var freshData = InvokeIfFunc(data);
+                        var freshUnwrapped = UnwrapTupleAot(freshData);
+                        return Task.FromResult<object?>(index < freshUnwrapped.Length ? freshUnwrapped[index] : null);
+                    };
+                }
+                return factories;
             }
             // If parameter count doesn't match, return as single tuple value
             return [() => Task.FromResult<object?>(InvokeIfFunc(data))];
@@ -282,15 +294,21 @@ public static class DataSourceHelpers
             // If expecting multiple parameters and array length matches, unwrap it
             if (expectedParameterCount > 1 && array.Length == expectedParameterCount)
             {
-                return array.Select((_, index) => new Func<Task<object?>>(() =>
+                var factories = new Func<Task<object?>>[array.Length];
+                for (var i = 0; i < factories.Length; i++)
                 {
-                    var freshData = InvokeIfFunc(data);
-                    if (freshData is object?[] freshArray && index < freshArray.Length)
+                    var index = i;
+                    factories[i] = () =>
                     {
-                        return Task.FromResult<object?>(freshArray[index]);
-                    }
-                    return Task.FromResult<object?>(null);
-                })).ToArray();
+                        var freshData = InvokeIfFunc(data);
+                        if (freshData is object?[] freshArray && index < freshArray.Length)
+                        {
+                            return Task.FromResult<object?>(freshArray[index]);
+                        }
+                        return Task.FromResult<object?>(null);
+                    };
+                }
+                return factories;
             }
             // If expecting 1 parameter, keep array as single value
             // Or if array length doesn't match expected count, treat as single value

--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -63,11 +63,9 @@ public static class DataSourceHelpers
             for (var i = 0; i < factories.Length; i++)
             {
                 var index = i;
-                factories[i] = () =>
-                {
-                    var freshUnwrapped = UnwrapTupleAot(value);
-                    return Task.FromResult<object?>(index < freshUnwrapped.Length ? freshUnwrapped[index] : null);
-                };
+                // Capture the already-unwrapped array directly: no Func is involved on this path,
+                // so the elements are stable and there is no need to re-unwrap `value` per invocation.
+                factories[i] = () => Task.FromResult<object?>(index < unwrapped.Length ? unwrapped[index] : null);
             }
             return factories;
         }

--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -63,9 +63,9 @@ public static class DataSourceHelpers
             for (var i = 0; i < factories.Length; i++)
             {
                 var index = i;
-                // Capture the already-unwrapped array directly: no Func is involved on this path,
-                // so the elements are stable and there is no need to re-unwrap `value` per invocation.
-                factories[i] = () => Task.FromResult<object?>(index < unwrapped.Length ? unwrapped[index] : null);
+                // Elements are stable: ValueTuple fields are value-copied at extraction time and
+                // Tuple<T> items are readonly, so re-unwrapping `value` would yield the same references.
+                factories[i] = () => Task.FromResult<object?>(unwrapped[index]);
             }
             return factories;
         }

--- a/TUnit.UnitTests/DataSourceHelpersTests.cs
+++ b/TUnit.UnitTests/DataSourceHelpersTests.cs
@@ -1,0 +1,59 @@
+using TUnit.Core.Helpers;
+
+namespace TUnit.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="DataSourceHelpers.HandleTupleValue"/>, which unwraps a tuple value into
+/// one factory per element. Each factory shares a single pre-unwrapped snapshot of the tuple.
+/// </summary>
+public class DataSourceHelpersTests
+{
+    [Test]
+    public async Task HandleTupleValue_Tuple_ReturnsFactoryPerElement()
+    {
+        var factories = DataSourceHelpers.HandleTupleValue((1, "two", 3.0), shouldUnwrap: true);
+
+        await Assert.That(factories.Length).IsEqualTo(3);
+        await Assert.That(await factories[0]()).IsEqualTo((object?)1);
+        await Assert.That(await factories[1]()).IsEqualTo((object?)"two");
+        await Assert.That(await factories[2]()).IsEqualTo((object?)3.0);
+    }
+
+    [Test]
+    public async Task HandleTupleValue_FactoriesReturnSameSnapshotOnRepeatedInvocation()
+    {
+        var factories = DataSourceHelpers.HandleTupleValue((1, 2), shouldUnwrap: true);
+
+        // Each factory shares the pre-unwrapped snapshot, so repeated invocations are stable.
+        await Assert.That(await factories[0]()).IsEqualTo(await factories[0]());
+        await Assert.That(await factories[1]()).IsEqualTo((object?)2);
+    }
+
+    [Test]
+    public async Task HandleTupleValue_NotUnwrapping_ReturnsSingleFactoryWithOriginalValue()
+    {
+        var value = (1, 2);
+        var factories = DataSourceHelpers.HandleTupleValue(value, shouldUnwrap: false);
+
+        await Assert.That(factories.Length).IsEqualTo(1);
+        await Assert.That(await factories[0]()).IsEqualTo((object?)value);
+    }
+
+    [Test]
+    public async Task HandleTupleValue_Null_ReturnsSingleNullFactory()
+    {
+        var factories = DataSourceHelpers.HandleTupleValue(null, shouldUnwrap: true);
+
+        await Assert.That(factories.Length).IsEqualTo(1);
+        await Assert.That(await factories[0]()).IsNull();
+    }
+
+    [Test]
+    public async Task HandleTupleValue_NonTuple_ReturnsSingleFactory()
+    {
+        var factories = DataSourceHelpers.HandleTupleValue(42, shouldUnwrap: true);
+
+        await Assert.That(factories.Length).IsEqualTo(1);
+        await Assert.That(await factories[0]()).IsEqualTo((object?)42);
+    }
+}


### PR DESCRIPTION
Replaces the three LINQ `Select(...).ToArray()` factory-building chains in `TUnit.Core/Helpers/DataSourceHelpers.cs` with manual loops that allocate the `Func<Task<object?>>[]` directly.

## What
- `HandleTupleValue` (was line 62) — tuple element factories
- `ProcessTestDataSource` tuple branch (was line 268)
- `ProcessTestDataSource` array branch (was line 285)

Each manual loop captures its own `index` local in the closure, preserving identical behavior, and writes directly into a pre-sized array.

## Why
This runs per data row of every parameterized test (the most-used data path). The LINQ form allocated a `SelectArrayIterator` plus a closure over the source on every call; the manual loop removes that iterator allocation.

## Notes
- Public API signature (`Func<Task<object?>>[]`) is unchanged, so no PublicAPI snapshot changes.
- AOT-compatible (no reflection, no new dynamic access).
- Builds clean across netstandard2.0/net8.0/net9.0/net10.0.

Closes #6058