### PR TITLE
perf: dedupe GetSimpleTypeName into shared TypeNameFormatter

### DIFF
--- a/TUnit.Core/DataSources/TestDataFormatter.cs
+++ b/TUnit.Core/DataSources/TestDataFormatter.cs
@@ -86,7 +86,7 @@ public static class TestDataFormatter
             var genericTypeNames = new string[genericTypes.Length];
             for (var i = 0; i < genericTypes.Length; i++)
             {
-                genericTypeNames[i] = GetSimpleTypeName(genericTypes[i]);
+                genericTypeNames[i] = TypeNameFormatter.GetSimpleTypeName(genericTypes[i]);
             }
             var genericPart = string.Join(", ", genericTypeNames);
             testName = $"{testName}<{genericPart}>";
@@ -100,30 +100,4 @@ public static class TestDataFormatter
         var argumentsText = FormatArguments(arguments);
         return $"{testName}({argumentsText})";
     }
-
-    private static string GetSimpleTypeName(Type type)
-    {
-        if (!type.IsGenericType)
-        {
-            return type.Name;
-        }
-
-        var genericTypeName = type.GetGenericTypeDefinition().Name;
-        var index = genericTypeName.IndexOf('`');
-        if (index > 0)
-        {
-            genericTypeName = genericTypeName.Substring(0, index);
-        }
-
-        var genericArgs = type.GetGenericArguments();
-        var genericArgNames = new string[genericArgs.Length];
-        for (var i = 0; i < genericArgs.Length; i++)
-        {
-            genericArgNames[i] = GetSimpleTypeName(genericArgs[i]);
-        }
-        var genericArgsText = string.Join(", ", genericArgNames);
-
-        return $"{genericTypeName}<{genericArgsText}>";
-    }
-
 }

--- a/TUnit.Core/Helpers/TypeNameFormatter.cs
+++ b/TUnit.Core/Helpers/TypeNameFormatter.cs
@@ -1,0 +1,71 @@
+using System.Text;
+
+namespace TUnit.Core.Helpers;
+
+/// <summary>
+/// Formats <see cref="Type"/> instances into simple, human-readable names for display purposes.
+/// </summary>
+internal static class TypeNameFormatter
+{
+    /// <summary>
+    /// Builds a simple type name, recursively expanding generic arguments
+    /// (e.g. <c>Dictionary&lt;String, List&lt;Int32&gt;&gt;</c>).
+    /// </summary>
+    /// <remarks>
+    /// Uses a single pooled <see cref="StringBuilder"/> for the entire recursive build,
+    /// allocating only the final string rather than one string per generic level.
+    /// </remarks>
+    public static string GetSimpleTypeName(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        var builder = StringBuilderPool.Get();
+        try
+        {
+            AppendSimpleTypeName(builder, type);
+            return builder.ToString();
+        }
+        finally
+        {
+            StringBuilderPool.Return(builder);
+        }
+    }
+
+    private static void AppendSimpleTypeName(StringBuilder builder, Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            builder.Append(type.Name);
+            return;
+        }
+
+        var genericTypeName = type.GetGenericTypeDefinition().Name;
+        var index = genericTypeName.IndexOf('`');
+        if (index > 0)
+        {
+            builder.Append(genericTypeName, 0, index);
+        }
+        else
+        {
+            builder.Append(genericTypeName);
+        }
+
+        builder.Append('<');
+
+        var genericArgs = type.GetGenericArguments();
+        for (var i = 0; i < genericArgs.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            AppendSimpleTypeName(builder, genericArgs[i]);
+        }
+
+        builder.Append('>');
+    }
+}

--- a/TUnit.Engine/Helpers/DisplayNameBuilder.cs
+++ b/TUnit.Engine/Helpers/DisplayNameBuilder.cs
@@ -110,7 +110,7 @@ internal static class DisplayNameBuilder
             var genericTypeNames = new string[genericTypes.Length];
             for (var i = 0; i < genericTypes.Length; i++)
             {
-                genericTypeNames[i] = GetSimpleTypeName(genericTypes[i]);
+                genericTypeNames[i] = TypeNameFormatter.GetSimpleTypeName(genericTypes[i]);
             }
             var genericPart = string.Join(", ", genericTypeNames);
             testName = $"{testName}<{genericPart}>";
@@ -123,31 +123,6 @@ internal static class DisplayNameBuilder
 
         var argumentsText = FormatArguments(arguments);
         return $"{testName}({argumentsText})";
-    }
-
-    private static string GetSimpleTypeName(Type type)
-    {
-        if (!type.IsGenericType)
-        {
-            return type.Name;
-        }
-
-        var genericTypeName = type.GetGenericTypeDefinition().Name;
-        var index = genericTypeName.IndexOf('`');
-        if (index > 0)
-        {
-            genericTypeName = genericTypeName.Substring(0, index);
-        }
-
-        var genericArgs = type.GetGenericArguments();
-        var genericArgNames = new string[genericArgs.Length];
-        for (var i = 0; i < genericArgs.Length; i++)
-        {
-            genericArgNames[i] = GetSimpleTypeName(genericArgs[i]);
-        }
-        var genericArgsText = string.Join(", ", genericArgNames);
-
-        return $"{genericTypeName}<{genericArgsText}>";
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Extracts the duplicated runtime `GetSimpleTypeName` logic from `TestDataFormatter` and `DisplayNameBuilder` into a single internal helper `TUnit.Core.Helpers.TypeNameFormatter.GetSimpleTypeName`, and updates both call sites to use it.

## Why

The two implementations were byte-for-byte identical (`TUnit.Core/DataSources/TestDataFormatter.cs` and `TUnit.Engine/Helpers/DisplayNameBuilder.cs`). Each one recursively allocated a `new string[genericArgs.Length]` plus a `string.Join` and an interpolated string **per generic level** of every parameterized generic test display name.

The shared helper builds the whole name into one pooled `StringBuilder`, allocating only the final string regardless of nesting depth.

## Validation

- Output is byte-identical to both previous call sites (same backtick truncation, same `<a, b>` formatting, recursive expansion of nested generics).
- Helper is `internal` in `TUnit.Core`; `TUnit.Engine` already has `InternalsVisibleTo`, so both source-gen and reflection modes share one implementation (dual-mode).
- AOT-safe: no new reflection introduced.
- Changed files are runtime-only (not source-generator output), so no generated snapshots / display-name verified tests are affected.
- `dotnet build TUnit.Engine` (net8.0/net9.0/net10.0/netstandard2.0): **0 warnings, 0 errors**.

Closes #6039