### PR TITLE
fix: dispose shared fixtures when only a subset of consuming tests runs

### DIFF
--- a/TUnit.Core/Data/ScopedDictionary.cs
+++ b/TUnit.Core/Data/ScopedDictionary.cs
@@ -11,4 +11,9 @@ public class ScopedDictionary<TScope>
 
         return innerDictionary.GetOrAdd(type, factory);
     }
+
+    /// <summary>
+    /// Removes all scopes and their cached instances.
+    /// </summary>
+    public void Clear() => _scopedContainers.Clear();
 }

--- a/TUnit.Core/Data/ThreadSafeDictionary.cs
+++ b/TUnit.Core/Data/ThreadSafeDictionary.cs
@@ -103,4 +103,9 @@ public class ThreadSafeDictionary<TKey, [DynamicallyAccessedMembers(DynamicallyA
     public TValue this[TKey key] => _innerDictionary.TryGetValue(key, out var lazy)
         ? lazy.Value
         : throw new KeyNotFoundException($"Key '{key}' not found in dictionary");
+
+    /// <summary>
+    /// Removes all keys and values from the dictionary.
+    /// </summary>
+    public void Clear() => _innerDictionary.Clear();
 }

--- a/TUnit.Core/TestDataContainer.cs
+++ b/TUnit.Core/TestDataContainer.cs
@@ -29,4 +29,17 @@ internal static class TestDataContainer
     {
         return _keyContainer.GetOrCreate(key, type, func);
     }
+
+    /// <summary>
+    /// Clears all cached shared instances. Called at the end of a run session so that a
+    /// subsequent run request in the same process (e.g. IDE server mode) creates fresh
+    /// instances instead of reusing already-disposed ones.
+    /// </summary>
+    public static void Reset()
+    {
+        _globalContainer.Clear();
+        _classContainer.Clear();
+        _assemblyContainer.Clear();
+        _keyContainer.Clear();
+    }
 }

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -37,6 +37,41 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     }
 
     /// <summary>
+    /// Disposes any objects still tracked with a positive reference count, then clears all
+    /// static tracking state. Call at the end of a run session: every executed test has
+    /// already decremented its references by then, so anything still alive would otherwise
+    /// leak (e.g. its remaining consumers were cancelled or a path miscounted). Clearing also
+    /// ensures a subsequent run request in the same process starts with fresh state.
+    /// </summary>
+    /// <returns>Any exceptions thrown by the disposals, or null if none.</returns>
+    public async ValueTask<List<Exception>?> DisposeAndClearStaticTrackingAsync()
+    {
+        List<Exception>? exceptions = null;
+
+        foreach (var kvp in s_trackedObjects)
+        {
+            // TryRemove guards against racing disposals (e.g. a late UntrackObject call)
+            if (!s_trackedObjects.TryRemove(kvp.Key, out _))
+            {
+                continue;
+            }
+
+            try
+            {
+                await disposer.DisposeAsync(kvp.Key).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (exceptions ??= []).Add(ex);
+            }
+        }
+
+        s_asyncCallbackErrors.Clear();
+
+        return exceptions;
+    }
+
+    /// <summary>
     /// Gets an existing counter for the object or creates a new one.
     /// Centralizes the GetOrAdd pattern to ensure consistent counter creation.
     /// </summary>

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -34,6 +34,8 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     /// already decremented its references by then, so anything still alive would otherwise
     /// leak (e.g. its remaining consumers were cancelled or a path miscounted). Clearing also
     /// ensures a subsequent run request in the same process starts with fresh state.
+    /// Intentionally an instance method despite operating on static state: disposal needs the
+    /// injected <see cref="Disposer"/> (for error logging), which only instances carry.
     /// </summary>
     /// <returns>Any exceptions thrown by the disposals, or null if none.</returns>
     public async ValueTask<List<Exception>?> DisposeAndClearStaticTrackingAsync()
@@ -215,6 +217,15 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
         var counter = GetOrCreateCounter(obj);
         counter.Increment();
     }
