### PR TITLE
perf: replace LINQ dependency extraction with manual loop

### DIFF
--- a/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
+++ b/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
@@ -269,7 +269,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
             TestName = testName,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = ExtractDependencies(result.Attributes),
+            Dependencies = AttributeHelpers.ExtractDependencies(result.Attributes),
             DataSources = [], // Dynamic tests don't use data sources in the same way
             ClassDataSources = [],
             PropertyDataSources = [],
@@ -284,21 +284,6 @@ internal sealed class AotTestDataCollector : ITestDataCollector
             AttributeFactory = () => GetDynamicTestAttributes(result),
             PropertyInjections = PropertySourceRegistry.DiscoverInjectableProperties(result.TestClassType)
         });
-    }
-
-    private static TestDependency[] ExtractDependencies(List<Attribute> attributes)
-    {
-        List<TestDependency>? dependencies = null;
-
-        foreach (var attribute in attributes)
-        {
-            if (attribute is DependsOnAttribute dependsOn)
-            {
-                (dependencies ??= []).Add(dependsOn.ToTestDependency());
-            }
-        }
-
-        return dependencies?.ToArray() ?? [];
     }
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)

--- a/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
+++ b/TUnit.Engine/Building/Collectors/AotTestDataCollector.cs
@@ -269,7 +269,7 @@ internal sealed class AotTestDataCollector : ITestDataCollector
             TestName = testName,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = result.Attributes.OfType<DependsOnAttribute>().Select(a => a.ToTestDependency()).ToArray(),
+            Dependencies = ExtractDependencies(result.Attributes),
             DataSources = [], // Dynamic tests don't use data sources in the same way
             ClassDataSources = [],
             PropertyDataSources = [],
@@ -284,6 +284,21 @@ internal sealed class AotTestDataCollector : ITestDataCollector
             AttributeFactory = () => GetDynamicTestAttributes(result),
             PropertyInjections = PropertySourceRegistry.DiscoverInjectableProperties(result.TestClassType)
         });
+    }
+
+    private static TestDependency[] ExtractDependencies(List<Attribute> attributes)
+    {
+        List<TestDependency>? dependencies = null;
+
+        foreach (var attribute in attributes)
+        {
+            if (attribute is DependsOnAttribute dependsOn)
+            {
+                (dependencies ??= []).Add(dependsOn.ToTestDependency());
+            }
+        }
+
+        return dependencies?.ToArray() ?? [];
     }
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -2229,7 +2229,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
             TestName = testName,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = result.Attributes.OfType<DependsOnAttribute>().Select(static a => a.ToTestDependency()).ToArray(),
+            Dependencies = ExtractDependencies(result.Attributes),
             DataSources = [], // Dynamic tests don't use data sources in the same way
             ClassDataSources = [],
             PropertyDataSources = [],
@@ -2246,6 +2246,21 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
         };
 
         return Task.FromResult<TestMetadata>(metadata);
+    }
+
+    private static TestDependency[] ExtractDependencies(List<Attribute> attributes)
+    {
+        List<TestDependency>? dependencies = null;
+
+        foreach (var attribute in attributes)
+        {
+            if (attribute is DependsOnAttribute dependsOn)
+            {
+                (dependencies ??= []).Add(dependsOn.ToTestDependency());
+            }
+        }
+
+        return dependencies?.ToArray() ?? [];
     }
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -2229,7 +2229,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
             TestName = testName,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = ExtractDependencies(result.Attributes),
+            Dependencies = AttributeHelpers.ExtractDependencies(result.Attributes),
             DataSources = [], // Dynamic tests don't use data sources in the same way
             ClassDataSources = [],
             PropertyDataSources = [],
@@ -2248,20 +2248,6 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
         return Task.FromResult<TestMetadata>(metadata);
     }
 
-    private static TestDependency[] ExtractDependencies(List<Attribute> attributes)
-    {
-        List<TestDependency>? dependencies = null;
-
-        foreach (var attribute in attributes)
-        {
-            if (attribute is DependsOnAttribute dependsOn)
-            {
-                (dependencies ??= []).Add(dependsOn.ToTestDependency());
-            }
-        }
-
-        return dependencies?.ToArray() ?? [];
-    }
 
     private static Attribute[] GetDynamicTestAttributes(DynamicDiscoveryResult result)
     {

--- a/TUnit.Engine/Helpers/AttributeHelpers.cs
+++ b/TUnit.Engine/Helpers/AttributeHelpers.cs
@@ -1,0 +1,29 @@
+using TUnit.Core;
+
+namespace TUnit.Engine.Helpers;
+
+/// <summary>
+/// Shared attribute-extraction helpers used by the dynamic-discovery code paths
+/// (AOT, reflection, and runtime registration) so they stay in sync.
+/// </summary>
+internal static class AttributeHelpers
+{
+    /// <summary>
+    /// Extracts <see cref="TestDependency"/> entries from a materialised attribute list.
+    /// Returns the shared empty array when no <see cref="DependsOnAttribute"/> is present.
+    /// </summary>
+    public static TestDependency[] ExtractDependencies(List<Attribute> attributes)
+    {
+        List<TestDependency>? dependencies = null;
+
+        foreach (var attribute in attributes)
+        {
+            if (attribute is DependsOnAttribute dependsOn)
+            {
+                (dependencies ??= []).Add(dependsOn.ToTestDependency());
+            }
+        }
+
+        return dependencies?.ToArray() ?? [];
+    }
+}

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -285,9 +285,7 @@ internal sealed class TestRegistry : ITestRegistry
             TestName = methodInfo.Name,
             TestClassType = result.TestClassType,
             TestMethodName = methodInfo.Name,
-            Dependencies = result.Attributes.OfType<DependsOnAttribute>()
-                .Select(x => x.ToTestDependency())
-                .ToArray(),
+            Dependencies = AttributeHelpers.ExtractDependencies(result.Attributes),
             DataSources = [],
             ClassDataSources = [],
             PropertyDataSources = [],


### PR DESCRIPTION
## What

Replaces the `OfType<DependsOnAttribute>().Select(a => a.ToTestDependency()).ToArray()` LINQ chain used to build the `Dependencies` array with a single-pass manual loop, in both dynamic-discovery code paths:

- `TUnit.Engine/Building/Collectors/AotTestDataCollector.cs` (AOT/source-gen path)
- `TUnit.Engine/Discovery/ReflectionTestDataCollector.cs` (reflection path)

Both now call a shared-shape `ExtractDependencies(List<Attribute>)` helper.

## Why

This runs per test during discovery in both AOT and reflection modes. The LINQ chain allocates an `OfTypeIterator`, a `SelectArrayIterator`, and the result array for every test. For the common case of tests with zero `DependsOnAttribute`, the new loop allocates nothing and returns the shared empty array. Output ordering and behavior are identical (single forward pass over the same attribute list).

## Validation

- `dotnet build TUnit.Engine -p:DisableGitVersionTask=true`: 0 warnings, 0 errors across net8.0/net9.0/net10.0/netstandard2.0.
- Change is internal metadata collection only - no public API or source-generator output change, so no snapshot updates required.
- Dual-mode: both AOT and reflection collectors updated identically.

Closes #6053