### PR TITLE
perf: optimize TestNameFormatter argument and bool formatting

### DIFF
--- a/TUnit.Core/Services/TestNameFormatter.cs
+++ b/TUnit.Core/Services/TestNameFormatter.cs
@@ -51,7 +51,7 @@ public class TestNameFormatter : ITestNameFormatter
             null => "null",
             string str => $"\"{str}\"",
             char ch => $"'{ch}'",
-            bool b => b.ToString().ToLowerInvariant(),
+            bool b => b ? "true" : "false",
             // Use InvariantCulture for numeric types to avoid culture-specific formatting issues
             double d => d.ToString(System.Globalization.CultureInfo.InvariantCulture),
             float f => f.ToString(System.Globalization.CultureInfo.InvariantCulture),
@@ -95,7 +95,26 @@ public class TestNameFormatter : ITestNameFormatter
             return string.Empty;
         }
 
-        return string.Join(", ", args.Select(FormatArgumentValue));
+        // Build directly into a pooled StringBuilder to avoid the LINQ iterator/closure
+        // and the temporary string[] that Select + string.Join would materialize.
+        var builder = StringBuilderPool.Get();
+        try
+        {
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+                builder.Append(FormatArgumentValue(args[i]));
+            }
+
+            return builder.ToString();
+        }
+        finally
+        {
+            StringBuilderPool.Return(builder);
+        }
     }
 
     private string FormatEnumerable(IEnumerable enumerable)


### PR DESCRIPTION
## What

Two allocation reductions in `TUnit.Core/Services/TestNameFormatter.cs`, combined into one PR since both touch the same file.

- **FormatArguments (#6031):** replaced `string.Join(", ", args.Select(FormatArgumentValue))` with a direct `for` loop into a pooled `StringBuilder`. This avoids the `Select` iterator + closure capturing `this`, and the temporary `string[]`/`IEnumerator<string>` that `string.Join` materializes.
- **FormatArgumentValue (#6030):** replaced `bool b => b.ToString().ToLowerInvariant()` (two allocations: `"True"`/`"False"`, then a lowercased copy) with the interned literals `b ? "true" : "false"`.

## Why

Both run on hot display-name formatting paths: `FormatArguments` per parameterized test/template, and the bool branch per bool argument formatted.

## Validation

- Output is byte-identical: bool still renders lowercase `true`/`false`; arguments still join with `", "`.
- Reuses the existing `StringBuilderPool` pattern already used by `BuildTestId` and `FormatEnumerable` in the same file.
- `dotnet build TUnit.Core -p:DisableGitVersionTask=true` succeeds across net8.0/net9.0/net10.0/netstandard2.0 with 0 warnings, 0 errors.
- No public API or source-generator output changed, so no snapshot `.verified.txt` updates required.

Closes #6030
Closes #6031