### PR TITLE
fix: resolve inherited instance data source members for MethodDataSource

### DIFF
--- a/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -1560,8 +1560,22 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
             return;
         }
 
-        // Find the data source method, property, or field
-        var dataSourceMember = targetType.GetMembers(methodName!).FirstOrDefault();
+        // Find the data source method, property, or field.
+        // Walk base types too: with [InheritsTests] (or a data member declared on a base class)
+        // the member may not be declared directly on the test class. Missing it here would emit
+        // a plain MethodDataSourceAttribute without a Factory, which falls back to
+        // Activator.CreateInstance at runtime and fails for classes without a parameterless
+        // constructor (https://github.com/thomhurst/TUnit/issues/6162).
+        ISymbol? dataSourceMember = null;
+        for (var searchType = targetType; searchType is not null; searchType = searchType.BaseType)
+        {
+            var members = searchType.GetMembers(methodName!);
+            if (members.Length > 0)
+            {
+                dataSourceMember = members[0];
+                break;
+            }
+        }
         var dataSourceMethod = dataSourceMember as IMethodSymbol;
         var dataSourceProperty = dataSourceMember as IPropertySymbol;
 

--- a/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
+++ b/TUnit.Core/Attributes/TestData/MethodDataSourceAttribute.cs
@@ -60,7 +60,7 @@ T>(string methodNameProvidingDataSource)
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
 {
-    private const BindingFlags BindingFlags = System.Reflection.BindingFlags.Public
+    internal const BindingFlags BindingFlags = System.Reflection.BindingFlags.Public
         | System.Reflection.BindingFlags.NonPublic
         | System.Reflection.BindingFlags.Static
         | System.Reflection.BindingFlags.Instance
@@ -126,6 +126,25 @@ public class MethodDataSourceAttribute : Attribute, IDataSourceAttribute
 
         ClassProvidingDataSource = classProvidingDataSource ?? throw new ArgumentNullException(nameof(classProvidingDataSource), "No class type was provided");
         MethodNameProvidingDataSource = methodNameProvidingDataSource;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="InstanceMethodDataSourceAttribute"/> copy of this attribute, preserving all
+    /// user-settable state. Used by reflection-mode discovery to mirror the conversion the source generator
+    /// performs at compile time for data sources that target instance members.
+    /// <see cref="Factory"/> is intentionally not copied: it is only populated by the source generator,
+    /// so it is always null on attributes discovered via reflection.
+    /// </summary>
+    internal InstanceMethodDataSourceAttribute ToInstanceVariant()
+    {
+        var converted = ClassProvidingDataSource is { } classProvidingDataSource
+            ? new InstanceMethodDataSourceAttribute(classProvidingDataSource, MethodNameProvidingDataSource)
+            : new InstanceMethodDataSourceAttribute(MethodNameProvidingDataSource);
+
+        converted.Arguments = Arguments;
+        converted.SkipIfEmpty = SkipIfEmpty;
+
+        return converted;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Method data sources require runtime discovery. AOT users should use Factory property.")]

--- a/TUnit.Engine/Discovery/ReflectionAttributeExtractor.cs
+++ b/TUnit.Engine/Discovery/ReflectionAttributeExtractor.cs
@@ -184,6 +184,81 @@ internal static class ReflectionAttributeExtractor
         return dataSources.ToArray();
     }
 
+    /// <summary>
+    /// Extracts method-level data sources, upgrading plain <see cref="MethodDataSourceAttribute"/>s that
+    /// target an instance member to <see cref="InstanceMethodDataSourceAttribute"/> so the engine creates
+    /// a properly-constructed instance instead of Activator.CreateInstance, mirroring the conversion the
+    /// source generator performs at compile time (https://github.com/thomhurst/TUnit/issues/6162).
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Reflection mode requires dynamic access")]
+    public static IDataSourceAttribute[] ExtractMethodDataSources(
+        MethodInfo testMethod,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)]
+        Type testClass)
+    {
+        var dataSources = ExtractDataSources(testMethod);
+
+        for (var i = 0; i < dataSources.Length; i++)
+        {
+            if (dataSources[i] is MethodDataSourceAttribute methodDataSource
+                and not InstanceMethodDataSourceAttribute
+                && TargetsInstanceMember(methodDataSource, testClass))
+            {
+                var converted = methodDataSource.ClassProvidingDataSource is { } classProvidingDataSource
+                    ? new InstanceMethodDataSourceAttribute(classProvidingDataSource, methodDataSource.MethodNameProvidingDataSource)
+                    : new InstanceMethodDataSourceAttribute(methodDataSource.MethodNameProvidingDataSource);
+
+                converted.Arguments = methodDataSource.Arguments;
+                converted.SkipIfEmpty = methodDataSource.SkipIfEmpty;
+
+                dataSources[i] = converted;
+            }
+        }
+
+        return dataSources;
+    }
+
+    // Must stay in sync with MethodDataSourceAttribute.BindingFlags so the static/instance
+    // pre-check here agrees with the member GetDataRowsAsync resolves at data-generation time.
+    private const BindingFlags DataSourceMemberBindingFlags = BindingFlags.Public
+        | BindingFlags.NonPublic
+        | BindingFlags.Static
+        | BindingFlags.Instance
+        | BindingFlags.FlattenHierarchy;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Reflection mode requires dynamic access")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Reflection mode requires dynamic access")]
+    private static bool TargetsInstanceMember(MethodDataSourceAttribute methodDataSource, Type testClass)
+    {
+        var targetType = methodDataSource.ClassProvidingDataSource ?? testClass;
+        var memberName = methodDataSource.MethodNameProvidingDataSource;
+
+        try
+        {
+            if (targetType.GetMethod(memberName, DataSourceMemberBindingFlags) is { } method)
+            {
+                return !method.IsStatic;
+            }
+        }
+        catch (AmbiguousMatchException)
+        {
+            // Ambiguous overloads - leave the attribute as-is and let runtime resolution handle it
+            return false;
+        }
+
+        if (targetType.GetProperty(memberName, DataSourceMemberBindingFlags) is { } property)
+        {
+            return property.GetMethod?.IsStatic != true;
+        }
+
+        if (targetType.GetField(memberName, DataSourceMemberBindingFlags) is { } field)
+        {
+            return !field.IsStatic;
+        }
+
+        return false;
+    }
+
     public static Attribute[] GetAllAttributes(Type testClass, MethodInfo testMethod)
     {
         return _allAttributesCache.GetOrAdd((testClass, testMethod), key =>

--- a/TUnit.Engine/Discovery/ReflectionAttributeExtractor.cs
+++ b/TUnit.Engine/Discovery/ReflectionAttributeExtractor.cs
@@ -204,27 +204,12 @@ internal static class ReflectionAttributeExtractor
                 and not InstanceMethodDataSourceAttribute
                 && TargetsInstanceMember(methodDataSource, testClass))
             {
-                var converted = methodDataSource.ClassProvidingDataSource is { } classProvidingDataSource
-                    ? new InstanceMethodDataSourceAttribute(classProvidingDataSource, methodDataSource.MethodNameProvidingDataSource)
-                    : new InstanceMethodDataSourceAttribute(methodDataSource.MethodNameProvidingDataSource);
-
-                converted.Arguments = methodDataSource.Arguments;
-                converted.SkipIfEmpty = methodDataSource.SkipIfEmpty;
-
-                dataSources[i] = converted;
+                dataSources[i] = methodDataSource.ToInstanceVariant();
             }
         }
 
         return dataSources;
     }
