### PR TITLE
feat(mocks): discriminate generic-method mocks by type argument

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -34,7 +34,7 @@ file sealed class IDialogReferenceMockImpl : global::IDialogReference, global::T
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<T?>(0, "GetReturnValueAsync", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+            var __result = _engine.HandleCallWithReturn<T?>(0, "GetReturnValueAsync", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<T?> __typedAsync) return __typedAsync;
@@ -95,7 +95,7 @@ public static class IDialogReference_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T?> GetReturnValueAsync<T>(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetReturnValueAsync", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetReturnValueAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     #if NET9_0_OR_GREATER
@@ -238,7 +238,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<global::IDialogReference?>(0, "UpdateDialogAsync", new object?[] { id, parameters }, default, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), new global::System.Type[] { typeof(TData) });
+            var __result = _engine.HandleCallWithReturn<global::IDialogReference?>(0, "UpdateDialogAsync", new object?[] { id, parameters }, default, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<global::IDialogReference?> __typedAsync) return __typedAsync;
@@ -256,7 +256,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<global::IDialogReference>(1, "ShowDialogAsync", new object?[] { data, parameters }, default!, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), new global::System.Type[] { typeof(TDialog) });
+            var __result = _engine.HandleCallWithReturn<global::IDialogReference>(1, "ShowDialogAsync", new object?[] { data, parameters }, default!, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), global::TUnit.Mocks.TypeArguments.Of<TDialog>.Value);
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<global::IDialogReference> __typedAsync) return __typedAsync;
@@ -347,21 +347,21 @@ public static class IDialogService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<string> id, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> parameters) where TData : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<string, bool> id, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> parameters) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<string> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<string> id, global::System.Func<global::DialogParameters<TData>, bool> parameters) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<string, bool> id, global::System.Func<global::DialogParameters<TData>, bool> parameters) where TData : class
@@ -369,27 +369,27 @@ public static class IDialogService_MockMemberExtensions
         global::TUnit.Mocks.Arguments.Arg<string> __fa_id = id;
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TDialog>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<object, bool> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
     {
         global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TDialog>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::System.Func<global::DialogParameters, bool> parameters) where TDialog : global::IDialogContentComponent
     {
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TDialog>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<object, bool> data, global::System.Func<global::DialogParameters, bool> parameters) where TDialog : global::IDialogContentComponent
@@ -397,7 +397,7 @@ public static class IDialogService_MockMemberExtensions
         global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<TDialog>.Value);
     }
 
     public static void RaiseOnShow(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::IDialogReference arg1, global::System.Type? arg2, global::DialogParameters arg3, object arg4)

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -34,7 +34,7 @@ file sealed class IDialogReferenceMockImpl : global::IDialogReference, global::T
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<T?>(0, "GetReturnValueAsync", global::System.Array.Empty<object?>(), default);
+            var __result = _engine.HandleCallWithReturn<T?>(0, "GetReturnValueAsync", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<T?> __typedAsync) return __typedAsync;
@@ -95,7 +95,7 @@ public static class IDialogReference_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T?> GetReturnValueAsync<T>(this global::TUnit.Mocks.Mock<global::IDialogReference> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetReturnValueAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetReturnValueAsync", matchers, new global::System.Type[] { typeof(T) });
     }
 
     #if NET9_0_OR_GREATER
