### PR TITLE
perf(engine): use CollectionsMarshal.GetValueRefOrAddDefault for dictionary index builds

### DIFF
--- a/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
+++ b/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
@@ -128,12 +128,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
                     var pair = (source, i);
                     byClassAndMethod[(fd.ClassName, fd.MethodName)] = pair;
 
-                    if (!byClass.TryGetValue(fd.ClassName, out var list))
-                    {
-                        list = [];
-                        byClass[fd.ClassName] = list;
-                    }
-                    list.Add(pair);
+                    byClass.AddToList(fd.ClassName, pair);
                 }
             }
 

--- a/TUnit.Engine/Services/DictionaryListExtensions.cs
+++ b/TUnit.Engine/Services/DictionaryListExtensions.cs
@@ -1,0 +1,35 @@
+#if NET
+using System.Runtime.InteropServices;
+#endif
+
+namespace TUnit.Engine.Services;
+
+/// <summary>
+/// Helpers for the common "group values into a <see cref="Dictionary{TKey, TValue}"/> of lists" pattern.
+/// On net6+ this collapses the two hash lookups (TryGetValue + indexer set) into a single
+/// ref-returning lookup via <see cref="CollectionsMarshal.GetValueRefOrAddDefault{TKey, TValue}"/>.
+/// </summary>
+internal static class DictionaryListExtensions
+{
+    /// <summary>
+    /// Appends <paramref name="value"/> to the list stored under <paramref name="key"/>,
+    /// creating the list on first use.
+    /// </summary>
+    public static void AddToList<TKey, TValue>(this Dictionary<TKey, List<TValue>> dictionary, TKey key, TValue value)
+        where TKey : notnull
+    {
+#if NET
+        ref var list = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out _);
+        list ??= [];
+        list.Add(value);
+#else
+        if (!dictionary.TryGetValue(key, out var list))
+        {
+            list = [];
+            dictionary[key] = list;
+        }
+
+        list.Add(value);
+#endif
+    }
+}

--- a/TUnit.Engine/Services/MetadataDependencyExpander.cs
+++ b/TUnit.Engine/Services/MetadataDependencyExpander.cs
@@ -112,29 +112,13 @@ internal sealed class MetadataDependencyExpander
             var methodName = metadata.TestMethodName;
 
             // Add to class type index
-            if (!byClassType.TryGetValue(classType, out var classTypeList))
-            {
-                classTypeList = [];
-                byClassType[classType] = classTypeList;
-            }
-            classTypeList.Add(metadata);
+            byClassType.AddToList(classType, metadata);
 
             // Add to class+method index
-            var classMethodKey = (classType, methodName);
-            if (!byClassAndMethod.TryGetValue(classMethodKey, out var classMethodList))
-            {
-                classMethodList = [];
-                byClassAndMethod[classMethodKey] = classMethodList;
-            }
-            classMethodList.Add(metadata);
+            byClassAndMethod.AddToList((classType, methodName), metadata);
 
             // Add to method name index
-            if (!byMethodName.TryGetValue(methodName, out var methodNameList))
-            {
-                methodNameList = [];
-                byMethodName[methodName] = methodNameList;
-            }
-            methodNameList.Add(metadata);
+            byMethodName.AddToList(methodName, metadata);
         }
 
         var queue = new Queue<TestMetadata>(matchingMetadata);

--- a/TUnit.Engine/Services/TestDependencyResolver.cs
+++ b/TUnit.Engine/Services/TestDependencyResolver.cs
@@ -27,24 +27,10 @@ internal sealed class TestDependencyResolver
             _allTests.Add(test);
 
             var testType = test.Metadata.TestClassType;
-            if (!_testsByType.TryGetValue(testType, out var testsForType))
-            {
-                testsForType =
-                [
-                ];
-                _testsByType[testType] = testsForType;
-            }
-            testsForType.Add(test);
+            _testsByType.AddToList(testType, test);
 
             var methodName = test.Metadata.TestMethodName;
-            if (!_testsByMethodName.TryGetValue(methodName, out var testsForMethod))
-            {
-                testsForMethod =
-                [
-                ];
-                _testsByMethodName[methodName] = testsForMethod;
-            }
-            testsForMethod.Add(test);
+            _testsByMethodName.AddToList(methodName, test);
 
             // Cache test by composite key for fast lookups in GetTransitiveDependencies
             _testLookupCache[(testType, methodName)] = test;