+
+    /// <summary>
+    /// Decrements a single object's reference count, disposing it (and removing it from the
+    /// static tracking dictionary) when the count reaches zero. Used by owners that hold their
+    /// own +1 reference (e.g. static properties) so disposal stays consistent with ref counting
+    /// instead of bypassing it — a direct dispose would leave a stale entry that the session-end
+    /// sweep would dispose a second time.
+    /// </summary>
+    public ValueTask UntrackObjectAsync(object? obj) => UntrackObject(obj);
 
     private async ValueTask UntrackObject(object? obj)
     {

--- a/TUnit.Core/Tracking/ObjectTracker.cs
+++ b/TUnit.Core/Tracking/ObjectTracker.cs
@@ -10,7 +10,8 @@ namespace TUnit.Core.Tracking;
 /// </summary>
 /// <remarks>
 /// The static <c>s_trackedObjects</c> dictionary is shared across all tests.
-/// Call <see cref="ClearStaticTracking"/> at the end of a test session to release memory.
+/// Call <see cref="DisposeAndClearStaticTrackingAsync"/> at the end of a run session to
+/// dispose any leftovers and release memory.
 /// </remarks>
 internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphProvider, Disposer disposer)
 {
@@ -26,15 +27,6 @@ internal class ObjectTracker(TrackableObjectGraphProvider trackableObjectGraphPr
     /// Check this at the end of a test session to surface hidden failures.
     /// </summary>
     public static IReadOnlyCollection<Exception> GetAsyncCallbackErrors() => s_asyncCallbackErrors.ToArray();
-
-    /// <summary>
-    /// Clears all static tracking state. Call at the end of a test session to release memory.
-    /// </summary>
-    public static void ClearStaticTracking()
-    {
-        s_trackedObjects.Clear();
-        s_asyncCallbackErrors.Clear();
-    }
 
     /// <summary>
     /// Disposes any objects still tracked with a positive reference count, then clears all

--- a/TUnit.Engine.Tests/FilteredSharedFixtureDisposalTests.cs
+++ b/TUnit.Engine.Tests/FilteredSharedFixtureDisposalTests.cs
@@ -1,0 +1,76 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+/// <summary>
+/// End-to-end regression tests for GitHub discussion #6151.
+/// A PerTestSession shared fixture must be disposed when only a subset of the tests that
+/// consume it executes. The [Explicit] sibling TestB is built (incrementing the fixture's
+/// ref count at build time) but excluded from execution — the same built-but-not-run shape
+/// an IDE's uid filter produces when running a single [Arguments] case. Previously the
+/// never-executed test's ref count kept the fixture alive forever, so DisposeAsync never ran.
+/// </summary>
+public class FilteredSharedFixtureDisposalTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Running_Subset_Of_Fixture_Consumers_Disposes_PerTestSession_Fixture()
+    {
+        // "/*" matches both tests, so both are built; TestB is then dropped post-build
+        // because it is [Explicit] and a non-explicit test also matched.
+        var markerPath = Path.Combine(Path.GetTempPath(), $"tunit-bug-6151-{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            await RunTestsWithFilter(
+                "/*/*/Bug6151FilteredDisposalTests/*",
+                [
+                    result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                    result => result.ResultSummary.Counters.Total.ShouldBe(1,
+                        $"Expected only TestA to run (TestB is [Explicit]). Test names: {string.Join(", ", result.Results.Select(r => r.TestName))}"),
+                    result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                    result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                    _ => File.Exists(markerPath).ShouldBeTrue($"Marker file '{markerPath}' was not written by the After(TestSession) hook"),
+                    _ => File.ReadAllText(markerPath).ShouldBe("Created=1;Disposed=1")
+                ],
+                new RunOptions().WithEnvironmentVariable("TUNIT_BUG_6151_MARKER_PATH", markerPath));
+        }
+        finally
+        {
+            if (File.Exists(markerPath))
+            {
+                File.Delete(markerPath);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Running_Single_Fixture_Consumer_Directly_Disposes_PerTestSession_Fixture()
+    {
+        // Sanity check — a literal method filter pre-filters at the metadata level, so only
+        // TestA is ever built. This path was already green; guard against regression.
+        var markerPath = Path.Combine(Path.GetTempPath(), $"tunit-bug-6151-{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            await RunTestsWithFilter(
+                "/*/*/Bug6151FilteredDisposalTests/TestA",
+                [
+                    result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                    result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                    result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                    result => result.ResultSummary.Counters.Failed.ShouldBe(0),
+                    _ => File.Exists(markerPath).ShouldBeTrue($"Marker file '{markerPath}' was not written by the After(TestSession) hook"),
+                    _ => File.ReadAllText(markerPath).ShouldBe("Created=1;Disposed=1")
+                ],
+                new RunOptions().WithEnvironmentVariable("TUNIT_BUG_6151_MARKER_PATH", markerPath));
+        }
+        finally
+        {
+            if (File.Exists(markerPath))
+            {
+                File.Delete(markerPath);
+            }
+        }
+    }
+}

--- a/TUnit.Engine.Tests/InvokableTestBase.cs
+++ b/TUnit.Engine.Tests/InvokableTestBase.cs
@@ -69,10 +69,7 @@ public abstract class InvokableTestBase(TestMode testMode)
                 ]
             )
             .WithWorkingDirectory(testProject.DirectoryName!)