@@ -238,7 +238,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<global::IDialogReference?, string, global::DialogParameters<TData>>(0, "UpdateDialogAsync", id, parameters, default, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior));
+            var __result = _engine.HandleCallWithReturn<global::IDialogReference?>(0, "UpdateDialogAsync", new object?[] { id, parameters }, default, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), new global::System.Type[] { typeof(TData) });
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<global::IDialogReference?> __typedAsync) return __typedAsync;
@@ -256,7 +256,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<global::IDialogReference, object, global::DialogParameters>(1, "ShowDialogAsync", data, parameters, default!, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior));
+            var __result = _engine.HandleCallWithReturn<global::IDialogReference>(1, "ShowDialogAsync", new object?[] { data, parameters }, default!, static __behavior => global::IDialogReferenceMockFactory.CreateAutoMock(__behavior), new global::System.Type[] { typeof(TDialog) });
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<global::IDialogReference> __typedAsync) return __typedAsync;
@@ -347,21 +347,21 @@ public static class IDialogService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<string> id, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> parameters) where TData : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<string, bool> id, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> parameters) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<string> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<string> id, global::System.Func<global::DialogParameters<TData>, bool> parameters) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference?> UpdateDialogAsync<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<string, bool> id, global::System.Func<global::DialogParameters<TData>, bool> parameters) where TData : class
@@ -369,27 +369,27 @@ public static class IDialogService_MockMemberExtensions
         global::TUnit.Mocks.Arguments.Arg<string> __fa_id = id;
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters<TData>> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "UpdateDialogAsync", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<object, bool> data, global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> parameters) where TDialog : global::IDialogContentComponent
     {
         global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<object> data, global::System.Func<global::DialogParameters, bool> parameters) where TDialog : global::IDialogContentComponent
     {
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::IDialogReference> ShowDialogAsync<TDialog>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<object, bool> data, global::System.Func<global::DialogParameters, bool> parameters) where TDialog : global::IDialogContentComponent
@@ -397,7 +397,7 @@ public static class IDialogService_MockMemberExtensions
         global::TUnit.Mocks.Arguments.Arg<object> __fa_data = data;
         global::TUnit.Mocks.Arguments.Arg<global::DialogParameters> __fa_parameters = parameters;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher, __fa_parameters.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::IDialogReference>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowDialogAsync", matchers, new global::System.Type[] { typeof(TDialog) });
     }
 
     public static void RaiseOnShow(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::IDialogReference arg1, global::System.Type? arg2, global::DialogParameters arg3, object arg4)

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
@@ -42,32 +42,32 @@ file sealed class IConstrainedMockImpl : global::IConstrained, global::TUnit.Moc
 
     public T GetNotnull<T>(string key) where T : notnull
     {
-        return _engine.HandleCallWithReturn<T>(0, "GetNotnull", new object?[] { key }, default!, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(0, "GetNotnull", new object?[] { key }, default!, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public T GetNew<T>() where T : new()
     {
-        return _engine.HandleCallWithReturn<T>(1, "GetNew", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(1, "GetNew", global::System.Array.Empty<object?>(), default!, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public T GetUnmanaged<T>() where T : struct, unmanaged
     {
-        return _engine.HandleCallWithReturn<T>(2, "GetUnmanaged", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(2, "GetUnmanaged", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public T GetDisposable<T>() where T : global::System.IDisposable
     {
-        return _engine.HandleCallWithReturn<T>(3, "GetDisposable", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(3, "GetDisposable", global::System.Array.Empty<object?>(), default!, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public T GetClassNew<T>() where T : class, global::System.IDisposable, new()
     {
-        return _engine.HandleCallWithReturn<T>(4, "GetClassNew", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(4, "GetClassNew", global::System.Array.Empty<object?>(), default!, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public T GetStructDisposable<T>() where T : struct, global::System.IDisposable
     {
-        return _engine.HandleCallWithReturn<T>(5, "GetStructDisposable", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(5, "GetStructDisposable", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -117,44 +117,44 @@ public static class IConstrained_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetNotnull<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock, global::TUnit.Mocks.Arguments.Arg<string> key) where T : notnull
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetNotnull<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock, global::System.Func<string, bool> key) where T : notnull
     {
         global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetNew<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : new()
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetNew", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetNew", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetUnmanaged<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : struct, unmanaged
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetUnmanaged", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetUnmanaged", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetDisposable<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : global::System.IDisposable
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetDisposable", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetDisposable", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetClassNew<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : class, global::System.IDisposable, new()
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "GetClassNew", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "GetClassNew", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetStructDisposable<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : struct, global::System.IDisposable
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 5, "GetStructDisposable", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 5, "GetStructDisposable", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
@@ -42,32 +42,32 @@ file sealed class IConstrainedMockImpl : global::IConstrained, global::TUnit.Moc
 
     public T GetNotnull<T>(string key) where T : notnull
     {
-        return _engine.HandleCallWithReturn<T, string>(0, "GetNotnull", key, default!);
+        return _engine.HandleCallWithReturn<T>(0, "GetNotnull", new object?[] { key }, default!, new global::System.Type[] { typeof(T) });
     }
 
     public T GetNew<T>() where T : new()
     {
-        return _engine.HandleCallWithReturn<T>(1, "GetNew", global::System.Array.Empty<object?>(), default!);
+        return _engine.HandleCallWithReturn<T>(1, "GetNew", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
     }
 
     public T GetUnmanaged<T>() where T : struct, unmanaged
     {
-        return _engine.HandleCallWithReturn<T>(2, "GetUnmanaged", global::System.Array.Empty<object?>(), default);
+        return _engine.HandleCallWithReturn<T>(2, "GetUnmanaged", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
     }
 
     public T GetDisposable<T>() where T : global::System.IDisposable
     {
-        return _engine.HandleCallWithReturn<T>(3, "GetDisposable", global::System.Array.Empty<object?>(), default!);
+        return _engine.HandleCallWithReturn<T>(3, "GetDisposable", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
     }
 
     public T GetClassNew<T>() where T : class, global::System.IDisposable, new()
     {
-        return _engine.HandleCallWithReturn<T>(4, "GetClassNew", global::System.Array.Empty<object?>(), default!);
+        return _engine.HandleCallWithReturn<T>(4, "GetClassNew", global::System.Array.Empty<object?>(), default!, new global::System.Type[] { typeof(T) });
     }
 
     public T GetStructDisposable<T>() where T : struct, global::System.IDisposable
     {
-        return _engine.HandleCallWithReturn<T>(5, "GetStructDisposable", global::System.Array.Empty<object?>(), default);
+        return _engine.HandleCallWithReturn<T>(5, "GetStructDisposable", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -117,44 +117,44 @@ public static class IConstrained_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetNotnull<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock, global::TUnit.Mocks.Arguments.Arg<string> key) where T : notnull
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { key.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetNotnull<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock, global::System.Func<string, bool> key) where T : notnull
     {
         global::TUnit.Mocks.Arguments.Arg<string> __fa_key = key;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_key.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetNotnull", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetNew<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : new()
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetNew", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetNew", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetUnmanaged<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : struct, unmanaged
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetUnmanaged", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetUnmanaged", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetDisposable<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : global::System.IDisposable
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetDisposable", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetDisposable", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetClassNew<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : class, global::System.IDisposable, new()
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "GetClassNew", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 4, "GetClassNew", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetStructDisposable<T>(this global::TUnit.Mocks.Mock<global::IConstrained> mock) where T : struct, global::System.IDisposable
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 5, "GetStructDisposable", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 5, "GetStructDisposable", matchers, new global::System.Type[] { typeof(T) });
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -39,17 +39,17 @@ file sealed class IRepositoryMockImpl : global::IRepository, global::TUnit.Mocks
 
     public T GetById<T>(int id) where T : class
     {
-        return _engine.HandleCallWithReturn<T, int>(0, "GetById", id, default!);
+        return _engine.HandleCallWithReturn<T>(0, "GetById", new object?[] { id }, default!, new global::System.Type[] { typeof(T) });
     }
 
     public void Save<T>(T entity) where T : class, new()
     {
-        _engine.HandleCall<T>(1, "Save", entity);
+        _engine.HandleCall(1, "Save", new object?[] { entity }, new global::System.Type[] { typeof(T) });
     }
 
     public TResult Transform<TInput, TResult>(TInput input) where TInput : notnull where TResult : struct
     {
-        return _engine.HandleCallWithReturn<TResult, TInput>(2, "Transform", input, default);
+        return _engine.HandleCallWithReturn<TResult>(2, "Transform", new object?[] { input }, default, new global::System.Type[] { typeof(TInput), typeof(TResult) });
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -99,40 +99,40 @@ public static class IRepository_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<T, bool> entity) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
     {
         global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -39,17 +39,17 @@ file sealed class IRepositoryMockImpl : global::IRepository, global::TUnit.Mocks
 
     public T GetById<T>(int id) where T : class
     {
-        return _engine.HandleCallWithReturn<T>(0, "GetById", new object?[] { id }, default!, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T>(0, "GetById", new object?[] { id }, default!, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public void Save<T>(T entity) where T : class, new()
     {
-        _engine.HandleCall(1, "Save", new object?[] { entity }, new global::System.Type[] { typeof(T) });
+        _engine.HandleCall(1, "Save", new object?[] { entity }, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public TResult Transform<TInput, TResult>(TInput input) where TInput : notnull where TResult : struct
     {
-        return _engine.HandleCallWithReturn<TResult>(2, "Transform", new object?[] { input }, default, new global::System.Type[] { typeof(TInput), typeof(TResult) });
+        return _engine.HandleCallWithReturn<TResult>(2, "Transform", new object?[] { input }, default, global::TUnit.Mocks.TypeArguments.Of<TInput, TResult>.Value);
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -99,40 +99,40 @@ public static class IRepository_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<T, bool> entity) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, global::TUnit.Mocks.TypeArguments.Of<TInput, TResult>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::IRepository> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
     {
         global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, global::TUnit.Mocks.TypeArguments.Of<TInput, TResult>.Value);
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -321,7 +321,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<string?, TData?>(1, "ShowPanel", data, default);
+            var __result = _engine.HandleCallWithReturn<string?>(1, "ShowPanel", new object?[] { data }, default, new global::System.Type[] { typeof(TData) });
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<string?> __typedAsync) return __typedAsync;
@@ -469,14 +469,14 @@ public static class IDialogService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<string?> ShowPanel<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<TData?> data) where TData : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<string?> ShowPanel<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<TData?, bool> data) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<TData?> __fa_data = data;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, new global::System.Type[] { typeof(TData) });
     }
 
     public static IDialogService_WithTrickyChars_M8_MockCall WithTrickyChars(this global::TUnit.Mocks.Mock<global::IDialogService> mock)

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -321,7 +321,7 @@ file sealed class IDialogServiceMockImpl : global::IDialogService, global::TUnit
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<string?>(1, "ShowPanel", new object?[] { data }, default, new global::System.Type[] { typeof(TData) });
+            var __result = _engine.HandleCallWithReturn<string?>(1, "ShowPanel", new object?[] { data }, default, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<string?> __typedAsync) return __typedAsync;
@@ -469,14 +469,14 @@ public static class IDialogService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<string?> ShowPanel<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::TUnit.Mocks.Arguments.Arg<TData?> data) where TData : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { data.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<string?> ShowPanel<TData>(this global::TUnit.Mocks.Mock<global::IDialogService> mock, global::System.Func<TData?, bool> data) where TData : class
     {
         global::TUnit.Mocks.Arguments.Arg<TData?> __fa_data = data;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_data.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, new global::System.Type[] { typeof(TData) });
+        return new global::TUnit.Mocks.MockMethodCall<string?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "ShowPanel", matchers, global::TUnit.Mocks.TypeArguments.Of<TData>.Value);
     }
 
     public static IDialogService_WithTrickyChars_M8_MockCall WithTrickyChars(this global::TUnit.Mocks.Mock<global::IDialogService> mock)

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -38,7 +38,7 @@ file sealed class IFooMockImpl : global::IFoo, global::TUnit.Mocks.IRaisable, gl
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<T?>(0, "DoSomethingAsync", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+            var __result = _engine.HandleCallWithReturn<T?>(0, "DoSomethingAsync", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<T?> __typedAsync) return __typedAsync;
@@ -54,12 +54,12 @@ file sealed class IFooMockImpl : global::IFoo, global::TUnit.Mocks.IRaisable, gl
 
     public T? GetValue<T>()
     {
-        return _engine.HandleCallWithReturn<T?>(1, "GetValue", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<T?>(1, "GetValue", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public (T?, string) GetPair<T>()
     {
-        return _engine.HandleCallWithReturn<(T?, string)>(2, "GetPair", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<(T?, string)>(2, "GetPair", global::System.Array.Empty<object?>(), default, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -109,19 +109,19 @@ public static class IFoo_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T?> DoSomethingAsync<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "DoSomethingAsync", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "DoSomethingAsync", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T?> GetValue<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<(T?, string)> GetPair<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<(T?, string)>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetPair", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<(T?, string)>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetPair", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -38,7 +38,7 @@ file sealed class IFooMockImpl : global::IFoo, global::TUnit.Mocks.IRaisable, gl
     {
         try
         {
-            var __result = _engine.HandleCallWithReturn<T?>(0, "DoSomethingAsync", global::System.Array.Empty<object?>(), default);
+            var __result = _engine.HandleCallWithReturn<T?>(0, "DoSomethingAsync", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
             if (global::TUnit.Mocks.Setup.RawReturnContext.TryConsume(out var __rawAsync))
             {
                 if (__rawAsync is global::System.Threading.Tasks.Task<T?> __typedAsync) return __typedAsync;
@@ -54,12 +54,12 @@ file sealed class IFooMockImpl : global::IFoo, global::TUnit.Mocks.IRaisable, gl
 
     public T? GetValue<T>()
     {
-        return _engine.HandleCallWithReturn<T?>(1, "GetValue", global::System.Array.Empty<object?>(), default);
+        return _engine.HandleCallWithReturn<T?>(1, "GetValue", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
     }
 
     public (T?, string) GetPair<T>()
     {
-        return _engine.HandleCallWithReturn<(T?, string)>(2, "GetPair", global::System.Array.Empty<object?>(), default);
+        return _engine.HandleCallWithReturn<(T?, string)>(2, "GetPair", global::System.Array.Empty<object?>(), default, new global::System.Type[] { typeof(T) });
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -109,19 +109,19 @@ public static class IFoo_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T?> DoSomethingAsync<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "DoSomethingAsync", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "DoSomethingAsync", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T?> GetValue<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "GetValue", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<(T?, string)> GetPair<T>(this global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<(T?, string)>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetPair", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<(T?, string)>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "GetPair", matchers, new global::System.Type[] { typeof(T) });
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -44,7 +44,7 @@ file sealed class BaseServiceMockImpl : global::BaseService, global::TUnit.Mocks
 
     public override global::System.Collections.Generic.IEnumerable<T> GetAll<T>()
     {
-        return _engine.HandleCallWithReturn<global::System.Collections.Generic.IEnumerable<T>>(3, "GetAll", global::System.Array.Empty<object?>(), global::System.Array.Empty<T>(), new global::System.Type[] { typeof(T) });
+        return _engine.HandleCallWithReturn<global::System.Collections.Generic.IEnumerable<T>>(3, "GetAll", global::System.Array.Empty<object?>(), global::System.Array.Empty<T>(), global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -84,46 +84,46 @@ public static class BaseService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<T, bool> entity) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, global::TUnit.Mocks.TypeArguments.Of<TInput, TResult>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
     {
         global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, global::TUnit.Mocks.TypeArguments.Of<TInput, TResult>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>> GetAll<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock) where T : class
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -44,7 +44,7 @@ file sealed class BaseServiceMockImpl : global::BaseService, global::TUnit.Mocks
 
     public override global::System.Collections.Generic.IEnumerable<T> GetAll<T>()
     {
-        return _engine.HandleCallWithReturn<global::System.Collections.Generic.IEnumerable<T>>(3, "GetAll", global::System.Array.Empty<object?>(), global::System.Array.Empty<T>());
+        return _engine.HandleCallWithReturn<global::System.Collections.Generic.IEnumerable<T>>(3, "GetAll", global::System.Array.Empty<object?>(), global::System.Array.Empty<T>(), new global::System.Type[] { typeof(T) });
     }
 
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -84,46 +84,46 @@ public static class BaseService_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> GetById<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "GetById", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<T> entity) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Save<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<T, bool> entity) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_entity = entity;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_entity.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Save", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::TUnit.Mocks.Arguments.Arg<TInput> input) where TInput : notnull where TResult : struct
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<TResult> Transform<TInput, TResult>(this global::TUnit.Mocks.Mock<global::BaseService> mock, global::System.Func<TInput, bool> input) where TInput : notnull where TResult : struct
     {
         global::TUnit.Mocks.Arguments.Arg<TInput> __fa_input = input;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_input.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<TResult>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 2, "Transform", matchers, new global::System.Type[] { typeof(TInput), typeof(TResult) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>> GetAll<T>(this global::TUnit.Mocks.Mock<global::BaseService> mock) where T : class
     {
         var matchers = global::System.Array.Empty<global::TUnit.Mocks.Arguments.IArgumentMatcher>();
-        return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<global::System.Collections.Generic.IEnumerable<T>>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 3, "GetAll", matchers, new global::System.Type[] { typeof(T) });
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -73,27 +73,27 @@ public static class Repository_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers);
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<T> item) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { item.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, new global::System.Type[] { typeof(T) });
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<T, bool> item) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_item = item;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_item.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers);
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, new global::System.Type[] { typeof(T) });
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -73,27 +73,27 @@ public static class Repository_MockMemberExtensions
     public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<int> id) where T : class
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.MockMethodCall<T> Get<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<int, bool> id) where T : class
     {
         global::TUnit.Mocks.Arguments.Arg<int> __fa_id = id;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_id.Matcher };
-        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.MockMethodCall<T>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 0, "Get", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::TUnit.Mocks.Arguments.Arg<T> item) where T : class, new()
     {
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { item.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     public static global::TUnit.Mocks.VoidMockMethodCall Store<T>(this global::TUnit.Mocks.Mock<global::Repository> mock, global::System.Func<T, bool> item) where T : class, new()
     {
         global::TUnit.Mocks.Arguments.Arg<T> __fa_item = item;
         var matchers = new global::TUnit.Mocks.Arguments.IArgumentMatcher[] { __fa_item.Matcher };
-        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, new global::System.Type[] { typeof(T) });
+        return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), 1, "Store", matchers, global::TUnit.Mocks.TypeArguments.Of<T>.Value);
     }
 
     #if NET9_0_OR_GREATER

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -744,6 +744,15 @@ internal static class MockImplBuilder
         }
 
         var (isTyped, typeArgs, argsList) = GetTypedDispatchInfo(method);
+        // Generic methods always dispatch through the object?[] + Type[] fallback so their concrete
+        // type arguments reach the engine (typed dispatch can't carry them). Force the fallback path
+        // here so argsArray is materialized; the emit helpers then select the type-arg overloads.
+        if (method.IsGenericMethod)
+        {
+            isTyped = false;
+            typeArgs = null;
+            argsList = null;
+        }
         var argsArray = isTyped ? null : EmitArgsArrayVariable(writer, method);
         var autoMockFactory = GetAutoMockFactoryLambda(method);
 
@@ -752,7 +761,7 @@ internal static class MockImplBuilder
         if (method.IsVoid && !method.IsAsync)
         {
             // Pure void method
-            writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)};");
+            writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name, method)};");
             EmitOutRefReadback(writer, method, model);
         }
         else if (method.IsVoid && method.IsAsync)
@@ -760,7 +769,7 @@ internal static class MockImplBuilder
             // Async void method (Task or ValueTask with no generic arg)
             using (writer.Block("try"))
             {
-                writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)};");
+                writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name, method)};");
                 EmitOutRefReadback(writer, method, model);
                 EmitRawReturnCheck(writer, method);
                 if (method.IsValueTask)
@@ -793,11 +802,11 @@ internal static class MockImplBuilder
             {
                 if (method.IsReturnTypeStaticAbstractInterface)
                 {
-                    writer.AppendLine($"var __result = ({method.UnwrappedReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, unwrappedArg, method.MemberId, method.Name, unwrappedDefault)}!;");
+                    writer.AppendLine($"var __result = ({method.UnwrappedReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, unwrappedArg, method.MemberId, method.Name, unwrappedDefault, method: method)}!;");
                 }
                 else
                 {
-                    writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, unwrappedArg, method.MemberId, method.Name, unwrappedDefault, autoMockFactory)};");
+                    writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, unwrappedArg, method.MemberId, method.Name, unwrappedDefault, autoMockFactory, method)};");
                 }
                 EmitOutRefReadback(writer, method, model);
                 EmitRawReturnCheck(writer, method);
@@ -827,7 +836,7 @@ internal static class MockImplBuilder
             // Synchronous method returning a ref struct — can't use HandleCallWithReturn<T> because
             // ref structs can't be generic type arguments. Use void dispatch for call tracking,
             // callbacks, and throws.
-            writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name)};");
+            writer.AppendLine($"{EmitHandleCall(isTyped, typeArgs, argsList, argsArray, method.MemberId, method.Name, method)};");
             if (method.SpanReturnElementType is not null)
             {
                 // Span return: read back out/ref params AND extract return value from OutRefContext index -1
@@ -845,13 +854,13 @@ internal static class MockImplBuilder
             // as a generic type argument. Use object? and cast.
             if (hasOutRef)
             {
-                writer.AppendLine($"var __result = ({method.ReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, "object?", method.MemberId, method.Name, "null")}!;");
+                writer.AppendLine($"var __result = ({method.ReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, "object?", method.MemberId, method.Name, "null", method: method)}!;");
                 EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return __result;");
             }
             else
             {
-                writer.AppendLine($"return ({method.ReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, "object?", method.MemberId, method.Name, "null")}!;");
+                writer.AppendLine($"return ({method.ReturnType}){EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, "object?", method.MemberId, method.Name, "null", method: method)}!;");
             }
         }
         else
@@ -859,13 +868,13 @@ internal static class MockImplBuilder
             // Synchronous method with return value — need to read back out/ref before returning
             if (hasOutRef)
             {
-                writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, autoMockFactory)};");
+                writer.AppendLine($"var __result = {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, autoMockFactory, method)};");
                 EmitOutRefReadback(writer, method, model);
                 writer.AppendLine("return __result;");
             }
             else
             {
-                writer.AppendLine($"return {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, autoMockFactory)};");
+                writer.AppendLine($"return {EmitHandleCallWithReturn(isTyped, typeArgs, argsList, argsArray, method.ReturnType, method.MemberId, method.Name, method.SmartDefault, autoMockFactory, method)};");
             }
         }
     }
@@ -1375,16 +1384,39 @@ internal static class MockImplBuilder
     }
 
     /// <summary>Emits a HandleCall or TryHandleCall invocation, choosing typed or fallback path.</summary>
-    private static string EmitHandleCall(bool isTyped, string? typeArgs, string? argsList, string? argsArray, int memberId, string memberName)
-        => isTyped
+    /// <remarks>
+    /// A generic method always uses the object?[] fallback overload that also takes the method's
+    /// concrete type arguments, so the engine can discriminate setups/calls by type argument.
+    /// </remarks>
+    private static string EmitHandleCall(bool isTyped, string? typeArgs, string? argsList, string? argsArray, int memberId, string memberName, MockMemberModel? method = null)
+    {
+        if (method is { IsGenericMethod: true })
+        {
+            return $"_engine.HandleCall({memberId}, \"{memberName}\", {argsArray}, {TypeArgumentsArrayLiteral(method)})";
+        }
+        return isTyped
             ? $"_engine.HandleCall<{typeArgs}>({memberId}, \"{memberName}\", {argsList})"
             : $"_engine.HandleCall({memberId}, \"{memberName}\", {argsArray})";
+    }
 
     /// <summary>Emits a HandleCallWithReturn invocation, choosing typed or fallback path.</summary>
-    private static string EmitHandleCallWithReturn(bool isTyped, string? typeArgs, string? argsList, string? argsArray, string returnTypeArg, int memberId, string memberName, string defaultValue, string? autoMockFactory = null)
-        => isTyped
+    /// <remarks>See <see cref="EmitHandleCall"/> for the generic-method type-argument path.</remarks>
+    private static string EmitHandleCallWithReturn(bool isTyped, string? typeArgs, string? argsList, string? argsArray, string returnTypeArg, int memberId, string memberName, string defaultValue, string? autoMockFactory = null, MockMemberModel? method = null)
+    {
+        if (method is { IsGenericMethod: true })
+        {
+            // Generic methods dispatch through the object?[] overload that carries the method's type
+            // arguments; an auto-mock factory (for an auto-mockable return type) is preserved before it.
+            return $"_engine.HandleCallWithReturn<{returnTypeArg}>({memberId}, \"{memberName}\", {argsArray}, {defaultValue}{FormatAutoMockFactoryArgument(autoMockFactory)}, {TypeArgumentsArrayLiteral(method)})";
+        }
+        return isTyped
             ? $"_engine.HandleCallWithReturn<{returnTypeArg}, {typeArgs}>({memberId}, \"{memberName}\", {argsList}, {defaultValue}{FormatAutoMockFactoryArgument(autoMockFactory)})"
             : $"_engine.HandleCallWithReturn<{returnTypeArg}>({memberId}, \"{memberName}\", {argsArray}, {defaultValue}{FormatAutoMockFactoryArgument(autoMockFactory)})";
+    }
+
+    /// <summary>Emits <c>new global::System.Type[] { typeof(T), ... }</c> for a generic method's type parameters.</summary>
+    private static string TypeArgumentsArrayLiteral(MockMemberModel method)
+        => $"new global::System.Type[] {{ {string.Join(", ", method.TypeParameters.Select(tp => $"typeof({tp.Name})"))} }}";
 
     /// <summary>Emits a TryHandleCall condition, choosing typed or fallback path.</summary>
     private static string EmitTryHandleCall(bool isTyped, string? typeArgs, string? argsList, string? argsArray, int memberId, string memberName)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -744,7 +744,7 @@ internal static class MockImplBuilder
         }
 
         var (isTyped, typeArgs, argsList) = GetTypedDispatchInfo(method);
-        // Generic methods always dispatch through the object?[] + Type[] fallback so their concrete
+        // Generic methods always dispatch through the object?[] + type-arguments fallback so their concrete
         // type arguments reach the engine (typed dispatch can't carry them). Force the fallback path
         // here so argsArray is materialized; the emit helpers then select the type-arg overloads.
         if (method.IsGenericMethod)
@@ -1415,9 +1415,9 @@ internal static class MockImplBuilder
     }
 
     /// <summary>
-    /// Emits the type-argument array for a generic method. For the common 1–2 type-parameter cases it
+    /// Emits the type-argument array for a generic method. For the common 1–4 type-parameter cases it
     /// references the per-closed-type cache (<c>TypeArguments.Of&lt;T&gt;.Value</c>) to avoid a per-call
-    /// allocation; higher arities fall back to a fresh <c>new global::System.Type[] { typeof(T), ... }</c>.
+    /// allocation; higher arities fall back to a per-call <c>ImmutableArray.Create(...)</c>.
     /// </summary>
     internal static string TypeArgumentsArrayLiteral(MockMemberModel method)
     {
@@ -1426,7 +1426,7 @@ internal static class MockImplBuilder
         {
             return $"global::TUnit.Mocks.TypeArguments.Of<{string.Join(", ", typeParams.Select(tp => tp.Name))}>.Value";
         }
-        return $"new global::System.Type[] {{ {string.Join(", ", typeParams.Select(tp => $"typeof({tp.Name})"))} }}";
+        return $"global::System.Collections.Immutable.ImmutableArray.Create<global::System.Type>({string.Join(", ", typeParams.Select(tp => $"typeof({tp.Name})"))})";
     }
 
     /// <summary>Emits a TryHandleCall condition, choosing typed or fallback path.</summary>

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1414,9 +1414,20 @@ internal static class MockImplBuilder
             : $"_engine.HandleCallWithReturn<{returnTypeArg}>({memberId}, \"{memberName}\", {argsArray}, {defaultValue}{FormatAutoMockFactoryArgument(autoMockFactory)})";
     }
 
-    /// <summary>Emits <c>new global::System.Type[] { typeof(T), ... }</c> for a generic method's type parameters.</summary>
+    /// <summary>
+    /// Emits the type-argument array for a generic method. For the common 1–2 type-parameter cases it
+    /// references the per-closed-type cache (<c>TypeArguments.Of&lt;T&gt;.Value</c>) to avoid a per-call
+    /// allocation; higher arities fall back to a fresh <c>new global::System.Type[] { typeof(T), ... }</c>.
+    /// </summary>
     internal static string TypeArgumentsArrayLiteral(MockMemberModel method)
-        => $"new global::System.Type[] {{ {string.Join(", ", method.TypeParameters.Select(tp => $"typeof({tp.Name})"))} }}";
+    {
+        var typeParams = method.TypeParameters;
+        if (typeParams.Length is 1 or 2)
+        {
+            return $"global::TUnit.Mocks.TypeArguments.Of<{string.Join(", ", typeParams.Select(tp => tp.Name))}>.Value";
+        }
+        return $"new global::System.Type[] {{ {string.Join(", ", typeParams.Select(tp => $"typeof({tp.Name})"))} }}";
+    }
 
     /// <summary>Emits a TryHandleCall condition, choosing typed or fallback path.</summary>
     private static string EmitTryHandleCall(bool isTyped, string? typeArgs, string? argsList, string? argsArray, int memberId, string memberName)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1422,7 +1422,7 @@ internal static class MockImplBuilder
     internal static string TypeArgumentsArrayLiteral(MockMemberModel method)
     {
         var typeParams = method.TypeParameters;
-        if (typeParams.Length is 1 or 2)
+        if (typeParams.Length is >= 1 and <= 4)
         {
             return $"global::TUnit.Mocks.TypeArguments.Of<{string.Join(", ", typeParams.Select(tp => tp.Name))}>.Value";
         }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockImplBuilder.cs
@@ -1415,7 +1415,7 @@ internal static class MockImplBuilder
     }
 
     /// <summary>Emits <c>new global::System.Type[] { typeof(T), ... }</c> for a generic method's type parameters.</summary>
-    private static string TypeArgumentsArrayLiteral(MockMemberModel method)
+    internal static string TypeArgumentsArrayLiteral(MockMemberModel method)
         => $"new global::System.Type[] {{ {string.Join(", ", method.TypeParameters.Select(tp => $"typeof({tp.Name})"))} }}";
 
     /// <summary>Emits a TryHandleCall condition, choosing typed or fallback path.</summary>

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -971,7 +971,8 @@ internal static class MockMembersBuilder
     {
         // For a generic method, pass the configured type arguments so the setup/verification can
         // discriminate calls by type argument. Non-generic methods omit the argument (overload with
-        // the trailing Type[] is not selected). The typed wrapper is never generated for generic methods.
+        // the trailing type-arguments parameter is not selected). The typed wrapper is never generated
+        // for generic methods.
         var typeArgs = method.IsGenericMethod
             ? $", {MockImplBuilder.TypeArgumentsArrayLiteral(method)}"
             : "";

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -973,7 +973,7 @@ internal static class MockMembersBuilder
         // discriminate calls by type argument. Non-generic methods omit the argument (overload with
         // the trailing Type[] is not selected). The typed wrapper is never generated for generic methods.
         var typeArgs = method.IsGenericMethod
-            ? $", new global::System.Type[] {{ {string.Join(", ", method.TypeParameters.Select(tp => $"typeof({tp.Name})"))} }}"
+            ? $", {MockImplBuilder.TypeArgumentsArrayLiteral(method)}"
             : "";
 
         if (useTypedWrapper)

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -969,6 +969,13 @@ internal static class MockMembersBuilder
     private static void EmitReturnConstruction(CodeWriter writer, MockMemberModel method, MockTypeModel model,
         string safeName, bool useTypedWrapper, string setupReturnType)
     {
+        // For a generic method, pass the configured type arguments so the setup/verification can
+        // discriminate calls by type argument. Non-generic methods omit the argument (overload with
+        // the trailing Type[] is not selected). The typed wrapper is never generated for generic methods.
+        var typeArgs = method.IsGenericMethod
+            ? $", new global::System.Type[] {{ {string.Join(", ", method.TypeParameters.Select(tp => $"typeof({tp.Name})"))} }}"
+            : "";
+
         if (useTypedWrapper)
         {
             var wrapperName = MockImplBuilder.GetGeneratedTypeName(GetWrapperName(safeName, method), model);
@@ -976,15 +983,15 @@ internal static class MockMembersBuilder
         }
         else if (method.IsVoid || method.IsRefStructReturn)
         {
-            writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+            writer.AppendLine($"return new global::TUnit.Mocks.VoidMockMethodCall(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers{typeArgs});");
         }
         else if (method.IsReturnTypeStaticAbstractInterface)
         {
-            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<object?>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers{typeArgs});");
         }
         else
         {
-            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers);");
+            writer.AppendLine($"return new global::TUnit.Mocks.MockMethodCall<{setupReturnType}>(global::TUnit.Mocks.MockRegistry.GetEngine(mock), {method.MemberId}, \"{method.Name}\", matchers{typeArgs});");
         }
     }
 

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -36,6 +36,15 @@ public interface IMultiGeneric
     void Handle<TInput, TOutput>(TInput input) where TInput : class where TOutput : class;
 }
 
+/// <summary>
+/// A struct-constrained generic method, to verify the <see cref="AnyValueType"/> wildcard works for
+/// <c>where T : struct</c> parameters (and is not dead code).
+/// </summary>
+public interface IValueDescriber
+{
+    string Describe<T>() where T : struct;
+}
+
 public class Customer
 {
     public int Id { get; set; }
@@ -299,5 +308,31 @@ public class GenericTests
 
         // The failure should name the type argument so the developer can tell which setup was expected.
         await Assert.That(ex!.ExpectedCall).Contains("Save<Customer>");
+    }
+
+    [Test]
+    public async Task Generic_Method_Struct_Constraint_AnyValueType_Wildcard()
+    {
+        // AnyValueType is a struct, so it satisfies `where T : struct` and acts as a wildcard there.
+        var mock = IValueDescriber.Mock();
+        mock.Describe<AnyValueType>().Returns("any-value");
+
+        IValueDescriber sut = mock.Object;
+
+        await Assert.That(sut.Describe<int>()).IsEqualTo("any-value");
+        await Assert.That(sut.Describe<System.DateTime>()).IsEqualTo("any-value");
+    }
+
+    [Test]
+    public async Task Generic_Method_Struct_Constraint_Distinguished_By_Type_Argument()
+    {
+        var mock = IValueDescriber.Mock();
+        mock.Describe<int>().Returns("int");
+        mock.Describe<long>().Returns("long");
+
+        IValueDescriber sut = mock.Object;
+
+        await Assert.That(sut.Describe<int>()).IsEqualTo("int");
+        await Assert.That(sut.Describe<long>()).IsEqualTo("long");
     }
 }

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -13,6 +13,15 @@ public interface IRepository
     TResult Transform<TInput, TResult>(TInput input) where TInput : class where TResult : class;
 }
 
+/// <summary>
+/// Generic method whose type parameter does not appear in the parameter list, so calls can only be
+/// distinguished by their type argument. Mirrors discussion #4981.
+/// </summary>
+public interface IGenericGreeter
+{
+    string Greet<T>() where T : class;
+}
+
 public class Customer
 {
     public int Id { get; set; }
@@ -23,6 +32,9 @@ public class Order
 {
     public int OrderId { get; set; }
 }
+
+public class Class1 { }
+public class Class2 { }
 
 /// <summary>
 /// US7 Integration Tests: Generic method support in mock generation.
@@ -144,5 +156,62 @@ public class GenericTests
         // Assert
         await Assert.That(result).IsNotNull();
         await Assert.That(result.OrderId).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task Generic_Method_ZeroArgs_Distinguished_By_Type_Argument()
+    {
+        // Regression for discussion #4981: with no parameters, only the type argument distinguishes
+        // the two setups. Before the fix both setups collided and the last one always won.
+        var mock = IGenericGreeter.Mock();
+        mock.Greet<Class1>().Returns("Hello!");
+        mock.Greet<Class2>().Returns("Goodbye!");
+
+        IGenericGreeter greeter = mock.Object;
+
+        await Assert.That(greeter.Greet<Class1>()).IsEqualTo("Hello!");
+        await Assert.That(greeter.Greet<Class2>()).IsEqualTo("Goodbye!");
+    }
+
+    [Test]
+    public async Task Generic_Method_Wildcard_AnyType_Matches_Any_Type_Argument()
+    {
+        var mock = IGenericGreeter.Mock();
+        mock.Greet<AnyType>().Returns("any");
+
+        IGenericGreeter greeter = mock.Object;
+
+        await Assert.That(greeter.Greet<Class1>()).IsEqualTo("any");
+        await Assert.That(greeter.Greet<Class2>()).IsEqualTo("any");
+    }
+
+    [Test]
+    public async Task Generic_Method_Exact_Type_Setup_Wins_Over_Wildcard()
+    {
+        // A later, more specific setup is matched first (last-wins iteration), while other type
+        // arguments still fall through to the wildcard.
+        var mock = IGenericGreeter.Mock();
+        mock.Greet<AnyType>().Returns("any");
+        mock.Greet<Class1>().Returns("specific");
+
+        IGenericGreeter greeter = mock.Object;
+
+        await Assert.That(greeter.Greet<Class1>()).IsEqualTo("specific");
+        await Assert.That(greeter.Greet<Class2>()).IsEqualTo("any");
+    }
+
+    [Test]
+    public void Generic_Void_Method_Verify_Discriminates_By_Type_Argument()
+    {
+        var mock = IRepository.Mock();
+        IRepository repo = mock.Object;
+
+        repo.Save(new Customer());
+        repo.Save(new Customer());
+        repo.Save(new Order());
+
+        mock.Save<Customer>(Any()).WasCalled(Times.Exactly(2));
+        mock.Save<Order>(Any()).WasCalled(Times.Once);
+        mock.Save<AnyType>(Any()).WasCalled(Times.Exactly(3));
     }
 }

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -1,5 +1,6 @@
 using TUnit.Mocks;
 using TUnit.Mocks.Arguments;
+using TUnit.Mocks.Exceptions;
 
 namespace TUnit.Mocks.Tests;
 
@@ -285,5 +286,18 @@ public class GenericTests
         mock.Handle<Customer, Customer>(Any()).WasNeverCalled();          // pair never called
         mock.Handle<AnyType, AnyType>(Any()).WasCalled(Times.Exactly(2)); // both wildcards
         mock.Handle<AnyType, Customer>(Any()).WasCalled(Times.Once);      // only Handle<Order, Customer>
+    }
+
+    [Test]
+    public async Task Generic_Verification_Failure_Message_Includes_Type_Argument()
+    {
+        var mock = IRepository.Mock();
+        mock.Object.Save(new Order()); // Save<Order>, never Save<Customer>
+
+        var ex = Assert.Throws<MockVerificationException>(() =>
+            mock.Save<Customer>(Any()).WasCalled(Times.Once));
+
+        // The failure should name the type argument so the developer can tell which setup was expected.
+        await Assert.That(ex!.ExpectedCall).Contains("Save<Customer>");
     }
 }

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -335,4 +335,46 @@ public class GenericTests
         await Assert.That(sut.Describe<int>()).IsEqualTo("int");
         await Assert.That(sut.Describe<long>()).IsEqualTo("long");
     }
