### PR TITLE
fix(tests): snapshot ExecutionLog under lock to fix parallel race

### DIFF
--- a/TUnit.Example.Asp.Net.TestProject/ExecutionOrderReproductionTests.cs
+++ b/TUnit.Example.Asp.Net.TestProject/ExecutionOrderReproductionTests.cs
@@ -89,9 +89,17 @@ public class ExecutionOrderReproductionTests : WebApplicationTest<WebApplication
         await Assert.That(testConfigApplied).IsEqualTo("true")
             .Because("Test configuration should have been applied before API started");
 
-        // Print the execution log
+        // Print the execution log. Snapshot under the lock first: ExecutionLog is a
+        // shared static list and parallel test instances may Add() to it via their
+        // lifecycle hooks while we enumerate, which would throw "Collection was modified".
+        List<string> executionLogSnapshot;
+        lock (Lock)
+        {
+            executionLogSnapshot = ExecutionLog.ToList();
+        }
+
         Console.WriteLine("\n=== FULL EXECUTION LOG ===");
-        foreach (var entry in ExecutionLog)
+        foreach (var entry in executionLogSnapshot)
         {
             Console.WriteLine(entry);
         }


### PR DESCRIPTION
## Problem

`ExecutionOrderReproductionTests` (TUnit.Example.Asp.Net.TestProject) intermittently fails on CI with:

```
InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
```

Observed on `modularpipeline (ubuntu-latest)` (e.g. PR #6188, where it is unrelated to the change under test).

## Root cause

`ExecutionLog` is a shared `static List<string>`. `Log()` takes a lock when **writing**, but the final `foreach (var entry in ExecutionLog)` enumerated the list **without** the lock. Tests in the class run in parallel, and their lifecycle hooks (`ConfigureTestOptions`, `SetupAsync`, `ConfigureTestConfiguration`, …) all call `Log()` → `Add()`. One instance mutating the list while another enumerates it throws.

## Fix

Snapshot the list under the lock before enumerating. Test-only change.