-            .WithEnvironmentVariables(new Dictionary<string, string?>
-            {
-                ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
-            })
+            .WithEnvironmentVariables(BuildEnvironmentVariables(runOptions))
             .WithValidation(CommandResultValidation.None);
 
         await RunWithFailureLogging(command, runOptions, trxFilename, assertions, assertionExpression);
@@ -105,13 +102,25 @@ public abstract class InvokableTestBase(TestMode testMode)
                     ..runOptions.AdditionalArguments
                 ]
             )
-            .WithEnvironmentVariables(new Dictionary<string, string?>
-            {
-                ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
-            })
+            .WithEnvironmentVariables(BuildEnvironmentVariables(runOptions))
             .WithValidation(CommandResultValidation.None);
 
         await RunWithFailureLogging(command, runOptions, trxFilename, assertions, assertionExpression);
+    }
+
+    private static Dictionary<string, string?> BuildEnvironmentVariables(RunOptions runOptions)
+    {
+        var environmentVariables = new Dictionary<string, string?>
+        {
+            ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
+        };
+
+        foreach (var (key, value) in runOptions.EnvironmentVariables)
+        {
+            environmentVariables[key] = value;
+        }
+
+        return environmentVariables;
     }
 
     protected static FileInfo? FindFile(Func<FileInfo, bool> predicate)
@@ -176,11 +185,19 @@ public record RunOptions
 
     public List<string> AdditionalArguments { get; init; } = [];
 
+    public Dictionary<string, string?> EnvironmentVariables { get; init; } = [];
+
     public List<Func<CommandTask<BufferedCommandResult>, Task>> OnExecutingDelegates { get; init; } = [];
 
     public RunOptions WithArgument(string argument)
     {
         AdditionalArguments.Add(argument);
+        return this;
+    }
+
+    public RunOptions WithEnvironmentVariable(string key, string? value)
+    {
+        EnvironmentVariables[key] = value;
         return this;
     }
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -23,7 +23,6 @@ internal sealed class TestBuilder : ITestBuilder
     private readonly IContextProvider _contextProvider;
     private readonly ObjectLifecycleService _objectLifecycleService;
     private readonly Discovery.IHookRegistrar _hookDiscoveryService;
-    private readonly TestArgumentRegistrationService _testArgumentRegistrationService;
     private readonly IMetadataFilterMatcher _filterMatcher;
 
     public TestBuilder(
@@ -32,7 +31,6 @@ internal sealed class TestBuilder : ITestBuilder
         IContextProvider contextProvider,
         ObjectLifecycleService objectLifecycleService,
         Discovery.IHookRegistrar hookDiscoveryService,
-        TestArgumentRegistrationService testArgumentRegistrationService,
         IMetadataFilterMatcher filterMatcher)
     {
         _sessionId = sessionId;
@@ -40,7 +38,6 @@ internal sealed class TestBuilder : ITestBuilder
         _eventReceiverOrchestrator = eventReceiverOrchestrator;
         _contextProvider = contextProvider;
         _objectLifecycleService = objectLifecycleService;
-        _testArgumentRegistrationService = testArgumentRegistrationService;
         _filterMatcher = filterMatcher ?? throw new ArgumentNullException(nameof(filterMatcher));
     }
 
@@ -934,25 +931,14 @@ internal sealed class TestBuilder : ITestBuilder
         // Set InternalExecutableTest so it's available during registration for error handling
         context.InternalExecutableTest = test;
 
-        // Register test arguments for property injection and reference counting
-        // Note: ITestRegisteredEventReceiver and ITestDiscoveryEventReceiver are invoked later
-        // in InvokePostResolutionEventsAsync after dependencies are resolved
-        try
-        {
-            await RegisterTestArgumentsAsync(context, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            // Property registration failed - mark the test as failed immediately
-            test.SetResult(TestState.Failed, ex);
-        }
-        finally
-        {
-            // Clear TestContext.Current so subsequent build operations use TestBuildContext.Current
-            // for output capture. This ensures console output during data source evaluation
-            // goes to the shared build context, not a previous test's context.
-            TestContext.Current = null;
-        }
+        // Test argument registration (property injection + reference counting) is NOT done here.
+        // It happens post-filter in TestFilterService.RegisterTest so that shared-object reference
+        // counts only include tests that will actually execute. Registering at build time inflated
+        // the counts with built-but-filtered-out tests (e.g. [Explicit] siblings or single
+        // [Arguments] cases selected by an IDE uid filter), so the count never drained to zero and
+        // shared fixtures were never disposed (#6151).
+        // ITestRegisteredEventReceiver and ITestDiscoveryEventReceiver are invoked later in
+        // InvokePostResolutionEventsAsync after dependencies are resolved.
 
         return test;
     }