+
+    [Test]
+    public void Ordered_Verification_Discriminates_By_Type_Argument()
+    {
+        var mock = IGenericGreeter.Mock();
+        IGenericGreeter greeter = mock.Object;
+
+        greeter.Greet<Class1>();
+        greeter.Greet<Class2>();
+
+        // Passes only if each expectation matches the call with its own type argument.
+        Mock.VerifyInOrder(() =>
+        {
+            mock.Greet<Class1>().WasCalled();
+            mock.Greet<Class2>().WasCalled();
+        });
+    }
+
+    [Test]
+    public async Task Ordered_Verification_Fails_When_Type_Arguments_Out_Of_Order()
+    {
+        var mock = IGenericGreeter.Mock();
+        IGenericGreeter greeter = mock.Object;
+
+        greeter.Greet<Class1>();
+        greeter.Greet<Class2>();
+
+        // Reversed type-argument order must fail. Before type arguments were threaded through
+        // ordered verification, both expectations matched both calls and this passed regardless
+        // of which type was actually called first.
+        var ex = Assert.Throws<MockVerificationException>(() =>
+            Mock.VerifyInOrder(() =>
+            {
+                mock.Greet<Class2>().WasCalled();
+                mock.Greet<Class1>().WasCalled();
+            }));
+
+        await Assert.That(ex!.Message).Contains("Ordered verification failed");
+        // The failure message names the expected calls with their type arguments.
+        await Assert.That(ex.Message).Contains("Greet<Class1>");
+        await Assert.That(ex.Message).Contains("Greet<Class2>");
+    }
 }

