### PR TITLE
fix(analyzers): decouple code fixers from Rules to prevent MissingFieldException in VS

### DIFF
--- a/SharedTestHelpers/RulesDecouplingVerifier.cs
+++ b/SharedTestHelpers/RulesDecouplingVerifier.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace TUnit.Tests.Shared;
+
+/// <summary>
+/// Verifies that a code fixer assembly carries no IL reference to its analyzer project's
+/// <c>Rules</c> type. Guards against https://github.com/thomhurst/TUnit/issues/6157.
+/// </summary>
+/// <remarks>
+/// Code fixer assemblies ship in the version-agnostic <c>analyzers/dotnet/cs</c> folder while the
+/// analyzer assemblies ship per-Roslyn (<c>analyzers/dotnet/roslyn4.x/cs</c>), and the dependency
+/// resolves at runtime by simple name. Visual Studio cannot unload analyzer assemblies, so after a
+/// package update (or with mixed TUnit versions in one VS session) a new code fixer can bind
+/// against a stale analyzer assembly. Any IL reference to the <c>Rules</c> type — e.g.
+/// <c>Rules.X.Id</c> inside the eagerly-evaluated <c>FixableDiagnosticIds</c> — then throws
+/// <see cref="System.MissingFieldException"/> for rules the stale assembly doesn't have. Code
+/// fixers must use the compile-time-baked <c>DiagnosticIds</c> constants instead, which this
+/// helper enforces at the IL level: a <c>TypeReference</c> to <c>Rules</c> appears for any usage
+/// (field access, <c>typeof</c>, method call), so an empty result proves full decoupling.
+/// <c>DiagnosticIds</c> itself is also scanned — its members must stay <c>const</c>; changing one
+/// to <c>static readonly</c> would silently reintroduce a runtime type reference, which surfaces
+/// here as a <c>TypeReference</c> to <c>DiagnosticIds</c>.
+/// <para>
+/// Linked into each code fixer test project via
+/// <c>&lt;Compile Include="..\SharedTestHelpers\RulesDecouplingVerifier.cs"&gt;</c>.
+/// </para>
+/// </remarks>
+internal static class RulesDecouplingVerifier
+{
+    /// <summary>
+    /// Returns the fully-qualified names of all <c>Rules</c> or <c>DiagnosticIds</c> type
+    /// references in <paramref name="codeFixersAssembly"/> whose namespace is
+    /// <paramref name="rulesNamespace"/>. An empty list means the assembly is fully decoupled.
+    /// </summary>
+    public static List<string> FindRulesTypeReferences(Assembly codeFixersAssembly, string rulesNamespace)
+    {
+        using var stream = File.OpenRead(codeFixersAssembly.Location);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+
+        var rulesReferences = new List<string>();
+
+        foreach (var handle in metadata.TypeReferences)
+        {
+            var typeReference = metadata.GetTypeReference(handle);
+            var name = metadata.GetString(typeReference.Name);
+            var typeNamespace = metadata.GetString(typeReference.Namespace);
+
+            if (name is "Rules" or "DiagnosticIds" && typeNamespace == rulesNamespace)
+            {
+                rulesReferences.Add($"{typeNamespace}.{name}");
+            }
+        }
+
+        return rulesReferences;
+    }
+}

--- a/TUnit.Analyzers.CodeFixers/Base/BaseMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/BaseMigrationCodeFixProvider.cs
@@ -15,10 +15,8 @@ public abstract class BaseMigrationCodeFixProvider : CodeFixProvider
     protected abstract string FrameworkName { get; }
 
     /// <summary>
-    /// The fixable diagnostic ID. Implementations MUST return a <see cref="DiagnosticIds"/> constant
-    /// (never <c>Rules.X.Id</c>): VS evaluates <see cref="FixableDiagnosticIds"/> eagerly, and a runtime
-    /// field reference into TUnit.Analyzers can bind against a stale copy already loaded in the IDE,
-    /// throwing MissingFieldException. See https://github.com/thomhurst/TUnit/issues/6157.
+    /// The fixable diagnostic ID. Implementations MUST return a <see cref="DiagnosticIds"/> constant,
+    /// never <c>Rules.X.Id</c> — see <see cref="DiagnosticIds"/> remarks (issue #6157).
     /// </summary>
     protected abstract string DiagnosticId { get; }
 

--- a/TUnit.Analyzers.CodeFixers/Base/BaseMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/BaseMigrationCodeFixProvider.cs
@@ -13,7 +13,15 @@ namespace TUnit.Analyzers.CodeFixers.Base;
 public abstract class BaseMigrationCodeFixProvider : CodeFixProvider
 {
     protected abstract string FrameworkName { get; }
+
+    /// <summary>
+    /// The fixable diagnostic ID. Implementations MUST return a <see cref="DiagnosticIds"/> constant
+    /// (never <c>Rules.X.Id</c>): VS evaluates <see cref="FixableDiagnosticIds"/> eagerly, and a runtime
+    /// field reference into TUnit.Analyzers can bind against a stale copy already loaded in the IDE,
+    /// throwing MissingFieldException. See https://github.com/thomhurst/TUnit/issues/6157.
+    /// </summary>
     protected abstract string DiagnosticId { get; }
+
     protected abstract string CodeFixTitle { get; }
     
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>

--- a/TUnit.Analyzers.CodeFixers/InheritsTestsCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/InheritsTestsCodeFixProvider.cs
@@ -16,8 +16,10 @@ namespace TUnit.Analyzers.CodeFixers;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InheritsTestsCodeFixProvider)), Shared]
 public class InheritsTestsCodeFixProvider : CodeFixProvider
 {
+    private const string CodeFixTitle = "Add [InheritsTests] attribute";
+
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.DoesNotInheritTestsWarning.Id);
+        ImmutableArray.Create(DiagnosticIds.DoesNotInheritTestsWarning);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -38,9 +40,9 @@ public class InheritsTestsCodeFixProvider : CodeFixProvider
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: Rules.DoesNotInheritTestsWarning.Title.ToString(),
+                    title: CodeFixTitle,
                     createChangedDocument: c => AddInheritsTests(context.Document, classDeclarationSyntax, c),