@@ -1100,23 +1086,6 @@ internal sealed class TestBuilder : ITestBuilder
         context.Metadata.TestDetails = testDetails;
 
         return context;
-    }
-
-    /// <summary>
-    /// Registers test arguments for property injection and reference counting.
-    /// Called during test building, before dependencies are resolved.
-    /// </summary>
-    private async Task RegisterTestArgumentsAsync(TestContext context, CancellationToken cancellationToken = default)
-    {
-        var discoveredTest = new DiscoveredTest<object>
-        {
-            TestContext = context
-        };
-
-        context.InternalDiscoveredTest = discoveredTest;
-
-        // Invoke the global test argument registration service to register shared instances
-        await _testArgumentRegistrationService.RegisterTestArgumentsAsync(context, cancellationToken);
     }
 
 #if NET8_0_OR_GREATER

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -203,7 +203,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         var dependencyExpander = Register(new MetadataDependencyExpander(filterMatcher));
 
         var testBuilder = Register<ITestBuilder>(
-            new TestBuilder(TestSessionId, EventReceiverOrchestrator, ContextProvider, ObjectLifecycleService, hookDiscoveryService, testArgumentRegistrationService, filterMatcher));
+            new TestBuilder(TestSessionId, EventReceiverOrchestrator, ContextProvider, ObjectLifecycleService, hookDiscoveryService, filterMatcher));
 
         TestBuilderPipeline = Register(
             new TestBuilderPipeline(
@@ -285,9 +285,10 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
             ContextProvider,
             lifecycleCoordinator,
             MessageBus,
-            staticPropertyInitializer));
+            staticPropertyInitializer,
+            objectTracker));
 
-        Register<ITestRegistry>(new TestRegistry(TestBuilderPipeline, testCoordinator, dynamicTestQueue, TestSessionId, CancellationToken.Token));
+        Register<ITestRegistry>(new TestRegistry(TestBuilderPipeline, testCoordinator, dynamicTestQueue, TestFilterService, TestSessionId, CancellationToken.Token));
 
         InitializeConsoleInterceptors();
     }

--- a/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -259,7 +259,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
             Logger,
             hashSetPool));
 
-        var staticPropertyHandler = Register(new StaticPropertyHandler(Logger, objectTracker, trackableObjectGraphProvider, disposer, lazyPropertyInjector, objectGraphDiscoveryService));
+        var staticPropertyHandler = Register(new StaticPropertyHandler(Logger, objectTracker, trackableObjectGraphProvider, lazyPropertyInjector, objectGraphDiscoveryService));
 
         var dynamicTestQueue = Register<IDynamicTestQueue>(new DynamicTestQueue(MessageBus));
 

--- a/TUnit.Engine/Services/StaticPropertyHandler.cs
+++ b/TUnit.Engine/Services/StaticPropertyHandler.cs
@@ -15,7 +15,6 @@ internal sealed class StaticPropertyHandler
     private readonly TUnitFrameworkLogger _logger;
     private readonly ObjectTracker _objectTracker;
     private readonly TrackableObjectGraphProvider _trackableObjectGraphProvider;
-    private readonly Disposer _disposer;
     private readonly Lazy<PropertyInjector> _propertyInjector;
     private readonly ObjectGraphDiscoveryService _objectGraphDiscoveryService;
     private readonly ConcurrentDictionary<string, object?> _sessionObjectBag = new();
@@ -24,14 +23,12 @@ internal sealed class StaticPropertyHandler
     public StaticPropertyHandler(TUnitFrameworkLogger logger,
         ObjectTracker objectTracker,
         TrackableObjectGraphProvider trackableObjectGraphProvider,
-        Disposer disposer,
         Lazy<PropertyInjector> propertyInjector,
         ObjectGraphDiscoveryService objectGraphDiscoveryService)
     {
         _logger = logger;
         _objectTracker = objectTracker;
         _trackableObjectGraphProvider = trackableObjectGraphProvider;
-        _disposer = disposer;
         _propertyInjector = propertyInjector;
         _objectGraphDiscoveryService = objectGraphDiscoveryService;
     }
@@ -96,7 +93,10 @@ internal sealed class StaticPropertyHandler
     }
 
     /// <summary>