--- a/TUnit.Mocks.Tests/GenericTests.cs
+++ b/TUnit.Mocks.Tests/GenericTests.cs
@@ -22,6 +22,19 @@ public interface IGenericGreeter
     string Greet<T>() where T : class;
 }
 
+/// <summary>
+/// Methods with two type parameters, used to verify discrimination is sensitive to the full,
+/// ordered list of type arguments — not just the first.
+/// </summary>
+public interface IMultiGeneric
+{
+    // Zero parameters: the only discriminator is the (T1, T2) type-argument pair.
+    string Describe<T1, T2>() where T1 : class where T2 : class;
+
+    // TOutput appears only as a type parameter; the argument matcher is on TInput.
+    void Handle<TInput, TOutput>(TInput input) where TInput : class where TOutput : class;
+}
+
 public class Customer
 {
     public int Id { get; set; }
@@ -213,5 +226,64 @@ public class GenericTests
         mock.Save<Customer>(Any()).WasCalled(Times.Exactly(2));
         mock.Save<Order>(Any()).WasCalled(Times.Once);
         mock.Save<AnyType>(Any()).WasCalled(Times.Exactly(3));
+    }
+
+    [Test]
+    public async Task Generic_Method_Two_Type_Params_Distinguished_By_Order()
+    {
+        // The two setups share the same (empty) argument list and the same type-argument *set* —
+        // only the order differs. Each must resolve independently.
+        var mock = IMultiGeneric.Mock();
+        mock.Describe<Class1, Class2>().Returns("1-2");
+        mock.Describe<Class2, Class1>().Returns("2-1");
+
+        IMultiGeneric sut = mock.Object;
+
+        await Assert.That(sut.Describe<Class1, Class2>()).IsEqualTo("1-2");
+        await Assert.That(sut.Describe<Class2, Class1>()).IsEqualTo("2-1");
+    }
+
+    [Test]
+    public async Task Generic_Method_Two_Type_Params_Partial_Wildcard()
+    {
+        // Wildcard the first type parameter, pin the second. Only the second must match exactly.
+        var mock = IMultiGeneric.Mock();
+        mock.Describe<AnyType, Class2>().Returns("any-2");
+
+        IMultiGeneric sut = mock.Object;
+
+        await Assert.That(sut.Describe<Class1, Class2>()).IsEqualTo("any-2"); // first wildcard, second matches
+        await Assert.That(sut.Describe<Class2, Class2>()).IsEqualTo("any-2"); // first wildcard, second matches
+        // Second type arg (Class1) != Class2 → no setup matches → unconfigured default (empty string)
+        await Assert.That(sut.Describe<Class1, Class1>()).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task Generic_Method_Two_Type_Params_Exact_Wins_Over_Partial_Wildcard()
+    {
+        var mock = IMultiGeneric.Mock();
+        mock.Describe<AnyType, Class2>().Returns("any-2");
+        mock.Describe<Class1, Class2>().Returns("1-2"); // more specific, added later → matched first
+
+        IMultiGeneric sut = mock.Object;
+
+        await Assert.That(sut.Describe<Class1, Class2>()).IsEqualTo("1-2");
+        await Assert.That(sut.Describe<Class2, Class2>()).IsEqualTo("any-2");
+    }
+
+    [Test]
+    public void Generic_Void_Method_Two_Type_Params_Verify_Discriminates()
+    {
+        var mock = IMultiGeneric.Mock();
+        IMultiGeneric sut = mock.Object;
+
+        sut.Handle<Customer, Order>(new Customer());
+        sut.Handle<Order, Customer>(new Order());
+
+        mock.Handle<Customer, Order>(Any()).WasCalled(Times.Once);
+        mock.Handle<Order, Customer>(Any()).WasCalled(Times.Once);
+        mock.Handle<Customer, Customer>(Any()).WasNeverCalled();          // pair never called
+        mock.Handle<AnyType, AnyType>(Any()).WasCalled(Times.Exactly(2)); // both wildcards
+        mock.Handle<AnyType, Customer>(Any()).WasCalled(Times.Once);      // only Handle<Order, Customer>
     }
 }

--- a/TUnit.Mocks/Arguments/AnyType.cs
+++ b/TUnit.Mocks/Arguments/AnyType.cs
@@ -1,0 +1,26 @@
+namespace TUnit.Mocks.Arguments;
+
+/// <summary>
+/// Wildcard marker for a generic method's reference-type argument. Use it as the type argument of a
+/// mock setup or verification on a generic method to match calls regardless of the concrete type
+/// argument supplied at the call site:
+/// <code>
+/// mock.Get&lt;AnyType&gt;(Arg.Any&lt;int&gt;()).Returns(value); // matches Get&lt;Customer&gt;, Get&lt;Order&gt;, ...
+/// </code>
+/// Satisfies a <c>where T : class</c>, <c>where T : class, new()</c>, or unconstrained type parameter
+/// (it has a public parameterless constructor). For a <c>where T : struct</c> parameter use
+/// <see cref="AnyValueType"/>. Type parameters constrained to a specific base class or interface
+/// support exact-type matching only.
+/// </summary>
+public sealed class AnyType
+{
+}
+
+/// <summary>
+/// Wildcard marker for a generic method's value-type argument. The struct counterpart of
+/// <see cref="AnyType"/>, for matching a <c>where T : struct</c> type parameter regardless of the
+/// concrete value type supplied at the call site.
+/// </summary>
+public struct AnyValueType
+{
+}

--- a/TUnit.Mocks/Arguments/AnyType.cs
+++ b/TUnit.Mocks/Arguments/AnyType.cs
@@ -20,6 +20,9 @@ public sealed class AnyType
 /// Wildcard marker for a generic method's value-type argument. The struct counterpart of
 /// <see cref="AnyType"/>, for matching a <c>where T : struct</c> type parameter regardless of the
 /// concrete value type supplied at the call site.
+/// A type parameter with constraints beyond <c>struct</c> (e.g. <c>where T : struct, IComparable</c>)
+/// supports exact-type matching only, since <see cref="AnyValueType"/> does not implement any
+/// interfaces and cannot be supplied as its type argument.
 /// </summary>
 public struct AnyValueType
 {

--- a/TUnit.Mocks/IMockEngineAccess.cs
+++ b/TUnit.Mocks/IMockEngineAccess.cs
@@ -24,6 +24,13 @@ public interface IMockEngineAccess
     /// <summary>Creates a call verification builder for the specified member.</summary>
     ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers);
 
+    /// <summary>
+    /// Creates a call verification builder for a generic-method member, filtering recorded calls by
+    /// the supplied type arguments (concrete types or <see cref="AnyType"/>/<see cref="AnyValueType"/>
+    /// wildcards).
+    /// </summary>
+    ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments);
+
     /// <summary>Registers a callback that fires when a handler subscribes to the named event.</summary>
     void OnSubscribe(string eventName, Action callback);
 

--- a/TUnit.Mocks/IMockEngineAccess.cs
+++ b/TUnit.Mocks/IMockEngineAccess.cs
@@ -24,13 +24,6 @@ public interface IMockEngineAccess
     /// <summary>Creates a call verification builder for the specified member.</summary>
     ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers);
 
-    /// <summary>
-    /// Creates a call verification builder for a generic-method member, filtering recorded calls by
-    /// the supplied type arguments (concrete types or <see cref="AnyType"/>/<see cref="AnyValueType"/>
-    /// wildcards).
-    /// </summary>
-    ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments);
-
     /// <summary>Registers a callback that fires when a handler subscribes to the named event.</summary>
     void OnSubscribe(string eventName, Action callback);
 

--- a/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
+++ b/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Verification;
 
@@ -17,5 +18,20 @@ internal interface ITypeArgumentVerificationFactory
     /// Creates a call verification builder that filters recorded calls by the supplied type arguments
     /// (concrete types or <see cref="AnyType"/>/<see cref="AnyValueType"/> wildcards).
     /// </summary>
-    ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments);
+    ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments);
+}
+
+/// <summary>
+/// Shared verification-builder routing for <see cref="MockMethodCall{TReturn}"/> and
+/// <see cref="VoidMockMethodCall"/>: non-generic calls use the public engine surface unchanged;
+/// generic calls route through <see cref="ITypeArgumentVerificationFactory"/> (always implemented by
+/// MockEngine). A custom <see cref="IMockEngineAccess"/> implementation falls back to the public
+/// surface, losing type-argument filtering but never throwing.
+/// </summary>
+internal static class MockCallVerification
+{
+    public static ICallVerification Create(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments)
+        => !typeArguments.IsDefault && engine is ITypeArgumentVerificationFactory typeArgFactory
+            ? typeArgFactory.CreateVerification(memberId, memberName, matchers, typeArguments)
+            : engine.CreateVerification(memberId, memberName, matchers);
 }

--- a/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
+++ b/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
@@ -6,8 +6,10 @@ namespace TUnit.Mocks;
 /// <summary>
 /// Internal extension of the engine's verification surface that also filters by a generic method's
 /// type arguments. Kept off the public <see cref="IMockEngineAccess"/> interface so adding generic
