### PR TITLE
perf(sourcegen): Single-pass attribute classification

### DIFF
--- a/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceAttributeHelper.cs
+++ b/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceAttributeHelper.cs
@@ -12,8 +12,8 @@ internal static class DataSourceAttributeHelper
             return false;
         }
 
-        // Check if the attribute implements IDataSourceAttribute (using cache)
-        return InterfaceCache.ImplementsInterface(attributeClass, "global::TUnit.Core.IDataSourceAttribute");
+        // Check if the attribute implements IDataSourceAttribute
+        return InterfaceHelper.ImplementsInterface(attributeClass, "global::TUnit.Core.IDataSourceAttribute");
     }
 
     public static bool IsTypedDataSourceAttribute(INamedTypeSymbol? attributeClass)
@@ -23,8 +23,8 @@ internal static class DataSourceAttributeHelper
             return false;
         }
 
-        // Check if the attribute implements ITypedDataSourceAttribute<T> (using cache)
-        return InterfaceCache.ImplementsGenericInterface(attributeClass, "global::TUnit.Core.ITypedDataSourceAttribute`1");
+        // Check if the attribute implements ITypedDataSourceAttribute<T>
+        return InterfaceHelper.ImplementsGenericInterface(attributeClass, "global::TUnit.Core.ITypedDataSourceAttribute`1");
     }
 
     public static ITypeSymbol? GetTypedDataSourceType(INamedTypeSymbol? attributeClass)
@@ -34,7 +34,7 @@ internal static class DataSourceAttributeHelper
             return null;
         }
 
-        var typedInterface = InterfaceCache.GetGenericInterface(attributeClass, "global::TUnit.Core.ITypedDataSourceAttribute`1");
+        var typedInterface = InterfaceHelper.GetGenericInterface(attributeClass, "global::TUnit.Core.ITypedDataSourceAttribute`1");
 
         return typedInterface?.TypeArguments.FirstOrDefault();
     }

--- a/TUnit.Core.SourceGenerator/CodeWriter.cs
+++ b/TUnit.Core.SourceGenerator/CodeWriter.cs
@@ -48,7 +48,25 @@ public class CodeWriter : ICodeWriter
     private string GetIndentation(int level)
     {
         var key = (_indentString, level);
-        return _indentCache.GetOrAdd(key, static k => string.Concat(Enumerable.Repeat(k.Item1, k.Item2)));
+        return _indentCache.GetOrAdd(key, static k =>
+        {
+            var (indent, count) = k;
+
+            // Fast path: a single-space indent (or any whitespace-only indent) can be built
+            // directly without allocating an intermediate sequence.
+            if (indent == " ")
+            {
+                return new string(' ', count);
+            }
+
+            var builder = new StringBuilder(indent.Length * count);
+            for (var i = 0; i < count; i++)
+            {
+                builder.Append(indent);
+            }
+
+            return builder.ToString();
+        });
     }
 
     /// <summary>

--- a/TUnit.Core.SourceGenerator/Extensions/AttributeDataExtensions.cs
+++ b/TUnit.Core.SourceGenerator/Extensions/AttributeDataExtensions.cs
@@ -22,8 +22,7 @@ public static class AttributeDataExtensions
             return false;
         }
 
-        // Use InterfaceCache instead of AllInterfaces.Any() for better performance
-        return InterfaceCache.ImplementsInterface(attributeData.AttributeClass,
+        return InterfaceHelper.ImplementsInterface(attributeData.AttributeClass,
             WellKnownFullyQualifiedClassNames.IDataSourceAttribute.WithGlobalPrefix);
     }
 
@@ -34,8 +33,7 @@ public static class AttributeDataExtensions
             return false;
         }
 
-        // Use InterfaceCache instead of AllInterfaces.Any() for better performance
-        return InterfaceCache.ImplementsGenericInterface(attributeData.AttributeClass,
+        return InterfaceHelper.ImplementsGenericInterface(attributeData.AttributeClass,
             WellKnownFullyQualifiedClassNames.ITypedDataSourceAttribute.WithGlobalPrefix + "`1");
     }
 
@@ -46,8 +44,7 @@ public static class AttributeDataExtensions
             return null;
         }
 