-
-    // Must stay in sync with MethodDataSourceAttribute.BindingFlags so the static/instance
-    // pre-check here agrees with the member GetDataRowsAsync resolves at data-generation time.
-    private const BindingFlags DataSourceMemberBindingFlags = BindingFlags.Public
-        | BindingFlags.NonPublic
-        | BindingFlags.Static
-        | BindingFlags.Instance
-        | BindingFlags.FlattenHierarchy;
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Reflection mode requires dynamic access")]
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Reflection mode requires dynamic access")]
@@ -233,27 +218,24 @@ internal static class ReflectionAttributeExtractor
         var targetType = methodDataSource.ClassProvidingDataSource ?? testClass;
         var memberName = methodDataSource.MethodNameProvidingDataSource;
 
-        try
+        // GetMember returns all matching members (it never throws AmbiguousMatchException for
+        // overloads, unlike GetMethod). Conservatively treat the data source as instance-targeting
+        // if ANY matching member is an instance member, so the engine pre-creates a properly
+        // constructed test class instance for it.
+        foreach (var member in targetType.GetMember(memberName, MethodDataSourceAttribute.BindingFlags))
         {
-            if (targetType.GetMethod(memberName, DataSourceMemberBindingFlags) is { } method)
+            var isStatic = member switch
             {
-                return !method.IsStatic;
+                MethodBase method => method.IsStatic,
+                PropertyInfo property => property.GetMethod?.IsStatic == true,
+                FieldInfo field => field.IsStatic,
+                _ => true
+            };
+
+            if (!isStatic)
+            {
+                return true;
             }
-        }
-        catch (AmbiguousMatchException)
-        {
-            // Ambiguous overloads - leave the attribute as-is and let runtime resolution handle it
-            return false;
-        }
-
-        if (targetType.GetProperty(memberName, DataSourceMemberBindingFlags) is { } property)
-        {
-            return property.GetMethod?.IsStatic != true;
-        }
-
-        if (targetType.GetField(memberName, DataSourceMemberBindingFlags) is { } field)
-        {
-            return !field.IsStatic;
         }
 
         return false;