-/// type-argument support does not break external implementers; the only implementer is
-/// <see cref="MockEngine{T}"/>, and generic mock-call wrappers reach it via an internal cast.
+/// type-argument support does not break external implementers (a default interface method is not an
+/// option while the library targets netstandard2.0). The only implementer is
+/// <see cref="MockEngine{T}"/>; generic mock-call wrappers reach it via a type test and fall back to
+/// the public, non-filtering surface for any custom engine.
 /// </summary>
 internal interface ITypeArgumentVerificationFactory
 {

--- a/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
+++ b/TUnit.Mocks/ITypeArgumentVerificationFactory.cs
@@ -1,0 +1,19 @@
+using TUnit.Mocks.Arguments;
+using TUnit.Mocks.Verification;
+
+namespace TUnit.Mocks;
+
+/// <summary>
+/// Internal extension of the engine's verification surface that also filters by a generic method's
+/// type arguments. Kept off the public <see cref="IMockEngineAccess"/> interface so adding generic
+/// type-argument support does not break external implementers; the only implementer is
+/// <see cref="MockEngine{T}"/>, and generic mock-call wrappers reach it via an internal cast.
+/// </summary>
+internal interface ITypeArgumentVerificationFactory
+{
+    /// <summary>
+    /// Creates a call verification builder that filters recorded calls by the supplied type arguments
+    /// (concrete types or <see cref="AnyType"/>/<see cref="AnyValueType"/> wildcards).
+    /// </summary>
+    ICallVerification CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments);
+}

--- a/TUnit.Mocks/MockEngine.cs
+++ b/TUnit.Mocks/MockEngine.cs
@@ -21,7 +21,7 @@ internal static class MockCallSequence
 }
 
 [EditorBrowsable(EditorBrowsableState.Never)]
-public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
+public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVerificationFactory where T : class
 {
     // Single lock for both setup and call mutations — reduces allocation by one Lock object.
     // Contention is acceptable since setup and call recording rarely overlap in typical usage.
@@ -224,7 +224,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
     ICallVerification IMockEngineAccess.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers)
         => new CallVerificationBuilder<T>(this, memberId, memberName, matchers);
 
-    ICallVerification IMockEngineAccess.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    ICallVerification ITypeArgumentVerificationFactory.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
         => new CallVerificationBuilder<T>(this, memberId, memberName, matchers, typeArguments);
 
     /// <summary>

--- a/TUnit.Mocks/MockEngine.cs
+++ b/TUnit.Mocks/MockEngine.cs
@@ -224,13 +224,27 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
     ICallVerification IMockEngineAccess.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers)
         => new CallVerificationBuilder<T>(this, memberId, memberName, matchers);
 
+    ICallVerification IMockEngineAccess.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+        => new CallVerificationBuilder<T>(this, memberId, memberName, matchers, typeArguments);
+
     /// <summary>
     /// Handles a void method call. Records the call and executes matching setup behavior.
     /// </summary>
     public void HandleCall(int memberId, string memberName, object?[] args)
+        => HandleCallCore(memberId, memberName, args, null);
+
+    /// <summary>
+    /// Handles a void generic-method call. <paramref name="typeArguments"/> are the concrete closed
+    /// type arguments, used to discriminate setups and recorded calls by type argument.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void HandleCall(int memberId, string memberName, object?[] args, Type[] typeArguments)
+        => HandleCallCore(memberId, memberName, args, typeArguments);
+
+    private void HandleCallCore(int memberId, string memberName, object?[] args, Type[]? typeArguments)
     {
         RawReturnContext.Clear();
-        var callRecord = RecordCall(memberId, memberName, args);
+        var callRecord = RecordCall(memberId, memberName, args, typeArguments);
 
         // Auto-track property setters: store value keyed by property name
         if (AutoTrackProperties && memberName.StartsWith("set_", StringComparison.Ordinal) && args.Length > 0)
@@ -238,7 +252,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
             AutoTrackValues[memberName[4..]] = args[0];
         }
 
-        var (setupFound, behavior, matchedSetup) = FindMatchingSetup(memberId, args);
+        var (setupFound, behavior, matchedSetup) = FindMatchingSetup(memberId, args, typeArguments);
 
         if (behavior is not null)
         {
@@ -282,15 +296,34 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
     /// or returns default/throws for strict mode.
     /// </summary>
     public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue)
-        => HandleCallWithReturn(memberId, memberName, args, defaultValue, null);
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, null, null);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory)
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, autoMockFactory, null);
+
+    /// <summary>
+    /// Handles a generic-method call with a return value. <paramref name="typeArguments"/> are the
+    /// concrete closed type arguments, used to discriminate setups and recorded calls by type argument.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Type[] typeArguments)
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, null, typeArguments);
+
+    /// <summary>
+    /// Generic-method call with a return value that may also auto-mock its return type. Combines the
+    /// <paramref name="autoMockFactory"/> and <paramref name="typeArguments"/> paths.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, Type[] typeArguments)
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, autoMockFactory, typeArguments);
+
+    private TReturn HandleCallWithReturnCore<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, Type[]? typeArguments)
     {
         RawReturnContext.Clear();
-        var callRecord = RecordCall(memberId, memberName, args);
+        var callRecord = RecordCall(memberId, memberName, args, typeArguments);
 
-        var (setupFound, behavior, matchedSetup) = FindMatchingSetup(memberId, args);
+        var (setupFound, behavior, matchedSetup) = FindMatchingSetup(memberId, args, typeArguments);
 
         if (behavior is not null)
         {
@@ -752,6 +785,9 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
     private CallRecord RecordCall(int memberId, string memberName, object?[] args)
         => StoreCallRecord(new CallRecord(memberId, memberName, args, MockCallSequence.Next()));
 
+    private CallRecord RecordCall(int memberId, string memberName, object?[] args, Type[]? typeArguments)
+        => StoreCallRecord(new CallRecord(memberId, memberName, args, MockCallSequence.Next(), typeArguments));
+
     private CallRecord RecordCall(int memberId, string memberName, IArgumentStore store)
         => StoreCallRecord(new CallRecord(memberId, memberName, store, MockCallSequence.Next()));
 
@@ -875,7 +911,14 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
         }
     }
 
+    // Non-generic two-arg overload kept distinct (no optional parameter) so it wins overload
+    // resolution against the generic FindMatchingSetup<T1>(int, T1) for object?[] call sites.
+    // Adding a defaulted third parameter here would let the generic overload bind instead,
+    // silently treating the args array as a single typed argument.
     private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup(int memberId, object?[] args)
+        => FindMatchingSetup(memberId, args, (Type[]?)null);
+
+    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup(int memberId, object?[] args, Type[]? typeArguments)
     {
         // Rebuild snapshots if setup phase just ended (batches all ToArray work into one pass)
         if (_hasStaleSetups)
@@ -887,7 +930,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
         // to prevent concurrent invocations from consuming the same state transition
         if (_hasStatefulSetups)
         {
-            return FindMatchingSetupLocked(memberId, args);
+            return FindMatchingSetupLocked(memberId, args, typeArguments);
         }
 
         var snapshot = _setupsByMemberId;
@@ -907,7 +950,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
         {
             var setup = setups[i];
 
-            if (setup.Matches(args))
+            if (setup.Matches(args) && setup.TypeArgumentsMatch(typeArguments))
             {
                 setup.IncrementInvokeCount();
                 setup.ApplyCaptures(args);
@@ -918,7 +961,9 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
         return (false, null, null);
     }
 
-    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetupLocked(int memberId, object?[] args)
+    // FindMatchingSetupLocked has no generic sibling, so a defaulted parameter is safe here
+    // (unlike FindMatchingSetup, which competes with FindMatchingSetup<T1>).
+    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetupLocked(int memberId, object?[] args, Type[]? typeArguments = null)
     {
         lock (Lock)
         {
@@ -942,7 +987,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess where T : class
                     continue;
                 }
 
-                if (setup.Matches(args))
+                if (setup.Matches(args) && setup.TypeArgumentsMatch(typeArguments))
                 {
                     setup.IncrementInvokeCount();
                     setup.ApplyCaptures(args);

--- a/TUnit.Mocks/MockEngine.cs
+++ b/TUnit.Mocks/MockEngine.cs
@@ -4,6 +4,7 @@ using TUnit.Mocks.Setup;
 using TUnit.Mocks.Setup.Behaviors;
 using TUnit.Mocks.Verification;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.ComponentModel;
@@ -224,24 +225,24 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     ICallVerification IMockEngineAccess.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers)
         => new CallVerificationBuilder<T>(this, memberId, memberName, matchers);
 
-    ICallVerification ITypeArgumentVerificationFactory.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    ICallVerification ITypeArgumentVerificationFactory.CreateVerification(int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments)
         => new CallVerificationBuilder<T>(this, memberId, memberName, matchers, typeArguments);
 
     /// <summary>
     /// Handles a void method call. Records the call and executes matching setup behavior.
     /// </summary>
     public void HandleCall(int memberId, string memberName, object?[] args)
-        => HandleCallCore(memberId, memberName, args, null);
+        => HandleCallCore(memberId, memberName, args, default);
 
     /// <summary>
     /// Handles a void generic-method call. <paramref name="typeArguments"/> are the concrete closed
     /// type arguments, used to discriminate setups and recorded calls by type argument.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void HandleCall(int memberId, string memberName, object?[] args, Type[] typeArguments)
+    public void HandleCall(int memberId, string memberName, object?[] args, ImmutableArray<Type> typeArguments)
         => HandleCallCore(memberId, memberName, args, typeArguments);
 
-    private void HandleCallCore(int memberId, string memberName, object?[] args, Type[]? typeArguments)
+    private void HandleCallCore(int memberId, string memberName, object?[] args, ImmutableArray<Type> typeArguments)
     {
         RawReturnContext.Clear();
         var callRecord = RecordCall(memberId, memberName, args, typeArguments);
@@ -296,18 +297,18 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     /// or returns default/throws for strict mode.
     /// </summary>
     public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue)
-        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, null, null);
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, null, default);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory)
-        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, autoMockFactory, null);
+        => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, autoMockFactory, default);
 
     /// <summary>
     /// Handles a generic-method call with a return value. <paramref name="typeArguments"/> are the
     /// concrete closed type arguments, used to discriminate setups and recorded calls by type argument.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Type[] typeArguments)
+    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, ImmutableArray<Type> typeArguments)
         => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, null, typeArguments);
 
     /// <summary>
@@ -315,10 +316,10 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     /// <paramref name="autoMockFactory"/> and <paramref name="typeArguments"/> paths.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, Type[] typeArguments)
+    public TReturn HandleCallWithReturn<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, ImmutableArray<Type> typeArguments)
         => HandleCallWithReturnCore(memberId, memberName, args, defaultValue, autoMockFactory, typeArguments);
 
-    private TReturn HandleCallWithReturnCore<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, Type[]? typeArguments)
+    private TReturn HandleCallWithReturnCore<TReturn>(int memberId, string memberName, object?[] args, TReturn defaultValue, Func<MockBehavior, IMock>? autoMockFactory, ImmutableArray<Type> typeArguments)
     {
         RawReturnContext.Clear();
         var callRecord = RecordCall(memberId, memberName, args, typeArguments);
@@ -785,7 +786,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     private CallRecord RecordCall(int memberId, string memberName, object?[] args)
         => StoreCallRecord(new CallRecord(memberId, memberName, args, MockCallSequence.Next()));
 
-    private CallRecord RecordCall(int memberId, string memberName, object?[] args, Type[]? typeArguments)
+    private CallRecord RecordCall(int memberId, string memberName, object?[] args, ImmutableArray<Type> typeArguments)
         => StoreCallRecord(new CallRecord(memberId, memberName, args, MockCallSequence.Next(), typeArguments));
 
     private CallRecord RecordCall(int memberId, string memberName, IArgumentStore store)
@@ -916,9 +917,9 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     // Adding a defaulted third parameter here would let the generic overload bind instead,
     // silently treating the args array as a single typed argument.
     private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup(int memberId, object?[] args)
-        => FindMatchingSetup(memberId, args, (Type[]?)null);
+        => FindMatchingSetup(memberId, args, default(ImmutableArray<Type>));
 
-    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup(int memberId, object?[] args, Type[]? typeArguments)
+    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup(int memberId, object?[] args, ImmutableArray<Type> typeArguments)
     {
         // Rebuild snapshots if setup phase just ended (batches all ToArray work into one pass)
         if (_hasStaleSetups)
@@ -963,7 +964,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
 
     // FindMatchingSetupLocked has no generic sibling, so a defaulted parameter is safe here
     // (unlike FindMatchingSetup, which competes with FindMatchingSetup<T1>).
-    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetupLocked(int memberId, object?[] args, Type[]? typeArguments = null)
+    private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetupLocked(int memberId, object?[] args, ImmutableArray<Type> typeArguments = default)
     {
         lock (Lock)
         {
@@ -999,6 +1000,14 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
         return (false, null, null);
     }
 
+    // The typed FindMatchingSetup<T1..T8> family deliberately omits a TypeArgumentsMatch check.
+    // Typed dispatch never carries call-side type arguments, and per TypeArgumentMatching.Matches a
+    // default call side matches any setup — so the check would be a constant `true`. Two paths land
+    // here: non-generic methods (their setups never carry type arguments), and virtual/partial/wrap
+    // generic methods, which use the documented graceful-degradation path where setups are matched by
+    // arguments only, regardless of configured type arguments. Interface generic methods never use
+    // typed dispatch (see MockMembersBuilder.ShouldGenerateTypedWrapper) and are fully discriminated
+    // via the object?[] overloads above.
     private (bool SetupFound, IBehavior? Behavior, MethodSetup? Setup) FindMatchingSetup<T1>(int memberId, T1 arg1)
     {
         if (_hasStaleSetups) RebuildStaleSnapshots();

--- a/TUnit.Mocks/MockMethodCall.cs
+++ b/TUnit.Mocks/MockMethodCall.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Setup;
@@ -20,7 +21,7 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
-    private readonly Type[]? _typeArguments;
+    private readonly ImmutableArray<Type> _typeArguments;
     private MethodSetupBuilder<TReturn>? _builder;
     private bool _builderInitialized;
     private object? _builderLock;
@@ -29,12 +30,12 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     // public binary signature for backward compatibility.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, null)
+        : this(engine, memberId, memberName, matchers, default)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
@@ -119,14 +120,8 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
 
     // ICallVerification implementation
 
-    // Non-generic calls use the public engine surface unchanged; generic calls route through the
-    // internal type-argument-aware factory (always implemented by MockEngine). A custom
-    // IMockEngineAccess implementation falls back to the public surface, losing type-argument
-    // filtering but never throwing.
     private ICallVerification CreateVerification()
-        => _typeArguments is not null && _engine is ITypeArgumentVerificationFactory typeArgFactory
-            ? typeArgFactory.CreateVerification(_memberId, _memberName, _matchers, _typeArguments)
-            : _engine.CreateVerification(_memberId, _memberName, _matchers);
+        => MockCallVerification.Create(_engine, _memberId, _memberName, _matchers, _typeArguments);
 
     public void WasCalled(Times times)
     {

--- a/TUnit.Mocks/MockMethodCall.cs
+++ b/TUnit.Mocks/MockMethodCall.cs
@@ -26,13 +26,7 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     private object? _builderLock;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, null)
-    {
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments = null)
     {
         _engine = engine;
         _memberId = memberId;

--- a/TUnit.Mocks/MockMethodCall.cs
+++ b/TUnit.Mocks/MockMethodCall.cs
@@ -20,23 +20,31 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
+    private readonly Type[]? _typeArguments;
     private MethodSetupBuilder<TReturn>? _builder;
     private bool _builderInitialized;
     private object? _builderLock;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
+        : this(engine, memberId, memberName, matchers, null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
         _memberName = memberName;
         _matchers = matchers;
+        _typeArguments = typeArguments;
     }
 
     private MethodSetupBuilder<TReturn> EnsureSetup() =>
         LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
         {
-            var setup = new MethodSetup(_memberId, _matchers, _memberName);
+            var setup = new MethodSetup(_memberId, _matchers, _memberName, _typeArguments);
             _engine.AddSetup(setup);
             return new MethodSetupBuilder<TReturn>(setup);
         })!;
@@ -111,31 +119,31 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
 
     public void WasCalled(Times times)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(times);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times);
     }
 
     public void WasCalled(Times times, string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(times, message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times, message);
     }
 
     public void WasNeverCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasNeverCalled();
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled();
     }
 
     public void WasNeverCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasNeverCalled(message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled(message);
     }
 
     public void WasCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled();
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled();
     }
 
     public void WasCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(message);
     }
 }

