### PR TITLE
fix(source-gen): correct source location for cross-project inherited tests

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -4061,16 +4061,27 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
                 !string.IsNullOrEmpty(attrFilePath) ? attrFilePath! : methodLocation.SourceTree?.FilePath ?? "");
         }
 
+        // The base method lives in a referenced assembly (cross-project inheritance), so its symbol
+        // has no source location in this compilation. The [Test] attribute's CallerFilePath and
+        // CallerLineNumber were baked at the base method declaration, so they remain the correct
+        // pointer to the test. We deliberately do NOT fall back to the derived class's syntax span:
+        // that pairs the base file path with the derived class's line range, sending the source view
+        // to unrelated lines in the base file.
+        if (!string.IsNullOrEmpty(attrFilePath))
+        {
+            return CreateFallbackSourceLocation(attrFilePath!, attrLineNumber);
+        }
+
         var classLocation = classInfo.ClassSyntax.GetLocation();
         if (classLocation.IsInSource)
         {
             return CreateSourceLocation(
                 classLocation.GetLineSpan(),
-                !string.IsNullOrEmpty(attrFilePath) ? attrFilePath! : classLocation.SourceTree?.FilePath ?? classInfo.ClassSyntax.SyntaxTree.FilePath ?? "");
+                classLocation.SourceTree?.FilePath ?? classInfo.ClassSyntax.SyntaxTree.FilePath ?? "");
         }
 
         return CreateFallbackSourceLocation(
-            !string.IsNullOrEmpty(attrFilePath) ? attrFilePath! : classInfo.ClassSyntax.SyntaxTree.FilePath ?? "",
+            classInfo.ClassSyntax.SyntaxTree.FilePath ?? "",
             attrLineNumber);
     }
 


### PR DESCRIPTION
## Problem

For a test inherited via `[InheritsTests]` from an abstract base class in a **referenced assembly** (a separate project), the generated source location pairs the **base file path** with the **derived class's line range**.

Concretely, a derived `SqsChangeMessageVisibilityAsyncVerificationTests : SqsChangeMessageVisibilityAsyncTests` reports every test method at `SqsChangeMessageVisibilityAsyncTests.cs` (base, correct) but lines **3–19** — which is the *derived* class's declaration span, not the method. Tooling consuming the test node location (e.g. the HTML report's Source tab) then opens the base file at unrelated lines.

## Cause

In `TestMetadataGenerator.GetTestMethodSourceLocation` (inherited overload), when the base method symbol has no source location in the current compilation (`method.Locations` is in *metadata*, because the base class is in a referenced assembly), the fallback used `classInfo.ClassSyntax.GetLineSpan()` (the derived class span) while keeping `attrFilePath` (the `[Test]` attribute's `CallerFilePath` → the base file). The two don't correspond.

## Fix

The `[Test]` attribute's `CallerFilePath`/`CallerLineNumber` are baked at the base method declaration and remain the correct pointer, so fall back to those instead of the derived class's syntax span. Same-compilation inheritance is unaffected — the base method is in source and its own span is still used (verified: existing `InheritsTests*` snapshot tests pass unchanged).

## Test coverage gap

The existing SG test harness compiles base + derived in a **single** compilation (`AdditionalFiles`), so the base method is always in-source and can't reproduce the metadata-symbol path. A genuine regression test needs the harness extended to add a pre-compiled assembly reference. Flagging as a follow-up.

## Regression range

This is a regression introduced between **1.45.8** and **1.47.0**. Verified against the real project that reported it (`LocalSqsSnsMessaging`, cross-project `[InheritsTests]`):

- **1.45.8** emits the correct `LineNumber` (the base method's `[Test]` line).
- **1.47.0** emits the derived class's declaration span instead (e.g. `LineNumber = 5, EndLineNumber = 17` for a method actually at line 90).
- **1.47.0 + this fix** restores the correct `LineNumber = 90`, and other inherited methods resolve to their real base-file lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