--- a/TUnit.Engine/Services/TestFinder.cs
+++ b/TUnit.Engine/Services/TestFinder.cs
@@ -42,21 +42,10 @@ internal class TestFinder : ITestFinder
             var testName = test.Metadata.TestDetails.TestName;
 
             // Index by type
-            if (!testsByType.TryGetValue(classType, out var testsForType))
-            {
-                testsForType = [];
-                testsByType[classType] = testsForType;
-            }
-            testsForType.Add(test);
+            testsByType.AddToList(classType, test);
 
             // Index by (type, name)
-            var key = (classType, testName);
-            if (!testsByTypeAndName.TryGetValue(key, out var testsForKey))
-            {
-                testsForKey = [];
-                testsByTypeAndName[key] = testsForKey;
-            }
-            testsForKey.Add(test);
+            testsByTypeAndName.AddToList((classType, testName), test);
         }
 
         _testsByType = testsByType;

--- a/TUnit.Engine/Services/TestGroupingService.cs
+++ b/TUnit.Engine/Services/TestGroupingService.cs
@@ -1,3 +1,6 @@
+#if NET
+using System.Runtime.InteropServices;
+#endif
 using TUnit.Core;
 using TUnit.Core.Logging;
 using TUnit.Engine.Logging;
@@ -255,12 +258,18 @@ internal sealed class TestGroupingService : ITestGroupingService
         ParallelGroupConstraint constraint,
         Dictionary<string, SortedDictionary<int, List<AbstractExecutableTest>>> parallelGroups)
     {
+#if NET
+        ref var orderGroups = ref CollectionsMarshal.GetValueRefOrAddDefault(parallelGroups, constraint.Group, out _);
+        orderGroups ??= new SortedDictionary<int, List<AbstractExecutableTest>>();
+#else
         if (!parallelGroups.TryGetValue(constraint.Group, out var orderGroups))
         {
             orderGroups = new SortedDictionary<int, List<AbstractExecutableTest>>();
             parallelGroups[constraint.Group] = orderGroups;
         }
+#endif
 
+        // SortedDictionary is not supported by CollectionsMarshal, so keep the two-lookup pattern here.
         if (!orderGroups.TryGetValue(constraint.Order, out var tests))
         {
             tests = [];
@@ -282,11 +291,17 @@ internal sealed class TestGroupingService : ITestGroupingService
         NotInParallelConstraint notInParallel,
         Dictionary<string, (List<AbstractExecutableTest> Unconstrained, List<(AbstractExecutableTest, string, IReadOnlyList<string>, TestPriority)> Keyed)> constrainedGroups)
     {
+#if NET
+        ref var group = ref CollectionsMarshal.GetValueRefOrAddDefault(constrainedGroups, parallelGroup.Group, out _);
+        group.Unconstrained ??= [];
+        group.Keyed ??= [];
+#else
         if (!constrainedGroups.TryGetValue(parallelGroup.Group, out var group))
         {
             group = ([], []);
             constrainedGroups[parallelGroup.Group] = group;
         }
+#endif
 
         // Add to keyed tests within the parallel group
         var order = notInParallel.Order;


### PR DESCRIPTION
Closes #6050

## What

Replaces the `if (!dict.TryGetValue(k, out var list)) { list = []; dict[k] = list; } list.Add(v);` pattern (two hash lookups per insert) with a single ref-returning lookup via `CollectionsMarshal.GetValueRefOrAddDefault`.

## How

- Adds an internal `DictionaryListExtensions.AddToList` helper that uses `CollectionsMarshal.GetValueRefOrAddDefault` on net6+ and falls back to the original two-lookup pattern on netstandard2.0 (where `CollectionsMarshal` is unavailable). This DRYs up 7 of the copy-paste `Dictionary<K, List<V>>` sites.
- Applies the helper across `MetadataDependencyExpander`, `TestDependencyResolver`, `TestFinder`, and `AotTestDataCollector`.
- The two `TestGroupingService` sites whose value type is not `List<V>` (`SortedDictionary`, and a `(List, List)` tuple) use the ref API inline, also guarded with `#if NET`. The inner `SortedDictionary` lookup is left unchanged since `CollectionsMarshal` does not support `SortedDictionary`.

## Notes

- The issue stated TUnit.Engine targets net8.0+ only, but it actually multi-targets `netstandard2.0;net8.0;net9.0;net10.0`, so the netstandard2.0 fallback is required.
- Behavior is identical across all paths; this is a pure allocation/lookup micro-optimization in per-test and per-discovery hot loops.

## Build

Built clean across all four TFMs (netstandard2.0, net8.0, net9.0, net10.0): 0 warnings, 0 errors.