--- a/TUnit.Mocks/MockMethodCall.cs
+++ b/TUnit.Mocks/MockMethodCall.cs
@@ -25,8 +25,16 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     private bool _builderInitialized;
     private object? _builderLock;
 
+    // Kept as a distinct overload (not a single optional-parameter ctor) to preserve the original
+    // public binary signature for backward compatibility.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments = null)
+    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
+        : this(engine, memberId, memberName, matchers, null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public MockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
@@ -111,33 +119,40 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
 
     // ICallVerification implementation
 
+    // Non-generic calls use the public engine surface unchanged; generic calls route through the
+    // internal type-argument-aware factory (the engine is always a MockEngine, which implements it).
+    private ICallVerification CreateVerification()
+        => _typeArguments is null
+            ? _engine.CreateVerification(_memberId, _memberName, _matchers)
+            : ((ITypeArgumentVerificationFactory)_engine).CreateVerification(_memberId, _memberName, _matchers, _typeArguments);
+
     public void WasCalled(Times times)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times);
+        CreateVerification().WasCalled(times);
     }
 
     public void WasCalled(Times times, string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times, message);
+        CreateVerification().WasCalled(times, message);
     }
 
     public void WasNeverCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled();
+        CreateVerification().WasNeverCalled();
     }
 
     public void WasNeverCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled(message);
+        CreateVerification().WasNeverCalled(message);
     }
 
     public void WasCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled();
+        CreateVerification().WasCalled();
     }
 
     public void WasCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(message);
+        CreateVerification().WasCalled(message);
     }
 }

--- a/TUnit.Mocks/MockMethodCall.cs
+++ b/TUnit.Mocks/MockMethodCall.cs
@@ -120,11 +120,13 @@ public sealed class MockMethodCall<TReturn> : IMethodSetup<TReturn>, ISetupChain
     // ICallVerification implementation
 
     // Non-generic calls use the public engine surface unchanged; generic calls route through the
-    // internal type-argument-aware factory (the engine is always a MockEngine, which implements it).
+    // internal type-argument-aware factory (always implemented by MockEngine). A custom
+    // IMockEngineAccess implementation falls back to the public surface, losing type-argument
+    // filtering but never throwing.
     private ICallVerification CreateVerification()