--- a/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
+++ b/TUnit.Engine/Discovery/ReflectionTestDataCollector.cs
@@ -1090,7 +1090,7 @@ internal sealed class ReflectionTestDataCollector : ITestDataCollector
                 TestClassType = typeForGenericResolution, // Use resolved type for generic resolution (may be constructed generic base)
                 TestMethodName = testMethod.Name,
                 Dependencies = ReflectionAttributeExtractor.ExtractDependencies(testClass, testMethod),
-                DataSources = ReflectionAttributeExtractor.ExtractDataSources(testMethod),
+                DataSources = ReflectionAttributeExtractor.ExtractMethodDataSources(testMethod, testClass),
                 ClassDataSources = classData != null
                     ? [new StaticDataSourceAttribute(new[] { classData })]
                     : ReflectionAttributeExtractor.ExtractDataSources(testClass),

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1029,7 +1029,7 @@ namespace
             "rty.")]
         [.("Trimming", "IL2075", Justification="Method data sources require runtime discovery. AOT users should use Factory prope" +
             "rty.")]
-        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__21))]
+        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__22))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Class | .Method | .Property | .Parameter, AllowMultiple=true)]

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1029,7 +1029,7 @@ namespace
             "rty.")]
         [.("Trimming", "IL2075", Justification="Method data sources require runtime discovery. AOT users should use Factory prope" +
             "rty.")]
-        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__21))]
+        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__22))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Class | .Method | .Property | .Parameter, AllowMultiple=true)]

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1029,7 +1029,7 @@ namespace
             "rty.")]
         [.("Trimming", "IL2075", Justification="Method data sources require runtime discovery. AOT users should use Factory prope" +
             "rty.")]
-        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__21))]
+        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__22))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Class | .Method | .Property | .Parameter, AllowMultiple=true)]

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -992,7 +992,7 @@ namespace
         public <.DataGeneratorMetadata, .<<.<object?[]?>>>>? Factory { get; set; }
         public string MethodNameProvidingDataSource { get; }
         public bool SkipIfEmpty { get; set; }
-        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__21))]
+        [.(typeof(.MethodDataSourceAttribute.<GetDataRowsAsync>d__22))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Class | .Method | .Property | .Parameter, AllowMultiple=true)]

