### PR TITLE
perf: hoist char[] alloc in FsCheckPropertyTestExecutor to static SearchValues

### DIFF
--- a/TUnit.FsCheck/FsCheckPropertyTestExecutor.cs
+++ b/TUnit.FsCheck/FsCheckPropertyTestExecutor.cs
@@ -18,7 +18,7 @@ namespace TUnit.FsCheck;
 public class FsCheckPropertyTestExecutor : ITestExecutor
 {
 #if NET8_0_OR_GREATER
-    private static readonly System.Buffers.SearchValues<char> LineEndings = System.Buffers.SearchValues.Create("\r\n");
+    private static readonly System.Buffers.SearchValues<char> _lineEndings = System.Buffers.SearchValues.Create("\r\n");
 #endif
 
     private readonly FsCheckPropertyAttribute _propertyAttribute;
@@ -197,7 +197,7 @@ public class FsCheckPropertyTestExecutor : ITestExecutor
 
         // Take only the first line
 #if NET8_0_OR_GREATER
-        var newlineIndex = afterShrunk.AsSpan().IndexOfAny(LineEndings);
+        var newlineIndex = afterShrunk.AsSpan().IndexOfAny(_lineEndings);
 #else
         var newlineIndex = afterShrunk.IndexOfAny(['\r', '\n']);
 #endif

--- a/TUnit.FsCheck/FsCheckPropertyTestExecutor.cs
+++ b/TUnit.FsCheck/FsCheckPropertyTestExecutor.cs
@@ -17,6 +17,10 @@ namespace TUnit.FsCheck;
 #pragma warning disable IL2072 // DynamicallyAccessedMembers warning
 public class FsCheckPropertyTestExecutor : ITestExecutor
 {
+#if NET8_0_OR_GREATER
+    private static readonly System.Buffers.SearchValues<char> LineEndings = System.Buffers.SearchValues.Create("\r\n");
+#endif
+
     private readonly FsCheckPropertyAttribute _propertyAttribute;
 
     public FsCheckPropertyTestExecutor(FsCheckPropertyAttribute propertyAttribute)
@@ -192,7 +196,11 @@ public class FsCheckPropertyTestExecutor : ITestExecutor
         var afterShrunk = message[(shrunkIndex + 7)..].TrimStart();
 
         // Take only the first line
+#if NET8_0_OR_GREATER
+        var newlineIndex = afterShrunk.AsSpan().IndexOfAny(LineEndings);
+#else
         var newlineIndex = afterShrunk.IndexOfAny(['\r', '\n']);
+#endif
         var shrunkLine = newlineIndex >= 0 ? afterShrunk[..newlineIndex] : afterShrunk;
 
         if (shrunkLine.StartsWith('('))


### PR DESCRIPTION
## What

`FsCheckPropertyTestExecutor.FormatCounterexample` allocated a `char[]` on every call via `afterShrunk.IndexOfAny(['\r', '\n'])`. This hoists the line-ending set into a static `SearchValues<char>` field and searches over a span instead, eliminating the per-call array allocation.

## Why

Follows the established pattern in `MetadataFilterMatcher.cs` and `PathValidator.cs`. Aligns with the project's performance-first principle (minimize allocations in hot paths).

## Notes on multi-targeting

`SearchValues` is only available on net8.0+. The project (via `Library.props`) targets `netstandard2.0;net8.0;net9.0;net10.0`, so the new path is guarded with `#if NET8_0_OR_GREATER` and the original collection-expression path is preserved for netstandard2.0.

## Validation

- Built `TUnit.FsCheck` in Release across all four TFMs (netstandard2.0, net8.0, net9.0, net10.0): 0 errors.
- Ran `TUnit.Example.FsCheck.TestProject` on net10.0: 17/17 passed.

Closes #6102