-        => _typeArguments is null
-            ? _engine.CreateVerification(_memberId, _memberName, _matchers)
-            : ((ITypeArgumentVerificationFactory)_engine).CreateVerification(_memberId, _memberName, _matchers, _typeArguments);
+        => _typeArguments is not null && _engine is ITypeArgumentVerificationFactory typeArgFactory
+            ? typeArgFactory.CreateVerification(_memberId, _memberName, _matchers, _typeArguments)
+            : _engine.CreateVerification(_memberId, _memberName, _matchers);
 
     public void WasCalled(Times times)
     {

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -78,12 +78,35 @@ public sealed class MethodSetup
     [EditorBrowsable(EditorBrowsableState.Never)]
     public string MemberName { get; }
 
+    /// <summary>
+    /// For a generic method, the configured type arguments (concrete types, or
+    /// <see cref="Arguments.AnyType"/>/<see cref="Arguments.AnyValueType"/> wildcards). Null for a
+    /// non-generic method, in which case the setup matches regardless of call-site type arguments.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Type[]? TypeArguments { get; }
+
     public MethodSetup(int memberId, IArgumentMatcher[] matchers, string memberName = "")
+        : this(memberId, matchers, memberName, null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public MethodSetup(int memberId, IArgumentMatcher[] matchers, string memberName, Type[]? typeArguments)
     {
         MemberId = memberId;
         _matchers = matchers;
         MemberName = memberName;
+        TypeArguments = typeArguments;
     }
+
+    /// <summary>
+    /// True if this setup's configured type arguments match a call made with
+    /// <paramref name="callTypeArgs"/>. Non-generic setups (null <see cref="TypeArguments"/>) match any call.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool TypeArgumentsMatch(Type[]? callTypeArgs)
+        => TypeArgumentMatching.Matches(TypeArguments, callTypeArgs);
 
     private RareState EnsureRareState()
     {

--- a/TUnit.Mocks/Setup/MethodSetup.cs
+++ b/TUnit.Mocks/Setup/MethodSetup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using TUnit.Mocks.Arguments;
@@ -80,19 +81,19 @@ public sealed class MethodSetup
 
     /// <summary>
     /// For a generic method, the configured type arguments (concrete types, or
-    /// <see cref="Arguments.AnyType"/>/<see cref="Arguments.AnyValueType"/> wildcards). Null for a
+    /// <see cref="Arguments.AnyType"/>/<see cref="Arguments.AnyValueType"/> wildcards). Default for a
     /// non-generic method, in which case the setup matches regardless of call-site type arguments.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public Type[]? TypeArguments { get; }
+    public ImmutableArray<Type> TypeArguments { get; }
 
     public MethodSetup(int memberId, IArgumentMatcher[] matchers, string memberName = "")
-        : this(memberId, matchers, memberName, null)
+        : this(memberId, matchers, memberName, default)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public MethodSetup(int memberId, IArgumentMatcher[] matchers, string memberName, Type[]? typeArguments)
+    public MethodSetup(int memberId, IArgumentMatcher[] matchers, string memberName, ImmutableArray<Type> typeArguments)
     {
         MemberId = memberId;
         _matchers = matchers;
@@ -102,10 +103,10 @@ public sealed class MethodSetup
 
     /// <summary>
     /// True if this setup's configured type arguments match a call made with
-    /// <paramref name="callTypeArgs"/>. Non-generic setups (null <see cref="TypeArguments"/>) match any call.
+    /// <paramref name="callTypeArgs"/>. Non-generic setups (default <see cref="TypeArguments"/>) match any call.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool TypeArgumentsMatch(Type[]? callTypeArgs)
+    public bool TypeArgumentsMatch(ImmutableArray<Type> callTypeArgs)
         => TypeArgumentMatching.Matches(TypeArguments, callTypeArgs);
 
     private RareState EnsureRareState()

--- a/TUnit.Mocks/TypeArgumentMatching.cs
+++ b/TUnit.Mocks/TypeArgumentMatching.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using TUnit.Mocks.Arguments;
 
 namespace TUnit.Mocks;
@@ -5,8 +6,8 @@ namespace TUnit.Mocks;
 /// <summary>
 /// Shared matching logic for a generic method's type arguments. Setups and verifications record the
 /// type arguments they were configured with (or <see cref="AnyType"/>/<see cref="AnyValueType"/>
-/// wildcards); recorded calls record the concrete closed types. A non-generic member carries
-/// <see langword="null"/> and always matches.
+/// wildcards); recorded calls record the concrete closed types. A non-generic member carries a
+/// default <see cref="ImmutableArray{T}"/> and always matches.
 /// </summary>
 internal static class TypeArgumentMatching
 {
@@ -16,15 +17,15 @@ internal static class TypeArgumentMatching
 
     /// <summary>
     /// Determines whether a setup configured with <paramref name="setupTypeArgs"/> matches a call
-    /// made with <paramref name="callTypeArgs"/>. A <see langword="null"/> setup (non-generic method,
-    /// or generic method whose setup did not specify type args) matches any call. A <see langword="null"/>
-    /// call (the dispatch path did not supply type arguments — e.g. partial/wrap virtual methods) is
-    /// not discriminated, so it matches any setup. Otherwise the arity must match and each slot must
-    /// be equal or a wildcard marker.
+    /// made with <paramref name="callTypeArgs"/>. A default setup array (non-generic method,
+    /// or generic method whose setup did not specify type args) matches any call. A default
+    /// call array (the dispatch path did not supply type arguments — e.g. partial/wrap virtual
+    /// methods) is not discriminated, so it matches any setup. Otherwise the arity must match and
+    /// each slot must be equal or a wildcard marker.
     /// </summary>
-    public static bool Matches(Type[]? setupTypeArgs, Type[]? callTypeArgs)
+    public static bool Matches(ImmutableArray<Type> setupTypeArgs, ImmutableArray<Type> callTypeArgs)
     {
-        if (setupTypeArgs is null || callTypeArgs is null)
+        if (setupTypeArgs.IsDefault || callTypeArgs.IsDefault)
         {
             return true;
         }
@@ -44,5 +45,22 @@ internal static class TypeArgumentMatching
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Formats type arguments as <c>&lt;T1, T2&gt;</c> for failure messages; empty string for a
+    /// non-generic member (default or empty array).
+    /// </summary>
+    public static string FormatForDiagnostics(ImmutableArray<Type> typeArguments)
+        => typeArguments.IsDefaultOrEmpty
+            ? ""
+            : "<" + string.Join(", ", typeArguments.Select(FriendlyTypeName)) + ">";
+
+    /// <summary>Short type name for diagnostics, without the CLR arity suffix (e.g. <c>List</c>, not <c>List`1</c>).</summary>
+    private static string FriendlyTypeName(Type type)
+    {
+        var name = type.Name;
+        var tick = name.IndexOf('`');
+        return tick < 0 ? name : name.Substring(0, tick);
     }
 }

--- a/TUnit.Mocks/TypeArgumentMatching.cs
+++ b/TUnit.Mocks/TypeArgumentMatching.cs
@@ -1,0 +1,48 @@
+using TUnit.Mocks.Arguments;
+
+namespace TUnit.Mocks;
+
+/// <summary>
+/// Shared matching logic for a generic method's type arguments. Setups and verifications record the
+/// type arguments they were configured with (or <see cref="AnyType"/>/<see cref="AnyValueType"/>
+/// wildcards); recorded calls record the concrete closed types. A non-generic member carries
+/// <see langword="null"/> and always matches.
+/// </summary>
+internal static class TypeArgumentMatching
+{
+    /// <summary>True if <paramref name="type"/> is a recognized "match any type argument" wildcard.</summary>
+    public static bool IsAnyMarker(Type type)
+        => type == typeof(AnyType) || type == typeof(AnyValueType);
+
+    /// <summary>
+    /// Determines whether a setup configured with <paramref name="setupTypeArgs"/> matches a call
+    /// made with <paramref name="callTypeArgs"/>. A <see langword="null"/> setup (non-generic method,
+    /// or generic method whose setup did not specify type args) matches any call. A <see langword="null"/>
+    /// call (the dispatch path did not supply type arguments — e.g. partial/wrap virtual methods) is
+    /// not discriminated, so it matches any setup. Otherwise the arity must match and each slot must
+    /// be equal or a wildcard marker.
+    /// </summary>
+    public static bool Matches(Type[]? setupTypeArgs, Type[]? callTypeArgs)
+    {
+        if (setupTypeArgs is null || callTypeArgs is null)
+        {
+            return true;
+        }
+
+        if (callTypeArgs.Length != setupTypeArgs.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < setupTypeArgs.Length; i++)
+        {
+            var slot = setupTypeArgs[i];
+            if (!IsAnyMarker(slot) && slot != callTypeArgs[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/TUnit.Mocks/TypeArguments.cs
+++ b/TUnit.Mocks/TypeArguments.cs
@@ -4,11 +4,10 @@ namespace TUnit.Mocks;
 
 /// <summary>
 /// Per-closed-type cache of a generic method's type-argument array, so a generic-method dispatch does
-/// not allocate a fresh <see cref="Type"/>[] on every call. The arrays are immutable in practice
-/// (only read by matching/verification), so sharing one instance per closed generic instantiation is
-/// safe. Generated code references <c>TypeArguments.Of&lt;T&gt;.Value</c> for the common 1–2 type-arg
-/// cases; higher arities fall back to a per-call <c>new Type[]</c> literal. Public for generated code
-/// access. Not intended for direct use.
+/// not allocate a fresh <see cref="Type"/>[] on every call. Generated code references
+/// <c>TypeArguments.Of&lt;T&gt;.Value</c> for the common 1–4 type-argument cases; higher arities fall
+/// back to a per-call <c>new Type[]</c> literal. Public for generated code access. Not intended for
+/// direct use.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class TypeArguments
@@ -16,12 +15,28 @@ public static class TypeArguments
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T>
     {
+        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T) };
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2>
     {
+        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T1), typeof(T2) };
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Of<T1, T2, T3>
+    {
+        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
+        public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3) };
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Of<T1, T2, T3, T4>
+    {
+        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
+        public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
     }
 }

--- a/TUnit.Mocks/TypeArguments.cs
+++ b/TUnit.Mocks/TypeArguments.cs
@@ -6,7 +6,8 @@ namespace TUnit.Mocks;
 /// Per-closed-type cache of a generic method's type-argument array, so a generic-method dispatch does
 /// not allocate a fresh <see cref="Type"/>[] on every call. Generated code references
 /// <c>TypeArguments.Of&lt;T&gt;.Value</c> for the common 1–4 type-argument cases; higher arities fall
-/// back to a per-call <c>new Type[]</c> literal. Public for generated code access. Not intended for
+/// back to a per-call <c>new Type[]</c> literal. Each <c>Value</c> is shared and read-only — it must
+/// never be mutated (matching only reads it). Public for generated code access. Not intended for
 /// direct use.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -15,28 +16,24 @@ public static class TypeArguments
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T>
     {
-        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T) };
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2>
     {
-        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T1), typeof(T2) };
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2, T3>
     {
-        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3) };
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2, T3, T4>
     {
-        /// <summary>Shared, read-only — must never be mutated (matching only reads it).</summary>
         public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
     }
 }

--- a/TUnit.Mocks/TypeArguments.cs
+++ b/TUnit.Mocks/TypeArguments.cs
@@ -1,14 +1,14 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 
 namespace TUnit.Mocks;
 
 /// <summary>
 /// Per-closed-type cache of a generic method's type-argument array, so a generic-method dispatch does
-/// not allocate a fresh <see cref="Type"/>[] on every call. Generated code references
+/// not allocate a fresh array on every call. Generated code references
 /// <c>TypeArguments.Of&lt;T&gt;.Value</c> for the common 1–4 type-argument cases; higher arities fall
-/// back to a per-call <c>new Type[]</c> literal. Each <c>Value</c> is shared and read-only — it must
-/// never be mutated (matching only reads it). Public for generated code access. Not intended for
-/// direct use.
+/// back to a per-call <see cref="ImmutableArray{T}"/> literal. Each <c>Value</c> is shared and
+/// immutable. Public for generated code access. Not intended for direct use.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class TypeArguments
@@ -16,24 +16,24 @@ public static class TypeArguments
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T>
     {
-        public static readonly Type[] Value = { typeof(T) };
+        public static readonly ImmutableArray<Type> Value = ImmutableArray.Create(typeof(T));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2>
     {
-        public static readonly Type[] Value = { typeof(T1), typeof(T2) };
+        public static readonly ImmutableArray<Type> Value = ImmutableArray.Create(typeof(T1), typeof(T2));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2, T3>
     {
-        public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3) };
+        public static readonly ImmutableArray<Type> Value = ImmutableArray.Create(typeof(T1), typeof(T2), typeof(T3));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class Of<T1, T2, T3, T4>
     {
-        public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
+        public static readonly ImmutableArray<Type> Value = ImmutableArray.Create(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
     }
 }

--- a/TUnit.Mocks/TypeArguments.cs
+++ b/TUnit.Mocks/TypeArguments.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+
+namespace TUnit.Mocks;
+
+/// <summary>
+/// Per-closed-type cache of a generic method's type-argument array, so a generic-method dispatch does
+/// not allocate a fresh <see cref="Type"/>[] on every call. The arrays are immutable in practice
+/// (only read by matching/verification), so sharing one instance per closed generic instantiation is
+/// safe. Generated code references <c>TypeArguments.Of&lt;T&gt;.Value</c> for the common 1–2 type-arg
+/// cases; higher arities fall back to a per-call <c>new Type[]</c> literal. Public for generated code
+/// access. Not intended for direct use.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class TypeArguments
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Of<T>
+    {
+        public static readonly Type[] Value = { typeof(T) };
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Of<T1, T2>
+    {
+        public static readonly Type[] Value = { typeof(T1), typeof(T2) };
+    }
+}

--- a/TUnit.Mocks/Verification/CallRecord.cs
+++ b/TUnit.Mocks/Verification/CallRecord.cs
@@ -17,11 +17,21 @@ public sealed class CallRecord
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public CallRecord(int memberId, string memberName, object?[] arguments, long sequenceNumber)
+        : this(memberId, memberName, arguments, sequenceNumber, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a call record with pre-boxed arguments and generic-method type arguments.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public CallRecord(int memberId, string memberName, object?[] arguments, long sequenceNumber, Type[]? typeArguments)
     {
         MemberId = memberId;
         MemberName = memberName;
         _arguments = arguments;
         SequenceNumber = sequenceNumber;
+        TypeArguments = typeArguments;
     }
 
     /// <summary>
@@ -44,6 +54,12 @@ public sealed class CallRecord
 
     /// <summary>The global sequence number for cross-mock ordering.</summary>
     public long SequenceNumber { get; }
+
+    /// <summary>
+    /// For a generic method, the concrete closed type arguments the call was made with; null for a
+    /// non-generic member. Used by verification to discriminate calls by type argument.
+    /// </summary>
+    public Type[]? TypeArguments { get; }
 
     /// <summary>
     /// The arguments passed to the call. Lazily materialized from the argument store if one was provided.

--- a/TUnit.Mocks/Verification/CallRecord.cs
+++ b/TUnit.Mocks/Verification/CallRecord.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using TUnit.Mocks.Arguments;
 
@@ -17,7 +18,7 @@ public sealed class CallRecord
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public CallRecord(int memberId, string memberName, object?[] arguments, long sequenceNumber)
-        : this(memberId, memberName, arguments, sequenceNumber, null)
+        : this(memberId, memberName, arguments, sequenceNumber, default)
     {
     }
 
@@ -25,7 +26,7 @@ public sealed class CallRecord
     /// Creates a call record with pre-boxed arguments and generic-method type arguments.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public CallRecord(int memberId, string memberName, object?[] arguments, long sequenceNumber, Type[]? typeArguments)
+    public CallRecord(int memberId, string memberName, object?[] arguments, long sequenceNumber, ImmutableArray<Type> typeArguments)
     {
         MemberId = memberId;
         MemberName = memberName;
@@ -56,10 +57,10 @@ public sealed class CallRecord
     public long SequenceNumber { get; }
 
     /// <summary>
-    /// For a generic method, the concrete closed type arguments the call was made with; null for a
+    /// For a generic method, the concrete closed type arguments the call was made with; default for a
     /// non-generic member. Used by verification to discriminate calls by type argument.
     /// </summary>
-    public Type[]? TypeArguments { get; }
+    public ImmutableArray<Type> TypeArguments { get; }
 
     /// <summary>
     /// The arguments passed to the call. Lazily materialized from the argument store if one was provided.

--- a/TUnit.Mocks/Verification/CallVerificationBuilder.cs
+++ b/TUnit.Mocks/Verification/CallVerificationBuilder.cs
@@ -15,13 +15,20 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
+    private readonly Type[]? _typeArguments;
 
     public CallVerificationBuilder(MockEngine<T> engine, int memberId, string memberName, IArgumentMatcher[] matchers)
+        : this(engine, memberId, memberName, matchers, null)
+    {
+    }
+
+    public CallVerificationBuilder(MockEngine<T> engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
         _memberName = memberName;
         _matchers = matchers;
+        _typeArguments = typeArguments;
     }
 
     /// <inheritdoc />
@@ -46,11 +53,13 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
             return;
         }
 
-        // Fast path: when no argument matchers, use the per-member call counter directly.
+        // Fast path: when no argument matchers (and no type-argument filter), use the per-member
+        // call counter directly. A type-argument filter forces the per-record path below, since the
+        // member counter aggregates calls across all type arguments.
         // Note: the count is read lock-free, then MarkCallsVerified acquires the lock.
         // Calls recorded between these two steps will be marked verified but weren't counted.
         // This is safe because verification should only run after all calls have completed.
-        if (_matchers.Length == 0)
+        if (_matchers.Length == 0 && _typeArguments is null)
         {
             var totalCount = _engine.GetCallCountFor(_memberId);
             if (!times.Matches(totalCount))
@@ -113,7 +122,7 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
         var count = 0;
         for (int i = 0; i < bufferCount; i++)
         {
-            if (MatchesArguments(items[i]!.Arguments))
+            if (MatchesCall(items[i]!))
             {
                 count++;
             }
@@ -127,12 +136,16 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
         for (int i = 0; i < bufferCount; i++)
         {
             var record = items[i]!;
-            if (MatchesArguments(record.Arguments))
+            if (MatchesCall(record))
             {
                 record.IsVerified = true;
             }
         }
     }
+
+    private bool MatchesCall(CallRecord record)
+        => MatchesArguments(record.Arguments)
+           && TypeArgumentMatching.Matches(_typeArguments, record.TypeArguments);
 
     private bool MatchesArguments(object?[] arguments)
     {

--- a/TUnit.Mocks/Verification/CallVerificationBuilder.cs
+++ b/TUnit.Mocks/Verification/CallVerificationBuilder.cs
@@ -168,8 +168,16 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
     {
         var argDescriptions = string.Join(", ", _matchers.Select(m => m.Describe()));
         var typeArgs = _typeArguments is { Length: > 0 } ta
-            ? "<" + string.Join(", ", ta.Select(t => t.Name)) + ">"
+            ? "<" + string.Join(", ", ta.Select(FriendlyTypeName)) + ">"
             : "";
         return $"{_memberName}{typeArgs}({argDescriptions})";
+    }
+
+    /// <summary>Short type name for diagnostics, without the CLR arity suffix (e.g. <c>List</c>, not <c>List`1</c>).</summary>
+    private static string FriendlyTypeName(Type type)
+    {
+        var name = type.Name;
+        var tick = name.IndexOf('`');
+        return tick < 0 ? name : name.Substring(0, tick);
     }
 }

--- a/TUnit.Mocks/Verification/CallVerificationBuilder.cs
+++ b/TUnit.Mocks/Verification/CallVerificationBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Exceptions;
@@ -15,14 +16,14 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
-    private readonly Type[]? _typeArguments;
+    private readonly ImmutableArray<Type> _typeArguments;
 
     public CallVerificationBuilder(MockEngine<T> engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, null)
+        : this(engine, memberId, memberName, matchers, default)
     {
     }
 
-    public CallVerificationBuilder(MockEngine<T> engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    public CallVerificationBuilder(MockEngine<T> engine, int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
@@ -49,7 +50,7 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
             }
 
             var allCalls = _engine.GetAllCalls();
-            OrderedVerification.RecordExpectation(_memberId, _memberName, _matchers, times, allCalls);
+            OrderedVerification.RecordExpectation(_memberId, _memberName, _matchers, _typeArguments, times, allCalls);
             return;
         }
 
@@ -59,7 +60,7 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
         // Note: the count is read lock-free, then MarkCallsVerified acquires the lock.
         // Calls recorded between these two steps will be marked verified but weren't counted.
         // This is safe because verification should only run after all calls have completed.
-        if (_matchers.Length == 0 && _typeArguments is null)
+        if (_matchers.Length == 0 && _typeArguments.IsDefault)
         {
             var totalCount = _engine.GetCallCountFor(_memberId);
             if (!times.Matches(totalCount))
@@ -167,17 +168,7 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
     private string FormatExpectedCall()
     {
         var argDescriptions = string.Join(", ", _matchers.Select(m => m.Describe()));
-        var typeArgs = _typeArguments is { Length: > 0 } ta
-            ? "<" + string.Join(", ", ta.Select(FriendlyTypeName)) + ">"
-            : "";
+        var typeArgs = TypeArgumentMatching.FormatForDiagnostics(_typeArguments);
         return $"{_memberName}{typeArgs}({argDescriptions})";
-    }
-
-    /// <summary>Short type name for diagnostics, without the CLR arity suffix (e.g. <c>List</c>, not <c>List`1</c>).</summary>
-    private static string FriendlyTypeName(Type type)
-    {
-        var name = type.Name;
-        var tick = name.IndexOf('`');
-        return tick < 0 ? name : name.Substring(0, tick);
     }
 }

--- a/TUnit.Mocks/Verification/CallVerificationBuilder.cs
+++ b/TUnit.Mocks/Verification/CallVerificationBuilder.cs
@@ -167,6 +167,9 @@ public sealed class CallVerificationBuilder<T> : ICallVerification where T : cla
     private string FormatExpectedCall()
     {
         var argDescriptions = string.Join(", ", _matchers.Select(m => m.Describe()));
-        return $"{_memberName}({argDescriptions})";
+        var typeArgs = _typeArguments is { Length: > 0 } ta
+            ? "<" + string.Join(", ", ta.Select(t => t.Name)) + ">"
+            : "";
+        return $"{_memberName}{typeArgs}({argDescriptions})";
     }
 }

--- a/TUnit.Mocks/Verification/OrderedVerification.cs
+++ b/TUnit.Mocks/Verification/OrderedVerification.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Exceptions;
 
@@ -21,9 +22,9 @@ public static class OrderedVerification
     /// Records an expectation during ordered verification collection.
     /// Called by <see cref="CallVerificationBuilder{T}.WasCalled()"/> and overloads.
     /// </summary>
-    internal static void RecordExpectation(int memberId, string memberName, IArgumentMatcher[] matchers, Times times, IReadOnlyList<CallRecord> allCalls)
+    internal static void RecordExpectation(int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments, Times times, IReadOnlyList<CallRecord> allCalls)
     {
-        _expectations.Value?.Add(new OrderedCallExpectation(memberId, memberName, matchers, times, allCalls));
+        _expectations.Value?.Add(new OrderedCallExpectation(memberId, memberName, matchers, typeArguments, times, allCalls));
     }
 
     /// <summary>
@@ -163,7 +164,9 @@ public static class OrderedVerification
         var result = new List<CallRecord>();
         foreach (var call in expectation.AllCalls)
         {
-            if (call.MemberId == expectation.MemberId && MatchesArguments(call.Arguments, expectation.Matchers))
+            if (call.MemberId == expectation.MemberId
+                && MatchesArguments(call.Arguments, expectation.Matchers)
+                && TypeArgumentMatching.Matches(expectation.TypeArguments, call.TypeArguments))
             {
                 result.Add(call);
             }
@@ -195,13 +198,14 @@ public static class OrderedVerification
 
     private static string FormatExpectedCall(OrderedCallExpectation expectation)
     {
+        var typeArgs = TypeArgumentMatching.FormatForDiagnostics(expectation.TypeArguments);
         if (expectation.Matchers.Length == 0)
         {
-            return $"{expectation.MemberName}()";
+            return $"{expectation.MemberName}{typeArgs}()";
         }
 
         var argDescriptions = string.Join(", ", expectation.Matchers.Select(m => m.Describe()));
-        return $"{expectation.MemberName}({argDescriptions})";
+        return $"{expectation.MemberName}{typeArgs}({argDescriptions})";
     }
 }
 
@@ -212,6 +216,7 @@ internal sealed record OrderedCallExpectation(
     int MemberId,
     string MemberName,
     IArgumentMatcher[] Matchers,
+    ImmutableArray<Type> TypeArguments,
     Times Times,
     IReadOnlyList<CallRecord> AllCalls
 );

--- a/TUnit.Mocks/VoidMockMethodCall.cs
+++ b/TUnit.Mocks/VoidMockMethodCall.cs
@@ -22,23 +22,37 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
+    private readonly Type[]? _typeArguments;
     private VoidMethodSetupBuilder? _builder;
     private bool _builderInitialized;
     private object? _builderLock;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, eagerRegister: true)
+        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments: null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister)
+        : this(engine, memberId, memberName, matchers, eagerRegister, typeArguments: null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
         _memberName = memberName;
         _matchers = matchers;
+        _typeArguments = typeArguments;
         if (eagerRegister)
         {
             _ = EnsureSetup();
@@ -48,7 +62,7 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     private VoidMethodSetupBuilder EnsureSetup() =>
         LazyInitializer.EnsureInitialized(ref _builder, ref _builderInitialized, ref _builderLock, () =>
         {
-            var setup = new MethodSetup(_memberId, _matchers, _memberName);
+            var setup = new MethodSetup(_memberId, _matchers, _memberName, _typeArguments);
             _engine.AddSetup(setup);
             return new VoidMethodSetupBuilder(setup);
         })!;
@@ -111,31 +125,31 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
 
     public void WasCalled(Times times)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(times);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times);
     }
 
     public void WasCalled(Times times, string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(times, message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times, message);
     }
 
     public void WasNeverCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasNeverCalled();
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled();
     }
 
     public void WasNeverCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasNeverCalled(message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled(message);
     }
 
     public void WasCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled();
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled();
     }
 
     public void WasCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers).WasCalled(message);
