### PR TITLE
perf(engine): replace magic-string RequiredAttribute match with type check in ConstructorHelper

### DIFF
--- a/TUnit.Engine/Discovery/ConstructorHelper.cs
+++ b/TUnit.Engine/Discovery/ConstructorHelper.cs
@@ -144,23 +144,10 @@ internal static class ConstructorHelper
         Type.GetType("System.ComponentModel.DataAnnotations.RequiredAttribute, System.ComponentModel.Annotations")
         ?? Type.GetType("System.ComponentModel.DataAnnotations.RequiredAttribute, System.ComponentModel.DataAnnotations");
 
-    private static bool HasRequiredAttribute(PropertyInfo property)
-    {
-        if (RequiredAttributeType is null)
-        {
-            return false;
-        }
-
-        foreach (var attribute in property.GetCustomAttributes())
-        {
-            if (RequiredAttributeType.IsInstanceOfType(attribute))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    private static bool HasRequiredAttribute(PropertyInfo property) =>
+        // IsDefined checks metadata tokens only — no attribute instances are materialised.
+        // It matches subclasses of RequiredAttributeType, same as the previous IsInstanceOfType.
+        RequiredAttributeType is not null && property.IsDefined(RequiredAttributeType, inherit: true);
 
     /// <summary>
     /// Tries to initialize required properties on an instance

--- a/TUnit.Engine/Discovery/ConstructorHelper.cs
+++ b/TUnit.Engine/Discovery/ConstructorHelper.cs
@@ -126,7 +126,40 @@ internal static class ConstructorHelper
 
         // Also check individual properties for RequiredAttribute (older approach)
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        return properties.Any(p => p.GetCustomAttributes().Any(a => a.GetType().Name == "RequiredAttribute"));
+        foreach (var property in properties)
+        {
+            if (HasRequiredAttribute(property))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // System.ComponentModel.DataAnnotations.RequiredAttribute, resolved once. It lives in a separate
+    // assembly that isn't referenced on netstandard2.0, so we look it up by name instead of a compile-time
+    // type reference. Null when the type can't be loaded (e.g. the assembly isn't present).
+    private static readonly Type? RequiredAttributeType =
+        Type.GetType("System.ComponentModel.DataAnnotations.RequiredAttribute, System.ComponentModel.Annotations")
+        ?? Type.GetType("System.ComponentModel.DataAnnotations.RequiredAttribute, System.ComponentModel.DataAnnotations");
+
+    private static bool HasRequiredAttribute(PropertyInfo property)
+    {
+        if (RequiredAttributeType is null)
+        {
+            return false;
+        }
+
+        foreach (var attribute in property.GetCustomAttributes())
+        {
+            if (RequiredAttributeType.IsInstanceOfType(attribute))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -145,7 +178,7 @@ internal static class ConstructorHelper
         {
             // In C# 11+, required properties are marked with RequiredMemberAttribute at the member level
             var isRequired = property.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>() != null ||
-                            property.GetCustomAttributes().Any(a => a.GetType().Name == "RequiredAttribute");
+                            HasRequiredAttribute(property);
 
             // Also check if property is marked with 'required' modifier by checking if it's init-only and the type has RequiredMemberAttribute
             if (!isRequired && property is { CanWrite: true, SetMethod.IsSpecialName: true } &&


### PR DESCRIPTION
## What

`TUnit.Engine/Discovery/ConstructorHelper.cs` detected required properties via a magic-string attribute-name comparison:

```csharp
properties.Any(p => p.GetCustomAttributes().Any(a => a.GetType().Name == "RequiredAttribute"));
```

Per property per type during reflection-mode construction this:
1. Allocated an `Any` iterator + lambda
2. Called `GetType()` per attribute, then string-compared `.Name`

## Change

Resolve `System.ComponentModel.DataAnnotations.RequiredAttribute` once into a cached `Type` and use `IsInstanceOfType` via a shared `HasRequiredAttribute` helper (used by both `HasRequiredProperties` and `InitializeRequiredProperties`).

- The type is looked up by assembly-qualified name (`Type.GetType`) rather than a compile-time reference, because its assembly isn't referenced on `netstandard2.0`. It gracefully returns `false` if the type can't be loaded.
- No new package dependency added (avoids touching Central Package Management for a perf cleanup).
- Behavior preserved: `IsInstanceOfType` matches the same `RequiredAttribute` (and subclasses, which is strictly more correct than the simple-name match).

## Validation

- Builds clean for `net8.0`, `net9.0`, `net10.0`, and `netstandard2.0` (0 warnings).

Closes #6056