### PR TITLE
fix: remove GitVersion MSBuild task, pin local builds to 99.99.99 (#6077)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,20 +14,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Disable GitVersion MSBuild task by default - CI computes version once and passes properties explicitly.
-         This prevents GitVersion from spawning a process per project×TFM (153+ invocations). -->
-    <DisableGitVersionTask>true</DisableGitVersionTask>
-    <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
-    <!-- Re-enable GitVersion for core library projects when building locally, so that
-         strong-named assembly versions match what NuGet packages (e.g. Verify.TUnit) expect. -->
-    <_EnableLocalGitVersion Condition="'$(GITHUB_ACTIONS)' != 'true' and (
-        '$(MSBuildProjectName)' == 'TUnit.Core' or
-        '$(MSBuildProjectName)' == 'TUnit.Engine' or
-        '$(MSBuildProjectName)' == 'TUnit.Mocks' or
-        '$(MSBuildProjectName)' == 'TUnit.Assertions'
-    )">true</_EnableLocalGitVersion>
-    <DisableGitVersionTask Condition="'$(_EnableLocalGitVersion)' == 'true'">false</DisableGitVersionTask>
-    <GenerateGitVersionInformation Condition="'$(_EnableLocalGitVersion)' == 'true'">true</GenerateGitVersionInformation>
+    <!-- Versioning: CI computes the version once (GitVersion GitHub Action) and passes it to
+         every build/pack via -p:Version/-p:AssemblyVersion/... (see .github/workflows/dotnet.yml).
+         The GitVersion MSBuild task is intentionally NOT used - it crashes on some local repo
+         states (issue #6077) and would spawn a process per project×TFM. Locally we pin a high
+         dummy version so strong-named TUnit.Core loads cleanly and project-to-project references
+         resolve consistently. CI overrides these because it sets the properties explicitly. -->
+    <Version Condition="'$(GITHUB_ACTIONS)' != 'true' and '$(Version)' == ''">99.99.99</Version>
+    <AssemblyVersion Condition="'$(GITHUB_ACTIONS)' != 'true' and '$(AssemblyVersion)' == ''">99.99.99.0</AssemblyVersion>
+    <FileVersion Condition="'$(GITHUB_ACTIONS)' != 'true' and '$(FileVersion)' == ''">99.99.99.0</FileVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -94,18 +89,6 @@
     <PackageReference Include="Polyfill">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <!-- GitVersion only needed by the 4 core library projects that produce versioned NuGet packages -->
-  <ItemGroup Condition="
-      '$(MSBuildProjectName)' == 'TUnit.Core' or
-      '$(MSBuildProjectName)' == 'TUnit.Engine' or
-      '$(MSBuildProjectName)' == 'TUnit.Mocks' or
-      '$(MSBuildProjectName)' == 'TUnit.Assertions'">
-    <PackageReference Include="GitVersion.MsBuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="FsCheck" Version="3.3.3" />
     <PackageVersion Include="FSharp.Core" Version="10.1.300" />
-    <PackageVersion Include="GitVersion.MsBuild" Version="6.7.0" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="MessagePack" Version="3.1.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />

--- a/TUnit.Pipeline/Modules/UploadToNuGetModule.cs
+++ b/TUnit.Pipeline/Modules/UploadToNuGetModule.cs
@@ -57,7 +57,8 @@ public class UploadToNuGetModule(IOptions<NuGetOptions> options) : Module<Comman
         }
 
         var nupkgs = context.Git().RootDirectory
