### PR TITLE
perf(assertions): allocation-free passing path (TUnit.Assertions)

### DIFF
--- a/TUnit.Assertions/Collections/CollectionChecks.cs
+++ b/TUnit.Assertions/Collections/CollectionChecks.cs
@@ -206,8 +206,34 @@ public static class CollectionChecks
     /// Checks if the collection has exactly one item.
     /// </summary>
     public static AssertionResult CheckHasSingleItem<TItem>(ICollectionAdapter<TItem> adapter)
+        => CheckHasSingleItem(adapter, out _);
+
+    /// <summary>
+    /// Checks if the collection has exactly one item.
+    /// Returns the single item via out parameter, captured during the single enumeration
+    /// pass to avoid re-enumerating non-replayable sequences.
+    /// </summary>
+    public static AssertionResult CheckHasSingleItem<TItem>(ICollectionAdapter<TItem> adapter, out TItem? singleItem)
     {
-        var count = adapter.Count;
+        singleItem = default;
+        var count = 0;
+
+        // Single enumeration pass: capture the first item, then keep counting so the
+        // failure message can report the true total without re-enumerating.
+        foreach (var item in adapter.AsEnumerable())
+        {
+            if (count == 0)
+            {
+                singleItem = item;
+            }
+            else if (count == 1)
+            {
+                singleItem = default;
+            }
+
+            count++;
+        }
+
         if (count == 1)
         {
             return AssertionResult.Passed;

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -494,13 +494,7 @@ public class HasSingleItemAssertion<TCollection, TItem> : Sources.CollectionAsse
         }
 
         var adapter = new EnumerableAdapter<TItem>(metadata.Value);
-        var result = CollectionChecks.CheckHasSingleItem(adapter);
-
-        if (result.IsPassed)
-        {
-            // Capture the single item for GetAwaiter
-            _singleItem = adapter.AsEnumerable().First();
-        }
+        var result = CollectionChecks.CheckHasSingleItem(adapter, out _singleItem);
 
         return Task.FromResult(result);
     }
@@ -869,23 +863,27 @@ public class CollectionIsOrderedByAssertion<TCollection, TItem, TKey> : Sources.
         }
 
         var comparer = _comparer ?? Comparer<TKey>.Default;
-        var enumerated = value.ToArray();
-        var ordered = enumerated.OrderBy(_keySelector, comparer).ToArray();
 
-        if (enumerated.SequenceEqual(ordered))
+        using var enumerator = value.GetEnumerator();
+        if (!enumerator.MoveNext())
         {
             return AssertionResult._passedTask;
         }
 
-        for (int i = 1; i < enumerated.Length; i++)
+        var prevKey = _keySelector(enumerator.Current);
+        var index = 1;
+
+        while (enumerator.MoveNext())
         {
-            var prevKey = _keySelector(enumerated[i - 1]);
-            var currKey = _keySelector(enumerated[i]);
+            var currKey = _keySelector(enumerator.Current);
 
             if (comparer.Compare(prevKey, currKey) > 0)
             {
-                return Task.FromResult(AssertionResult.Failed($"item at index {i} is out of order (key: {currKey}) compared to previous item (key: {prevKey})"));
+                return Task.FromResult(AssertionResult.Failed($"item at index {index} is out of order (key: {currKey}) compared to previous item (key: {prevKey})"));
             }
+
+            prevKey = currKey;
+            index++;
         }
 
         return AssertionResult._passedTask;
@@ -931,23 +929,27 @@ public class CollectionIsOrderedByDescendingAssertion<TCollection, TItem, TKey> 
         }
 
         var comparer = _comparer ?? Comparer<TKey>.Default;
-        var enumerated = value.ToArray();
-        var ordered = enumerated.OrderByDescending(_keySelector, comparer).ToArray();
 
-        if (enumerated.SequenceEqual(ordered))
+        using var enumerator = value.GetEnumerator();
+        if (!enumerator.MoveNext())
         {
             return AssertionResult._passedTask;
         }
 
