### PR TITLE
perf(engine): use SearchValues<char> for reporter filename sanitization

### DIFF
--- a/TUnit.Engine/Helpers/PathValidator.cs
+++ b/TUnit.Engine/Helpers/PathValidator.cs
@@ -12,10 +12,12 @@ internal static class PathValidator
 #endif
 
     /// <summary>
-    /// Removes any characters that are invalid in a file name (e.g. path separators),
-    /// preventing path traversal via crafted assembly names. Equivalent to
-    /// <c>string.Concat(name.Split(Path.GetInvalidFileNameChars()))</c> but allocation-free
-    /// when the name is already clean.
+    /// Strips characters that are invalid in a file name component (those returned by
+    /// <see cref="Path.GetInvalidFileNameChars"/>). This is not full path-traversal protection
+    /// — e.g. on Linux only <c>/</c> and <c>\0</c> are invalid, so a value like <c>..foo</c>
+    /// passes through unchanged; use <see cref="ValidateAndNormalizePath"/> for that.
+    /// Equivalent to <c>string.Concat(name.Split(Path.GetInvalidFileNameChars()))</c> but
+    /// allocation-free when the name is already clean.
     /// </summary>
     internal static string SanitizeFileName(string name)
     {

--- a/TUnit.Engine/Helpers/PathValidator.cs
+++ b/TUnit.Engine/Helpers/PathValidator.cs
@@ -1,7 +1,57 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+#endif
+
 namespace TUnit.Engine.Helpers;
 
 internal static class PathValidator
 {
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<char> _invalidFileNameChars =
+        SearchValues.Create(Path.GetInvalidFileNameChars());
+#endif
+
+    /// <summary>
+    /// Removes any characters that are invalid in a file name (e.g. path separators),
+    /// preventing path traversal via crafted assembly names. Equivalent to
+    /// <c>string.Concat(name.Split(Path.GetInvalidFileNameChars()))</c> but allocation-free
+    /// when the name is already clean.
+    /// </summary>
+    internal static string SanitizeFileName(string name)
+    {
+#if NET8_0_OR_GREATER
+        var span = name.AsSpan();
+        var firstInvalid = span.IndexOfAny(_invalidFileNameChars);
+
+        // Fast path: nothing to strip, return the original string unchanged.
+        if (firstInvalid < 0)
+        {
+            return name;
+        }
+
+        // Worst case the result is the same length as the input (no chars removed
+        // after the first), so a single stack/heap buffer of that size suffices.
+        var buffer = name.Length <= 256 ? stackalloc char[name.Length] : new char[name.Length];
+
+        // Everything before the first invalid char is known-good.
+        span.Slice(0, firstInvalid).CopyTo(buffer);
+        var written = firstInvalid;
+
+        for (var i = firstInvalid; i < span.Length; i++)
+        {
+            var c = span[i];
+            if (!_invalidFileNameChars.Contains(c))
+            {
+                buffer[written++] = c;
+            }
+        }
+
+        return new string(buffer.Slice(0, written));
+#else
+        return string.Concat(name.Split(Path.GetInvalidFileNameChars()));
+#endif
+    }
+
     /// <summary>
     /// Validates and normalizes a file path to prevent path traversal attacks.
     /// Returns the normalized full path if valid, or throws an <see cref="ArgumentException"/> if the path is unsafe.

--- a/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -16,6 +16,7 @@ using TUnit.Engine.Configuration;
 using TUnit.Engine.Constants;
 using TUnit.Engine.Exceptions;
 using TUnit.Engine.Framework;
+using TUnit.Engine.Helpers;
 
 #pragma warning disable TPEXP
 
@@ -647,7 +648,7 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
     private string GetDefaultOutputPath()
     {
         var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? "TestResults";
-        var sanitizedName = string.Concat(assemblyName.Split(Path.GetInvalidFileNameChars()));
+        var sanitizedName = PathValidator.SanitizeFileName(assemblyName);
         var os = GetShortOsName();
         var tfm = GetShortFrameworkName();
         return Path.GetFullPath(Path.Combine(_resultsDirectory, $"{sanitizedName}-{os}-{tfm}-report.html"));

--- a/TUnit.Engine/Reporters/JUnitReporter.cs
+++ b/TUnit.Engine/Reporters/JUnitReporter.cs
@@ -121,7 +121,7 @@ public class JUnitReporter(IExtension extension) : IDataConsumer, ITestHostAppli
         var assemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? "TestResults";
 
         // Sanitize assembly name to remove any characters that could be used for path traversal
-        var sanitizedName = string.Concat(assemblyName.Split(Path.GetInvalidFileNameChars()));
+        var sanitizedName = PathValidator.SanitizeFileName(assemblyName);
 
         return Path.GetFullPath(Path.Combine(_resultsDirectory, $"{sanitizedName}-junit.xml"));
     }

--- a/TUnit.UnitTests/PathValidatorTests.cs
+++ b/TUnit.UnitTests/PathValidatorTests.cs
@@ -1,0 +1,74 @@
+using TUnit.Assertions.Extensions;
+using TUnit.Engine.Helpers;
+
+namespace TUnit.UnitTests;
+
+public class PathValidatorTests
+{
+    [Test]
+    public async Task SanitizeFileName_CleanName_ReturnsSameReference()
+    {
+        var name = "MyAssembly.Tests";
+
+        var result = PathValidator.SanitizeFileName(name);
+
+        // Fast path: no invalid chars, the original instance is returned unchanged.
+        await Assert.That(result).IsSameReferenceAs(name);
+    }
+
+    [Test]
+    public async Task SanitizeFileName_EmptyString_ReturnsSameReference()
+    {
+        var name = string.Empty;
+
+        var result = PathValidator.SanitizeFileName(name);
+
+        await Assert.That(result).IsSameReferenceAs(name);
+    }
+
+    [Test]
+    public async Task SanitizeFileName_StripsPathSeparators()
+    {
+        // '/' is invalid on every platform; '\' is invalid on Windows.
+        var result = PathValidator.SanitizeFileName("foo/bar");
+
+        await Assert.That(result).DoesNotContain("/");
+    }
+
+    [Test]
+    public async Task SanitizeFileName_StripsInvalidChars()
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+
+        // Skip platforms with no invalid chars (none in practice, but keep the test honest).
+        if (invalid.Length == 0)
+        {
+            return;
+        }
+
+        var name = $"a{invalid[0]}b";
+
+        var result = PathValidator.SanitizeFileName(name);
+
+        await Assert.That(result).IsEqualTo("ab");
+    }
+
+    [Test]
+    public async Task SanitizeFileName_LongNameWithInvalidChar_ExercisesHeapBranch()
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+
+        if (invalid.Length == 0)
+        {
+            return;
+        }
+
+        // > 256 chars forces the heap-allocated (non-stackalloc) slow path.
+        var prefix = new string('a', 300);
+        var name = prefix + invalid[0];
+
+        var result = PathValidator.SanitizeFileName(name);
+
+        await Assert.That(result).IsEqualTo(prefix);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #6035. Replaces the allocating `string.Concat(name.Split(Path.GetInvalidFileNameChars()))` pattern used to sanitize the entry-assembly name in `HtmlReporter` and `JUnitReporter` with a shared `PathValidator.SanitizeFileName` helper.

- **net8.0+**: single-pass `SearchValues<char>` scan into a stack (or heap, for names > 256 chars) buffer, with an allocation-free fast path that returns the original string unchanged when no invalid characters are present.
- **netstandard2.0**: keeps the existing `Split` implementation as a fallback (guarded with `#if NET8_0_OR_GREATER`), so all TFMs compile.

Behavior is identical (invalid filename characters are removed). The two previously-duplicated call sites now share one helper.

## Testing

`dotnet build TUnit.Engine/TUnit.Engine.csproj -c Release` succeeds across all four TFMs (netstandard2.0, net8.0, net9.0, net10.0). The GitVersion MSBuild task fails in the worktree due to git state, so the build was run with `-p:DisableGitVersionTask=true`; the failure is unrelated to these code changes.

Closes #6035