-    /// Dispose all tracked static properties at session end
+    /// Dispose all tracked static properties at session end.
+    /// Goes through the ObjectTracker (decrementing the +1 reference TrackStaticProperties took)
+    /// rather than disposing directly, so the tracking entry is removed and the session-end
+    /// sweep in TestSessionCoordinator does not dispose the same object a second time.
     /// </summary>
     public async Task DisposeStaticPropertiesAsync(List<Exception> cleanupExceptions)
     {
@@ -106,7 +106,7 @@ internal sealed class StaticPropertyHandler
         {
             try
             {
-                await _disposer.DisposeAsync(staticProperty).ConfigureAwait(false);
+                await _objectTracker.UntrackObjectAsync(staticProperty).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/TUnit.Engine/Services/TestFilterService.cs
+++ b/TUnit.Engine/Services/TestFilterService.cs
@@ -61,7 +61,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         return filteredTests;
     }
 
-    private async Task RegisterTest(AbstractExecutableTest test)
+    private async Task RegisterTest(AbstractExecutableTest test, bool isForExecution)
     {
         var discoveredTest = new DiscoveredTest<object>
         {
@@ -102,14 +102,21 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
             return;
         }
 
-        try
+        // Argument registration creates shared data-source objects and increments their
+        // reference counts. Only do this for tests that will actually execute — those counts
+        // are only ever decremented on test completion, so registering during discovery-only
+        // requests would create fixtures as a side effect and leak them forever (#6151).
+        if (isForExecution)
         {
-            await testArgumentRegistrationService.RegisterTestArgumentsAsync(test.Context);
-        }
-        catch (Exception ex)
-        {
-            // Mark the test as failed - event receivers have already run above
-            test.SetResult(TestState.Failed, ex);
+            try
+            {
+                await testArgumentRegistrationService.RegisterTestArgumentsAsync(test.Context);
+            }
+            catch (Exception ex)
+            {
+                // Mark the test as failed - event receivers have already run above
+                test.SetResult(TestState.Failed, ex);
+            }
         }
 
         // Clear the cached display name after registration events
@@ -125,7 +132,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
     /// TestArgumentRegistrationService) use ConcurrentDictionary internally.
     /// ITestRegisteredEventReceiver implementations must be thread-safe.
     /// </summary>
-    public async Task RegisterTestsAsync(IEnumerable<AbstractExecutableTest> tests)
+    public async Task RegisterTestsAsync(IEnumerable<AbstractExecutableTest> tests, bool isForExecution)
     {
         var testList = tests as IReadOnlyList<AbstractExecutableTest> ?? tests.ToList();
 
@@ -133,7 +140,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         {
             foreach (var test in testList)
             {
-                await RegisterTest(test);
+                await RegisterTest(test, isForExecution);
             }
             return;
         }
@@ -141,7 +148,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         await Parallel.ForEachAsync(
             testList,
             new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            async (test, _) => await RegisterTest(test).ConfigureAwait(false)
+            async (test, _) => await RegisterTest(test, isForExecution).ConfigureAwait(false)
         ).ConfigureAwait(false);
     }
 

--- a/TUnit.Engine/Services/TestRegistry.cs
+++ b/TUnit.Engine/Services/TestRegistry.cs
@@ -20,18 +20,21 @@ internal sealed class TestRegistry : ITestRegistry
     private readonly TestBuilderPipeline? _testBuilderPipeline;
     private readonly ITestCoordinator _testCoordinator;
     private readonly IDynamicTestQueue _dynamicTestQueue;
+    private readonly TestFilterService _testFilterService;
     private readonly CancellationToken _sessionCancellationToken;
     private readonly string? _sessionId;
 
     public TestRegistry(TestBuilderPipeline testBuilderPipeline,
         ITestCoordinator testCoordinator,
         IDynamicTestQueue dynamicTestQueue,
+        TestFilterService testFilterService,
         string sessionId,
         CancellationToken sessionCancellationToken)
     {
         _testBuilderPipeline = testBuilderPipeline;
         _testCoordinator = testCoordinator;
         _dynamicTestQueue = dynamicTestQueue;
+        _testFilterService = testFilterService;
         _sessionId = sessionId;
         _sessionCancellationToken = sessionCancellationToken;
     }
@@ -98,6 +101,10 @@ internal sealed class TestRegistry : ITestRegistry
         // These are dynamic tests registered after discovery, so not in execution mode with a filter
         var buildingContext = new Building.TestBuildingContext(IsForExecution: false, Filter: null);
         var builtTests = await _testBuilderPipeline!.BuildTestsFromMetadataAsync(testMetadataList, buildingContext);
+
+        // Dynamic tests bypass the discovery pipeline's post-filter registration, so register them
+        // here (event receivers + argument registration/reference counting) before they execute.
+        await _testFilterService.RegisterTestsAsync(builtTests, isForExecution: true);
 
         foreach (var test in builtTests)
         {
@@ -264,6 +271,10 @@ internal sealed class TestRegistry : ITestRegistry
 
         var builtTest = builtTests.FirstOrDefault()
             ?? throw new InvalidOperationException("Failed to build test variant");
+
+        // Variants bypass the discovery pipeline's post-filter registration, so register here
+        // (event receivers + argument registration/reference counting) before execution.
+        await _testFilterService.RegisterTestsAsync([builtTest], isForExecution: true);
 
         _dynamicTestQueue.Enqueue(builtTest);
 

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -103,7 +103,7 @@ internal sealed class TestDiscoveryService : IDataProducer
             filteredTests = [.. testsToInclude];
         }
 
-        await _testFilterService.RegisterTestsAsync(filteredTests).ConfigureAwait(false);
+        await _testFilterService.RegisterTestsAsync(filteredTests, isForExecution).ConfigureAwait(false);
 
         var finalContext = ExecutionContext.Capture();
         return new TestDiscoveryResult(filteredTests, finalContext);

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -232,6 +232,11 @@ internal sealed class TestDiscoveryService : IDataProducer
         }
     }
 
+    // NOTE: This streaming path never calls _testFilterService.RegisterTestsAsync, so yielded
+    // tests have NOT had argument registration (shared-object creation + reference counting).
+    // It currently has no callers; if it is ever wired into an execution path, tests must be
+    // registered with isForExecution: true before they run, or property injection and shared
+    // fixture disposal will silently break.
     #if NET8_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Generic test instantiation requires MakeGenericType")]
     #endif

--- a/TUnit.Engine/TestSessionCoordinator.cs
+++ b/TUnit.Engine/TestSessionCoordinator.cs
@@ -4,6 +4,7 @@ using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Services;
+using TUnit.Core.Tracking;
 using TUnit.Engine.Framework;
 using TUnit.Engine.Logging;
 using TUnit.Engine.Scheduling;
@@ -22,6 +23,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     private readonly TestLifecycleCoordinator _lifecycleCoordinator;
     private readonly ITUnitMessageBus _messageBus;
     private readonly IStaticPropertyInitializer _staticPropertyInitializer;
+    private readonly ObjectTracker _objectTracker;
 
     public TestSessionCoordinator(EventReceiverOrchestrator eventReceiverOrchestrator,
         TUnitFrameworkLogger logger,
@@ -30,7 +32,8 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
         IContextProvider contextProvider,
         TestLifecycleCoordinator lifecycleCoordinator,
         ITUnitMessageBus messageBus,
-        IStaticPropertyInitializer staticPropertyInitializer)
+        IStaticPropertyInitializer staticPropertyInitializer,
+        ObjectTracker objectTracker)
     {
         _eventReceiverOrchestrator = eventReceiverOrchestrator;
         _logger = logger;
@@ -40,6 +43,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
         _messageBus = messageBus;
         _testScheduler = testScheduler;
         _staticPropertyInitializer = staticPropertyInitializer;
+        _objectTracker = objectTracker;
     }
 
     public async Task ExecuteTests(
@@ -59,6 +63,23 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
         }
         finally
         {
+            // Dispose anything still ref-counted (e.g. consumers were cancelled or filtered out)
+            // and reset the static shared-instance caches so a subsequent run request in the same
+            // process (IDE server mode) creates fresh fixtures instead of reusing disposed ones.
+            // Runs after After(TestSession) hooks and static property disposal (both inside
+            // ExecuteTestsCore via the scheduler), preserving existing disposal ordering.
+            var sweepExceptions = await _objectTracker.DisposeAndClearStaticTrackingAsync();
+
+            if (sweepExceptions is { Count: > 0 })
+            {
+                foreach (var exception in sweepExceptions)
+                {
+                    await _logger.LogErrorAsync($"Error disposing tracked object at session end: {exception}");
+                }
+            }
+
+            TestDataContainer.Reset();
+
             foreach (var artifact in _contextProvider.TestSessionContext.Artifacts)
             {
                 await _messageBus.SessionArtifact(artifact);

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1857,6 +1857,7 @@ namespace .Data
         where TScope :  notnull
     {
         public ScopedDictionary() { }
+        public void Clear() { }
         public object? GetOrCreate(TScope scope,  type, <, object?> factory) { }
     }
     public class ThreadSafeDictionary<TKey, [.(..PublicParameterlessConstructor)]  TValue>
@@ -1866,6 +1867,7 @@ namespace .Data
         public TValue this[TKey key] { get; }
         public .<TKey> Keys { get; }
         public .<TValue> Values { get; }
+        public void Clear() { }
         public TValue GetOrAdd(TKey key, <TKey, TValue> func) { }
         public TValue GetOrAdd<TArg>(TKey key, <TKey, TArg, TValue> func, TArg arg) { }
         public TValue? Remove(TKey key) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1857,6 +1857,7 @@ namespace .Data
         where TScope :  notnull
     {
         public ScopedDictionary() { }
+        public void Clear() { }
         public object? GetOrCreate(TScope scope,  type, <, object?> factory) { }
     }
     public class ThreadSafeDictionary<TKey, [.(..PublicParameterlessConstructor)]  TValue>
@@ -1866,6 +1867,7 @@ namespace .Data
         public TValue this[TKey key] { get; }
         public .<TKey> Keys { get; }
         public .<TValue> Values { get; }
+        public void Clear() { }
         public TValue GetOrAdd(TKey key, <TKey, TValue> func) { }
         public TValue GetOrAdd<TArg>(TKey key, <TKey, TArg, TValue> func, TArg arg) { }
         public TValue? Remove(TKey key) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1857,6 +1857,7 @@ namespace .Data
         where TScope :  notnull
     {
         public ScopedDictionary() { }
+        public void Clear() { }
         public object? GetOrCreate(TScope scope,  type, <, object?> factory) { }
     }
     public class ThreadSafeDictionary<TKey, [.(..PublicParameterlessConstructor)]  TValue>
@@ -1866,6 +1867,7 @@ namespace .Data
         public TValue this[TKey key] { get; }
         public .<TKey> Keys { get; }
         public .<TValue> Values { get; }
+        public void Clear() { }
         public TValue GetOrAdd(TKey key, <TKey, TValue> func) { }
         public TValue GetOrAdd<TArg>(TKey key, <TKey, TArg, TValue> func, TArg arg) { }
         public TValue? Remove(TKey key) { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1795,6 +1795,7 @@ namespace .Data
         where TScope :  notnull
     {
         public ScopedDictionary() { }
+        public void Clear() { }
         public object? GetOrCreate(TScope scope,  type, <, object?> factory) { }
     }
     public class ThreadSafeDictionary<TKey, TValue>
@@ -1804,6 +1805,7 @@ namespace .Data
         public TValue this[TKey key] { get; }
         public .<TKey> Keys { get; }
         public .<TValue> Values { get; }
+        public void Clear() { }
         public TValue GetOrAdd(TKey key, <TKey, TValue> func) { }
         public TValue GetOrAdd<TArg>(TKey key, <TKey, TArg, TValue> func, TArg arg) { }
         public TValue? Remove(TKey key) { }

--- a/TUnit.TestProject/Bugs/6151/Bug6151FilteredDisposalTests.cs
+++ b/TUnit.TestProject/Bugs/6151/Bug6151FilteredDisposalTests.cs
@@ -60,5 +60,10 @@ public static class Bug6151SessionMarker
         }
 
         File.WriteAllText(markerPath, $"Created={SessionSharedFixture.CreatedCount};Disposed={SessionSharedFixture.DisposedCount}");
+
+        // Reset so a later run session in the same process (IDE server mode) reports
+        // per-session counts instead of cumulative ones.
+        Interlocked.Exchange(ref SessionSharedFixture.CreatedCount, 0);
+        Interlocked.Exchange(ref SessionSharedFixture.DisposedCount, 0);
     }
 }