-        for (int i = 1; i < enumerated.Length; i++)
+        var prevKey = _keySelector(enumerator.Current);
+        var index = 1;
+
+        while (enumerator.MoveNext())
         {
-            var prevKey = _keySelector(enumerated[i - 1]);
-            var currKey = _keySelector(enumerated[i]);
+            var currKey = _keySelector(enumerator.Current);
 
             if (comparer.Compare(prevKey, currKey) < 0)
             {
-                return Task.FromResult(AssertionResult.Failed($"item at index {i} is out of order (key: {currKey}) compared to previous item (key: {prevKey})"));
+                return Task.FromResult(AssertionResult.Failed($"item at index {index} is out of order (key: {currKey}) compared to previous item (key: {prevKey})"));
             }
+
+            prevKey = currKey;
+            index++;
         }
 
         return AssertionResult._passedTask;

--- a/TUnit.Assertions/Conditions/IsEquivalentToAssertion.cs
+++ b/TUnit.Assertions/Conditions/IsEquivalentToAssertion.cs
@@ -19,6 +19,7 @@ public class IsEquivalentToAssertion<TCollection, TItem> : CollectionComparerBas
 {
     private readonly IEnumerable<TItem> _expected;
     private readonly CollectionOrdering _ordering;
+    private string? _cachedExpectedFormat;
 
     [RequiresUnreferencedCode("Collection equivalency uses structural comparison for complex objects, which requires reflection and is not compatible with AOT")]
     public IsEquivalentToAssertion(
@@ -77,5 +78,5 @@ public class IsEquivalentToAssertion<TCollection, TItem> : CollectionComparerBas
     }
 
     protected override string GetExpectation() =>
-        $"to be equivalent to [{string.Join(", ", _expected)}]";
+        $"to be equivalent to [{_cachedExpectedFormat ??= string.Join(", ", _expected)}]";
 }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -493,6 +493,7 @@ namespace .Collections
         public static . CheckHasCountBetween<TItem>(.<TItem> adapter, int min, int max) { }
         public static . CheckHasDistinctItems<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }
         public static . CheckHasSingleItem<TItem>(.<TItem> adapter) { }
+        public static . CheckHasSingleItem<TItem>(.<TItem> adapter, out TItem? singleItem) { }
         public static . CheckHasSingleItemPredicate<TItem>(.<TItem> adapter, <TItem, bool> predicate, out TItem? matchingItem) { }
         public static . CheckIsEmpty<TItem>(.<TItem> adapter) { }
         public static . CheckIsInDescendingOrder<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -476,6 +476,7 @@ namespace .Collections
         public static . CheckHasCountBetween<TItem>(.<TItem> adapter, int min, int max) { }
         public static . CheckHasDistinctItems<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }
         public static . CheckHasSingleItem<TItem>(.<TItem> adapter) { }
+        public static . CheckHasSingleItem<TItem>(.<TItem> adapter, out TItem? singleItem) { }
         public static . CheckHasSingleItemPredicate<TItem>(.<TItem> adapter, <TItem, bool> predicate, out TItem? matchingItem) { }
         public static . CheckIsEmpty<TItem>(.<TItem> adapter) { }
         public static . CheckIsInDescendingOrder<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -493,6 +493,7 @@ namespace .Collections
         public static . CheckHasCountBetween<TItem>(.<TItem> adapter, int min, int max) { }
         public static . CheckHasDistinctItems<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }
         public static . CheckHasSingleItem<TItem>(.<TItem> adapter) { }
+        public static . CheckHasSingleItem<TItem>(.<TItem> adapter, out TItem? singleItem) { }
         public static . CheckHasSingleItemPredicate<TItem>(.<TItem> adapter, <TItem, bool> predicate, out TItem? matchingItem) { }
         public static . CheckIsEmpty<TItem>(.<TItem> adapter) { }
         public static . CheckIsInDescendingOrder<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -435,6 +435,7 @@ namespace .Collections
         public static . CheckHasCountBetween<TItem>(.<TItem> adapter, int min, int max) { }
         public static . CheckHasDistinctItems<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }
         public static . CheckHasSingleItem<TItem>(.<TItem> adapter) { }
