### PR TITLE
feat(analyzers): suppress VSTHRD200 on test and hook methods

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.SourceGenerators.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/TUnit.Analyzers.Tests/TUnit.Analyzers.Tests.csproj
+++ b/TUnit.Analyzers.Tests/TUnit.Analyzers.Tests.csproj
@@ -49,6 +49,13 @@
              Link="Shared\AnalyzerTestCompatibility.cs" />
   </ItemGroup>
 
+  <!-- Reference the VSTHRD analyzer assembly (Analyzer="false") so its analyzer types are
+       usable in suppressor tests via WithAnalyzer<>, without running it against this project. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_VisualStudio_Threading_Analyzers)\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" Analyzer="false" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" VersionOverride="9.0.0" PrivateAssets="all" GeneratePathProperty="true" />
     <Reference Include="$(PkgMicrosoft_CodeAnalysis_NetAnalyzers)\analyzers\dotnet\cs\Microsoft.CodeAnalysis.NetAnalyzers.dll" Analyzer="false" />

--- a/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
+++ b/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
@@ -16,6 +16,10 @@ public class Vsthrd200AsyncSuffixSuppressorTests
     [Arguments("After(Test)")]
     [Arguments("BeforeEvery(Test)")]
     [Arguments("AfterEvery(Test)")]
+    [Arguments("Before(Class)")]
+    [Arguments("After(Class)")]
+    [Arguments("Before(Assembly)")]
+    [Arguments("After(Assembly)")]
     public async Task WarningsOnTestAndHookMethodsAreSuppressed(string attribute) =>
         await AnalyzerTestHelpers
             .CreateSuppressorTest<Vsthrd200AsyncSuffixSuppressor>(

--- a/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
+++ b/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
@@ -1,0 +1,62 @@
+#if NET8_0_OR_GREATER
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.Threading.Analyzers;
+
+namespace TUnit.Analyzers.Tests;
+
+public class Vsthrd200AsyncSuffixSuppressorTests
+{
+    private static readonly DiagnosticResult VSTHRD200 = new("VSTHRD200", DiagnosticSeverity.Warning);
+
+    [Test]
+    [Arguments("Test")]
+    [Arguments("Before(Test)")]
+    [Arguments("After(Test)")]
+    [Arguments("BeforeEvery(Test)")]
+    [Arguments("AfterEvery(Test)")]
+    public async Task WarningsOnTestAndHookMethodsAreSuppressed(string attribute) =>
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<Vsthrd200AsyncSuffixSuppressor>(
+                $$"""
+                using System.Threading.Tasks;
+                using TUnit.Core;
+                using static TUnit.Core.HookType;
+
+                public class MyTests
+                {
+                    [{{attribute}}]
+                    public async Task {|#0:Foo|}()
+                    {
+                        await Task.CompletedTask;
+                    }
+                }
+                """
+            )
+            .WithAnalyzer<VSTHRD200UseAsyncNamingConventionAnalyzer>()
+            .WithSpecificDiagnostics(VSTHRD200)
+            .WithExpectedDiagnosticsResults(VSTHRD200.WithLocation(0).WithIsSuppressed(true))
+            .RunAsync();
+
+    [Test]
+    public async Task WarningsAllowedElsewhere() =>
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<Vsthrd200AsyncSuffixSuppressor>(
+                """
+                using System.Threading.Tasks;
+
+                public class MyTests
+                {
+                    public async Task {|#0:DoSomething|}()
+                    {
+                        await Task.CompletedTask;
+                    }
+                }
+                """
+            )
+            .WithAnalyzer<VSTHRD200UseAsyncNamingConventionAnalyzer>()
+            .WithSpecificDiagnostics(VSTHRD200)
+            .WithExpectedDiagnosticsResults(VSTHRD200.WithLocation(0).WithIsSuppressed(false))
+            .RunAsync();
+}
+#endif

--- a/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
+++ b/TUnit.Analyzers.Tests/Vsthrd200AsyncSuffixSuppressorTests.cs
@@ -11,6 +11,7 @@ public class Vsthrd200AsyncSuffixSuppressorTests
 
     [Test]
     [Arguments("Test")]
+    [Arguments("DynamicTestBuilder")]
     [Arguments("Before(Test)")]
     [Arguments("After(Test)")]
     [Arguments("BeforeEvery(Test)")]

--- a/TUnit.Analyzers/Extensions/MethodExtensions.cs
+++ b/TUnit.Analyzers/Extensions/MethodExtensions.cs
@@ -33,9 +33,11 @@ public static class MethodExtensions
             return false;
         }
 
