### PR TITLE
perf: use OrdinalIgnoreCase Contains in HtmlReportGenerator span mapping

### DIFF
--- a/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
+++ b/TUnit.Engine/Reporters/Html/HtmlReportGenerator.cs
@@ -751,12 +751,12 @@ internal static class HtmlReportGenerator
         }
         if (!string.IsNullOrEmpty(s.Source))
         {
-            var src = s.Source.ToLowerInvariant();
-            if (src.Contains("npgsql")) return "npgsql";
-            if (src.Contains("httpclient") || src.Contains("http.client")) return "http.client";
-            if (src.Contains("aspnetcore") || src.Contains("kestrel") || src.Contains("http.server")) return "http.server";
-            if (src.Contains("rabbit")) return "rabbitmq";
-            if (src.Contains("tunit")) return "test";
+            var src = s.Source!;
+            if (src.Contains("npgsql", StringComparison.OrdinalIgnoreCase)) return "npgsql";
+            if (src.Contains("httpclient", StringComparison.OrdinalIgnoreCase) || src.Contains("http.client", StringComparison.OrdinalIgnoreCase)) return "http.client";
+            if (src.Contains("aspnetcore", StringComparison.OrdinalIgnoreCase) || src.Contains("kestrel", StringComparison.OrdinalIgnoreCase) || src.Contains("http.server", StringComparison.OrdinalIgnoreCase)) return "http.server";
+            if (src.Contains("rabbit", StringComparison.OrdinalIgnoreCase)) return "rabbitmq";
+            if (src.Contains("tunit", StringComparison.OrdinalIgnoreCase)) return "test";
         }
         if (s.Name is { Length: > 0 } name)
         {


### PR DESCRIPTION
## What
Replaces the `ToLowerInvariant()` copy + `Contains()` chain in `HtmlReportGenerator.MapSpanService` with in-place case-insensitive `string.Contains(..., StringComparison.OrdinalIgnoreCase)` calls.

## Why
`ToLowerInvariant()` allocated a new lowercased string per span before running 5+ `Contains` scans over the copy. The `StringComparison` overload matches case-insensitively in place, removing the allocation with comparable performance. This path runs per span emitted into the HTML report.

## Notes
- The final `return ... s.Source.ToLowerInvariant()` (line 765) is intentionally left unchanged: its result is serialized as the span `service` value and consumed downstream as a CSS/URL identifier, so the lowercased form is semantically required there.
- `string.Contains(string, StringComparison)` is net2.1+/net5+; for the `netstandard2.0` target it is supplied by the existing `Polyfill` package included for all internal projects.

## Validation
- `dotnet build TUnit.Engine -p:DisableGitVersionTask=true` — 0 warnings, 0 errors across net8.0/net9.0/net10.0/netstandard2.0.
- Reflection-mode-only file; no source-generator output or public API changes, so no snapshot updates required.

Closes #6057