-        // Use InterfaceCache instead of AllInterfaces.FirstOrDefault() for better performance
-        var typedInterface = InterfaceCache.GetGenericInterface(attributeData.AttributeClass,
+        var typedInterface = InterfaceHelper.GetGenericInterface(attributeData.AttributeClass,
             WellKnownFullyQualifiedClassNames.ITypedDataSourceAttribute.WithGlobalPrefix + "`1");
 
         return typedInterface?.TypeArguments.FirstOrDefault();

--- a/TUnit.Core.SourceGenerator/Extensions/MethodExtensions.cs
+++ b/TUnit.Core.SourceGenerator/Extensions/MethodExtensions.cs
@@ -19,8 +19,16 @@ public static class MethodExtensions
             return null;
         }
 
-        return attributes
-            .FirstOrDefault(x => x.AttributeClass?.BaseType?.GloballyQualified()
-                                 == WellKnownFullyQualifiedClassNames.BaseTestAttribute.WithGlobalPrefix);
+        var baseTestAttribute = WellKnownFullyQualifiedClassNames.BaseTestAttribute.WithGlobalPrefix;
+
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass?.BaseType?.GloballyQualified() == baseTestAttribute)
+            {
+                return attribute;
+            }
+        }
+
+        return null;
     }
 }

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -620,9 +620,46 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
             });
         }
 
-        var methodArgumentsAttributes = testMethod.MethodAttributes
-            .Where(a => a.AttributeClass?.Name == "ArgumentsAttribute")
-            .ToArray();
+        // Single-pass classification of method attributes into named buckets, replacing the
+        // repeated `.Where(...).ToArray()` scans that previously walked MethodAttributes 6-8 times.
+        List<AttributeData>? methodArgumentsBucket = null;
+        List<AttributeData>? methodDataSourceBucket = null;
+        List<AttributeData>? typedDataSourceBucket = null;
+        List<AttributeData>? generateGenericTestBucket = null;
+
+        foreach (var attribute in testMethod.MethodAttributes)
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null)
+            {
+                continue;
+            }
+
+            // Buckets are independent: an attribute may match more than one (e.g.
+            // MethodDataSourceAttribute is also an IDataSourceAttribute), matching the original
+            // behaviour where each `.Where(...)` scan was evaluated separately.
+            switch (attributeClass.Name)
+            {
+                case "ArgumentsAttribute":
+                    (methodArgumentsBucket ??= []).Add(attribute);
+                    break;
+                case "MethodDataSourceAttribute":
+                    (methodDataSourceBucket ??= []).Add(attribute);
+                    break;
+            }
+
+            if (DataSourceAttributeHelper.IsDataSourceAttribute(attributeClass))
+            {
+                (typedDataSourceBucket ??= []).Add(attribute);
+            }
+
+            if (attributeClass.IsOrInherits("global::TUnit.Core.GenerateGenericTestAttribute"))
+            {
+                (generateGenericTestBucket ??= []).Add(attribute);
+            }
+        }
+
+        var methodArgumentsAttributes = methodArgumentsBucket ?? [];
 
         var classArgumentsAttributes = testMethod.IsGenericType
             ? testMethod.TypeSymbol.GetAttributes()
@@ -679,7 +716,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         }
 
         // Handle generic classes with non-generic methods that have method-level Arguments