+        // Use Any(...) rather than Contains(...): the latter walks the whole base-type chain even
+        // after a match, whereas Any short-circuits on the first matching type.
         return methodSymbol.GetAttributes().Any(attribute =>
             attribute.AttributeClass?.GetSelfAndBaseTypes()
-                .Contains(baseTestAttribute, SymbolEqualityComparer.Default) == true);
+                .Any(t => SymbolEqualityComparer.Default.Equals(t, baseTestAttribute)) == true);
     }
 
     public static bool IsHookMethod(this IMethodSymbol methodSymbol, Compilation compilation, [NotNullWhen(true)] out INamedTypeSymbol? type, [NotNullWhen(true)] out HookLevel? hookLevel, [NotNullWhen(true)] out HookType? hookType)

--- a/TUnit.Analyzers/Extensions/MethodExtensions.cs
+++ b/TUnit.Analyzers/Extensions/MethodExtensions.cs
@@ -12,6 +12,24 @@ public static class MethodExtensions
         return methodSymbol.GetAttributes().Any(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, testAttribute));
     }
 
+    /// <summary>
+    /// Returns true if the method is decorated with any attribute deriving from
+    /// <c>TUnit.Core.BaseTestAttribute</c> (e.g. <c>[Test]</c> or <c>[DynamicTestBuilder]</c>).
+    /// </summary>
+    public static bool HasTestAttribute(this IMethodSymbol methodSymbol, Compilation compilation)
+    {
+        var baseTestAttribute = compilation.GetTypeByMetadataName("TUnit.Core.BaseTestAttribute");
+
+        if (baseTestAttribute is null)
+        {
+            return false;
+        }
+
+        return methodSymbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.GetSelfAndBaseTypes()
+                .Contains(baseTestAttribute, SymbolEqualityComparer.Default) == true);
+    }
+
     public static bool IsHookMethod(this IMethodSymbol methodSymbol, Compilation compilation, [NotNullWhen(true)] out INamedTypeSymbol? type, [NotNullWhen(true)] out HookLevel? hookLevel, [NotNullWhen(true)] out HookType? hookType)
     {
         return IsStandardHookMethod(methodSymbol, compilation, out type, out hookLevel, out hookType) || IsEveryHookMethod(methodSymbol, compilation, out type, out hookLevel, out hookType);

--- a/TUnit.Analyzers/Extensions/MethodExtensions.cs
+++ b/TUnit.Analyzers/Extensions/MethodExtensions.cs
@@ -33,11 +33,9 @@ public static class MethodExtensions
             return false;
         }
 
-        // Use Any(...) rather than Contains(...): the latter walks the whole base-type chain even
-        // after a match, whereas Any short-circuits on the first matching type.
         return methodSymbol.GetAttributes().Any(attribute =>
             attribute.AttributeClass?.GetSelfAndBaseTypes()
-                .Any(t => SymbolEqualityComparer.Default.Equals(t, baseTestAttribute)) == true);
+                .Contains(baseTestAttribute, SymbolEqualityComparer.Default) == true);
     }
 
     public static bool IsHookMethod(this IMethodSymbol methodSymbol, Compilation compilation, [NotNullWhen(true)] out INamedTypeSymbol? type, [NotNullWhen(true)] out HookLevel? hookLevel, [NotNullWhen(true)] out HookType? hookType)

--- a/TUnit.Analyzers/Extensions/MethodExtensions.cs
+++ b/TUnit.Analyzers/Extensions/MethodExtensions.cs
@@ -6,6 +6,14 @@ namespace TUnit.Analyzers.Extensions;
 
 public static class MethodExtensions
 {
+    /// <summary>
+    /// Returns true if the method is decorated with the exact <c>TUnit.Core.TestAttribute</c>.
+    /// </summary>
+    /// <remarks>
+    /// This is an exact-match check — it does not match subclasses of <c>BaseTestAttribute</c>
+    /// (e.g. <c>[DynamicTestBuilder]</c>). Use <see cref="HasTestAttribute"/> for the broader,
+    /// inheritance-aware check.
+    /// </remarks>
     public static bool IsTestMethod(this IMethodSymbol methodSymbol, Compilation compilation)
     {
         var testAttribute = compilation.GetTypeByMetadataName("TUnit.Core.TestAttribute")!;

--- a/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
+++ b/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
@@ -42,14 +42,16 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
         }
     }
 