--- a/TUnit.TestProject/Bugs/6151/Bug6151FilteredDisposalTests.cs
+++ b/TUnit.TestProject/Bugs/6151/Bug6151FilteredDisposalTests.cs
@@ -1,0 +1,64 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6151;
+
+public sealed class SessionSharedFixture : IAsyncDisposable
+{
+    public static int CreatedCount;
+    public static int DisposedCount;
+
+    public SessionSharedFixture()
+    {
+        Interlocked.Increment(ref CreatedCount);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Interlocked.Increment(ref DisposedCount);
+        return default;
+    }
+}
+
+/// <summary>
+/// Repro for https://github.com/thomhurst/TUnit/discussions/6151 — a PerTestSession shared
+/// fixture must be disposed even when only a subset of the tests that consume it executes.
+/// The [Explicit] sibling is built (incrementing the fixture's ref count) but excluded from
+/// execution, mirroring how an IDE's uid filter selects a single [Arguments] case: the
+/// never-executed test's ref count previously kept the fixture alive forever.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+public class Bug6151FilteredDisposalTests
+{
+    [ClassDataSource<SessionSharedFixture>(Shared = SharedType.PerTestSession)]
+    public required SessionSharedFixture Fixture { get; init; }
+
+    [Test]
+    public void TestA()
+    {
+    }
+
+    [Test]
+    [Explicit]
+    public void TestB()
+    {
+    }
+}
+
+public static class Bug6151SessionMarker
+{
+    // Shared-object disposal is ref-counted and fires when the last consuming test completes,
+    // which is before After(TestSession) hooks run — so the counts are final here.
+    // No-op unless the engine test opted in via the environment variable, so this hook is
+    // inert for every other TestProject invocation.
+    [After(TestSession)]
+    public static void WriteDisposalMarker()
+    {
+        var markerPath = Environment.GetEnvironmentVariable("TUNIT_BUG_6151_MARKER_PATH");
+        if (string.IsNullOrEmpty(markerPath))
+        {
+            return;
+        }
+
+        File.WriteAllText(markerPath, $"Created={SessionSharedFixture.CreatedCount};Disposed={SessionSharedFixture.DisposedCount}");
+    }
+}


