### PR TITLE
perf: dedupe TestDataFormatter.FormatArguments with pooled StringBuilder

### DIFF
--- a/TUnit.Core/DataSources/TestDataFormatter.cs
+++ b/TUnit.Core/DataSources/TestDataFormatter.cs
@@ -26,31 +26,30 @@ public static class TestDataFormatter
             return string.Empty;
         }
 
-        var formattedArgs = new string[arguments.Length];
-        for (var i = 0; i < arguments.Length; i++)
+        var builder = StringBuilderPool.Get();
+        try
         {
-            formattedArgs[i] = ArgumentFormatter.Format(arguments[i], formatters);
+            for (var i = 0; i < arguments.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+                builder.Append(ArgumentFormatter.Format(arguments[i], formatters));
+            }
+            return builder.ToString();
         }
-        return string.Join(", ", formattedArgs);
+        finally
+        {
+            StringBuilderPool.Return(builder);
+        }
     }
 
     /// <summary>
     /// Formats an array of arguments using default formatting
     /// </summary>
     public static string FormatArguments(object?[] arguments)
-    {
-        if (arguments.Length == 0)
-        {
-            return string.Empty;
-        }
-
-        var formattedArgs = new string[arguments.Length];
-        for (var i = 0; i < arguments.Length; i++)
-        {
-            formattedArgs[i] = ArgumentFormatter.Format(arguments[i], []);
-        }
-        return string.Join(", ", formattedArgs);
-    }
+        => FormatArguments(arguments, []);
 
     /// <summary>
     /// Creates a display name from test metadata and arguments


### PR DESCRIPTION
## Summary

Dedupes the two duplicated `FormatArguments` overloads in `TUnit.Core/DataSources/TestDataFormatter.cs` and replaces the `string[]` + `string.Join` intermediate allocation with a pooled `StringBuilder` from `TUnit.Core.Helpers.StringBuilderPool`.

- The no-formatter `FormatArguments(object?[])` overload now delegates to `FormatArguments(object?[], List<...>)`, eliminating the copy-pasted body.
- The canonical implementation builds the comma-separated string with a pooled `StringBuilder` (rented + returned in a `try/finally`), removing the per-call temporary `string[]` and the `string.Join` pass.

Behavior is identical (empty input still returns `string.Empty`, same `", "` separator). This is on a hot path: per parameterized test row during display-name and data formatting.

Scope is limited to `TestDataFormatter.cs` only. `DisplayNameBuilder` (#6028) and `ArgumentFormatter` (#6033) are intentionally left untouched — separate PRs own those.

## Testing

`dotnet build TUnit.Core/TUnit.Core.csproj -c Release` succeeds across netstandard2.0/net8.0/net9.0/net10.0 with 0 warnings. (The GitVersion MSBuild task fails in the worktree environment; built with `-p:DisableGitVersionTask=true`.)

Closes #6038
