### PR TITLE
perf: collapse Replace chain in TestNameFormatter.BuildTestId

### DIFF
--- a/TUnit.Core/Services/TestNameFormatter.cs
+++ b/TUnit.Core/Services/TestNameFormatter.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Text;
+using TUnit.Core.Helpers;
 using TUnit.Core.Interfaces;
 
 namespace TUnit.Core.Services;
@@ -68,11 +69,23 @@ public class TestNameFormatter : ITestNameFormatter
         int classDataIndex = 0,
         int methodDataIndex = 0)
     {
-        return template
-            .Replace("{TestIndex}", testIndex.ToString())
-            .Replace("{RepeatIndex}", repeatIndex.ToString())
-            .Replace("{ClassDataIndex}", classDataIndex.ToString())
-            .Replace("{MethodDataIndex}", methodDataIndex.ToString());
+        // Mutate a pooled StringBuilder in place then materialize once, instead of
+        // allocating a new string per Replace call. Only the final string allocates.
+        var builder = StringBuilderPool.Get();
+        try
+        {
+            return builder
+                .Append(template)
+                .Replace("{TestIndex}", testIndex.ToString())
+                .Replace("{RepeatIndex}", repeatIndex.ToString())
+                .Replace("{ClassDataIndex}", classDataIndex.ToString())
+                .Replace("{MethodDataIndex}", methodDataIndex.ToString())
+                .ToString();
+        }
+        finally
+        {
+            StringBuilderPool.Return(builder);
+        }
     }
 
     private string FormatArguments(object?[] args)

--- a/TUnit.Core/Services/TestNameFormatter.cs
+++ b/TUnit.Core/Services/TestNameFormatter.cs
@@ -100,20 +100,30 @@ public class TestNameFormatter : ITestNameFormatter
 
     private string FormatEnumerable(IEnumerable enumerable)
     {
-        var sb = new StringBuilder("[");
-        var first = true;
-
-        foreach (var item in enumerable)
+        // Pool the builder like BuildTestId. Reentrant-safe: a nested enumerable draws a
+        // distinct instance from the pool, and each Get is balanced by a Return.
+        var sb = StringBuilderPool.Get();
+        try
         {
-            if (!first)
-            {
-                sb.Append(", ");
-            }
-            first = false;
-            sb.Append(FormatArgumentValue(item));
-        }
+            sb.Append('[');
+            var first = true;
 
-        sb.Append(']');
-        return sb.ToString();
+            foreach (var item in enumerable)
+            {
+                if (!first)
+                {
+                    sb.Append(", ");
+                }
+                first = false;
+                sb.Append(FormatArgumentValue(item));
+            }
+
+            sb.Append(']');
+            return sb.ToString();
+        }
+        finally
+        {
+            StringBuilderPool.Return(sb);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Collapses the four chained `string.Replace` calls in `TestNameFormatter.BuildTestId` into a single pooled `StringBuilder` pass.

Previously each `Replace` allocated a fresh intermediate string (up to 4 per call) even when the token wasn't present. Now a `StringBuilder` is rented from the existing `StringBuilderPool`, mutated in place, and materialized once — only the final `ToString()` allocates.

## Correctness

Output is byte-identical: `StringBuilder.Replace(string, string)` shares the same ordinal, case-sensitive, all-occurrences semantics as `string.Replace(string, string)`.

## Notes

- Hot path: a test ID is built per test during discovery.
- Works on all TFMs (the pool is allocation-free everywhere); no net8+-only span APIs used.
- AOT-safe, no public API change.
- Builds clean across netstandard2.0/net8.0/net9.0/net10.0.

Closes #6032