### PR DESCRIPTION
## Problem

Discussion #6151: a `[ClassDataSource<T>(Shared = SharedType.PerTestSession)]` fixture implementing `IAsyncDisposable` never gets `DisposeAsync` called when running a single test from Rider (one of two `[Arguments]` cases).

## Root cause

Shared-object disposal is pure ref-counting (`ObjectTracker`): +1 per test that registers the object, -1 when a test finishes, dispose at 0.

The increment happened at **build time** (`TestBuilder.BuildTestAsync` -> `RegisterTestArgumentsAsync`), but filtering happens **after** building, and decrements only happen for **executed** tests. Any built-but-not-run test permanently inflated the count, so it never reached zero:

- A single `[Arguments]` case selected by an IDE uid filter (both cases share one metadata entry, so both are always built) - the reported repro
- An `[Explicit]` sibling matched-then-excluded by a filter
- Discovery-only requests (IDE server mode), which built and registered **all** tests - also meaning discovery constructed expensive fixtures (e.g. WebApplicationFactory) as a side effect

## Fix

1. **Move argument registration post-filter.** Removed the build-time `RegisterTestArgumentsAsync` call; `TestFilterService.RegisterTest` (which already performed the same call with identical failure semantics) is now the single registration point, running only for tests that will execute (incl. dependency-expanded ones).
2. **Discovery-only requests skip argument registration** (event receivers still run, so skip reasons / display-name formatters are unaffected). Discovery no longer creates shared fixtures at all.
3. **Dynamic tests register explicitly.** `AddDynamicTest` / `CreateTestVariant` bypass the discovery pipeline, so `TestRegistry` now registers built tests before enqueueing them (this also gives them `OnTestRegistered` receivers, which previously never fired for dynamic tests).
4. **Session-end sweep + cache reset.** At the end of each run session, any still-tracked objects are disposed (covers cancellation/miscounts) and `TestDataContainer` is cleared, so a subsequent run request in the same process (IDE server mode) creates fresh fixtures instead of receiving disposed ones. Runs after `After(TestSession)` hooks and static-property disposal - existing ordering preserved.