+        public static . CheckHasSingleItem<TItem>(.<TItem> adapter, out TItem? singleItem) { }
         public static . CheckHasSingleItemPredicate<TItem>(.<TItem> adapter, <TItem, bool> predicate, out TItem? matchingItem) { }
         public static . CheckIsEmpty<TItem>(.<TItem> adapter) { }
         public static . CheckIsInDescendingOrder<TItem>(.<TItem> adapter, .<TItem>? comparer = null) { }


### PR DESCRIPTION
Closes #6107

## What

Removes avoidable allocations and re-enumeration on the **passing path** of several `TUnit.Assertions` collection assertions.

### 1. `IsOrderedBy` / `IsOrderedByDescending` (`CollectionAssertions.cs`)
Previously did `value.ToArray()` then `OrderBy(...).ToArray()` then `SequenceEqual` — O(n log n) plus **two array allocations even when the collection is already ordered**, followed by an adjacent-pair loop only on failure. Replaced with a **single-pass O(n) adjacent-pair comparison** over an enumerator (keep previous key, compare to current, fail on inversion). Zero allocation on the passing path.

### 3. `HasSingleItem` (`CollectionAssertions.cs` + `CollectionChecks.cs`)
The assertion called `CheckHasSingleItem` (which reads `Count`) and then `adapter.AsEnumerable().First()` — **double-enumerating non-replayable sequences**. Added a `CheckHasSingleItem(adapter, out item)` overload that captures the single item during one enumeration pass, mirroring the existing `CheckHasSingleItemPredicate(..., out item)`.

### 4. `IsEquivalentTo` (`IsEquivalentToAssertion.cs`)
`GetExpectation()` re-ran `string.Join(", ", _expected)` (re-enumerating `_expected`) on every call. Now cached in `_cachedExpectedFormat`, matching the `EqualsAssertion._cachedExpectedFormat` pattern.

## Why
These run on the success path of common collection assertions; the allocations/re-enumeration are pure overhead and the re-enumeration is a latent correctness hazard for lazy/non-replayable sequences.

## Failure semantics
Failure messages, index semantics, and comparer usage are **unchanged**. The ordering loop reports the same 1-based index and the same keys; `HasSingleItem` still reports `received N item(s)` with the true total.

## Validation
- `dotnet build TUnit.Assertions` across `netstandard2.0;net8.0;net9.0;net10.0` — 0 errors, 0 new warnings (pre-existing analyzer/source-gen warnings only).
- Focused tests pass (net10.0): `EnumerableTests` (ordering + single item), `CollectionStructuralEquivalenceTests`, `Old/EquivalentAssertionTests`, `ListAssertionTests`, `IsEquivalentTo_TypeProperty_Tests`, `IgnoringTypeEquivalentTests`, `MemberCollectionAssertionTests`, `MemoryAssertionTests`, `FuncCollectionAssertionTests`, `DictionaryAssertionTests` — all green.

## Deferred
- **Finding #2 (deferred `ExpressionBuilder` across 60+ sites)** — intentionally **deferred to a follow-up**. It is contract-changing and too broad/risky to combine with this parallel change, as noted in the issue.
- **Finding #5 (boxing of `ICollectionAdapter<T>`)** — verified to be **real boxing**: all adapters (`EnumerableAdapter<T>` etc.) are `readonly struct`s and are boxed when passed to the `ICollectionAdapter<TItem>` parameter of `CollectionChecks.Check*`. The clean fix (generic `<TAdapter, TItem> where TAdapter : ICollectionAdapter<TItem>`) is **not** applied here because C# cannot infer `TItem` from the constraint, forcing explicit type arguments at 24+ call sites and changing the public `CollectionChecks` API surface — the same invasiveness class the issue flags for the deferred item. Documenting it here and **deferring to a follow-up** rather than taking that risk in this PR.