### PR TITLE
perf(engine): replace LINQ Where closure with inline filter in MetadataDependencyExpander BFS

### DIFF
--- a/TUnit.Engine/Services/MetadataDependencyExpander.cs
+++ b/TUnit.Engine/Services/MetadataDependencyExpander.cs
@@ -148,6 +148,11 @@ internal sealed class MetadataDependencyExpander
                 // Get candidate list based on dependency type for O(1) lookup
                 IEnumerable<TestMetadata> candidates;
 
+                // When matching same-class dependencies by method name only, the candidate
+                // list spans all classes, so we must additionally filter by the current
+                // test's class type inside the loop below (avoids a per-iteration closure).
+                var filterByCurrentClassType = false;
+
                 if (dependency.ClassType != null && !string.IsNullOrEmpty(dependency.MethodName))
                 {
                     // Specific class and method - use most specific index
@@ -176,7 +181,8 @@ internal sealed class MetadataDependencyExpander
                     // Same-class dependency by method name - look up by method name, then filter by class
                     if (byMethodName.TryGetValue(dependency.MethodName!, out var list))
                     {
-                        candidates = list.Where(m => m.TestClassType == current.TestClassType);
+                        candidates = list;
+                        filterByCurrentClassType = true;
                     }
                     else
                     {
@@ -191,6 +197,11 @@ internal sealed class MetadataDependencyExpander
 
                 foreach (var candidateMetadata in candidates)
                 {
+                    if (filterByCurrentClassType && candidateMetadata.TestClassType != current.TestClassType)
+                    {
+                        continue;
+                    }
+
                     if (dependency.Matches(candidateMetadata, current))
                     {
                         if (result.Add(candidateMetadata))


### PR DESCRIPTION
## Summary

`MetadataDependencyExpander.cs` BFS loop used a LINQ `Where` whose lambda captured the per-iteration local `current`, allocating a closure on **every** BFS loop iteration plus a deferred `IEnumerable` iterator that then flowed into the enclosing `foreach`.

This replaces the `Where` with a flag-gated inline class-type check inside the existing candidate `foreach`, eliminating both the closure and the iterator allocation. The class-type filter only applies to the same-class-by-method-name branch (gated by `filterByCurrentClassType`); all other candidate branches are unaffected.

**Behavior is identical** — the inline `continue` applies the exact same `TestClassType == current.TestClassType` predicate before `dependency.Matches`.

**Why hot:** BFS over the dependency graph scales with test count x dependency depth.

## Validation

- Builds cleanly across `net8.0;net9.0;net10.0;netstandard2.0` (`TUnit.Engine` + `TUnit.Core`).
- No TFM gating; AOT-safe (no reflection); applies equally in source-gen and reflection modes.

Closes #6051