`ObjectTracker.ClearStaticTracking` previously had zero callers; the new sweep wires that lifecycle up properly.

## Tests (TDD - red first, then green)

- `TUnit.TestProject/Bugs/6151/Bug6151FilteredDisposalTests.cs` - PerTestSession fixture with a normal test + `[Explicit]` sibling (same built-but-not-run shape as the IDE uid-filter case, reproducible via `--treenode-filter`). A guarded `[After(TestSession)]` hook writes created/disposed counts to a marker file (opt-in via env var, inert otherwise).
- `TUnit.Engine.Tests/FilteredSharedFixtureDisposalTests.cs` - asserts `Created=1;Disposed=1` for the filtered-subset run (failed with `Disposed=0` before the fix) plus a direct-single-test sanity case.
- `InvokableTestBase.RunOptions` gained `WithEnvironmentVariable` to support the marker handshake.

## Verification

- New regression test red before fix (`Created=1;Disposed=0`), green after - both source-gen and reflection modes
- `TUnit.UnitTests`: 218/218
- Engine-test batch (dynamic, explicit, skip, retry, cancellation, data-source, property-injection, session/discovery hooks, disposal): 35/35 (AOT variants run in CI)
- TestProject disposal suites both modes: Bugs 1924 (660 tests), 5982, 2867, SharedDisposalTest, DisposalRegressionTests, NestedDisposalOrder - all green
- `TUnit.PublicAPI` snapshots updated for the two new `Clear()` members (`ScopedDictionary`, `ThreadSafeDictionary`)

Note: `ClassDataSourceTupleTests.Test_ClassDataSource_UnwrapsTuples` fails identically with and without this change (verified via stash) - pre-existing, unrelated.

Fixes #6151