-    private void Suppress(SuppressionAnalysisContext context, Diagnostic diagnostic)
-    {
-        var descriptor = SupportedSuppressions.First(s => s.SuppressedDiagnosticId == diagnostic.Id);
-        context.ReportSuppression(Suppression.Create(descriptor, diagnostic));
-    }
+    // Exactly one descriptor is registered (VSTHRD200), and Roslyn only routes diagnostics whose id
+    // matches it here, so referencing the single descriptor directly is correct and avoids a
+    // per-call predicate scan.
+    private static void Suppress(SuppressionAnalysisContext context, Diagnostic diagnostic)
+        => context.ReportSuppression(Suppression.Create(Vsthrd200Descriptor, diagnostic));
+
+    private static readonly SuppressionDescriptor Vsthrd200Descriptor = CreateDescriptor("VSTHRD200");
 
     public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
-        ImmutableArray.Create(CreateDescriptor("VSTHRD200"));
+        ImmutableArray.Create(Vsthrd200Descriptor);
 
     private static SuppressionDescriptor CreateDescriptor(string id)
         => new(

--- a/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
+++ b/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
@@ -28,6 +28,9 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
                 continue;
             }
 
+            // IsHookMethod covers all hook levels (Before/After/BeforeEvery/AfterEvery) intentionally —
+            // no hook method requires the 'Async' suffix regardless of scope. (This is deliberately
+            // broader than MarkMethodStaticSuppressor, which only narrows CA1822 to Test-level hooks.)
             if (methodSymbol.HasTestAttribute(context.Compilation)
                 || methodSymbol.IsHookMethod(context.Compilation, out _, out _, out _))
             {
@@ -36,17 +39,10 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
         }
     }
 
+    // This suppressor only ever handles VSTHRD200, so reference the single descriptor directly
+    // rather than scanning SupportedSuppressions on every reported diagnostic.
     private void Suppress(SuppressionAnalysisContext context, Diagnostic diagnostic)
-    {
-        var suppression = SupportedSuppressions.First(s => s.SuppressedDiagnosticId == diagnostic.Id);
-
-        context.ReportSuppression(
-            Suppression.Create(
-                suppression,
-                diagnostic
-            )
-        );
-    }
+        => context.ReportSuppression(Suppression.Create(SupportedSuppressions[0], diagnostic));
 
     public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
         ImmutableArray.Create(CreateDescriptor("VSTHRD200"));

--- a/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
+++ b/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
@@ -16,7 +16,7 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
     {
         foreach (var diagnostic in context.ReportedDiagnostics)
         {
-            if (diagnostic.Location.SourceTree?.GetRoot().FindNode(diagnostic.Location.SourceSpan) is not { } node)
+            if (diagnostic.Location.SourceTree?.GetRoot(context.CancellationToken).FindNode(diagnostic.Location.SourceSpan) is not { } node)
             {
                 continue;
             }
@@ -28,9 +28,12 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
                 continue;
             }
 
-            // IsHookMethod covers all hook levels (Before/After/BeforeEvery/AfterEvery) intentionally —
-            // no hook method requires the 'Async' suffix regardless of scope. (This is deliberately
-            // broader than MarkMethodStaticSuppressor, which only narrows CA1822 to Test-level hooks.)
+            // HasTestAttribute is inheritance-aware (covers [Test], [DynamicTestBuilder], etc.) and
+            // IsHookMethod covers all hook levels (Before/After/BeforeEvery/AfterEvery). This is
+            // deliberately broader than MarkMethodStaticSuppressor (CA1822), which uses the exact-match
+            // IsTestMethod and only narrows to Test-level hooks — so a [DynamicTestBuilder] method may
+            // still see CA1822. That divergence is intentional: VSTHRD200 (async naming) never applies
+            // to any test/hook method, whereas CA1822 (make-static) has narrower, scope-specific intent.
             if (methodSymbol.HasTestAttribute(context.Compilation)
                 || methodSymbol.IsHookMethod(context.Compilation, out _, out _, out _))
             {
@@ -39,10 +42,11 @@ public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
         }
     }
 
