### PR TITLE
perf: avoid GetCustomAttributes() + LINQ chain for per-property attribute scans

### DIFF
--- a/TUnit.Core/StaticPropertyReflectionInitializer.cs
+++ b/TUnit.Core/StaticPropertyReflectionInitializer.cs
@@ -60,15 +60,26 @@ public static class StaticPropertyReflectionInitializer
             return;
         }
 
-        // Get all static properties with data source attributes
-        var staticProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Static)
-            .Where(p => p.CanWrite && HasDataSourceAttribute(p));
+        var staticProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Static);
 
         foreach (var property in staticProperties)
         {
+            if (!property.CanWrite)
+            {
+                continue;
+            }
+
+            // Single-pass lookup avoids materialising the attribute array twice
+            // (once to filter, once to fetch) and skips properties with no data source.
+            var dataSourceAttr = GetFirstDataSourceAttribute(property);
+            if (dataSourceAttr is null)
+            {
+                continue;
+            }
+
             try
             {
-                await InitializeStaticProperty(type, property);
+                await InitializeStaticProperty(property, dataSourceAttr);
             }
             catch (Exception ex)
             {
@@ -78,23 +89,24 @@ public static class StaticPropertyReflectionInitializer
         }
     }
 
-    private static bool HasDataSourceAttribute(PropertyInfo property)
+    private static IDataSourceAttribute? GetFirstDataSourceAttribute(PropertyInfo property)
     {
-        return property.GetCustomAttributes()
-            .Any(attr => attr is IDataSourceAttribute);
+        foreach (var attribute in property.GetCustomAttributes())
+        {
+            if (attribute is IDataSourceAttribute dataSource)
+            {
+                return dataSource;
+            }
+        }
+
+        return null;
     }
 
 #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode("Data source initialization may require dynamic code generation")]
 #endif
-    private static async Task InitializeStaticProperty(Type type, PropertyInfo property)
+    private static async Task InitializeStaticProperty(PropertyInfo property, IDataSourceAttribute dataSourceAttr)
     {
-        if (property.GetCustomAttributes()
-                .FirstOrDefault(attr => attr is IDataSourceAttribute) is not IDataSourceAttribute dataSourceAttr)
-        {
-            return;
-        }
-
         // Create metadata for the data source
         var metadata = new DataGeneratorMetadata
         {

--- a/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
+++ b/TUnit.Engine/Discovery/ReflectionInstanceFactory.cs
@@ -62,18 +62,15 @@ internal static class ReflectionInstanceFactory
                 continue;
             }
 
-            // Look for data source attributes on the property
-            var dataSourceAttrs = property.GetCustomAttributes()
-                .OfType<IDataSourceAttribute>()
-                .ToArray();
+            // Look for the first data source attribute on the property.
+            // Single-pass avoids allocating the OfType iterator + array for the
+            // common case of properties without a data source attribute.
+            var dataSource = GetFirstDataSourceAttribute(property);
 
-            if (dataSourceAttrs.Length == 0)
+            if (dataSource is null)
             {
                 continue;
             }
-
-            // Try to get data from the first data source
-            var dataSource = dataSourceAttrs[0];
 
             try
             {
@@ -114,6 +111,19 @@ internal static class ReflectionInstanceFactory
                 // Ignore errors during property injection - the test will fail with a better error message
             }
         }
+    }
+
+    private static IDataSourceAttribute? GetFirstDataSourceAttribute(PropertyInfo property)
+    {
+        foreach (var attribute in property.GetCustomAttributes())
+        {
+            if (attribute is IDataSourceAttribute dataSource)
+            {
+                return dataSource;
+            }
+        }
+
+        return null;
     }
 
     private static DataGeneratorMetadata CreatePropertyMetadata(PropertyInfo property, Type containingType, IDataSourceAttribute dataSource)


### PR DESCRIPTION
@
## What

Replaces `GetCustomAttributes()` + LINQ (`OfType`/`Any`/`FirstOrDefault`) per-property attribute scans with a single-pass `foreach` that returns the first `IDataSourceAttribute`.

- **`ReflectionInstanceFactory.InjectPropertiesAsync`** — was `GetCustomAttributes().OfType<IDataSourceAttribute>().ToArray()`. Now a single-pass helper. Drops the `OfType` iterator + materialised array; for the common case (property with no data source) nothing extra is allocated.
- **`StaticPropertyReflectionInitializer`** — previously materialised the attribute array twice per property (once in a `.Where(HasDataSourceAttribute)` filter, again via `FirstOrDefault` inside `InitializeStaticProperty`). Collapsed into a single scan per property; the resolved attribute is passed straight through.

Per the issue, `ConstructorHelper.cs` is intentionally **not** modified here — it is covered by separate open PR #6056.

## Why

`GetCustomAttributes()` allocates an `object[]`, and the LINQ chain layers iterators + lambdas + a final array on top. These run per property per type during reflection-mode discovery/construction (a hot path), and for the common no-data-source case it was pure waste.

## Validation

- `dotnet build TUnit.Core` and `dotnet build TUnit.Engine` (`-p:DisableGitVersionTask=true`): 0 warnings, 0 errors across net8.0/net9.0/net10.0/netstandard2.0.
- Reflection-only changes; all touched members are private. No public API or source-generator output changed, so no snapshot updates required.
- Dual-mode preserved: these paths are reflection-mode only; source-gen mode is unaffected.

Closes #6055
@