### PR TITLE
perf: use FrozenSet/FrozenDictionary for read-only static lookups

### DIFF
--- a/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
+++ b/TUnit.Core/Discovery/ObjectGraphDiscoverer.cs
@@ -1,4 +1,7 @@
 using System.Collections.Concurrent;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -48,16 +51,26 @@ internal sealed class ObjectGraphDiscoverer : IObjectGraphTracker
     // Reference equality comparer for object tracking (ignores Equals overrides)
     private static readonly Helpers.ReferenceEqualityComparer ReferenceComparer = Helpers.ReferenceEqualityComparer.Instance;
 
-    // Types to skip during discovery (primitives, strings, system types)
+    // Types to skip during discovery (primitives, strings, system types).
+    // Frozen on net8+ for faster lookups; this set is read-many during per-test traversal.
+#if NET8_0_OR_GREATER
+    private static readonly System.Collections.Frozen.FrozenSet<Type> SkipTypes =
+#else
     private static readonly HashSet<Type> SkipTypes =
-    [
-        typeof(string),
-        typeof(decimal),
-        typeof(DateTime),
-        typeof(DateTimeOffset),
-        typeof(TimeSpan),
-        typeof(Guid)
-    ];
+#endif
+        new HashSet<Type>
+        {
+            typeof(string),
+            typeof(decimal),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan),
+            typeof(Guid)
+        }
+#if NET8_0_OR_GREATER
+        .ToFrozenSet()
+#endif
+        ;
 
     // Thread-safe collection of discovery errors for diagnostics
     private static readonly ConcurrentBag<DiscoveryError> DiscoveryErrors = [];

--- a/TUnit.Core/Helpers/TupleFactory.cs
+++ b/TUnit.Core/Helpers/TupleFactory.cs
@@ -7,28 +7,41 @@ namespace TUnit.Core.Helpers;
 /// </summary>
 public static class TupleFactory
 {
-    private static readonly Dictionary<Type, Func<object?[], object?>> TypedFactories = new();
-    
+    // Read-only after the static initializer completes; TryGetValue is called per
+    // tuple-arg conversion. Frozen on net8+ for faster lookups.
+#if NET8_0_OR_GREATER
+    private static readonly System.Collections.Frozen.FrozenDictionary<Type, Func<object?[], object?>> TypedFactories;
+#else
+    private static readonly Dictionary<Type, Func<object?[], object?>> TypedFactories;
+#endif
+
     static TupleFactory()
     {
         // Register factories for common tuple types with object elements
-        RegisterFactory<ValueTuple<object?, object?>>((args) => 
+        var factories = new Dictionary<Type, Func<object?[], object?>>();
+        RegisterFactory<ValueTuple<object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?>(args[0], args[1]));
-        RegisterFactory<ValueTuple<object?, object?, object?>>((args) => 
+        RegisterFactory<ValueTuple<object?, object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?, object?>(args[0], args[1], args[2]));
-        RegisterFactory<ValueTuple<object?, object?, object?, object?>>((args) => 
+        RegisterFactory<ValueTuple<object?, object?, object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?, object?, object?>(args[0], args[1], args[2], args[3]));
-        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?>>((args) => 
+        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?, object?, object?, object?>(args[0], args[1], args[2], args[3], args[4]));
-        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?, object?>>((args) => 
+        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?, object?, object?, object?, object?>(args[0], args[1], args[2], args[3], args[4], args[5]));
-        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?, object?, object?>>((args) => 
+        RegisterFactory<ValueTuple<object?, object?, object?, object?, object?, object?, object?>>(factories, (args) =>
             new ValueTuple<object?, object?, object?, object?, object?, object?, object?>(args[0], args[1], args[2], args[3], args[4], args[5], args[6]));
+
+#if NET8_0_OR_GREATER
+        TypedFactories = System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(factories);
+#else
+        TypedFactories = factories;
+#endif
     }
-    
-    private static void RegisterFactory<T>(Func<object?[], T> factory) where T : struct
+
+    private static void RegisterFactory<T>(Dictionary<Type, Func<object?[], object?>> factories, Func<object?[], T> factory) where T : struct
     {
-        TypedFactories[typeof(T)] = args => factory(args);
+        factories[typeof(T)] = args => factory(args);
     }
     
     /// <summary>

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -1,5 +1,8 @@
 ﻿using System.Buffers;
 using System.Collections.Concurrent;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -206,8 +209,17 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
         });
     }
 
+    // Read-many during reflection discovery (one Contains per assembly).
+    // Frozen on net8+ for faster lookups.
+#if NET8_0_OR_GREATER
+    private static readonly System.Collections.Frozen.FrozenSet<string> ExcludedAssemblyNames =
+        new HashSet<string>
+        {
+#else
     private static readonly HashSet<string> ExcludedAssemblyNames =
-    [
+        new()
+        {
+#endif
         "mscorlib",
         "System",
         "System.Core",
@@ -269,7 +281,11 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
         "Shouldly",
         "NSubstitute",
         "Rhino.Mocks"
-    ];
+        }
+#if NET8_0_OR_GREATER
+        .ToFrozenSet()
+#endif
+        ;
 
     private static bool ShouldScanAssembly(Assembly assembly)
     {


### PR DESCRIPTION
## What

Converts three read-only static collections — populated once and read-many inside hot per-test / per-assembly loops — to `FrozenSet`/`FrozenDictionary` (`System.Collections.Frozen`, net8+) for faster lookups:

1. `TUnit.Core/Discovery/ObjectGraphDiscoverer.cs` — `SkipTypes` (`HashSet<Type>`), queried via `Contains` in `ShouldSkipType` during per-test object-graph traversal.
2. `TUnit.Engine/Discovery/ReflectionTestDataCollector.cs` — `ExcludedAssemblyNames` (`HashSet<string>`), one `Contains` per assembly during reflection discovery.
3. `TUnit.Core/Helpers/TupleFactory.cs` — `TypedFactories` (`Dictionary<Type, Func<...>>`), `TryGetValue` per tuple-arg conversion. Now built into a temp dictionary in the static ctor, then frozen.

## Why

All three are read-only after initialization and queried in hot paths. `FrozenSet`/`FrozenDictionary` trade slightly higher build cost (one-time, at static init) for faster steady-state lookups.

## netstandard2.0 guarding

`FrozenSet`/`FrozenDictionary` do not exist on netstandard2.0, and both `TUnit.Core` and `TUnit.Engine` multi-target `netstandard2.0;net8.0;net9.0;net10.0`. Every conversion is guarded with `#if NET8_0_OR_GREATER`: net8+ uses the frozen type, netstandard2.0 keeps the original `HashSet`/`Dictionary`. The `using System.Collections.Frozen;` is likewise guarded. All fields are `private`/`internal` static — no public API surface change, no source-gen output change.

## Validation

- `dotnet build` of both projects across all four TFMs: **0 warnings, 0 errors**.
- Verified netstandard2.0 compiles explicitly (`-f netstandard2.0`).
- AOT-compatible (frozen collections are AOT-safe; no new reflection).

Closes #6047
