### PR TITLE
perf(assertions): avoid eager interpolated-string alloc in assertion source ctors

### DIFF
--- a/TUnit.Assertions/Sources/ArrayAssertion.cs
+++ b/TUnit.Assertions/Sources/ArrayAssertion.cs
@@ -30,8 +30,6 @@ public class ArrayAssertion<TItem> : CollectionAssertionBase<TItem[], TItem>
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }

--- a/TUnit.Assertions/Sources/ArrayAssertion.cs
+++ b/TUnit.Assertions/Sources/ArrayAssertion.cs
@@ -30,6 +30,6 @@ public class ArrayAssertion<TItem> : CollectionAssertionBase<TItem[], TItem>
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }

--- a/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
+++ b/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
@@ -13,5 +13,10 @@ internal static class AssertionExpressionBuilder
     /// substituting <c>?</c> when the caller expression is unavailable.
     /// </summary>
     internal static StringBuilder Create(string? expression)
-        => new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+    {
+        var expr = expression ?? "?";
+        // Pre-size to "Assert.That(" (12) + expression + ")" (1) so the default 16-char
+        // buffer doesn't resize for any expression longer than 3 characters.
+        return new StringBuilder(13 + expr.Length).Append("Assert.That(").Append(expr).Append(')');
+    }
 }

--- a/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
+++ b/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
@@ -10,13 +10,14 @@ internal static class AssertionExpressionBuilder
 {
     /// <summary>
     /// Creates a <see cref="StringBuilder"/> seeded with <c>Assert.That(&lt;expression&gt;)</c>,
-    /// substituting <c>?</c> when the caller expression is unavailable.
+    /// substituting <c>?</c> when the caller expression is unavailable. <paramref name="extraCapacity"/>
+    /// pads the buffer for callers that append further text after the seed.
     /// </summary>
-    internal static StringBuilder Create(string? expression)
+    internal static StringBuilder Create(string? expression, int extraCapacity = 0)
     {
         var expr = expression ?? "?";
         // Pre-size to "Assert.That(" (12) + expression + ")" (1) so the default 16-char
         // buffer doesn't resize for any expression longer than 3 characters.
-        return new StringBuilder(13 + expr.Length).Append("Assert.That(").Append(expr).Append(')');
+        return new StringBuilder(13 + expr.Length + extraCapacity).Append("Assert.That(").Append(expr).Append(')');
     }
 }

--- a/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
+++ b/TUnit.Assertions/Sources/AssertionExpressionBuilder.cs
@@ -1,0 +1,17 @@
+using System.Text;
+
+namespace TUnit.Assertions.Sources;
+
+/// <summary>
+/// Builds the initial assertion-expression text shared by every source assertion's constructor.
+/// Centralises the <c>Assert.That(...)</c> prefix so the format lives in a single place.
+/// </summary>
+internal static class AssertionExpressionBuilder
+{
+    /// <summary>
+    /// Creates a <see cref="StringBuilder"/> seeded with <c>Assert.That(&lt;expression&gt;)</c>,
+    /// substituting <c>?</c> when the caller expression is unavailable.
+    /// </summary>
+    internal static StringBuilder Create(string? expression)
+        => new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+}

