### PR TITLE
perf: use [GeneratedRegex] in MetadataFilterMatcher

### DIFF
--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -131,11 +131,11 @@ internal sealed partial class MetadataFilterMatcher : IMetadataFilterMatcher
     private static readonly ConcurrentDictionary<string, string> _strippedFilterCache = new();
 
     // Matches property-bag filters like [key=value]; used to strip them before path parsing.
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(@"\[([^\]]*)\]")]
+#if NET8_0_OR_GREATER
+    [GeneratedRegex(@"\[[^\]]*\]")]
     private static partial Regex PropertyFilterRegex();
 #else
-    private static readonly Regex _propertyFilterRegex = new(@"\[([^\]]*)\]", RegexOptions.Compiled);
+    private static readonly Regex _propertyFilterRegex = new(@"\[[^\]]*\]", RegexOptions.Compiled);
 
     private static Regex PropertyFilterRegex() => _propertyFilterRegex;
 #endif

--- a/TUnit.Engine/Services/MetadataFilterMatcher.cs
+++ b/TUnit.Engine/Services/MetadataFilterMatcher.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.RegularExpressions;
 #if NET8_0_OR_GREATER
 using System.Buffers;
 #endif
@@ -117,7 +118,7 @@ internal readonly struct FilterHints
 /// Implementation of metadata filter matching logic extracted from TestBuilder.
 /// Evaluates if test metadata could match an execution filter without building tests.
 /// </summary>
-internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
+internal sealed partial class MetadataFilterMatcher : IMetadataFilterMatcher
 {
 #pragma warning disable TPEXP
     private static readonly ConstructorInfo _treeNodeFilterConstructor =
@@ -128,6 +129,16 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
     private static readonly PropertyBag _emptyPropertyBag = new();
 
     private static readonly ConcurrentDictionary<string, string> _strippedFilterCache = new();
+
+    // Matches property-bag filters like [key=value]; used to strip them before path parsing.
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"\[([^\]]*)\]")]
+    private static partial Regex PropertyFilterRegex();
+#else
+    private static readonly Regex _propertyFilterRegex = new(@"\[([^\]]*)\]", RegexOptions.Compiled);
+
+    private static Regex PropertyFilterRegex() => _propertyFilterRegex;
+#endif
 
     /// <summary>
     /// Extract hints from a filter that can be used to pre-filter test sources by type.
@@ -149,7 +160,7 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
         // Strip property filters like [key=value]
         if (filterString.Contains('['))
         {
-            filterString = System.Text.RegularExpressions.Regex.Replace(filterString, @"\[([^\]]*)\]", "");
+            filterString = PropertyFilterRegex().Replace(filterString, "");
         }
 
         // Parse path: /{assembly}/{namespace}/{className}/{methodName}
@@ -407,7 +418,7 @@ internal sealed class MetadataFilterMatcher : IMetadataFilterMatcher
         if (filterString.Contains('['))
         {
             var strippedFilterString = _strippedFilterCache.GetOrAdd(filterString,
-                static fs => System.Text.RegularExpressions.Regex.Replace(fs, @"\[([^\]]*)\]", ""));
+                static fs => PropertyFilterRegex().Replace(fs, ""));
             pathOnlyFilter = CreateTreeNodeFilterViaReflection(strippedFilterString);
         }
         else


### PR DESCRIPTION
## What

Replace runtime `Regex.Replace` calls in `MetadataFilterMatcher` (in `ExtractFilterHints` and the metadata-match path that strips property-bag filters) with a shared, source-generated `PropertyFilterRegex()` on net7+. On netstandard2.0 (which lacks `[GeneratedRegex]`) it falls back to a cached `static readonly Regex` compiled once.

## Why

The previous code called `Regex.Replace(filterString, @"\[([^\]]*)\]", "")` at two sites, re-parsing the pattern on every call. `[GeneratedRegex]` emits the matcher at compile time, eliminating the per-call parse and being Native AOT friendly (no runtime regex compilation). Both call sites now share one regex member.

## Validation

- `dotnet build TUnit.Engine -p:DisableGitVersionTask=true` succeeds across all TFMs (netstandard2.0, net8.0, net9.0, net10.0) with **0 warnings / 0 errors**.
- The GeneratedRegex source generator runs on net7+; the compiled-Regex fallback compiles on netstandard2.0.
- No source-generator output or public API changes, so no snapshot updates required.

Closes #6036