### PR TITLE
Add global mock default mode

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
+++ b/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
@@ -1294,7 +1294,7 @@ public class MockGeneratorTests : SnapshotTestBase
         AssertContains(
             generated,
             "public static global::Microsoft.Extensions.Configuration.IConfigurationMock Mock"
-            + "(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)");
+            + "(global::TUnit.Mocks.MockBehavior behavior)");
 
         return VerifyGeneratorOutput(source, [externalRef]);
     }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
@@ -127,7 +127,12 @@ namespace TUnit.Mocks
     {
         extension(global::StaticAbstractImpl _)
         {
-            public static global::TUnit.Mocks.Mock<global::StaticAbstractImpl> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::StaticAbstractImpl> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::StaticAbstractImpl>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::StaticAbstractImpl> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::StaticAbstractImpl>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
@@ -164,17 +164,32 @@ namespace TUnit.Mocks
     {
         extension(global::MyService _)
         {
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(connectionString, timeout);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, connectionString, timeout);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout, bool verbose, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout, bool verbose)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(connectionString, timeout, verbose);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string connectionString, int timeout, bool verbose, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, connectionString, timeout, verbose);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
@@ -109,7 +109,12 @@ namespace TUnit.Mocks
     {
         extension(global::ConfigBase _)
         {
-            public static global::TUnit.Mocks.Mock<global::ConfigBase> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::ConfigBase> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::ConfigBase>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::ConfigBase> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::ConfigBase>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
@@ -173,27 +173,52 @@ namespace TUnit.Mocks
     {
         extension(global::MyService _)
         {
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string name, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string name)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(name);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string name, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, name);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int id, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int id)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(id);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int id, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, id);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string host, int port, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string host, int port)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(host, port);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(string host, int port, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, host, port);
             }
 
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int timeout, bool verbose, global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int timeout, bool verbose)
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>(timeout, verbose);
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(int timeout, bool verbose, global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior, timeout, verbose);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
@@ -251,7 +251,12 @@ namespace TUnit.Mocks
     {
         extension(global::MyApp.IGreeter _)
         {
-            public static global::TUnit.Mocks.Generated.MyApp.IGreeterMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Generated.MyApp.IGreeterMock Mock()
+            {
+                return (global::TUnit.Mocks.Generated.MyApp.IGreeterMock)global::TUnit.Mocks.Generated.MyApp.IGreeterMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::TUnit.Mocks.Generated.MyApp.IGreeterMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::TUnit.Mocks.Generated.MyApp.IGreeterMock)global::TUnit.Mocks.Generated.MyApp.IGreeterMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/External_Interface_With_Indexer_Static_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/External_Interface_With_Indexer_Static_Extension_Discovery.verified.txt
@@ -271,7 +271,12 @@ namespace TUnit.Mocks
     {
         extension(global::Microsoft.Extensions.Configuration.IConfiguration _)
         {
-            public static global::Microsoft.Extensions.Configuration.IConfigurationMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Microsoft.Extensions.Configuration.IConfigurationMock Mock()
+            {
+                return (global::Microsoft.Extensions.Configuration.IConfigurationMock)global::Microsoft.Extensions.Configuration.IConfigurationMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Microsoft.Extensions.Configuration.IConfigurationMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Microsoft.Extensions.Configuration.IConfigurationMock)global::Microsoft.Extensions.Configuration.IConfigurationMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
@@ -139,7 +139,12 @@ namespace TUnit.Mocks
     {
         extension(global::MyService _)
         {
-            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::MyService>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::MyService> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::MyService>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
@@ -339,7 +339,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::IRepository<T> _)
         {
-            public static global::IRepository_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IRepository_T_Mock<T> Mock()
+            {
+                return (global::IRepository_T_Mock<T>)global::IRepository_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IRepository_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IRepository_T_Mock<T>)global::IRepository_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
@@ -251,7 +251,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::Sandbox.IFoo<T> _)
         {
-            public static global::Sandbox.IFoo_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Sandbox.IFoo_T_Mock<T> Mock()
+            {
+                return (global::Sandbox.IFoo_T_Mock<T>)global::Sandbox.IFoo_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Sandbox.IFoo_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Sandbox.IFoo_T_Mock<T>)global::Sandbox.IFoo_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
@@ -148,7 +148,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::Sandbox.IFoo<T> _)
         {
-            public static global::Sandbox.IFoo_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Sandbox.IFoo_T_Mock<T> Mock()
+            {
+                return (global::Sandbox.IFoo_T_Mock<T>)global::Sandbox.IFoo_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Sandbox.IFoo_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Sandbox.IFoo_T_Mock<T>)global::Sandbox.IFoo_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
@@ -245,7 +245,12 @@ namespace TUnit.Mocks
     {
         extension<TIn, TOut>(global::Sandbox.IMapper<TIn, TOut> _)
         {
-            public static global::Sandbox.IMapper_TIn_TOut_Mock<TIn, TOut> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Sandbox.IMapper_TIn_TOut_Mock<TIn, TOut> Mock()
+            {
+                return (global::Sandbox.IMapper_TIn_TOut_Mock<TIn, TOut>)global::Sandbox.IMapper_TIn_TOut_MockFactory.CreateAutoMock<TIn, TOut>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Sandbox.IMapper_TIn_TOut_Mock<TIn, TOut> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Sandbox.IMapper_TIn_TOut_Mock<TIn, TOut>)global::Sandbox.IMapper_TIn_TOut_MockFactory.CreateAutoMock<TIn, TOut>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
@@ -148,7 +148,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::Sandbox.IProvider<T> _)
         {
-            public static global::Sandbox.IProvider_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Sandbox.IProvider_T_Mock<T> Mock()
+            {
+                return (global::Sandbox.IProvider_T_Mock<T>)global::Sandbox.IProvider_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Sandbox.IProvider_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Sandbox.IProvider_T_Mock<T>)global::Sandbox.IProvider_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
@@ -251,7 +251,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::Sandbox.IService<T> _)
         {
-            public static global::Sandbox.IService_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::Sandbox.IService_T_Mock<T> Mock()
+            {
+                return (global::Sandbox.IService_T_Mock<T>)global::Sandbox.IService_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::Sandbox.IService_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::Sandbox.IService_T_Mock<T>)global::Sandbox.IService_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
@@ -265,7 +265,12 @@ namespace TUnit.Mocks
     {
         extension(global::ICustomCollection _)
         {
-            public static global::ICustomCollectionMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::ICustomCollectionMock Mock()
+            {
+                return (global::ICustomCollectionMock)global::ICustomCollectionMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::ICustomCollectionMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::ICustomCollectionMock)global::ICustomCollectionMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -234,7 +234,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDialogReference _)
         {
-            public static global::IDialogReferenceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDialogReferenceMock Mock()
+            {
+                return (global::IDialogReferenceMock)global::IDialogReferenceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDialogReferenceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDialogReferenceMock)global::IDialogReferenceMockFactory.CreateAutoMock(behavior);
             }
@@ -755,7 +760,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDialogService _)
         {
-            public static global::IDialogServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDialogServiceMock Mock()
+            {
+                return (global::IDialogServiceMock)global::IDialogServiceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDialogServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDialogServiceMock)global::IDialogServiceMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
@@ -143,7 +143,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::ITestEnum<T> _)
         {
-            public static global::ITestEnum_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::ITestEnum_T_Mock<T> Mock()
+            {
+                return (global::ITestEnum_T_Mock<T>)global::ITestEnum_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::ITestEnum_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::ITestEnum_T_Mock<T>)global::ITestEnum_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
@@ -264,7 +264,12 @@ namespace TUnit.Mocks
     {
         extension(global::IReadWriter _)
         {
-            public static global::IReadWriterMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IReadWriterMock Mock()
+            {
+                return (global::IReadWriterMock)global::IReadWriterMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IReadWriterMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IReadWriterMock)global::IReadWriterMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
@@ -166,7 +166,12 @@ namespace TUnit.Mocks
     {
         extension<T>(global::IPagedResult<T> _)
         {
-            public static global::IPagedResult_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IPagedResult_T_Mock<T> Mock()
+            {
+                return (global::IPagedResult_T_Mock<T>)global::IPagedResult_T_MockFactory.CreateAutoMock<T>(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IPagedResult_T_Mock<T> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IPagedResult_T_Mock<T>)global::IPagedResult_T_MockFactory.CreateAutoMock<T>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -621,7 +621,12 @@ namespace TUnit.Mocks
     {
         extension(global::IAsyncService _)
         {
-            public static global::IAsyncServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IAsyncServiceMock Mock()
+            {
+                return (global::IAsyncServiceMock)global::IAsyncServiceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IAsyncServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IAsyncServiceMock)global::IAsyncServiceMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
@@ -297,7 +297,12 @@ namespace TUnit.Mocks
     {
         extension(global::INotifier _)
         {
-            public static global::INotifierMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::INotifierMock Mock()
+            {
+                return (global::INotifierMock)global::INotifierMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::INotifierMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::INotifierMock)global::INotifierMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
@@ -309,7 +309,12 @@ namespace TUnit.Mocks
     {
         extension(global::IConstrained _)
         {
-            public static global::IConstrainedMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IConstrainedMock Mock()
+            {
+                return (global::IConstrainedMock)global::IConstrainedMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IConstrainedMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IConstrainedMock)global::IConstrainedMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -461,7 +461,12 @@ namespace TUnit.Mocks
     {
         extension(global::IRepository _)
         {
-            public static global::IRepositoryMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IRepositoryMock Mock()
+            {
+                return (global::IRepositoryMock)global::IRepositoryMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IRepositoryMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IRepositoryMock)global::IRepositoryMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
@@ -393,7 +393,12 @@ namespace TUnit.Mocks
     {
         extension(global::IEscapedNames _)
         {
-            public static global::IEscapedNamesMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IEscapedNamesMock Mock()
+            {
+                return (global::IEscapedNamesMock)global::IEscapedNamesMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IEscapedNamesMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IEscapedNamesMock)global::IEscapedNamesMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -367,7 +367,12 @@ namespace TUnit.Mocks
     {
         extension(global::ITest _)
         {
-            public static global::ITestMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::ITestMock Mock()
+            {
+                return (global::ITestMock)global::ITestMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::ITestMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::ITestMock)global::ITestMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -459,7 +459,12 @@ namespace TUnit.Mocks
     {
         extension(global::IService _)
         {
-            public static global::IServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IServiceMock Mock()
+            {
+                return (global::IServiceMock)global::IServiceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IServiceMock)global::IServiceMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
@@ -234,7 +234,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDualEvents _)
         {
-            public static global::IDualEventsMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDualEventsMock Mock()
+            {
+                return (global::IDualEventsMock)global::IDualEventsMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDualEventsMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDualEventsMock)global::IDualEventsMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
@@ -191,7 +191,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFoo _)
         {
-            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFooMock Mock()
+            {
+                return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
@@ -191,7 +191,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFoo _)
         {
-            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFooMock Mock()
+            {
+                return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
@@ -191,7 +191,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFoo _)
         {
-            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFooMock Mock()
+            {
+                return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -673,7 +673,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFoo _)
         {
-            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFooMock Mock()
+            {
+                return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
@@ -147,7 +147,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDeprecatedApi _)
         {
-            public static global::IDeprecatedApiMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDeprecatedApiMock Mock()
+            {
+                return (global::IDeprecatedApiMock)global::IDeprecatedApiMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDeprecatedApiMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDeprecatedApiMock)global::IDeprecatedApiMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -222,7 +222,12 @@ namespace TUnit.Mocks
     {
         extension(global::BaseDialog _)
         {
-            public static global::TUnit.Mocks.Mock<global::BaseDialog> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::BaseDialog> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::BaseDialog>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::BaseDialog> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::BaseDialog>(behavior);
             }
@@ -834,7 +839,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDialogService _)
         {
-            public static global::IDialogServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDialogServiceMock Mock()
+            {
+                return (global::IDialogServiceMock)global::IDialogServiceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDialogServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDialogServiceMock)global::IDialogServiceMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
@@ -359,7 +359,12 @@ namespace TUnit.Mocks
     {
         extension(global::IDictionary _)
         {
-            public static global::IDictionaryMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IDictionaryMock Mock()
+            {
+                return (global::IDictionaryMock)global::IDictionaryMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IDictionaryMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IDictionaryMock)global::IDictionaryMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
@@ -634,7 +634,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFormatter _)
         {
-            public static global::IFormatterMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFormatterMock Mock()
+            {
+                return (global::IFormatterMock)global::IFormatterMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFormatterMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFormatterMock)global::IFormatterMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
@@ -166,7 +166,12 @@ namespace TUnit.Mocks
     {
         extension(global::IRepository _)
         {
-            public static global::IRepositoryMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IRepositoryMock Mock()
+            {
+                return (global::IRepositoryMock)global::IRepositoryMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IRepositoryMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IRepositoryMock)global::IRepositoryMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
@@ -200,7 +200,12 @@ namespace TUnit.Mocks
     {
         extension(global::IBufferProcessor _)
         {
-            public static global::IBufferProcessorMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IBufferProcessorMock Mock()
+            {
+                return (global::IBufferProcessorMock)global::IBufferProcessorMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IBufferProcessorMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IBufferProcessorMock)global::IBufferProcessorMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
@@ -261,7 +261,12 @@ namespace TUnit.Mocks
     {
         extension(global::IMyService _)
         {
-            public static global::IMyServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IMyServiceMock Mock()
+            {
+                return (global::IMyServiceMock)global::IMyServiceMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IMyServiceMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IMyServiceMock)global::IMyServiceMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -260,7 +260,12 @@ namespace TUnit.Mocks
     {
         extension(global::IFoo _)
         {
-            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IFooMock Mock()
+            {
+                return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IFooMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IFooMock)global::IFooMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -408,7 +408,12 @@ namespace TUnit.Mocks
     {
         extension(global::ICalculator _)
         {
-            public static global::ICalculatorMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::ICalculatorMock Mock()
+            {
+                return (global::ICalculatorMock)global::ICalculatorMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::ICalculatorMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::ICalculatorMock)global::ICalculatorMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -267,7 +267,12 @@ namespace TUnit.Mocks
     {
         extension(global::ExternalLib.ExternalClient _)
         {
-            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ExternalClient>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ExternalClient>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
@@ -227,7 +227,12 @@ namespace TUnit.Mocks
     {
         extension(global::ExternalLib.ServiceClient _)
         {
-            public static global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ServiceClient>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ServiceClient>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
@@ -170,7 +170,12 @@ namespace TUnit.Mocks
     {
         extension(global::ExternalLib.ExternalResponse _)
         {
-            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ExternalResponse>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::ExternalLib.ExternalResponse>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -452,7 +452,12 @@ namespace TUnit.Mocks
     {
         extension(global::BaseService _)
         {
-            public static global::TUnit.Mocks.Mock<global::BaseService> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::BaseService> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::BaseService>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::BaseService> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::BaseService>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
@@ -363,7 +363,12 @@ namespace TUnit.Mocks
     {
         extension(global::SelfEquatableSnapshot _)
         {
-            public static global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> Mock()
+            {
+                return global::TUnit.Mocks.Mock.Of<global::SelfEquatableSnapshot>();
+            }
+
+            public static global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return global::TUnit.Mocks.Mock.Of<global::SelfEquatableSnapshot>(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
@@ -242,7 +242,12 @@ namespace TUnit.Mocks
     {
         extension(global::IGreeter _)
         {
-            public static global::IGreeterMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::IGreeterMock Mock()
+            {
+                return (global::IGreeterMock)global::IGreeterMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::IGreeterMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::IGreeterMock)global::IGreeterMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
@@ -248,7 +248,12 @@ namespace TUnit.Mocks
     {
         extension(global::INotifier _)
         {
-            public static global::INotifierMock Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)
+            public static global::INotifierMock Mock()
+            {
+                return (global::INotifierMock)global::INotifierMockFactory.CreateAutoMock(global::TUnit.Mocks.Mock.DefaultBehavior);
+            }
+
+            public static global::INotifierMock Mock(global::TUnit.Mocks.MockBehavior behavior)
             {
                 return (global::INotifierMock)global::INotifierMockFactory.CreateAutoMock(behavior);
             }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockStaticExtensionBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockStaticExtensionBuilder.cs
@@ -16,12 +16,19 @@ internal static class MockStaticExtensionBuilder
 
         return BuildCore(model, (writer, mockableType, visibility) =>
         {
-            using (writer.Block($"{visibility} static {globalPrefix}{MockImplBuilder.GetGeneratedTypeName($"{shortName}Mock", model)} Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)"))
-            {
-                var generatedMockType = $"{globalPrefix}{MockImplBuilder.GetGeneratedTypeName($"{shortName}Mock", model)}";
-                var factoryType = $"{globalPrefix}{shortName}MockFactory";
-                var typeArguments = MockImplBuilder.GetTypeParameterList(model);
+            var generatedMockType = $"{globalPrefix}{MockImplBuilder.GetGeneratedTypeName($"{shortName}Mock", model)}";
+            var factoryType = $"{globalPrefix}{shortName}MockFactory";
+            var typeArguments = MockImplBuilder.GetTypeParameterList(model);
 
+            using (writer.Block($"{visibility} static {generatedMockType} Mock()"))
+            {
+                writer.AppendLine($"return ({generatedMockType}){factoryType}.CreateAutoMock{typeArguments}(global::TUnit.Mocks.Mock.DefaultBehavior);");
+            }
+
+            writer.AppendLine();
+
+            using (writer.Block($"{visibility} static {generatedMockType} Mock(global::TUnit.Mocks.MockBehavior behavior)"))
+            {
                 writer.AppendLine($"return ({generatedMockType}){factoryType}.CreateAutoMock{typeArguments}(behavior);");
             }
         });
@@ -34,7 +41,14 @@ internal static class MockStaticExtensionBuilder
     {
         return BuildCore(model, (writer, mockableType, visibility) =>
         {
-            using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock(global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose)"))
+            using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock()"))
+            {
+                writer.AppendLine($"return global::TUnit.Mocks.Mock.Of<{mockableType}>();");
+            }
+
+            writer.AppendLine();
+
+            using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock(global::TUnit.Mocks.MockBehavior behavior)"))
             {
                 writer.AppendLine($"return global::TUnit.Mocks.Mock.Of<{mockableType}>(behavior);");
             }
@@ -50,14 +64,21 @@ internal static class MockStaticExtensionBuilder
 
                 writer.AppendLine();
 
-                var paramList = string.Join(", ",
-                    ctor.Parameters.Select(FormatParameter)
-                        .Append($"global::TUnit.Mocks.MockBehavior behavior = global::TUnit.Mocks.MockBehavior.Loose"));
+                var parameterListWithoutBehavior = string.Join(", ", ctor.Parameters.Select(FormatParameter));
+                var parameterListWithBehavior = string.Join(", ",
+                    ctor.Parameters.Select(FormatParameter).Append("global::TUnit.Mocks.MockBehavior behavior"));
 
                 var argList = string.Join(", ",
                     ctor.Parameters.Select(p => p.Name));
 
-                using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock({paramList})"))
+                using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock({parameterListWithoutBehavior})"))
+                {
+                    writer.AppendLine($"return global::TUnit.Mocks.Mock.Of<{mockableType}>({argList});");
+                }
+
+                writer.AppendLine();
+
+                using (writer.Block($"{visibility} static global::TUnit.Mocks.Mock<{mockableType}> Mock({parameterListWithBehavior})"))
                 {
                     writer.AppendLine($"return global::TUnit.Mocks.Mock.Of<{mockableType}>(behavior, {argList});");
                 }

--- a/TUnit.Mocks.Tests/KitchenSinkConcreteTests.cs
+++ b/TUnit.Mocks.Tests/KitchenSinkConcreteTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using TUnit.Mocks;
 using TUnit.Mocks.Arguments;
 using TUnit.Mocks.Verification;
@@ -514,5 +515,25 @@ public class KitchenSinkConcreteTests
         await Assert.That(mock.Object.Describe()).IsEqualTo("mocked");
         await Assert.That(mock.Object.Describe()).IsEqualTo("mocked");
         mock.Describe().WasCalled(Times.Exactly(2));
+    }
+
+    public class MyService
+    {
+        public IConfiguration Configuration { get; }
+
+        public MyService(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+    }
+
+
+    [Test]
+    public async Task IConfiguration_Param_Mock()
+    {
+        var configuration = IConfiguration.Mock();
+        var service = new MyService(configuration);
+
+        await Assert.That(service.Configuration).IsEqualTo(configuration);
     }
 }

--- a/TUnit.Mocks.Tests/MockSettingsTests.cs
+++ b/TUnit.Mocks.Tests/MockSettingsTests.cs
@@ -1,0 +1,77 @@
+using TUnit.Mocks.Exceptions;
+
+namespace TUnit.Mocks.Tests;
+
+[NotInParallel]
+public class MockSettingsTests
+{
+    private MockBehavior _savedDefaultMode;
+
+    [Before(HookType.Test)]
+    public void SnapshotSettings()
+    {
+        _savedDefaultMode = TUnitMocksSettings.Default.DefaultMode;
+    }
+
+    [After(HookType.Test)]
+    public void RestoreSettings()
+    {
+        TUnitMocksSettings.Default.DefaultMode = _savedDefaultMode;
+    }
+
+    [Test]
+    public async Task Default_Mode_Is_Loose()
+    {
+        await Assert.That(TUnitMocksSettings.Default.DefaultMode).IsEqualTo(MockBehavior.Loose);
+    }
+
+    [Test]
+    public async Task Default_Mode_Applies_To_Parameterless_Mock_Factories()
+    {
+        TUnitMocksSettings.Default.DefaultMode = MockBehavior.Strict;
+
+        var extensionMock = ICalculator.Mock();
+        var staticMock = Mock.Of<IGreeter>();
+        var repositoryMock = new MockRepository().Of<IRepoService>();
+
+        await Assert.That(Mock.Behavior(extensionMock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(staticMock)).IsEqualTo(MockBehavior.Strict);
+        await Assert.That(Mock.Behavior(repositoryMock)).IsEqualTo(MockBehavior.Strict);
+    }
+
+    [Test]
+    public async Task Explicit_Behavior_Overrides_Default_Mode()
+    {
+        TUnitMocksSettings.Default.DefaultMode = MockBehavior.Strict;
+
+        var mock = ICalculator.Mock(MockBehavior.Loose);
+
+        mock.Object.Add(1, 2);
+
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Loose);
+    }
+
+    [Test]
+    public async Task Strict_Default_Mode_Throws_For_Unconfigured_Calls()
+    {
+        TUnitMocksSettings.Default.DefaultMode = MockBehavior.Strict;
+
+        var mock = ICalculator.Mock();
+
+        var exception = Assert.Throws<MockStrictBehaviorException>(() => mock.Object.Add(1, 2));
+
+        await Assert.That(exception.UnconfiguredCall).Contains("Add");
+    }
+
+    [Test]
+    public async Task Repository_Default_Mode_Is_Resolved_When_Mock_Is_Created()
+    {
+        var repository = new MockRepository();
+
+        TUnitMocksSettings.Default.DefaultMode = MockBehavior.Strict;
+
+        var mock = repository.Of<IRepoService>();
+
+        await Assert.That(Mock.Behavior(mock)).IsEqualTo(MockBehavior.Strict);
+    }
+}

--- a/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
+++ b/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
@@ -8,6 +8,11 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\strongname.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />

--- a/TUnit.Mocks/Mock.cs
+++ b/TUnit.Mocks/Mock.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using TUnit.Mocks.Diagnostics;
 using TUnit.Mocks.Verification;
 
@@ -8,6 +9,14 @@ namespace TUnit.Mocks;
 /// </summary>
 public static class Mock
 {
+    /// <summary>Current default behavior used by parameterless mock factory APIs.</summary>
+    /// <remarks>
+    /// Hidden from IntelliSense because user code should configure this through
+    /// <c>context.Settings.Mocks.DefaultMode</c>; generated code and factory APIs use this as the runtime lookup.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static MockBehavior DefaultBehavior => TUnitMocksSettings.Default.DefaultMode;
+
     /// <summary>
     /// Retrieves the <see cref="Mock{T}"/> wrapper for a mock implementation object.
     /// Use this to access the mock wrapper from auto-mocked return values or any mocked object.
@@ -38,8 +47,8 @@ public static class Mock
             $"Mock.Get can only be used with objects created by Mock.Of, auto-mocking, or other Mock factory methods.");
     }
 
-    /// <summary>Creates a mock of T in loose mode.</summary>
-    public static Mock<T> Of<T>() where T : class => Of<T>(MockBehavior.Loose);
+    /// <summary>Creates a mock of T using the configured default behavior.</summary>
+    public static Mock<T> Of<T>() where T : class => Of<T>(DefaultBehavior);
 
     /// <summary>Creates a mock of T with specified behavior and custom default value provider.</summary>
     public static Mock<T> Of<T>(MockBehavior behavior, IDefaultValueProvider defaultValueProvider) where T : class
@@ -53,9 +62,9 @@ public static class Mock
     public static Mock<T> Of<T>(MockBehavior behavior) where T : class
         => Of<T>(behavior, Array.Empty<object>());
 
-    /// <summary>Creates a mock of T in loose mode, optionally passing constructor arguments for concrete classes.</summary>
+    /// <summary>Creates a mock of T using the configured default behavior, optionally passing constructor arguments for concrete classes.</summary>
     public static Mock<T> Of<T>(params object[] constructorArgs) where T : class
-        => Of<T>(MockBehavior.Loose, constructorArgs);
+        => Of<T>(DefaultBehavior, constructorArgs);
 
     /// <summary>Creates a mock of T with specified behavior, optionally passing constructor arguments for concrete classes.</summary>
     public static Mock<T> Of<T>(MockBehavior behavior, params object[] constructorArgs) where T : class
@@ -70,12 +79,12 @@ public static class Mock
             $"Ensure the TUnit.Mocks source generator is referenced in your project.");
     }
 
-    /// <summary>Creates a delegate mock of T in loose mode.</summary>
+    /// <summary>Creates a delegate mock of T using the configured default behavior.</summary>
     /// <remarks>
     /// Delegate parameters with <c>out</c> modifiers will always receive <c>default</c> values.
     /// Use interface mocks for full <c>out</c> parameter configuration support.
     /// </remarks>
-    public static Mock<T> OfDelegate<T>() where T : class => OfDelegate<T>(MockBehavior.Loose);
+    public static Mock<T> OfDelegate<T>() where T : class => OfDelegate<T>(DefaultBehavior);
 
     /// <summary>Creates a delegate mock of T with specified behavior.</summary>
     /// <remarks>
@@ -94,8 +103,8 @@ public static class Mock
             $"Ensure the TUnit.Mocks source generator is referenced and the type is a delegate type.");
     }
 
-    /// <summary>Creates a wrap mock around an existing instance of T in loose mode.</summary>
-    public static Mock<T> Wrap<T>(T instance) where T : class => Wrap(MockBehavior.Loose, instance);
+    /// <summary>Creates a wrap mock around an existing instance of T using the configured default behavior.</summary>
+    public static Mock<T> Wrap<T>(T instance) where T : class => Wrap(DefaultBehavior, instance);
 
     /// <summary>Creates a wrap mock around an existing instance of T with specified behavior.</summary>
     public static Mock<T> Wrap<T>(MockBehavior behavior, T instance) where T : class
@@ -110,10 +119,10 @@ public static class Mock
             $"Ensure the TUnit.Mocks source generator is referenced and the type is a non-sealed class with virtual members.");
     }
 
-    /// <summary>Creates a mock implementing both T1 and T2 in loose mode.</summary>
+    /// <summary>Creates a mock implementing both T1 and T2 using the configured default behavior.</summary>
     public static Mock<T1> Of<T1, T2>()
         where T1 : class where T2 : class
-        => Of<T1, T2>(MockBehavior.Loose);
+        => Of<T1, T2>(DefaultBehavior);
 
     /// <summary>Creates a mock implementing both T1 and T2 with specified behavior.</summary>
     public static Mock<T1> Of<T1, T2>(MockBehavior behavior)
@@ -130,10 +139,10 @@ public static class Mock
             $"Ensure the TUnit.Mocks source generator is referenced in your project.");
     }
 
-    /// <summary>Creates a mock implementing T1, T2, and T3 in loose mode.</summary>
+    /// <summary>Creates a mock implementing T1, T2, and T3 using the configured default behavior.</summary>
     public static Mock<T1> Of<T1, T2, T3>()
         where T1 : class where T2 : class where T3 : class
-        => Of<T1, T2, T3>(MockBehavior.Loose);
+        => Of<T1, T2, T3>(DefaultBehavior);
 
     /// <summary>Creates a mock implementing T1, T2, and T3 with specified behavior.</summary>
     public static Mock<T1> Of<T1, T2, T3>(MockBehavior behavior)
@@ -150,10 +159,10 @@ public static class Mock
             $"Ensure the TUnit.Mocks source generator is referenced in your project.");
     }
 
-    /// <summary>Creates a mock implementing T1, T2, T3, and T4 in loose mode.</summary>
+    /// <summary>Creates a mock implementing T1, T2, T3, and T4 using the configured default behavior.</summary>
     public static Mock<T1> Of<T1, T2, T3, T4>()
         where T1 : class where T2 : class where T3 : class where T4 : class
-        => Of<T1, T2, T3, T4>(MockBehavior.Loose);
+        => Of<T1, T2, T3, T4>(DefaultBehavior);
 
     /// <summary>Creates a mock implementing T1, T2, T3, and T4 with specified behavior.</summary>
     public static Mock<T1> Of<T1, T2, T3, T4>(MockBehavior behavior)

--- a/TUnit.Mocks/MockExtension.cs
+++ b/TUnit.Mocks/MockExtension.cs
@@ -17,7 +17,14 @@ public static class MockExtension
         /// will prefer it over this generic fallback.
         /// </summary>
         [OverloadResolutionPriority(-1)]
-        public static Mock<T> Mock(MockBehavior behavior = MockBehavior.Loose)
+        public static Mock<T> Mock()
+            => TUnit.Mocks.Mock.Of<T>();
+
+        /// <summary>
+        /// Creates a mock of <typeparamref name="T"/> with the specified behavior.
+        /// </summary>
+        [OverloadResolutionPriority(-1)]
+        public static Mock<T> Mock(MockBehavior behavior)
             => TUnit.Mocks.Mock.Of<T>(behavior);
     }
 }

--- a/TUnit.Mocks/MockRepository.cs
+++ b/TUnit.Mocks/MockRepository.cs
@@ -6,12 +6,14 @@ namespace TUnit.Mocks;
 /// </summary>
 public class MockRepository
 {
-    private readonly MockBehavior _defaultBehavior;
+    private readonly MockBehavior? _defaultBehavior;
     private readonly List<IMock> _mocks = new();
     private readonly Lock _lock = new();
 
-    /// <summary>Creates a repository with <see cref="MockBehavior.Loose"/> as the default behavior.</summary>
-    public MockRepository() : this(MockBehavior.Loose) { }
+    /// <summary>Creates a repository with the configured mock default behavior.</summary>
+    public MockRepository()
+    {
+    }
 
     /// <summary>Creates a repository with the specified default behavior for all mocks created through it.</summary>
     public MockRepository(MockBehavior defaultBehavior)
@@ -20,7 +22,7 @@ public class MockRepository
     }
 
     /// <summary>Creates and tracks a mock of T using the repository's default behavior.</summary>
-    public Mock<T> Of<T>() where T : class => Of<T>(_defaultBehavior);
+    public Mock<T> Of<T>() where T : class => Of<T>(EffectiveBehavior);
 
     /// <summary>Creates and tracks a mock of T with the specified behavior.</summary>
     public Mock<T> Of<T>(MockBehavior behavior) where T : class
@@ -28,7 +30,7 @@ public class MockRepository
 
     /// <summary>Creates and tracks a mock of T using the repository's default behavior, optionally passing constructor arguments for concrete classes.</summary>
     public Mock<T> Of<T>(params object[] constructorArgs) where T : class
-        => Of<T>(_defaultBehavior, constructorArgs);
+        => Of<T>(EffectiveBehavior, constructorArgs);
 
     /// <summary>Creates and tracks a mock of T with the specified behavior, optionally passing constructor arguments for concrete classes.</summary>
     public Mock<T> Of<T>(MockBehavior behavior, params object[] constructorArgs) where T : class
@@ -129,4 +131,6 @@ public class MockRepository
             return _mocks.ToArray();
         }
     }
+
+    private MockBehavior EffectiveBehavior => _defaultBehavior ?? Mock.DefaultBehavior;
 }

--- a/TUnit.Mocks/TUnit.Mocks.csproj
+++ b/TUnit.Mocks/TUnit.Mocks.csproj
@@ -10,6 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\TUnit.Core\TUnit.Core.csproj" />
         <ProjectReference Include="..\TUnit.Mocks.Analyzers\TUnit.Mocks.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 
         <None Include="$(MSBuildProjectDirectory)\..\TUnit.Mocks.Analyzers\bin\$(Configuration)\netstandard2.0\TUnit.Mocks.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />

--- a/TUnit.Mocks/TUnitMocksSettings.cs
+++ b/TUnit.Mocks/TUnitMocksSettings.cs
@@ -1,0 +1,29 @@
+using TUnit.Core.Settings;
+
+namespace TUnit.Mocks;
+
+public static class TUnitMocksSettingsExtensions
+{
+    extension(TUnitSettings _)
+    {
+        // TUnit.Mocks cannot add instance state to TUnitSettings, so package settings live in this singleton.
+        public TUnitMocksSettings Mocks => TUnitMocksSettings.Default;
+    }
+}
+
+public class TUnitMocksSettings
+{
+    internal static readonly TUnitMocksSettings Default = new();
+
+    internal TUnitMocksSettings()
+    {
+    }
+
+    /// <summary>
+    /// Default behavior used when creating mocks without an explicit <see cref="MockBehavior"/>.
+    /// </summary>
+    /// <remarks>
+    /// Configure this during test discovery, before tests create mocks.
+    /// </remarks>
+    public MockBehavior DefaultMode { get; set; } = MockBehavior.Loose;
+}

--- a/docs/docs/reference/programmatic-configuration.md
+++ b/docs/docs/reference/programmatic-configuration.md
@@ -14,6 +14,7 @@ Settings are organized into logical groups:
 - `Parallelism` — concurrent test execution limits
 - `Execution` — runtime behavior such as fail-fast
 - `Display` — output and display options
+- `Mocks` — defaults for TUnit.Mocks when the package is referenced
 
 ## Usage
 
@@ -21,6 +22,7 @@ Set values inside a `[Before(HookType.TestDiscovery)]` hook so they are applied 
 
 ```csharp
 using TUnit.Core;
+using TUnit.Mocks;
 
 public class TestSetup
 {
@@ -30,6 +32,7 @@ public class TestSetup
         context.Settings.Timeouts.DefaultTestTimeout = TimeSpan.FromMinutes(5);
         context.Settings.Timeouts.DefaultHookTimeout = TimeSpan.FromMinutes(2);
         context.Settings.Execution.FailFast = true;
+        context.Settings.Mocks.DefaultMode = MockBehavior.Strict;
 
         return Task.CompletedTask;
     }
@@ -68,6 +71,14 @@ Settings are accessed exclusively through `context.Settings` in the discovery ho
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `FailFast` | `bool` | `false` | Cancels the remaining test run after the first test failure. |
+
+### `context.Settings.Mocks`
+
+Available when `TUnit.Mocks` is referenced.
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `DefaultMode` | `MockBehavior` | `MockBehavior.Loose` | Default behavior for mocks created without an explicit mode. Set to `MockBehavior.Strict` to make unconfigured calls throw by default. |
 
 ## Precedence
 

--- a/docs/docs/writing-tests/mocking/index.md
+++ b/docs/docs/writing-tests/mocking/index.md
@@ -4,9 +4,9 @@ sidebar_position: 1
 
 # TUnit.Mocks
 
-TUnit.Mocks is a **standalone, source-generated, AOT-compatible** mocking framework. Because mocks are generated at compile time, it works with Native AOT, trimming, and single-file publishing — unlike traditional mocking libraries that rely on runtime proxy generation.
+TUnit.Mocks is a **source-generated, AOT-compatible** mocking framework. Because mocks are generated at compile time, it works with Native AOT, trimming, and single-file publishing — unlike traditional mocking libraries that rely on runtime proxy generation.
 
-While it integrates seamlessly with TUnit's assertion engine, TUnit.Mocks has **no dependency on the TUnit test framework** and works with any test runner — xUnit, NUnit, MSTest, or no framework at all.
+While it integrates seamlessly with TUnit's assertion engine, TUnit.Mocks does **not require the TUnit test runner** and works with any test runner — xUnit, NUnit, MSTest, or no framework at all.
 
 ## Installation
 
@@ -86,6 +86,31 @@ All factory methods accept an optional `MockBehavior` parameter:
 ```csharp
 var loose = IService.Mock();                           // loose (default)
 var strict = IService.Mock(MockBehavior.Strict);       // throws on unconfigured calls
+```
+
+### Global Default Mode
+
+In TUnit test projects, you can change the default mode for all mocks that are created without an explicit `MockBehavior`:
+
+```csharp
+using TUnit.Core;
+using TUnit.Mocks;
+
+public class GlobalSetup
+{
+    [Before(HookType.TestDiscovery)]
+    public static void Configure(BeforeTestDiscoveryContext context)
+    {
+        context.Settings.Mocks.DefaultMode = MockBehavior.Strict;
+    }
+}
+```
+
+With this setting, `IService.Mock()`, `Mock.Of<IService>()`, `Mock.Wrap(instance)`, `Mock.OfDelegate<T>()`, and `new MockRepository()` use strict mode by default. Passing a `MockBehavior` still overrides the global default:
+
+```csharp
+var strict = IService.Mock();                    // uses global strict default
+var loose = IService.Mock(MockBehavior.Loose);   // explicit override
 ```
 
 ### The Mock Wrapper


### PR DESCRIPTION
## Summary

Adds a `context.Settings.Mocks.DefaultMode` setting for TUnit.Mocks so projects can set strict mocks as the global default in a `[Before(HookType.TestDiscovery)]` hook.

The parameterless mock creation APIs now read the configured default mode, while overloads that accept `MockBehavior` continue to override it explicitly. Source-generated `T.Mock()` extensions now emit separate parameterless and explicit-behavior overloads so omitted behavior can be resolved at runtime.

This makes TUnit.Mocks reference TUnit.Core so the package can expose the settings extension on `TUnitSettings`.

Docs were updated with strict-mode configuration examples, and regression coverage was added for default mode behavior plus generated extension output.

## Validation

- `dotnet test TUnit.Mocks.Tests\TUnit.Mocks.Tests.csproj --no-restore`
- `dotnet test TUnit.Mocks.SourceGenerator.Tests\TUnit.Mocks.SourceGenerator.Tests.csproj --no-restore`