--- a/TUnit.TestProject/Bugs/6162/Tests.cs
+++ b/TUnit.TestProject/Bugs/6162/Tests.cs
@@ -1,0 +1,56 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6162;
+
+// Repro for https://github.com/thomhurst/TUnit/issues/6162
+// An instance MethodDataSource declared on an abstract base class, combined with
+// [InheritsTests] on a derived class whose instances are produced by a
+// DependencyInjectionDataSourceAttribute (no parameterless constructor),
+// previously fell back to Activator.CreateInstance and failed with
+// "No parameterless constructor defined".
+
+public interface IExportService
+{
+    string Export(string path);
+}
+
+public sealed class ExportService : IExportService
+{
+    public string Export(string path) => $"exported:{path}";
+}
+
+public sealed class SimpleDependencyInjectionAttribute : DependencyInjectionDataSourceAttribute<SimpleDependencyInjectionAttribute.Scope>
+{
+    public sealed class Scope;
+
+    public override Scope CreateScope(DataGeneratorMetadata dataGeneratorMetadata) => new();
+
+    public override object? Create(Scope scope, Type type)
+    {
+        if (type == typeof(IExportService))
+        {
+            return new ExportService();
+        }
+
+        return null;
+    }
+}
+
+public abstract class BaseExportTests(IExportService exportService)
+{
+    public IEnumerable<string> DocumentPaths => ["doc1", "doc2"];
+
+    [Test]
+    [MethodDataSource(nameof(DocumentPaths))]
+    public async Task Export_ReturnsResult(string path)
+    {
+        var result = exportService.Export(path);
+
+        await Assert.That(result).IsEqualTo($"exported:{path}");
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[InheritsTests]
+[SimpleDependencyInjection]
+public sealed class InheritedExportTests(IExportService exportService) : BaseExportTests(exportService);


### PR DESCRIPTION
## Summary

Fixes #6162 — `[MethodDataSource]` targeting an instance member, combined with `[InheritsTests]` and a class-level `DependencyInjectionDataSourceAttribute`, failed with:

```
Cannot dynamically create an instance of type '...'. Reason: No parameterless constructor defined.
   at TUnit.Core.MethodDataSourceAttribute.GetOrCreateInstanceAsync(...)
```

## Root cause

Both modes failed to recognise the data source as instance-targeting, so the engine never pre-created a properly-constructed test class instance (via the class-level data source) and `MethodDataSourceAttribute` fell back to `Activator.CreateInstance`:

- **Source-gen mode**: `GenerateMethodDataSourceAttribute` resolved the data source member with `GetMembers` on the test class symbol only — Roslyn's `GetMembers` does not include inherited members. With `[InheritsTests]` the member lives on a base class, so the lookup missed, and the generator emitted a plain `MethodDataSourceAttribute` without a `Factory` and without the `InstanceMethodDataSourceAttribute` conversion that triggers early instance creation.
- **Reflection mode**: extraction returned the raw attribute instance, which never gets upgraded to `InstanceMethodDataSourceAttribute` (the source generator normally does this at compile time), so the same `Activator.CreateInstance` fallback was hit — independent of `[InheritsTests]`.

## Changes

- `TestMetadataGenerator.cs`: walk the base-type chain (most-derived first) when resolving the data source member.
- `ReflectionAttributeExtractor.cs`: new `ExtractMethodDataSources` upgrades plain `MethodDataSourceAttribute`s targeting an instance member to `InstanceMethodDataSourceAttribute`, mirroring the source generator's compile-time conversion. Method-level only — class-level data sources keep their existing circular-dependency guard.
- `ReflectionTestDataCollector.cs`: use the new extraction for method-level data sources (single choke point — all reflection paths that build method-level data sources route through `BuildTestMetadata`).
- `TUnit.TestProject/Bugs/6162/Tests.cs`: regression test — abstract base with an instance property data source, inherited by a sealed class constructed via a DI data source.

## Verification

- Repro test: failed in both modes before, passes in both modes after
- `*MethodDataSource*` sweep (85 tests): identical results to `main` in both modes (1 pre-existing Bug3266 failure, stash-verified)
- `*Inherit*` sweep: 36/36 in both modes
- Source generator snapshot tests: 118 passed, no `.received.txt` produced
- `TUnit.Engine` and `TUnit.Core.SourceGenerator` build clean across all TFMs, no new IL trim warnings