+        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(message);
     }
 }

--- a/TUnit.Mocks/VoidMockMethodCall.cs
+++ b/TUnit.Mocks/VoidMockMethodCall.cs
@@ -28,25 +28,13 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     private object? _builderLock;
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments: null)
-    {
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments = null)
         : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister)
-        : this(engine, memberId, memberName, matchers, eagerRegister, typeArguments: null)
-    {
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments)
+    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments = null)
     {
         _engine = engine;
         _memberId = memberId;

--- a/TUnit.Mocks/VoidMockMethodCall.cs
+++ b/TUnit.Mocks/VoidMockMethodCall.cs
@@ -126,11 +126,13 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     // ICallVerification implementation
 
     // Non-generic calls use the public engine surface unchanged; generic calls route through the
-    // internal type-argument-aware factory (the engine is always a MockEngine, which implements it).
+    // internal type-argument-aware factory (always implemented by MockEngine). A custom
+    // IMockEngineAccess implementation falls back to the public surface, losing type-argument
+    // filtering but never throwing.
     private ICallVerification CreateVerification()
-        => _typeArguments is null
-            ? _engine.CreateVerification(_memberId, _memberName, _matchers)
-            : ((ITypeArgumentVerificationFactory)_engine).CreateVerification(_memberId, _memberName, _matchers, _typeArguments);
+        => _typeArguments is not null && _engine is ITypeArgumentVerificationFactory typeArgFactory
+            ? typeArgFactory.CreateVerification(_memberId, _memberName, _matchers, _typeArguments)
+            : _engine.CreateVerification(_memberId, _memberName, _matchers);
 
     public void WasCalled(Times times)
     {

--- a/TUnit.Mocks/VoidMockMethodCall.cs
+++ b/TUnit.Mocks/VoidMockMethodCall.cs
@@ -27,14 +27,28 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     private bool _builderInitialized;
     private object? _builderLock;
 
+    // Kept as distinct overloads (not single optional-parameter ctors) to preserve the original
+    // public/internal binary signatures for backward compatibility.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments = null)
+    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
+        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments: null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
         : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments = null)
+    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister)
+        : this(engine, memberId, memberName, matchers, eagerRegister, typeArguments: null)
+    {
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
@@ -111,33 +125,40 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
 
     // ICallVerification implementation
 
+    // Non-generic calls use the public engine surface unchanged; generic calls route through the
+    // internal type-argument-aware factory (the engine is always a MockEngine, which implements it).
+    private ICallVerification CreateVerification()
+        => _typeArguments is null
+            ? _engine.CreateVerification(_memberId, _memberName, _matchers)
+            : ((ITypeArgumentVerificationFactory)_engine).CreateVerification(_memberId, _memberName, _matchers, _typeArguments);
+
     public void WasCalled(Times times)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times);
+        CreateVerification().WasCalled(times);
     }
 
     public void WasCalled(Times times, string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(times, message);
+        CreateVerification().WasCalled(times, message);
     }
 
     public void WasNeverCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled();
+        CreateVerification().WasNeverCalled();
     }
 
     public void WasNeverCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasNeverCalled(message);
+        CreateVerification().WasNeverCalled(message);
     }
 
     public void WasCalled()
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled();
+        CreateVerification().WasCalled();
     }
 
     public void WasCalled(string? message)
     {
-        _engine.CreateVerification(_memberId, _memberName, _matchers, _typeArguments).WasCalled(message);
+        CreateVerification().WasCalled(message);
     }
 }

--- a/TUnit.Mocks/VoidMockMethodCall.cs
+++ b/TUnit.Mocks/VoidMockMethodCall.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Setup;
@@ -22,7 +23,7 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     private readonly int _memberId;
     private readonly string _memberName;
     private readonly IArgumentMatcher[] _matchers;
-    private readonly Type[]? _typeArguments;
+    private readonly ImmutableArray<Type> _typeArguments;
     private VoidMethodSetupBuilder? _builder;
     private bool _builderInitialized;
     private object? _builderLock;
@@ -31,24 +32,24 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
     // public/internal binary signatures for backward compatibility.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers)
-        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments: null)
+        : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments: default)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, Type[]? typeArguments)
+    public VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, ImmutableArray<Type> typeArguments)
         : this(engine, memberId, memberName, matchers, eagerRegister: true, typeArguments)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister)
-        : this(engine, memberId, memberName, matchers, eagerRegister, typeArguments: null)
+        : this(engine, memberId, memberName, matchers, eagerRegister, typeArguments: default)
     {
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, Type[]? typeArguments)
+    internal VoidMockMethodCall(IMockEngineAccess engine, int memberId, string memberName, IArgumentMatcher[] matchers, bool eagerRegister, ImmutableArray<Type> typeArguments)
     {
         _engine = engine;
         _memberId = memberId;
@@ -125,14 +126,8 @@ public sealed class VoidMockMethodCall : IVoidMethodSetup, IVoidSetupChain, ICal
 
     // ICallVerification implementation
 
-    // Non-generic calls use the public engine surface unchanged; generic calls route through the
-    // internal type-argument-aware factory (always implemented by MockEngine). A custom
-    // IMockEngineAccess implementation falls back to the public surface, losing type-argument
-    // filtering but never throwing.
     private ICallVerification CreateVerification()
-        => _typeArguments is not null && _engine is ITypeArgumentVerificationFactory typeArgFactory
-            ? typeArgFactory.CreateVerification(_memberId, _memberName, _matchers, _typeArguments)
-            : _engine.CreateVerification(_memberId, _memberName, _matchers);
+        => MockCallVerification.Create(_engine, _memberId, _memberName, _matchers, _typeArguments);
 
     public void WasCalled(Times times)
     {


### PR DESCRIPTION
## Problem

[Discussion #4981](https://github.com/thomhurst/TUnit/discussions/4981) (latest comment) reported that TUnit.Mocks cannot distinguish generic-method setups by their type argument:

```csharp
public interface IGreeter { string Greet<T>() where T : class; }

var mock = IGreeter.Mock();
mock.Greet<Class1>().Returns("Hello!");
mock.Greet<Class2>().Returns("Goodbye!");

greeter.Greet<Class1>(); // returned "Goodbye!" — both setups collided
```

**Root cause:** the whole match key was `(memberId, argument-matchers)`. A generic method's *type arguments* (`typeof(Class1)` vs `typeof(Class2)`) were dropped at the runtime boundary — `MethodSetup`, `CallRecord`, and `FindMatchingSetup` had no notion of them. The existing `Generic_Method_Different_Type_Arguments` test only passed because it also varied a normal `int` arg, which masked the bug. The reported case has zero parameters, so the two setups were byte-identical.

## Fix

Thread an optional `Type[]? typeArguments` (closed `typeof(T)` captured at the call site) through setup registration, call dispatch, and verification. `null` ⇒ non-generic ⇒ identical behaviour to before.

- **Runtime:** `MethodSetup`/`CallRecord` carry the type args; `MockEngine` gains `object[]`+`Type[]` `HandleCall`/`HandleCallWithReturn` overloads and a `TypeArgumentsMatch` gate in `FindMatchingSetup`; `CallVerificationBuilder` filters recorded calls by type argument.
- **Generator:** generic methods emit `new Type[] { typeof(T), ... }` and route through the fallback dispatch (typed dispatch can't carry type args), preserving any auto-mock factory.
- **Wildcards:** new `AnyType` / `AnyValueType` markers (`TUnit.Mocks.Arguments`) let a setup match any type argument, e.g. `mock.Greet<AnyType>().Returns(...)`.

### Scope / limitations
- Exact closed-type matching plus the `Any` wildcard.
- Type params constrained to a specific base class/interface support exact matching only (no marker can satisfy an arbitrary base).
- Partial/wrap **virtual** methods record no type args and are not discriminated — graceful, documented degradation (their **abstract** members, which route through `HandleCallWithReturn`, *are* discriminated).

## Tests
New integration tests in `GenericTests.cs`:
- the zero-arg regression from the discussion;
- `AnyType` wildcard and exact-wins-over-wildcard;
- type-arg-aware verification;
- **multiple type parameters** — `(T1, T2)` order sensitivity, partial wildcards (one `AnyType` + one concrete), exact-wins-over-partial-wildcard, and multi-param verification with wildcard counts.

Plus updated generic-method snapshots.

**Green:** 1010 integration, 62 snapshot, 30 analyzer tests (net8.0 + net10.0); runtime builds across all TFMs + Roslyn variants.

## Note for reviewers
`FindMatchingSetup` keeps a separate no-default `(int, object?[])` overload. Collapsing it into a single defaulted-`Type[]?` overload makes 2-arg call sites silently bind to the generic `FindMatchingSetup<T1>` instead — which broke every wrap/partial mock during development. A comment marks the constraint.