-    // This suppressor only ever handles VSTHRD200, so reference the single descriptor directly
-    // rather than scanning SupportedSuppressions on every reported diagnostic.
     private void Suppress(SuppressionAnalysisContext context, Diagnostic diagnostic)
-        => context.ReportSuppression(Suppression.Create(SupportedSuppressions[0], diagnostic));
+    {
+        var descriptor = SupportedSuppressions.First(s => s.SuppressedDiagnosticId == diagnostic.Id);
+        context.ReportSuppression(Suppression.Create(descriptor, diagnostic));
+    }
 
     public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
         ImmutableArray.Create(CreateDescriptor("VSTHRD200"));

--- a/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
+++ b/TUnit.Analyzers/Vsthrd200AsyncSuffixSuppressor.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TUnit.Analyzers.Extensions;
+
+namespace TUnit.Analyzers;
+
+/// <summary>
+/// Suppresses VSTHRD200 ("Use 'Async' suffix for async methods") on TUnit test
+/// methods and hook methods, which intentionally do not follow the Async naming convention.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class Vsthrd200AsyncSuffixSuppressor : DiagnosticSuppressor
+{
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        foreach (var diagnostic in context.ReportedDiagnostics)
+        {
+            if (diagnostic.Location.SourceTree?.GetRoot().FindNode(diagnostic.Location.SourceSpan) is not { } node)
+            {
+                continue;
+            }
+
+            var semanticModel = context.GetSemanticModel(diagnostic.Location.SourceTree);
+
+            if (semanticModel.GetDeclaredSymbol(node) is not IMethodSymbol methodSymbol)
+            {
+                continue;
+            }
+
+            if (methodSymbol.HasTestAttribute(context.Compilation)
+                || methodSymbol.IsHookMethod(context.Compilation, out _, out _, out _))
+            {
+                Suppress(context, diagnostic);
+            }
+        }
+    }
+
+    private void Suppress(SuppressionAnalysisContext context, Diagnostic diagnostic)
+    {
+        var suppression = SupportedSuppressions.First(s => s.SuppressedDiagnosticId == diagnostic.Id);
+
+        context.ReportSuppression(
+            Suppression.Create(
+                suppression,
+                diagnostic
+            )
+        );
+    }
+
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } =
+        ImmutableArray.Create(CreateDescriptor("VSTHRD200"));
+
+    private static SuppressionDescriptor CreateDescriptor(string id)
+        => new(
+            id: $"{id}Suppression",
+            suppressedDiagnosticId: id,
+            justification: "TUnit test and hook methods do not require the 'Async' suffix."
+        );
+}


### PR DESCRIPTION
## What

Adds `Vsthrd200AsyncSuffixSuppressor`, a Roslyn `DiagnosticSuppressor` that silences **VSTHRD200** ("Use `Async` suffix for async methods") on:

- **Test methods** — any method decorated with an attribute deriving from `TUnit.Core.BaseTestAttribute` (covers `[Test]`, `[DynamicTestBuilder]`, and any future subclass).
- **Hook methods** — `[Before]` / `[After]` / `[BeforeEvery]` / `[AfterEvery]`.

VSTHRD200 is useful for production code but noisy on tests: `[Test] async Task MyTest()` shouldn't be forced to `MyTestAsync`. This mirrors the convention MSTest and xUnit already ship.

## How

- New suppressor follows the existing `MarkMethodStaticSuppressor` (CA1822) pattern.
- New `MethodExtensions.HasTestAttribute` walks the attribute inheritance chain via the existing `GetSelfAndBaseTypes()` helper. Left the existing exact-match `IsTestMethod` untouched to avoid changing behavior of the ~14 analyzers that call it.
- Test project references `Microsoft.VisualStudio.Threading.Analyzers` (analyzer dll, `Analyzer="false"`) so the VSTHRD200 analyzer type is loadable in suppressor tests.

No `AnalyzerReleases.*.md` change — suppressors are not tracked there.

## Tests

`Vsthrd200AsyncSuffixSuppressorTests` — VSTHRD200 suppressed on `[Test]` + 4 hook variants; **not** suppressed on a plain async non-test method. All pass.

Closes #6121