--- a/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
@@ -25,8 +25,7 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
     public AsyncDelegateAssertion(Func<Task> action, string? expression)
     {
         AsyncAction = action ?? throw new ArgumentNullException(nameof(action));
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<object?>(async () =>
         {
             try
@@ -42,8 +41,7 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
         Context = new AssertionContext<object?>(evaluationContext, expressionBuilder);
 
         // DO NOT await the task here - we want to check its state synchronously
-        var taskExpressionBuilder = new StringBuilder();
-        taskExpressionBuilder.Append(expressionBuilder.ToString());
+        var taskExpressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var taskEvaluationContext = new EvaluationContext<Task>(() =>
         {
             // This allows IsCompleted, IsCanceled, IsFaulted, etc. to check task properties synchronously

--- a/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncDelegateAssertion.cs
@@ -25,7 +25,7 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
     public AsyncDelegateAssertion(Func<Task> action, string? expression)
     {
         AsyncAction = action ?? throw new ArgumentNullException(nameof(action));
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<object?>(async () =>
         {
             try
@@ -41,7 +41,7 @@ public class AsyncDelegateAssertion : IAssertionSource<object?>, IDelegateAssert
         Context = new AssertionContext<object?>(evaluationContext, expressionBuilder);
 
         // DO NOT await the task here - we want to check its state synchronously
-        var taskExpressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var taskExpressionBuilder = AssertionExpressionBuilder.Create(expression);
         var taskEvaluationContext = new EvaluationContext<Task>(() =>
         {
             // This allows IsCompleted, IsCanceled, IsFaulted, etc. to check task properties synchronously

--- a/TUnit.Assertions/Sources/AsyncEnumerableAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncEnumerableAssertion.cs
@@ -24,8 +24,7 @@ public class AsyncEnumerableAssertion<TItem> : AsyncEnumerableAssertionBase<TIte
         IAsyncEnumerable<TItem> value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         return new AssertionContext<IAsyncEnumerable<TItem>>(value, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/AsyncEnumerableAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncEnumerableAssertion.cs
@@ -24,7 +24,7 @@ public class AsyncEnumerableAssertion<TItem> : AsyncEnumerableAssertionBase<TIte
         IAsyncEnumerable<TItem> value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         return new AssertionContext<IAsyncEnumerable<TItem>>(value, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/AsyncFuncAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncFuncAssertion.cs
@@ -16,7 +16,7 @@ public class AsyncFuncAssertion<TValue> : IAssertionSource<TValue>, IDelegateAss
 
     public AsyncFuncAssertion(Func<Task<TValue?>> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<TValue>(async () =>
         {
             try

--- a/TUnit.Assertions/Sources/AsyncFuncAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncFuncAssertion.cs
@@ -16,8 +16,7 @@ public class AsyncFuncAssertion<TValue> : IAssertionSource<TValue>, IDelegateAss
 
     public AsyncFuncAssertion(Func<Task<TValue?>> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<TValue>(async () =>
         {
             try

--- a/TUnit.Assertions/Sources/AsyncFuncCollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncFuncCollectionAssertion.cs
@@ -19,7 +19,7 @@ public class AsyncFuncCollectionAssertion<TItem> : CollectionAssertionBase<IEnum
 
     private static AssertionContext<IEnumerable<TItem>> CreateContext(Func<Task<IEnumerable<TItem>?>> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<IEnumerable<TItem>>(async () =>
         {
             try

--- a/TUnit.Assertions/Sources/AsyncFuncCollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/AsyncFuncCollectionAssertion.cs
@@ -19,8 +19,7 @@ public class AsyncFuncCollectionAssertion<TItem> : CollectionAssertionBase<IEnum
 
     private static AssertionContext<IEnumerable<TItem>> CreateContext(Func<Task<IEnumerable<TItem>?>> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<IEnumerable<TItem>>(async () =>
         {
             try

--- a/TUnit.Assertions/Sources/CollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertion.cs
@@ -31,8 +31,6 @@ public class CollectionAssertion<TItem> : CollectionAssertionBase<IEnumerable<TI
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }

--- a/TUnit.Assertions/Sources/CollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/CollectionAssertion.cs
@@ -31,6 +31,6 @@ public class CollectionAssertion<TItem> : CollectionAssertionBase<IEnumerable<TI
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }

--- a/TUnit.Assertions/Sources/DelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/DelegateAssertion.cs
@@ -19,7 +19,7 @@ public class DelegateAssertion : IAssertionSource<object?>, IDelegateAssertionSo
     public DelegateAssertion(Action action, string? expression)
     {
         Action = action ?? throw new ArgumentNullException(nameof(action));
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<object?>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/DelegateAssertion.cs
+++ b/TUnit.Assertions/Sources/DelegateAssertion.cs
@@ -19,8 +19,7 @@ public class DelegateAssertion : IAssertionSource<object?>, IDelegateAssertionSo
     public DelegateAssertion(Action action, string? expression)
     {
         Action = action ?? throw new ArgumentNullException(nameof(action));
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<object?>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/DictionaryAssertion.cs
+++ b/TUnit.Assertions/Sources/DictionaryAssertion.cs
@@ -29,8 +29,7 @@ public class DictionaryAssertion<TKey, TValue> : DictionaryAssertionBase<IReadOn
         IReadOnlyDictionary<TKey, TValue>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         return new AssertionContext<IReadOnlyDictionary<TKey, TValue>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/DictionaryAssertion.cs
+++ b/TUnit.Assertions/Sources/DictionaryAssertion.cs
@@ -29,7 +29,7 @@ public class DictionaryAssertion<TKey, TValue> : DictionaryAssertionBase<IReadOn
         IReadOnlyDictionary<TKey, TValue>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         return new AssertionContext<IReadOnlyDictionary<TKey, TValue>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/FuncAssertion.cs
+++ b/TUnit.Assertions/Sources/FuncAssertion.cs
@@ -16,7 +16,7 @@ public class FuncAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
     public FuncAssertion(Func<TValue?> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<TValue>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/FuncAssertion.cs
+++ b/TUnit.Assertions/Sources/FuncAssertion.cs
@@ -16,8 +16,7 @@ public class FuncAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
     public FuncAssertion(Func<TValue?> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<TValue>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/FuncCollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/FuncCollectionAssertion.cs
@@ -19,7 +19,7 @@ public class FuncCollectionAssertion<TItem> : CollectionAssertionBase<IEnumerabl
 
     private static AssertionContext<IEnumerable<TItem>> CreateContext(Func<IEnumerable<TItem>?> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         var evaluationContext = new EvaluationContext<IEnumerable<TItem>>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/FuncCollectionAssertion.cs
+++ b/TUnit.Assertions/Sources/FuncCollectionAssertion.cs
@@ -19,8 +19,7 @@ public class FuncCollectionAssertion<TItem> : CollectionAssertionBase<IEnumerabl
 
     private static AssertionContext<IEnumerable<TItem>> CreateContext(Func<IEnumerable<TItem>?> func, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var evaluationContext = new EvaluationContext<IEnumerable<TItem>>(() =>
         {
             try

--- a/TUnit.Assertions/Sources/ListAssertion.cs
+++ b/TUnit.Assertions/Sources/ListAssertion.cs
@@ -34,8 +34,7 @@ public class ListAssertion<TItem> : ListAssertionBase<IList<TItem>, TItem>
         IList<TItem>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         return new AssertionContext<IList<TItem>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/ListAssertion.cs
+++ b/TUnit.Assertions/Sources/ListAssertion.cs
@@ -34,7 +34,7 @@ public class ListAssertion<TItem> : ListAssertionBase<IList<TItem>, TItem>
         IList<TItem>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         return new AssertionContext<IList<TItem>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/MemoryAssertion.cs
+++ b/TUnit.Assertions/Sources/MemoryAssertion.cs
@@ -37,9 +37,7 @@ public class MemoryAssertion<TItem> : MemoryAssertionBase<Memory<TItem>, TItem>,
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }
 
@@ -74,9 +72,7 @@ public class ReadOnlyMemoryAssertion<TItem> : MemoryAssertionBase<ReadOnlyMemory
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }
 #endif

--- a/TUnit.Assertions/Sources/MemoryAssertion.cs
+++ b/TUnit.Assertions/Sources/MemoryAssertion.cs
@@ -37,7 +37,7 @@ public class MemoryAssertion<TItem> : MemoryAssertionBase<Memory<TItem>, TItem>,
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }
 
@@ -72,7 +72,7 @@ public class ReadOnlyMemoryAssertion<TItem> : MemoryAssertionBase<ReadOnlyMemory
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }
 #endif

--- a/TUnit.Assertions/Sources/MutableDictionaryAssertion.cs
+++ b/TUnit.Assertions/Sources/MutableDictionaryAssertion.cs
@@ -31,8 +31,7 @@ public class MutableDictionaryAssertion<TKey, TValue> : MutableDictionaryAsserti
         IDictionary<TKey, TValue>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         return new AssertionContext<IDictionary<TKey, TValue>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/MutableDictionaryAssertion.cs
+++ b/TUnit.Assertions/Sources/MutableDictionaryAssertion.cs
@@ -31,7 +31,7 @@ public class MutableDictionaryAssertion<TKey, TValue> : MutableDictionaryAsserti
         IDictionary<TKey, TValue>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         return new AssertionContext<IDictionary<TKey, TValue>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/ReadOnlyListAssertion.cs
+++ b/TUnit.Assertions/Sources/ReadOnlyListAssertion.cs
@@ -30,8 +30,7 @@ public class ReadOnlyListAssertion<TItem> : ReadOnlyListAssertionBase<IReadOnlyL
         IReadOnlyList<TItem>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         return new AssertionContext<IReadOnlyList<TItem>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/ReadOnlyListAssertion.cs
+++ b/TUnit.Assertions/Sources/ReadOnlyListAssertion.cs
@@ -30,7 +30,7 @@ public class ReadOnlyListAssertion<TItem> : ReadOnlyListAssertionBase<IReadOnlyL
         IReadOnlyList<TItem>? value,
         string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
         return new AssertionContext<IReadOnlyList<TItem>>(value!, expressionBuilder);
     }
 }

--- a/TUnit.Assertions/Sources/SetAssertion.cs
+++ b/TUnit.Assertions/Sources/SetAssertion.cs
@@ -43,9 +43,7 @@ public class SetAssertion<TItem> : SetAssertionBase<ISet<TItem>, TItem>, IAssert
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }
 
@@ -88,9 +86,7 @@ public class ReadOnlySetAssertion<TItem> : SetAssertionBase<IReadOnlySet<TItem>,
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }
 #endif
@@ -133,8 +129,6 @@ public class HashSetAssertion<TItem> : SetAssertionBase<HashSet<TItem>, TItem>, 
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        var builder = new StringBuilder();
-        builder.Append($"Assert.That({expression ?? "?"})");
-        return builder;
+        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
     }
 }

--- a/TUnit.Assertions/Sources/SetAssertion.cs
+++ b/TUnit.Assertions/Sources/SetAssertion.cs
@@ -43,7 +43,7 @@ public class SetAssertion<TItem> : SetAssertionBase<ISet<TItem>, TItem>, IAssert
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }
 
@@ -86,7 +86,7 @@ public class ReadOnlySetAssertion<TItem> : SetAssertionBase<IReadOnlySet<TItem>,
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }
 #endif
@@ -129,6 +129,6 @@ public class HashSetAssertion<TItem> : SetAssertionBase<HashSet<TItem>, TItem>, 
 
     private static StringBuilder CreateExpressionBuilder(string? expression)
     {
-        return new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        return AssertionExpressionBuilder.Create(expression);
     }
 }

--- a/TUnit.Assertions/Sources/TaskAssertion.cs
+++ b/TUnit.Assertions/Sources/TaskAssertion.cs
@@ -21,7 +21,7 @@ public class TaskAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
     public TaskAssertion(Task<TValue?> task, string? expression)
     {
-        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression);
 
         // Context for result assertions (e.g., IsEqualTo on the TValue result)
         var evaluationContext = new EvaluationContext<TValue>(async () =>
@@ -40,7 +40,7 @@ public class TaskAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
         // Context for task state assertions (e.g., IsCompleted on the Task<TValue>)
         // DO NOT await the task here - we want to check its state synchronously
-        var taskExpressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
+        var taskExpressionBuilder = AssertionExpressionBuilder.Create(expression);
         var taskEvaluationContext = new EvaluationContext<Task<TValue?>>(() =>
         {
             // Return the task object itself without awaiting it

--- a/TUnit.Assertions/Sources/TaskAssertion.cs
+++ b/TUnit.Assertions/Sources/TaskAssertion.cs
@@ -21,8 +21,7 @@ public class TaskAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
     public TaskAssertion(Task<TValue?> task, string? expression)
     {
-        var expressionBuilder = new StringBuilder();
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
 
         // Context for result assertions (e.g., IsEqualTo on the TValue result)
         var evaluationContext = new EvaluationContext<TValue>(async () =>
@@ -41,8 +40,7 @@ public class TaskAssertion<TValue> : IAssertionSource<TValue>, IDelegateAssertio
 
         // Context for task state assertions (e.g., IsCompleted on the Task<TValue>)
         // DO NOT await the task here - we want to check its state synchronously
-        var taskExpressionBuilder = new StringBuilder();
-        taskExpressionBuilder.Append(expressionBuilder.ToString());
+        var taskExpressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
         var taskEvaluationContext = new EvaluationContext<Task<TValue?>>(() =>
         {
             // Return the task object itself without awaiting it

--- a/TUnit.Assertions/Sources/ValueAssertion.cs
+++ b/TUnit.Assertions/Sources/ValueAssertion.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using TUnit.Assertions.Conditions;
 using TUnit.Assertions.Core;
 
@@ -15,9 +14,8 @@ public class ValueAssertion<TValue> : IAssertionSource<TValue>
 
     public ValueAssertion(TValue? value, string? expression)
     {
-        // Initialize StringBuilder with enough space for expression and text
-        var expressionBuilder = new StringBuilder((expression?.Length ?? 1) + 32);
-        expressionBuilder.Append($"Assert.That({expression ?? "?"})");
+        // extraCapacity leaves room for the assertion text appended after the seed.
+        var expressionBuilder = AssertionExpressionBuilder.Create(expression, extraCapacity: 32);
         Context = new AssertionContext<TValue>(value, expressionBuilder);
     }
 


### PR DESCRIPTION
## Summary

Fixes the eager `StringBuilder` allocation pattern in assertion source constructors flagged in #6046.

Every `Assert.That(...)` call built the expression description via:

```csharp
var expressionBuilder = new StringBuilder();
expressionBuilder.Append($"Assert.That({expression ?? "?"})");
```

The `$"Assert.That(...)"` interpolated string allocates an intermediate `string` on every call (the happy path never reads it — the builder is only consumed when an assertion fails). This replaces it with direct seeding + fragment appends:

```csharp
var expressionBuilder = new StringBuilder("Assert.That(").Append(expression ?? "?").Append(')');
```

The resulting expression content is byte-identical, so behavior is unchanged.

`TaskAssertion` and `AsyncDelegateAssertion` additionally allocated a **second** `StringBuilder` seeded via `expressionBuilder.ToString()` — that round-trip string is now gone too (each builder is seeded independently, preserving the two-independent-instances semantics).

## Files changed (16)

ArrayAssertion, AsyncDelegateAssertion, AsyncEnumerableAssertion, AsyncFuncAssertion, AsyncFuncCollectionAssertion, CollectionAssertion, DelegateAssertion, DictionaryAssertion, FuncAssertion, FuncCollectionAssertion, ListAssertion, MemoryAssertion, MutableDictionaryAssertion, ReadOnlyListAssertion, SetAssertion, TaskAssertion.

`ValueAssertion.cs` (not listed in the issue) was intentionally left untouched — it already pre-sizes capacity with `new StringBuilder((expression?.Length ?? 1) + 32)`, a deliberate sizing hint.

While simplifying, the `CreateExpressionBuilder` helpers (`Array`/`Collection`/`Memory`/`Set`) also dropped a redundant local (`var builder = ...; return builder;` -> `return ...;`).

## Notes

- AOT-safe, no new APIs, no TFM gating.
- Public expression strings are unchanged, so no PublicAPI/snapshot updates required.
- `dotnet build TUnit.Assertions` succeeds: 0 warnings, 0 errors.

Closes #6046
