### PR TITLE
perf(engine): pool StringBuilder in DisplayNameBuilder.FormatArguments

### DIFF
--- a/TUnit.Engine/Helpers/DisplayNameBuilder.cs
+++ b/TUnit.Engine/Helpers/DisplayNameBuilder.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using TUnit.Core;
 using TUnit.Core.Helpers;
 

--- a/TUnit.Engine/Helpers/DisplayNameBuilder.cs
+++ b/TUnit.Engine/Helpers/DisplayNameBuilder.cs
@@ -51,16 +51,23 @@ internal static class DisplayNameBuilder
             return string.Empty;
         }
 
-        var sb = new StringBuilder();
-        for (var i = 0; i < arguments.Length; i++)
+        var sb = StringBuilderPool.Get();
+        try
         {
-            if (i > 0)
+            for (var i = 0; i < arguments.Length; i++)
             {
-                sb.Append(", ");
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append(ArgumentFormatter.Format(arguments[i], []));
             }
-            sb.Append(ArgumentFormatter.Format(arguments[i], []));
+            return sb.ToString();
         }
-        return sb.ToString();
+        finally
+        {
+            StringBuilderPool.Return(sb);
+        }
     }
 
     /// <summary>
@@ -73,16 +80,23 @@ internal static class DisplayNameBuilder
             return string.Empty;
         }
 
-        var sb = new StringBuilder();
-        for (var i = 0; i < arguments.Length; i++)
+        var sb = StringBuilderPool.Get();
+        try
         {
-            if (i > 0)
+            for (var i = 0; i < arguments.Length; i++)
             {
-                sb.Append(", ");
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+                sb.Append(ArgumentFormatter.Format(arguments[i], formatters));
             }
-            sb.Append(ArgumentFormatter.Format(arguments[i], formatters));
+            return sb.ToString();
         }
-        return sb.ToString();
+        finally
+        {
+            StringBuilderPool.Return(sb);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`TUnit.Engine/Helpers/DisplayNameBuilder.cs` allocated a fresh `StringBuilder` per call in both `FormatArguments` overloads. This runs for every data-driven test row when building display names.

This routes both overloads through the existing `TUnit.Core.Helpers.StringBuilderPool` (already present in the codebase, already accessible via `InternalsVisibleTo`), reusing pooled builders instead of allocating new ones. A `try/finally` guarantees the builder is returned even if `ArgumentFormatter.Format` throws.

Behavior is identical — same output, same formatting.

## Testing

- `dotnet build TUnit.Engine -c Release -f net10.0` succeeds (0 warnings, 0 errors).

Closes #6028