-        if (testMethod is { IsGenericType: true, IsGenericMethod: false } && methodArgumentsAttributes.Length > 0)
+        if (testMethod is { IsGenericType: true, IsGenericMethod: false } && methodArgumentsAttributes.Count > 0)
         {
             foreach (var methodArgAttr in methodArgumentsAttributes)
             {
@@ -692,7 +729,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         }
 
         // Process typed data source attributes
-        foreach (var dataSourceAttr in testMethod.MethodAttributes.Where(a => DataSourceAttributeHelper.IsDataSourceAttribute(a.AttributeClass)))
+        foreach (var dataSourceAttr in typedDataSourceBucket ?? Enumerable.Empty<AttributeData>())
         {
             var inferredTypes = InferTypesFromDataSourceAttribute(testMethod.MethodSymbol, dataSourceAttr);
             if (inferredTypes is { Length: > 0 })
@@ -714,7 +751,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         // Process MethodDataSource attributes for generic classes (non-generic methods)
         if (testMethod is { IsGenericType: true, IsGenericMethod: false })
         {
-            foreach (var mdsAttr in testMethod.MethodAttributes.Where(a => a.AttributeClass?.Name == "MethodDataSourceAttribute"))
+            foreach (var mdsAttr in methodDataSourceBucket ?? Enumerable.Empty<AttributeData>())
             {
                 var inferredTypes = InferClassTypesFromMethodDataSource(testMethod, mdsAttr);
                 if (inferredTypes is { Length: > 0 })
@@ -734,7 +771,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         // Process MethodDataSource attributes for generic methods
         if (testMethod.IsGenericMethod)
         {
-            foreach (var mdsAttr in testMethod.MethodAttributes.Where(a => a.AttributeClass?.Name == "MethodDataSourceAttribute"))
+            foreach (var mdsAttr in methodDataSourceBucket ?? Enumerable.Empty<AttributeData>())
             {
                 var inferredTypes = InferTypesFromMethodDataSource(testMethod, mdsAttr);
                 if (inferredTypes is { Length: > 0 })
@@ -754,7 +791,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
                 {
                     if (testMethod.IsGenericMethod)
                     {
-                        foreach (var methodArgAttr in testMethod.MethodAttributes.Where(a => a.AttributeClass?.Name == "ArgumentsAttribute"))
+                        foreach (var methodArgAttr in methodArgumentsAttributes)
                         {
                             var methodInferredTypes = InferTypesFromArgumentsAttribute(testMethod.MethodSymbol, methodArgAttr, compilation);
                             if (methodInferredTypes is { Length: > 0 })
@@ -774,9 +811,8 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
         // Process GenerateGenericTest attributes
         // GenerateGenericTestAttribute takes params Type[] in its constructor, so extract from constructor args
         {
-            var methodGenericTestAttrs = testMethod.IsGenericMethod
-                ? testMethod.MethodAttributes
-                    .Where(a => a.AttributeClass?.IsOrInherits("global::TUnit.Core.GenerateGenericTestAttribute") is true)
+            var methodGenericTestAttrs = testMethod.IsGenericMethod && generateGenericTestBucket is not null
+                ? generateGenericTestBucket
                     .Select(ExtractTypeArgsFromGenerateGenericTestAttribute)
                     .Where(t => t is { Length: > 0 })
                     .ToList()

--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -2004,8 +2004,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static bool IsAsyncEnumerable(ITypeSymbol type)
     {
-        // Use cached interface check
-        return InterfaceCache.IsAsyncEnumerable(type);
+        return InterfaceHelper.IsAsyncEnumerable(type);
     }
 
     private static bool IsTask(ITypeSymbol type)
@@ -2017,8 +2016,8 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
 
     private static bool IsEnumerable(ITypeSymbol type)
     {
-        // Use cached interface check (already handles string exclusion)
-        return InterfaceCache.IsEnumerable(type);
+        // Already handles string exclusion
+        return InterfaceHelper.IsEnumerable(type);
     }
 
     private static void WriteTypedConstant(CodeWriter writer, TypedConstant constant)

--- a/TUnit.Core.SourceGenerator/Helpers/InterfaceCache.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/InterfaceCache.cs
@@ -1,27 +1,47 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using TUnit.Core.SourceGenerator.Extensions;
 
 namespace TUnit.Core.SourceGenerator.Helpers;
 
 /// <summary>
-/// Caches interface implementation checks to avoid repeated AllInterfaces traversals
+/// Caches interface implementation checks to avoid repeated AllInterfaces traversals.
 /// </summary>
+/// <remarks>
+/// Cache entries are keyed by the <see cref="ITypeSymbol"/> itself and held in a
+/// <see cref="ConditionalWeakTable{TKey,TValue}"/>. This ties each entry's lifetime to the
+/// symbol's lifetime, so the cache is reclaimed automatically when a <see cref="Compilation"/>
+/// is collected. This avoids the cross-compilation symbol leak a long-lived static dictionary
+/// would cause in extended IDE sessions.
+/// </remarks>
 public static class InterfaceCache
 {
+    /// <summary>
+    /// Per-type cache of the globally-qualified names of every interface the type implements.
+    /// </summary>
+    private static readonly ConditionalWeakTable<ITypeSymbol, ImmutableHashSet<string>> InterfaceNames = new();
+
+    private static ImmutableHashSet<string> GetInterfaceNames(ITypeSymbol type)
+    {
+        return InterfaceNames.GetValue(type, static t =>
+        {
+            var builder = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+            foreach (var i in t.AllInterfaces)
+            {
+                builder.Add(i.GloballyQualified());
+            }
+
+            return builder.ToImmutable();
+        });
+    }
+
     /// <summary>
     /// Checks if a type implements a specific interface
     /// </summary>
     public static bool ImplementsInterface(ITypeSymbol type, string fullyQualifiedInterfaceName)
     {
-        foreach (var i in type.AllInterfaces)
-        {
-            if (i.GloballyQualified() == fullyQualifiedInterfaceName)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return GetInterfaceNames(type).Contains(fullyQualifiedInterfaceName);
     }
 
     /// <summary>

--- a/TUnit.Core.SourceGenerator/Helpers/InterfaceHelper.cs
+++ b/TUnit.Core.SourceGenerator/Helpers/InterfaceHelper.cs
@@ -1,47 +1,27 @@
-using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using TUnit.Core.SourceGenerator.Extensions;
 
 namespace TUnit.Core.SourceGenerator.Helpers;
 
 /// <summary>
-/// Caches interface implementation checks to avoid repeated AllInterfaces traversals.
+/// Helpers for interface implementation checks over <see cref="ITypeSymbol.AllInterfaces"/>.
 /// </summary>
-/// <remarks>
-/// Cache entries are keyed by the <see cref="ITypeSymbol"/> itself and held in a
-/// <see cref="ConditionalWeakTable{TKey,TValue}"/>. This ties each entry's lifetime to the
-/// symbol's lifetime, so the cache is reclaimed automatically when a <see cref="Compilation"/>
-/// is collected. This avoids the cross-compilation symbol leak a long-lived static dictionary
-/// would cause in extended IDE sessions.
-/// </remarks>
-public static class InterfaceCache
+public static class InterfaceHelper
 {
-    /// <summary>
-    /// Per-type cache of the globally-qualified names of every interface the type implements.
-    /// </summary>
-    private static readonly ConditionalWeakTable<ITypeSymbol, ImmutableHashSet<string>> InterfaceNames = new();
-
-    private static ImmutableHashSet<string> GetInterfaceNames(ITypeSymbol type)
-    {
-        return InterfaceNames.GetValue(type, static t =>
-        {
-            var builder = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
-            foreach (var i in t.AllInterfaces)
-            {
-                builder.Add(i.GloballyQualified());
-            }
-
-            return builder.ToImmutable();
-        });
-    }
-
     /// <summary>
     /// Checks if a type implements a specific interface
     /// </summary>
     public static bool ImplementsInterface(ITypeSymbol type, string fullyQualifiedInterfaceName)
     {
-        return GetInterfaceNames(type).Contains(fullyQualifiedInterfaceName);
+        foreach (var i in type.AllInterfaces)
+        {
+            if (i.GloballyQualified() == fullyQualifiedInterfaceName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #6106. Single-pass attribute classification and LINQ removals in `TUnit.Core.SourceGenerator`. Generated output is byte-identical (snapshots unchanged).

## Changes
- **`Generators/TestMetadataGenerator.cs`** — `CollectConcreteInstantiations` replaced 6-8 repeated `.Where(...).ToArray()` scans over `MethodAttributes` with one classification `foreach` into four null-init buckets. Buckets are independent, so multi-membership (e.g. `MethodDataSourceAttribute` is also `IDataSourceAttribute`) is preserved exactly.
- **`Extensions/MethodExtensions.cs`** — `GetTestAttribute`: `FirstOrDefault(lambda)` -> `foreach` + early return.
- **`CodeWriter.cs`** — `GetIndentation`: cache-miss path drops `Enumerable.Repeat` (single-space fast path + StringBuilder loop). Byte-identical.
- **`Helpers/InterfaceHelper.cs`** (renamed from `InterfaceCache.cs`) — **no Roslyn-type caching.** An earlier revision added a `ConditionalWeakTable<ITypeSymbol,...>` interface-name cache; that was reverted. Caching Roslyn symbols in persistent generator state is an anti-pattern (cross-compilation rooting risk), and `AllInterfaces` is already lazily cached on the symbol by Roslyn, so the gain was marginal. The class no longer caches anything, so it is renamed to `InterfaceHelper` to stop lying.

## Validation
- `TUnit.Core.SourceGenerator` + `Roslyn414` variant build clean (0/0).
- `TUnit.Core.SourceGenerator.Tests` (net10.0): passed, 0 failed, 1 pre-existing skip. **No `.received.txt`** — generated output unchanged.
- No `ISymbol` added to incremental pipeline nodes; only post-Collect consumers touch symbols.