-                    equivalenceKey: Rules.DoesNotInheritTestsWarning.Title.ToString()),
+                    equivalenceKey: CodeFixTitle),
                 diagnostic);
         }
     }

--- a/TUnit.Analyzers.CodeFixers/MSTestMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/MSTestMigrationCodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace TUnit.Analyzers.CodeFixers;
 public class MSTestMigrationCodeFixProvider : BaseMigrationCodeFixProvider
 {
     protected override string FrameworkName => "MSTest";
-    protected override string DiagnosticId => Rules.MSTestMigration.Id;
+    protected override string DiagnosticId => DiagnosticIds.MSTestMigration;
     protected override string CodeFixTitle => "Convert MSTest code to TUnit";
 
     protected override bool ShouldAddTUnitUsings() => true;

--- a/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/MatrixDataSourceCodeFixProvider.cs
@@ -15,7 +15,7 @@ public class MatrixDataSourceCodeFixProvider : CodeFixProvider
     private const string Title = "Add [MatrixDataSource]";
 
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.MatrixDataSourceAttributeRequired.Id);
+        ImmutableArray.Create(DiagnosticIds.MatrixDataSourceAttributeRequired);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Analyzers.CodeFixers/NUnitMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/NUnitMigrationCodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace TUnit.Analyzers.CodeFixers;
 public class NUnitMigrationCodeFixProvider : BaseMigrationCodeFixProvider
 {
     protected override string FrameworkName => "NUnit";
-    protected override string DiagnosticId => Rules.NUnitMigration.Id;
+    protected override string DiagnosticId => DiagnosticIds.NUnitMigration;
     protected override string CodeFixTitle => "Convert NUnit code to TUnit";
     
     protected override AttributeRewriter CreateAttributeRewriter(Compilation compilation)

--- a/TUnit.Analyzers.CodeFixers/TimeoutCancellationTokenCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/TimeoutCancellationTokenCodeFixProvider.cs
@@ -17,7 +17,7 @@ public class TimeoutCancellationTokenCodeFixProvider : CodeFixProvider
     private const string ParameterName = "cancellationToken";
 
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.MissingTimeoutCancellationTokenAttributes.Id);
+        ImmutableArray.Create(DiagnosticIds.MissingTimeoutCancellationTokenAttributes);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Analyzers.CodeFixers/VirtualHookOverrideCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/VirtualHookOverrideCodeFixProvider.cs
@@ -15,7 +15,7 @@ public class VirtualHookOverrideCodeFixProvider : CodeFixProvider
     private const string Title = "Remove redundant hook attribute";
 
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.RedundantHookAttributeOnOverride.Id);
+        ImmutableArray.Create(DiagnosticIds.RedundantHookAttributeOnOverride);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Analyzers.CodeFixers/XUnitMigrationCodeFixProvider.cs
+++ b/TUnit.Analyzers.CodeFixers/XUnitMigrationCodeFixProvider.cs
@@ -13,8 +13,8 @@ namespace TUnit.Analyzers.CodeFixers;
 public class XUnitMigrationCodeFixProvider : BaseMigrationCodeFixProvider
 {
     protected override string FrameworkName => "XUnit";
-    protected override string DiagnosticId => Rules.XunitMigration.Id;
-    protected override string CodeFixTitle => Rules.XunitMigration.Title.ToString();
+    protected override string DiagnosticId => DiagnosticIds.XunitMigration;
+    protected override string CodeFixTitle => "Convert xUnit code to TUnit";
 
     protected override bool ShouldAddTUnitUsings() => true;
 

--- a/TUnit.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
+++ b/TUnit.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
@@ -1,43 +1,19 @@
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using TUnit.Analyzers.CodeFixers;
+using TUnit.Tests.Shared;
 
 namespace TUnit.Analyzers.Tests;
 
 /// <summary>
-/// Guards against https://github.com/thomhurst/TUnit/issues/6157.
-///
-/// TUnit.Analyzers.CodeFixers.dll ships in the version-agnostic analyzers/dotnet/cs folder and
-/// resolves its TUnit.Analyzers dependency at runtime by simple name. Visual Studio cannot unload
-/// analyzer assemblies, so after a package update (or with mixed TUnit versions in one VS session)
-/// the new code fixers can bind against a stale TUnit.Analyzers.dll. Any IL reference to the
-/// <c>Rules</c> type (e.g. <c>Rules.MSTestMigration.Id</c> inside the eagerly-evaluated
-/// <c>FixableDiagnosticIds</c>) then throws MissingFieldException for rules the stale assembly
-/// doesn't have. Code fixers must use the compile-time-baked <c>DiagnosticIds</c> constants instead.
+/// Code fixers must use <c>DiagnosticIds</c> constants, never <c>Rules.X</c> — see
+/// <see cref="RulesDecouplingVerifier"/> for the full rationale (issue #6157).
 /// </summary>
 public class CodeFixerRulesDecouplingTests
 {
     [Test]
     public async Task CodeFixers_Assembly_Has_No_Reference_To_Rules_Type()
     {
-        var assemblyPath = typeof(MSTestMigrationCodeFixProvider).Assembly.Location;
-
-        using var stream = File.OpenRead(assemblyPath);
-        using var peReader = new PEReader(stream);
-        var metadata = peReader.GetMetadataReader();
-
-        var rulesReferences = new List<string>();
-
-        foreach (var handle in metadata.TypeReferences)
-        {
-            var typeReference = metadata.GetTypeReference(handle);
-
-            if (metadata.GetString(typeReference.Name) == "Rules" &&
-                metadata.GetString(typeReference.Namespace) == "TUnit.Analyzers")
-            {
-                rulesReferences.Add($"{metadata.GetString(typeReference.Namespace)}.{metadata.GetString(typeReference.Name)}");
-            }
-        }
+        var rulesReferences = RulesDecouplingVerifier.FindRulesTypeReferences(
+            typeof(MSTestMigrationCodeFixProvider).Assembly, "TUnit.Analyzers");
 
         await TUnit.Assertions.Assert.That(rulesReferences)
             .IsEmpty()

--- a/TUnit.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
+++ b/TUnit.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using TUnit.Analyzers.CodeFixers;
+
+namespace TUnit.Analyzers.Tests;
+
+/// <summary>
+/// Guards against https://github.com/thomhurst/TUnit/issues/6157.
+///
+/// TUnit.Analyzers.CodeFixers.dll ships in the version-agnostic analyzers/dotnet/cs folder and
+/// resolves its TUnit.Analyzers dependency at runtime by simple name. Visual Studio cannot unload
+/// analyzer assemblies, so after a package update (or with mixed TUnit versions in one VS session)
+/// the new code fixers can bind against a stale TUnit.Analyzers.dll. Any IL reference to the
+/// <c>Rules</c> type (e.g. <c>Rules.MSTestMigration.Id</c> inside the eagerly-evaluated
+/// <c>FixableDiagnosticIds</c>) then throws MissingFieldException for rules the stale assembly
+/// doesn't have. Code fixers must use the compile-time-baked <c>DiagnosticIds</c> constants instead.
+/// </summary>
+public class CodeFixerRulesDecouplingTests
+{
+    [Test]
+    public async Task CodeFixers_Assembly_Has_No_Reference_To_Rules_Type()
+    {
+        var assemblyPath = typeof(MSTestMigrationCodeFixProvider).Assembly.Location;
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+
+        var rulesReferences = new List<string>();
+
+        foreach (var handle in metadata.TypeReferences)
+        {
+            var typeReference = metadata.GetTypeReference(handle);
+
+            if (metadata.GetString(typeReference.Name) == "Rules" &&
+                metadata.GetString(typeReference.Namespace) == "TUnit.Analyzers")
+            {
+                rulesReferences.Add($"{metadata.GetString(typeReference.Namespace)}.{metadata.GetString(typeReference.Name)}");
+            }
+        }
+
+        await TUnit.Assertions.Assert.That(rulesReferences)
+            .IsEmpty()
+            .Because("TUnit.Analyzers.CodeFixers must not reference TUnit.Analyzers.Rules at runtime - " +
+                     "use DiagnosticIds constants instead (see issue #6157)");
+    }
+}

--- a/TUnit.Analyzers.Tests/TUnit.Analyzers.Tests.csproj
+++ b/TUnit.Analyzers.Tests/TUnit.Analyzers.Tests.csproj
@@ -47,6 +47,8 @@
           Visible="false" />
     <Compile Include="..\SharedTestHelpers\AnalyzerTestCompatibility.cs"
              Link="Shared\AnalyzerTestCompatibility.cs" />
+    <Compile Include="..\SharedTestHelpers\RulesDecouplingVerifier.cs"
+             Link="Shared\RulesDecouplingVerifier.cs" />
   </ItemGroup>
 
   <!-- Reference the VSTHRD analyzer assembly (Analyzer="false") so its analyzer types are

--- a/TUnit.Analyzers/DiagnosticIds.cs
+++ b/TUnit.Analyzers/DiagnosticIds.cs
@@ -1,0 +1,71 @@
+namespace TUnit.Analyzers;
+
+/// <summary>
+/// Diagnostic ID constants for all TUnit analyzer rules.
+/// </summary>
+/// <remarks>
+/// Code fix providers (TUnit.Analyzers.CodeFixers) MUST reference these constants instead of
+/// <c>Rules.X.Id</c>. Constants are baked into the consuming assembly at compile time, so the
+/// code fixers carry no runtime reference to the <see cref="Rules"/> type. A runtime reference
+/// can bind against a stale TUnit.Analyzers.dll already loaded in Visual Studio (analyzers
+/// cannot be unloaded), throwing <see cref="System.MissingFieldException"/> for newly added
+/// rules. See https://github.com/thomhurst/TUnit/issues/6157.
+/// </remarks>
+public static class DiagnosticIds
+{
+    public const string WrongArgumentTypeTestData = "TUnit0001";
+    public const string NoTestDataProvided = "TUnit0002";
+    public const string NoMethodFound = "TUnit0004";
+    public const string MethodParameterBadNullability = "TUnit0005";
+    public const string MethodMustBeStatic = "TUnit0007";
+    public const string MethodMustBePublic = "TUnit0008";
+    public const string MethodMustNotBeAbstract = "TUnit0009";
+    public const string MethodMustBeParameterless = "TUnit0010";
+    public const string MethodMustReturnData = "TUnit0011";
+    public const string TooManyArgumentsInTestMethod = "TUnit0013";
+    public const string PublicMethodMissingTestAttribute = "TUnit0014";
+    public const string MissingTimeoutCancellationTokenAttributes = "TUnit0015";
+    public const string MethodMustNotBeStatic = "TUnit0016";
+    public const string ConflictingExplicitAttributes = "TUnit0017";
+    public const string InstanceAssignmentInTestClass = "TUnit0018";
+    public const string MissingTestAttribute = "TUnit0019";
+    public const string Dispose_Member_In_Cleanup = "TUnit0023";
+    public const string UnknownParameters = "TUnit0027";
+    public const string DoNotOverrideAttributeUsageMetadata = "TUnit0028";
+    public const string DuplicateSingleAttribute = "TUnit0029";
+    public const string DoesNotInheritTestsWarning = "TUnit0030";
+    public const string AsyncVoidMethod = "TUnit0031";
+    public const string DependsOnConflicts = "TUnit0033";
+    public const string NoMainMethod = "TUnit0034";
+    public const string NoDataSourceProvided = "TUnit0038";
+    public const string SingleTestContextParameterRequired = "TUnit0039";
+    public const string SingleClassHookContextParameterRequired = "TUnit0040";
+    public const string SingleAssemblyHookContextParameterRequired = "TUnit0041";
+    public const string GlobalHooksSeparateClass = "TUnit0042";
+    public const string PropertyRequiredNotSet = "TUnit0043";
+    public const string MustHavePropertySetter = "TUnit0044";
+    public const string TooManyDataAttributes = "TUnit0045";
+    public const string ReturnFunc = "TUnit0046";
+    public const string AsyncLocalCallFlowValues = "TUnit0047";
+    public const string InstanceTestMethod = "TUnit0048";
+    public const string MatrixDataSourceAttributeRequired = "TUnit0049";
+    public const string TooManyArguments = "TUnit0050";
+    public const string TypeMustBePublic = "TUnit0051";
+    public const string MultipleConstructorsWithoutTestConstructor = "TUnit0052";
+    public const string XunitMigration = "TUXU0001";
+    public const string NUnitMigration = "TUNU0001";
+    public const string MSTestMigration = "TUMS0001";
+    public const string OverwriteConsole = "TUnit0055";
+    public const string InstanceMethodSource = "TUnit0056";
+    public const string HookContextParameterOptional = "TUnit0057";
+    public const string HookUnknownParameters = "TUnit0058";
+    public const string AbstractTestClassWithDataSources = "TUnit0059";
+    public const string PotentialEmptyDataSource = "TUnit0060";
+    public const string NoAccessibleConstructor = "TUnit0061";
+    public const string CancellationTokenMustBeLastParameter = "TUnit0062";
+    public const string CombinedDataSourceAttributeRequired = "TUnit0070";
+    public const string CombinedDataSourceMissingParameterDataSource = "TUnit0071";
+    public const string CombinedDataSourceConflictWithMatrix = "TUnit0072";
+    public const string MissingPolyfillPackage = "TUnit0073";
+    public const string RedundantHookAttributeOnOverride = "TUnit0074";
+}

--- a/TUnit.Analyzers/DiagnosticIds.cs
+++ b/TUnit.Analyzers/DiagnosticIds.cs
@@ -2,15 +2,12 @@ namespace TUnit.Analyzers;
 
 /// <summary>
 /// Diagnostic ID constants for all TUnit analyzer rules.
+/// Code fix providers MUST reference these constants instead of <c>Rules.X.Id</c> — consts are
+/// baked into the consuming IL at compile time, avoiding a runtime bind against a stale
+/// analyzer assembly in Visual Studio. See https://github.com/thomhurst/TUnit/issues/6157.
+/// Members MUST stay <c>const</c>: <c>static readonly</c> would reintroduce the runtime
+/// reference (and fails the IL regression tests).
 /// </summary>
-/// <remarks>
-/// Code fix providers (TUnit.Analyzers.CodeFixers) MUST reference these constants instead of
-/// <c>Rules.X.Id</c>. Constants are baked into the consuming assembly at compile time, so the
-/// code fixers carry no runtime reference to the <see cref="Rules"/> type. A runtime reference
-/// can bind against a stale TUnit.Analyzers.dll already loaded in Visual Studio (analyzers
-/// cannot be unloaded), throwing <see cref="System.MissingFieldException"/> for newly added
-/// rules. See https://github.com/thomhurst/TUnit/issues/6157.
-/// </remarks>
 public static class DiagnosticIds
 {
     public const string WrongArgumentTypeTestData = "TUnit0001";

--- a/TUnit.Analyzers/Rules.cs
+++ b/TUnit.Analyzers/Rules.cs
@@ -111,10 +111,10 @@ public static class Rules
     public static readonly DiagnosticDescriptor AsyncLocalCallFlowValues =
         CreateDescriptor(DiagnosticIds.AsyncLocalCallFlowValues, UsageCategory, DiagnosticSeverity.Warning);
 
-    public static DiagnosticDescriptor InstanceTestMethod =
+    public static readonly DiagnosticDescriptor InstanceTestMethod =
         CreateDescriptor(DiagnosticIds.InstanceTestMethod, UsageCategory, DiagnosticSeverity.Error);
 
-    public static DiagnosticDescriptor MatrixDataSourceAttributeRequired =
+    public static readonly DiagnosticDescriptor MatrixDataSourceAttributeRequired =
         CreateDescriptor(DiagnosticIds.MatrixDataSourceAttributeRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor TooManyArguments =

--- a/TUnit.Analyzers/Rules.cs
+++ b/TUnit.Analyzers/Rules.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 
 namespace TUnit.Analyzers;
 
@@ -7,171 +7,171 @@ public static class Rules
     private const string UsageCategory = "Usage";
 
     public static readonly DiagnosticDescriptor WrongArgumentTypeTestData =
-        CreateDescriptor("TUnit0001", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.WrongArgumentTypeTestData, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor NoTestDataProvided =
-        CreateDescriptor("TUnit0002", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.NoTestDataProvided, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor NoMethodFound =
-        CreateDescriptor("TUnit0004", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.NoMethodFound, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MethodParameterBadNullability =
-        CreateDescriptor("TUnit0005", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.MethodParameterBadNullability, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MethodMustBeStatic =
-        CreateDescriptor("TUnit0007", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustBeStatic, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MethodMustBePublic =
-        CreateDescriptor("TUnit0008", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustBePublic, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MethodMustNotBeAbstract =
-        CreateDescriptor("TUnit0009", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustNotBeAbstract, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MethodMustBeParameterless =
-        CreateDescriptor("TUnit0010", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustBeParameterless, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MethodMustReturnData =
-        CreateDescriptor("TUnit0011", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustReturnData, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor TooManyArgumentsInTestMethod =
-        CreateDescriptor("TUnit0013", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.TooManyArgumentsInTestMethod, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor PublicMethodMissingTestAttribute =
-        CreateDescriptor("TUnit0014", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.PublicMethodMissingTestAttribute, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MissingTimeoutCancellationTokenAttributes =
-        CreateDescriptor("TUnit0015", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.MissingTimeoutCancellationTokenAttributes, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor CancellationTokenMustBeLastParameter =
-        CreateDescriptor("TUnit0062", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.CancellationTokenMustBeLastParameter, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MethodMustNotBeStatic =
-        CreateDescriptor("TUnit0016", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MethodMustNotBeStatic, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor ConflictingExplicitAttributes =
-        CreateDescriptor("TUnit0017", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.ConflictingExplicitAttributes, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor InstanceAssignmentInTestClass =
-        CreateDescriptor("TUnit0018", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.InstanceAssignmentInTestClass, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor MissingTestAttribute =
-        CreateDescriptor("TUnit0019", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MissingTestAttribute, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor Dispose_Member_In_Cleanup =
-        CreateDescriptor("TUnit0023", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.Dispose_Member_In_Cleanup, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor UnknownParameters =
-        CreateDescriptor("TUnit0027", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.UnknownParameters, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DoNotOverrideAttributeUsageMetadata =
-        CreateDescriptor("TUnit0028", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.DoNotOverrideAttributeUsageMetadata, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DuplicateSingleAttribute =
-        CreateDescriptor("TUnit0029", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.DuplicateSingleAttribute, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DoesNotInheritTestsWarning =
-        CreateDescriptor("TUnit0030", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.DoesNotInheritTestsWarning, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor AsyncVoidMethod =
-        CreateDescriptor("TUnit0031", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.AsyncVoidMethod, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DependsOnConflicts =
-        CreateDescriptor("TUnit0033", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.DependsOnConflicts, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor NoMainMethod =
-        CreateDescriptor("TUnit0034", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.NoMainMethod, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor NoDataSourceProvided =
-        CreateDescriptor("TUnit0038", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.NoDataSourceProvided, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor SingleTestContextParameterRequired =
-        CreateDescriptor("TUnit0039", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.SingleTestContextParameterRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor SingleClassHookContextParameterRequired =
-        CreateDescriptor("TUnit0040", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.SingleClassHookContextParameterRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor SingleAssemblyHookContextParameterRequired =
-        CreateDescriptor("TUnit0041", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.SingleAssemblyHookContextParameterRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor GlobalHooksSeparateClass =
-        CreateDescriptor("TUnit0042", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.GlobalHooksSeparateClass, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor PropertyRequiredNotSet =
-        CreateDescriptor("TUnit0043", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.PropertyRequiredNotSet, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor MustHavePropertySetter =
-        CreateDescriptor("TUnit0044", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MustHavePropertySetter, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor TooManyDataAttributes =
-        CreateDescriptor("TUnit0045", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.TooManyDataAttributes, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor ReturnFunc =
-        CreateDescriptor("TUnit0046", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.ReturnFunc, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor AsyncLocalCallFlowValues =
-        CreateDescriptor("TUnit0047", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.AsyncLocalCallFlowValues, UsageCategory, DiagnosticSeverity.Warning);
 
     public static DiagnosticDescriptor InstanceTestMethod =
-        CreateDescriptor("TUnit0048", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.InstanceTestMethod, UsageCategory, DiagnosticSeverity.Error);
 
     public static DiagnosticDescriptor MatrixDataSourceAttributeRequired =
-        CreateDescriptor("TUnit0049", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.MatrixDataSourceAttributeRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor TooManyArguments =
-        CreateDescriptor("TUnit0050", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.TooManyArguments, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor TypeMustBePublic =
-        CreateDescriptor("TUnit0051", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.TypeMustBePublic, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MultipleConstructorsWithoutTestConstructor =
-        CreateDescriptor("TUnit0052", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.MultipleConstructorsWithoutTestConstructor, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor XunitMigration =
-        CreateDescriptor("TUXU0001", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.XunitMigration, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor NUnitMigration =
-        CreateDescriptor("TUNU0001", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.NUnitMigration, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor MSTestMigration =
-        CreateDescriptor("TUMS0001", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.MSTestMigration, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor OverwriteConsole =
-        CreateDescriptor("TUnit0055", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.OverwriteConsole, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor CombinedDataSourceAttributeRequired =
-        CreateDescriptor("TUnit0070", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.CombinedDataSourceAttributeRequired, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor CombinedDataSourceMissingParameterDataSource =
-        CreateDescriptor("TUnit0071", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.CombinedDataSourceMissingParameterDataSource, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor CombinedDataSourceConflictWithMatrix =
-        CreateDescriptor("TUnit0072", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.CombinedDataSourceConflictWithMatrix, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor InstanceMethodSource =
-        CreateDescriptor("TUnit0056", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.InstanceMethodSource, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor HookContextParameterOptional =
-        CreateDescriptor("TUnit0057", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.HookContextParameterOptional, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor HookUnknownParameters =
-        CreateDescriptor("TUnit0058", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.HookUnknownParameters, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor AbstractTestClassWithDataSources =
-        CreateDescriptor("TUnit0059", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.AbstractTestClassWithDataSources, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor PotentialEmptyDataSource =
-        CreateDescriptor("TUnit0060", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.PotentialEmptyDataSource, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor NoAccessibleConstructor =
-        CreateDescriptor("TUnit0061", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.NoAccessibleConstructor, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor MissingPolyfillPackage =
-        CreateDescriptor("TUnit0073", UsageCategory, DiagnosticSeverity.Error,
+        CreateDescriptor(DiagnosticIds.MissingPolyfillPackage, UsageCategory, DiagnosticSeverity.Error,
             customTags: [WellKnownDiagnosticTags.CompilationEnd],
             helpLinkUri: "https://www.nuget.org/packages/Polyfill");
 
     public static readonly DiagnosticDescriptor RedundantHookAttributeOnOverride =
-        CreateDescriptor("TUnit0074", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.RedundantHookAttributeOnOverride, UsageCategory, DiagnosticSeverity.Error);
 
     private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity,
         string[]? customTags = null, string? helpLinkUri = null)

--- a/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
+++ b/TUnit.AspNetCore.Analyzers.CodeFixers/UseTestWebApplicationFactoryCodeFixProvider.cs
@@ -20,7 +20,7 @@ public class UseTestWebApplicationFactoryCodeFixProvider : CodeFixProvider
     private const string TestWebApplicationFactoryNamespace = "TUnit.AspNetCore";
 
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.DirectWebApplicationFactoryInheritance.Id);
+        ImmutableArray.Create(DiagnosticIds.DirectWebApplicationFactoryInheritance);
 
     public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.AspNetCore.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
+++ b/TUnit.AspNetCore.Analyzers.Tests/CodeFixerRulesDecouplingTests.cs
@@ -1,6 +1,7 @@
+using TUnit.AspNetCore.Analyzers.CodeFixers;
 using TUnit.Tests.Shared;
 
-namespace TUnit.Assertions.Analyzers.CodeFixers.Tests;
+namespace TUnit.AspNetCore.Analyzers.Tests;
 
 /// <summary>
 /// Code fixers must use <c>DiagnosticIds</c> constants, never <c>Rules.X</c> — see
@@ -12,11 +13,11 @@ public class CodeFixerRulesDecouplingTests
     public async Task CodeFixers_Assembly_Has_No_Reference_To_Rules_Type()
     {
         var rulesReferences = RulesDecouplingVerifier.FindRulesTypeReferences(
-            typeof(AwaitAssertionCodeFixProvider).Assembly, "TUnit.Assertions.Analyzers");
+            typeof(UseTestWebApplicationFactoryCodeFixProvider).Assembly, "TUnit.AspNetCore.Analyzers");
 
         await Assert.That(rulesReferences)
             .IsEmpty()
-            .Because("TUnit.Assertions.Analyzers.CodeFixers must not reference TUnit.Assertions.Analyzers.Rules at runtime - " +
+            .Because("TUnit.AspNetCore.Analyzers.CodeFixers must not reference TUnit.AspNetCore.Analyzers.Rules at runtime - " +
                      "use DiagnosticIds constants instead (see issue #6157)");
     }
 }

--- a/TUnit.AspNetCore.Analyzers.Tests/TUnit.AspNetCore.Analyzers.Tests.csproj
+++ b/TUnit.AspNetCore.Analyzers.Tests/TUnit.AspNetCore.Analyzers.Tests.csproj
@@ -29,6 +29,8 @@
           Visible="false" />
     <Compile Include="..\SharedTestHelpers\AnalyzerTestCompatibility.cs"
              Link="Shared\AnalyzerTestCompatibility.cs" />
+    <Compile Include="..\SharedTestHelpers\RulesDecouplingVerifier.cs"
+             Link="Shared\RulesDecouplingVerifier.cs" />
   </ItemGroup>
 
   <Import Project="..\TestProject.targets" />

--- a/TUnit.AspNetCore.Analyzers/DiagnosticIds.cs
+++ b/TUnit.AspNetCore.Analyzers/DiagnosticIds.cs
@@ -10,6 +10,10 @@ namespace TUnit.AspNetCore.Analyzers;
 /// </summary>
 public static class DiagnosticIds
 {
+    // NOTE: "TUnit0062" collides with TUnit.Analyzers.DiagnosticIds.CancellationTokenMustBeLastParameter.
+    // Pre-existing (both Rules.cs files shipped this literal); .editorconfig severity for TUnit0062
+    // affects both rules in projects referencing both analyzers. Renumbering is a user-facing change
+    // tracked separately from #6157.
     public const string FactoryAccessedTooEarly = "TUnit0062";
     public const string GlobalFactoryMemberAccess = "TUnit0063";
     public const string DirectWebApplicationFactoryInheritance = "TUnit0064";

--- a/TUnit.AspNetCore.Analyzers/DiagnosticIds.cs
+++ b/TUnit.AspNetCore.Analyzers/DiagnosticIds.cs
@@ -1,0 +1,16 @@
+namespace TUnit.AspNetCore.Analyzers;
+
+/// <summary>
+/// Diagnostic ID constants for all TUnit ASP.NET Core analyzer rules.
+/// Code fix providers MUST reference these constants instead of <c>Rules.X.Id</c> — consts are
+/// baked into the consuming IL at compile time, avoiding a runtime bind against a stale
+/// analyzer assembly in Visual Studio. See https://github.com/thomhurst/TUnit/issues/6157.
+/// Members MUST stay <c>const</c>: <c>static readonly</c> would reintroduce the runtime
+/// reference (and fails the IL regression tests).
+/// </summary>
+public static class DiagnosticIds
+{
+    public const string FactoryAccessedTooEarly = "TUnit0062";
+    public const string GlobalFactoryMemberAccess = "TUnit0063";
+    public const string DirectWebApplicationFactoryInheritance = "TUnit0064";
+}

--- a/TUnit.AspNetCore.Analyzers/Rules.cs
+++ b/TUnit.AspNetCore.Analyzers/Rules.cs
@@ -7,14 +7,14 @@ public static class Rules
     private const string UsageCategory = "Usage";
 
     public static readonly DiagnosticDescriptor FactoryAccessedTooEarly =
-        CreateDescriptor("TUnit0062", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.FactoryAccessedTooEarly, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor GlobalFactoryMemberAccess =
-        CreateDescriptor("TUnit0063", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.GlobalFactoryMemberAccess, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DirectWebApplicationFactoryInheritance =
         CreateDescriptor(
-            "TUnit0064",
+            DiagnosticIds.DirectWebApplicationFactoryInheritance,
             UsageCategory,
             DiagnosticSeverity.Warning,
             helpLinkUri: "https://tunit.dev/docs/guides/distributed-tracing");

--- a/TUnit.Assertions.Analyzers.CodeFixers.Tests/CodeFixerRulesDecouplingTests.cs
+++ b/TUnit.Assertions.Analyzers.CodeFixers.Tests/CodeFixerRulesDecouplingTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace TUnit.Assertions.Analyzers.CodeFixers.Tests;
+
+/// <summary>
+/// Guards against https://github.com/thomhurst/TUnit/issues/6157.
+///
+/// TUnit.Assertions.Analyzers.CodeFixers.dll ships in the version-agnostic analyzers/dotnet/cs
+/// folder and resolves its TUnit.Assertions.Analyzers dependency at runtime by simple name.
+/// Visual Studio cannot unload analyzer assemblies, so after a package update the new code fixers
+/// can bind against a stale TUnit.Assertions.Analyzers.dll. Any IL reference to the <c>Rules</c>
+/// type inside the eagerly-evaluated <c>FixableDiagnosticIds</c> then throws
+/// MissingFieldException for rules the stale assembly doesn't have. Code fixers must use the
+/// compile-time-baked <c>DiagnosticIds</c> constants instead.
+/// </summary>
+public class CodeFixerRulesDecouplingTests
+{
+    [Test]
+    public async Task CodeFixers_Assembly_Has_No_Reference_To_Rules_Type()
+    {
+        var assemblyPath = typeof(AwaitAssertionCodeFixProvider).Assembly.Location;
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var metadata = peReader.GetMetadataReader();
+
+        var rulesReferences = new List<string>();
+
+        foreach (var handle in metadata.TypeReferences)
+        {
+            var typeReference = metadata.GetTypeReference(handle);
+
+            if (metadata.GetString(typeReference.Name) == "Rules" &&
+                metadata.GetString(typeReference.Namespace) == "TUnit.Assertions.Analyzers")
+            {
+                rulesReferences.Add($"{metadata.GetString(typeReference.Namespace)}.{metadata.GetString(typeReference.Name)}");
+            }
+        }
+
+        await Assert.That(rulesReferences)
+            .IsEmpty()
+            .Because("TUnit.Assertions.Analyzers.CodeFixers must not reference TUnit.Assertions.Analyzers.Rules at runtime - " +
+                     "use DiagnosticIds constants instead (see issue #6157)");
+    }
+}

--- a/TUnit.Assertions.Analyzers.CodeFixers.Tests/TUnit.Assertions.Analyzers.CodeFixers.Tests.csproj
+++ b/TUnit.Assertions.Analyzers.CodeFixers.Tests/TUnit.Assertions.Analyzers.CodeFixers.Tests.csproj
@@ -22,6 +22,8 @@
               Visible="false" />
         <Compile Include="..\SharedTestHelpers\AnalyzerTestCompatibility.cs"
                  Link="Shared\AnalyzerTestCompatibility.cs" />
+        <Compile Include="..\SharedTestHelpers\RulesDecouplingVerifier.cs"
+                 Link="Shared\RulesDecouplingVerifier.cs" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />

--- a/TUnit.Assertions.Analyzers.CodeFixers/AwaitAssertionCodeFixProvider.cs
+++ b/TUnit.Assertions.Analyzers.CodeFixers/AwaitAssertionCodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace TUnit.Assertions.Analyzers.CodeFixers;
 public class AwaitAssertionCodeFixProvider : CodeFixProvider
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.AwaitAssertion.Id);
+        ImmutableArray.Create(DiagnosticIds.AwaitAssertion);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Assertions.Analyzers.CodeFixers/CollectionIsEqualToCodeFixProvider.cs
+++ b/TUnit.Assertions.Analyzers.CodeFixers/CollectionIsEqualToCodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace TUnit.Assertions.Analyzers.CodeFixers;
 public class CollectionIsEqualToCodeFixProvider : CodeFixProvider
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.CollectionIsEqualToUsesReferenceEquality.Id);
+        ImmutableArray.Create(DiagnosticIds.CollectionIsEqualToUsesReferenceEquality);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Assertions.Analyzers.CodeFixers/XUnitAssertionCodeFixProvider.cs
+++ b/TUnit.Assertions.Analyzers.CodeFixers/XUnitAssertionCodeFixProvider.cs
@@ -14,7 +14,7 @@ namespace TUnit.Assertions.Analyzers.CodeFixers;
 public class XUnitAssertionCodeFixProvider : CodeFixProvider
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
-        ImmutableArray.Create(Rules.XUnitAssertion.Id);
+        ImmutableArray.Create(DiagnosticIds.XUnitAssertion);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/TUnit.Assertions.Analyzers/DiagnosticIds.cs
+++ b/TUnit.Assertions.Analyzers/DiagnosticIds.cs
@@ -1,0 +1,32 @@
+namespace TUnit.Assertions.Analyzers;
+
+/// <summary>
+/// Diagnostic ID constants for all TUnit assertions analyzer rules.
+/// </summary>
+/// <remarks>
+/// Code fix providers (TUnit.Assertions.Analyzers.CodeFixers) MUST reference these constants instead
+/// of <c>Rules.X.Id</c>. Constants are baked into the consuming assembly at compile time, so the
+/// code fixers carry no runtime reference to the <see cref="Rules"/> type. A runtime reference
+/// can bind against a stale TUnit.Assertions.Analyzers.dll already loaded in Visual Studio
+/// (analyzers cannot be unloaded), throwing <see cref="System.MissingFieldException"/> for newly
+/// added rules. See https://github.com/thomhurst/TUnit/issues/6157.
+/// </remarks>
+public static class DiagnosticIds
+{
+    public const string MixAndOrConditionsAssertion = "TUnitAssertions0001";
+    public const string AwaitAssertion = "TUnitAssertions0002";
+    public const string CompilerArgumentsPopulated = "TUnitAssertions0003";
+    public const string DisposableUsingMultiple = "TUnitAssertions0004";
+    public const string ConstantValueInAssertThat = "TUnitAssertions0005";
+    public const string ObjectEqualsBaseMethod = "TUnitAssertions0006";
+    public const string DynamicValueInAssertThat = "TUnitAssertions0007";
+    public const string AwaitValueTaskInAssertThat = "TUnitAssertions0008";
+    public const string XUnitAssertion = "TUnitAssertions0009";
+    public const string GenerateAssertionMethodMustBeStatic = "TUnitAssertions0010";
+    public const string GenerateAssertionMethodMustHaveParameter = "TUnitAssertions0011";
+    public const string GenerateAssertionInvalidReturnType = "TUnitAssertions0012";
+    public const string GenerateAssertionShouldBeExtensionMethod = "TUnitAssertions0013";
+    public const string PreferIsNullOverIsEqualToNull = "TUnitAssertions0014";
+    public const string PreferIsTrueOrIsFalseOverIsEqualToBool = "TUnitAssertions0015";
+    public const string CollectionIsEqualToUsesReferenceEquality = "TUnitAssertions0016";
+}

--- a/TUnit.Assertions.Analyzers/DiagnosticIds.cs
+++ b/TUnit.Assertions.Analyzers/DiagnosticIds.cs
@@ -2,15 +2,12 @@ namespace TUnit.Assertions.Analyzers;
 
 /// <summary>
 /// Diagnostic ID constants for all TUnit assertions analyzer rules.
+/// Code fix providers MUST reference these constants instead of <c>Rules.X.Id</c> — consts are
+/// baked into the consuming IL at compile time, avoiding a runtime bind against a stale
+/// analyzer assembly in Visual Studio. See https://github.com/thomhurst/TUnit/issues/6157.
+/// Members MUST stay <c>const</c>: <c>static readonly</c> would reintroduce the runtime
+/// reference (and fails the IL regression tests).
 /// </summary>
-/// <remarks>
-/// Code fix providers (TUnit.Assertions.Analyzers.CodeFixers) MUST reference these constants instead
-/// of <c>Rules.X.Id</c>. Constants are baked into the consuming assembly at compile time, so the
-/// code fixers carry no runtime reference to the <see cref="Rules"/> type. A runtime reference
-/// can bind against a stale TUnit.Assertions.Analyzers.dll already loaded in Visual Studio
-/// (analyzers cannot be unloaded), throwing <see cref="System.MissingFieldException"/> for newly
-/// added rules. See https://github.com/thomhurst/TUnit/issues/6157.
-/// </remarks>
 public static class DiagnosticIds
 {
     public const string MixAndOrConditionsAssertion = "TUnitAssertions0001";

--- a/TUnit.Assertions.Analyzers/Rules.cs
+++ b/TUnit.Assertions.Analyzers/Rules.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 
 namespace TUnit.Assertions.Analyzers;
 
@@ -7,52 +7,52 @@ internal static class Rules
     private const string UsageCategory = "Usage";
 
     public static readonly DiagnosticDescriptor MixAndOrConditionsAssertion =
-        CreateDescriptor("TUnitAssertions0001", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.MixAndOrConditionsAssertion, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor AwaitAssertion =
-        CreateDescriptor("TUnitAssertions0002", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.AwaitAssertion, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor CompilerArgumentsPopulated =
-        CreateDescriptor("TUnitAssertions0003", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.CompilerArgumentsPopulated, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor DisposableUsingMultiple =
-        CreateDescriptor("TUnitAssertions0004", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.DisposableUsingMultiple, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor ConstantValueInAssertThat =
-        CreateDescriptor("TUnitAssertions0005", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.ConstantValueInAssertThat, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor ObjectEqualsBaseMethod =
-        CreateDescriptor("TUnitAssertions0006", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.ObjectEqualsBaseMethod, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor DynamicValueInAssertThat =
-        CreateDescriptor("TUnitAssertions0007", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.DynamicValueInAssertThat, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor AwaitValueTaskInAssertThat =
-        CreateDescriptor("TUnitAssertions0008", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.AwaitValueTaskInAssertThat, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor XUnitAssertion =
-        CreateDescriptor("TUnitAssertions0009", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.XUnitAssertion, UsageCategory, DiagnosticSeverity.Info);
 
     public static readonly DiagnosticDescriptor GenerateAssertionMethodMustBeStatic =
-        CreateDescriptor("TUnitAssertions0010", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.GenerateAssertionMethodMustBeStatic, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor GenerateAssertionMethodMustHaveParameter =
-        CreateDescriptor("TUnitAssertions0011", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.GenerateAssertionMethodMustHaveParameter, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor GenerateAssertionInvalidReturnType =
-        CreateDescriptor("TUnitAssertions0012", UsageCategory, DiagnosticSeverity.Error);
+        CreateDescriptor(DiagnosticIds.GenerateAssertionInvalidReturnType, UsageCategory, DiagnosticSeverity.Error);
 
     public static readonly DiagnosticDescriptor GenerateAssertionShouldBeExtensionMethod =
-        CreateDescriptor("TUnitAssertions0013", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.GenerateAssertionShouldBeExtensionMethod, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor PreferIsNullOverIsEqualToNull =
-        CreateDescriptor("TUnitAssertions0014", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.PreferIsNullOverIsEqualToNull, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor PreferIsTrueOrIsFalseOverIsEqualToBool =
-        CreateDescriptor("TUnitAssertions0015", UsageCategory, DiagnosticSeverity.Warning);
+        CreateDescriptor(DiagnosticIds.PreferIsTrueOrIsFalseOverIsEqualToBool, UsageCategory, DiagnosticSeverity.Warning);
 
     public static readonly DiagnosticDescriptor CollectionIsEqualToUsesReferenceEquality =
-        CreateDescriptor("TUnitAssertions0016", UsageCategory, DiagnosticSeverity.Info);
+        CreateDescriptor(DiagnosticIds.CollectionIsEqualToUsesReferenceEquality, UsageCategory, DiagnosticSeverity.Info);
 
     private static DiagnosticDescriptor CreateDescriptor(string diagnosticId, string category, DiagnosticSeverity severity)
     {


### PR DESCRIPTION
Fixes #6157

## Root cause

`TUnit.Analyzers.CodeFixers.dll` ships in the version-agnostic `analyzers/dotnet/cs` folder while `TUnit.Analyzers.dll` ships per-Roslyn (`analyzers/dotnet/roslyn4.x/cs`), and the code fixers reference the analyzers assembly at runtime (ProjectReference, resolved by simple name — the assemblies are not strong-named).

Visual Studio cannot unload analyzer assemblies. After a TUnit package update without a VS restart (or with mixed TUnit versions in one VS session), the **new** code fixers bind against a **stale** `TUnit.Analyzers.dll`. VS evaluates `FixableDiagnosticIds` eagerly on every lightbulb pass, which JITs the field reference `Rules.MSTestMigration` / `Rules.NUnitMigration` — fields added in #3195 that the stale assembly lacks — throwing `MissingFieldException` "at random parts of coding".

The heavy migration machinery (`TUnit.Analyzers.Migrators.Base.*`) is only touched lazily inside `RegisterCodeFixesAsync`, which can only run when the matching (new) analyzer reported the diagnostic — so decoupling the eager members removes the failure mode entirely.

The same latent landmine existed in `TUnit.Assertions.Analyzers.CodeFixers`.

## Fix

- New `DiagnosticIds` classes with `public const string` per rule in `TUnit.Analyzers` and `TUnit.Assertions.Analyzers`; `Rules.cs` consumes the constants (single source of truth).
- All code fixers now use `DiagnosticIds.X` (consts are baked into the consuming IL at compile time) instead of `Rules.X.Id`; the two lazy `Rules.X.Title` usages replaced with literals. Both code fixer assemblies now carry **zero** references to the `Rules` type.
- IL-level regression tests (`System.Reflection.Metadata`) assert the built code fixer dlls contain no `TypeReference` to `Rules` — any future `Rules.X.Id` reintroduction fails the test.

No behavior change: same diagnostic IDs, same code-fix titles (copied from resx).

## Testing

- `TUnit.Analyzers.Tests`: 705 passed, 0 failed, 1 skipped (pre-existing skip)
- `TUnit.Assertions.Analyzers.CodeFixers.Tests`: 19 passed, 0 failed
- All three Roslyn variant projects (4.4 / 4.7 / 4.14) build clean with the source-linked `DiagnosticIds.cs`

## User-facing note

Existing affected sessions are environmental (stale assembly already loaded): restarting VS after updating TUnit clears it. This change makes future version-skew sessions benign.