### PR TITLE
feat(assertions): add WasCalled to tunit mocks assertions

### DIFF
--- a/TUnit.Mocks.Assertions/MockAssertionExtensions.cs
+++ b/TUnit.Mocks.Assertions/MockAssertionExtensions.cs
@@ -11,6 +11,16 @@ namespace TUnit.Mocks.Assertions;
 public static class MockAssertionExtensions
 {
     /// <summary>
+    /// Asserts that the mock member was called at least once.
+    /// </summary>
+    public static WasCalledAssertion WasCalled(
+        this IAssertionSource<ICallVerification> source)
+    {
+        source.Context.ExpressionBuilder.Append($".WasCalled({nameof(Times.AtLeastOnce)})");
+        return new WasCalledAssertion(source.Context, Times.AtLeastOnce);
+    }
+
+    /// <summary>
     /// Asserts that the mock member was called the specified number of times.
     /// </summary>
     public static WasCalledAssertion WasCalled(

--- a/TUnit.Mocks.Assertions/MockAssertionExtensions.cs
+++ b/TUnit.Mocks.Assertions/MockAssertionExtensions.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
+using TUnit.Assertions.Attributes;
 using TUnit.Assertions.Core;
+using TUnit.Mocks.Exceptions;
 using TUnit.Mocks.Verification;
 
 namespace TUnit.Mocks.Assertions;
@@ -12,12 +14,25 @@ public static class MockAssertionExtensions
 {
     /// <summary>
     /// Asserts that the mock member was called at least once.
+    /// Generates the <c>WasCalled()</c> assertion on <see cref="IAssertionSource{ICallVerification}"/>.
     /// </summary>
-    public static WasCalledAssertion WasCalled(
-        this IAssertionSource<ICallVerification> source)
+    [GenerateAssertion(ExpectationMessage = "to have been called")]
+    public static AssertionResult WasCalled(ICallVerification verification)
     {
-        source.Context.ExpressionBuilder.Append($".WasCalled({nameof(Times.AtLeastOnce)})");
-        return new WasCalledAssertion(source.Context, Times.AtLeastOnce);
+        if (verification is null)
+        {
+            return AssertionResult.Failed("Verification target is null");
+        }
+
+        try
+        {
+            verification.WasCalled();
+            return AssertionResult.Passed;
+        }
+        catch (MockVerificationException ex)
+        {
+            return AssertionResult.Failed(ex.Message);
+        }
     }
 
     /// <summary>

--- a/TUnit.Mocks.Assertions/TUnit.Mocks.Assertions.csproj
+++ b/TUnit.Mocks.Assertions/TUnit.Mocks.Assertions.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\TUnit.Mocks\TUnit.Mocks.csproj" />
         <ProjectReference Include="..\TUnit.Assertions\TUnit.Assertions.csproj" />
+        <ProjectReference Include="..\TUnit.Assertions.SourceGenerator\TUnit.Assertions.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <Import Project="..\Library.targets" />

--- a/TUnit.Mocks.Tests/AsyncVerificationTests.cs
+++ b/TUnit.Mocks.Tests/AsyncVerificationTests.cs
@@ -99,6 +99,16 @@ public class AsyncVerificationTests
     }
 
     [Test]
+    public async Task WasCalled_Default_Fails_When_Not_Called()
+    {
+        var mock = ICalculator.Mock();
+
+        await Assert.ThrowsAsync(async () =>
+            await Assert.That(mock.Add(Any(), Any()))
+                .WasCalled());
+    }
+
+    [Test]
     public async Task Property_Getter_WasCalled_Via_Assert()
     {
         var mock = IPropertyService.Mock();

--- a/TUnit.Mocks.Tests/AsyncVerificationTests.cs
+++ b/TUnit.Mocks.Tests/AsyncVerificationTests.cs
@@ -85,6 +85,20 @@ public class AsyncVerificationTests
     }
 
     [Test]
+    public async Task WasCalled_AtLeastOnceByDefault_Passes()
+    {
+        var mock = ICalculator.Mock();
+        mock.Add(Any(), Any()).Returns(42);
+
+        ICalculator calc = mock.Object;
+        _ = calc.Add(1, 2);
+        _ = calc.Add(3, 4);
+
+        await Assert.That(mock.Add(Any(), Any()))
+            .WasCalled();
+    }
+
+    [Test]
     public async Task Property_Getter_WasCalled_Via_Assert()
     {
         var mock = IPropertyService.Mock();


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the issue this PR addresses (use "Fixes #123" or "Closes #123" to auto-close) -->

Fixes #5977

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [x] All existing tests pass (`dotnet test`)
- [x] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