-            .GetFiles(x => x.NameWithoutExtension.Contains("TUnit") && x.Extension is ".nupkg");
+            .GetFiles(x => x.NameWithoutExtension.Contains("TUnit") && x.Extension is ".nupkg")
+            .ToArray();
 
         if (nupkgs.Any(file => file.NameWithoutExtension.Contains(DummyLocalVersion)))
         {

--- a/TUnit.Pipeline/Modules/UploadToNuGetModule.cs
+++ b/TUnit.Pipeline/Modules/UploadToNuGetModule.cs
@@ -15,6 +15,7 @@ namespace TUnit.Pipeline.Modules;
 
 [RunOnlyOnBranch("main")]
 [RunOnLinuxOnly]
+[DependsOn<GenerateVersionModule>]
 [DependsOn<PackTUnitFilesModule>]
 [DependsOn<TestNugetPackageModule>]
 [DependsOn<RunEngineTestsModule>]
@@ -22,6 +23,10 @@ namespace TUnit.Pipeline.Modules;
 [DependsOn<TestVBNugetPackageModule>]
 public class UploadToNuGetModule(IOptions<NuGetOptions> options) : Module<CommandResult[]>
 {
+    // Local builds pin this dummy version (see Directory.Build.props). Pushing it to NuGet.org
+    // would burn the version and ship an unbuildable package, so guard against it explicitly.
+    private const string DummyLocalVersion = "99.99.99";
+
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithSkipWhen(_ =>
         {
@@ -41,8 +46,24 @@ public class UploadToNuGetModule(IOptions<NuGetOptions> options) : Module<Comman
 
     protected override async Task<CommandResult[]?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
+        var versionResult = await context.GetModule<GenerateVersionModule>();
+        var semVer = versionResult.ValueOrDefault?.SemVer;
+
+        if (string.IsNullOrWhiteSpace(semVer) || semVer.StartsWith(DummyLocalVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to publish to NuGet: resolved version '{semVer}' is missing or is the dummy local version '{DummyLocalVersion}'. " +
+                "This indicates the CI versioning step did not run; aborting to avoid shipping a bad package.");
+        }
+
         var nupkgs = context.Git().RootDirectory
             .GetFiles(x => x.NameWithoutExtension.Contains("TUnit") && x.Extension is ".nupkg");
+
+        if (nupkgs.Any(file => file.NameWithoutExtension.Contains(DummyLocalVersion)))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to publish to NuGet: found a package stamped with the dummy local version '{DummyLocalVersion}'.");
+        }
 
         return await nupkgs.SelectAsync(file =>
                 context.DotNet().Nuget.Push(new DotNetNugetPushOptions

--- a/TUnit.PublicAPI/TUnit.PublicAPI.csproj
+++ b/TUnit.PublicAPI/TUnit.PublicAPI.csproj
@@ -31,15 +31,9 @@
       <ProjectReference Include="..\TUnit.OpenTelemetry\TUnit.OpenTelemetry.csproj" />
     </ItemGroup>
 
-    <!-- Pin transitive ProjectReference builds (TUnit.Core, TUnit.Assertions, ...) to the same
-         dummy version locally so strong-named references resolve consistently. MSBuild flows
-         AdditionalProperties as global properties to the referenced build, which then carry on
-         to its own ProjectReferences. Skipped under GitHub Actions where the workflow drives
-         versioning explicitly. -->
-    <ItemGroup Condition="'$(GITHUB_ACTIONS)' != 'true'">
-      <ProjectReference Update="@(ProjectReference)"
-                        AdditionalProperties="AssemblyVersion=99.99.99.0;FileVersion=99.99.99.0;Version=99.99.99" />
-    </ItemGroup>
+    <!-- No transitive version pin needed: each referenced project (TUnit.Core, TUnit.Assertions,
+         ...) self-pins to the same dummy version via the root Directory.Build.props when built
+         locally, so strong-named references resolve consistently. -->
 
     <Import Project="..\TestProject.targets" />
 

--- a/TUnit.PublicAPI/TUnit.PublicAPI.csproj
+++ b/TUnit.PublicAPI/TUnit.PublicAPI.csproj
@@ -11,18 +11,6 @@
         <Configuration>Release</Configuration>
     </PropertyGroup>
 
-    <!-- Local-only: bypass GitVersion (which can fail on some local repo states) and pin the
-         assembly version so strong-named TUnit.Core loads cleanly. CI keeps GitVersion-driven
-         versioning because GITHUB_ACTIONS=true. -->
-    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' != 'true'">
-        <DisableGitVersionTask>true</DisableGitVersionTask>
-        <GenerateGitVersionInformation>false</GenerateGitVersionInformation>
-        <_EnableLocalGitVersion>false</_EnableLocalGitVersion>
-        <AssemblyVersion>99.99.99.0</AssemblyVersion>
-        <FileVersion>99.99.99.0</FileVersion>
-        <Version>99.99.99</Version>
-    </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
       <PackageReference Include="PublicApiGenerator" />
@@ -43,14 +31,14 @@
       <ProjectReference Include="..\TUnit.OpenTelemetry\TUnit.OpenTelemetry.csproj" />
     </ItemGroup>
 
-    <!-- Propagate the GitVersion-disable + pinned-version properties to every transitive
-         ProjectReference build (e.g. TUnit.Core, TUnit.Assertions). MSBuild flows
-         AdditionalProperties as global properties for the referenced build, and globals
-         then carry on to its own ProjectReferences. Skipped under GitHub Actions where
-         the workflow drives versioning explicitly. -->
+    <!-- Pin transitive ProjectReference builds (TUnit.Core, TUnit.Assertions, ...) to the same
+         dummy version locally so strong-named references resolve consistently. MSBuild flows
+         AdditionalProperties as global properties to the referenced build, which then carry on
+         to its own ProjectReferences. Skipped under GitHub Actions where the workflow drives
+         versioning explicitly. -->
     <ItemGroup Condition="'$(GITHUB_ACTIONS)' != 'true'">
       <ProjectReference Update="@(ProjectReference)"
-                        AdditionalProperties="DisableGitVersionTask=true;GenerateGitVersionInformation=false;_EnableLocalGitVersion=false;AssemblyVersion=99.99.99.0;FileVersion=99.99.99.0;Version=99.99.99" />
+                        AdditionalProperties="AssemblyVersion=99.99.99.0;FileVersion=99.99.99.0;Version=99.99.99" />
     </ItemGroup>
 
     <Import Project="..\TestProject.targets" />


### PR DESCRIPTION
Fixes #6077.

## Problem
Local `dotnet build`/`test` crash in the `GitVersion.MsBuild` task (6.7.0):
`InvalidOperationException` in `MainlineVersionStrategy.GetCommitsWasBranchedFrom`. Contributors had to pass `-p:DisableGitVersionTask=true` manually.

## Root cause
The MSBuild GitVersion task was **only** ever exercised locally. CI computes the version once via the GitVersion **GitHub Action** and passes `-p:Version/-p:AssemblyVersion/...` to every build/pack (`.github/workflows/dotnet.yml`). The MSBuild task was pure dead weight + the crash source.

## Changes
- Remove the `GitVersion.MsBuild` `PackageReference` (and its `Directory.Packages.props` version entry).
- Pin `Version=99.99.99` / `AssemblyVersion=99.99.99.0` / `FileVersion=99.99.99.0` in `Directory.Build.props` when `GITHUB_ACTIONS != true`, guarded by an `is-empty` check so explicit `-p:` overrides win. CI behaviour unchanged.
- Drop the now-dead local-GitVersion plumbing from `TUnit.PublicAPI.csproj` (it duplicated the global pin).
- **Defensive guard** in `UploadToNuGetModule`: throw if the resolved version is missing or starts with `99.99.99`, and if any packed `.nupkg` is stamped with it — a dummy-versioned package can never reach NuGet.org.

## Verification
- `TUnit.Pipeline` and `TUnit.Core` build clean locally with no flag.
- Built `TUnit.Core.dll` stamps `99.99.99.0` locally (even with `-p:DisableGitVersionTask=false`, proving the task is gone).
