### PR TITLE
fix(engine): run lifecycle hooks before test class construction (#6192)

### DIFF
--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -133,6 +133,11 @@ internal sealed class TestCoordinator : ITestCoordinator
                     // constructor (#6192). Hook tasks are cached, so ExecuteAsync's later awaits are no-ops.
                     await _testExecutor.EnsureClassAndAssemblyHooksExecutedAsync(test, cancellationToken).ConfigureAwait(false);
 
+                    // Flow AsyncLocals captured by Before(Assembly)/Before(Class) hooks into the
+                    // constructor. Must run here (not inside the gate above) so the restored ambient
+                    // ExecutionContext is still in effect when CreateInstanceAsync runs the constructor.
+                    test.Context.ClassContext.RestoreExecutionContext();
+
                     test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 
                     // Drop the cached eligible-objects list so any later consumer rebuilds it with the new ClassInstance included — the initial list was built before the instance existed.
@@ -358,6 +363,11 @@ internal sealed class TestCoordinator : ITestCoordinator
         // Run Before(TestSession/Assembly/Class) hooks (incl. BeforeEvery) before constructing the
         // instance so hooks precede the constructor (#6192). Cached, so ExecuteAsync re-awaits are no-ops.
         await _testExecutor.EnsureClassAndAssemblyHooksExecutedAsync(test, cancellationToken).ConfigureAwait(false);
+
+        // Flow AsyncLocals captured by Before(Assembly)/Before(Class) hooks into the constructor.
+        // Must run here (not inside the gate above) so the restored ambient ExecutionContext is still
+        // in effect when CreateInstanceAsync runs the constructor.
+        test.Context.ClassContext.RestoreExecutionContext();
 
         test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -128,6 +128,11 @@ internal sealed class TestCoordinator : ITestCoordinator
                 }
                 else
                 {
+                    // Run Before(TestSession/Assembly/Class) hooks (incl. BeforeEvery) before constructing
+                    // the instance so the documented lifecycle contract holds — hooks precede the
+                    // constructor (#6192). Hook tasks are cached, so ExecuteAsync's later awaits are no-ops.
+                    await _testExecutor.EnsureClassAndAssemblyHooksExecutedAsync(test, cancellationToken).ConfigureAwait(false);
+
                     test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 
                     // Drop the cached eligible-objects list so any later consumer rebuilds it with the new ClassInstance included — the initial list was built before the instance existed.
@@ -349,6 +354,10 @@ internal sealed class TestCoordinator : ITestCoordinator
 
             return;
         }
+
+        // Run Before(TestSession/Assembly/Class) hooks (incl. BeforeEvery) before constructing the
+        // instance so hooks precede the constructor (#6192). Cached, so ExecuteAsync re-awaits are no-ops.
+        await _testExecutor.EnsureClassAndAssemblyHooksExecutedAsync(test, cancellationToken).ConfigureAwait(false);
 
         test.Context.Metadata.TestDetails.ClassInstance = await test.CreateInstanceAsync().ConfigureAwait(false);
 

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -27,6 +27,11 @@ internal class TestExecutor
     private readonly IContextProvider _contextProvider;
     private readonly EventReceiverOrchestrator _eventReceiverOrchestrator;
 
+    // Cached hook-factory delegates so the per-test before-hook awaits don't allocate a fresh closure
+    // each time (these run on the hot path and the factory is only invoked on the first cache miss).
+    private readonly Func<CancellationToken, ValueTask> _beforeTestSessionHookFactory;
+    private readonly Func<Assembly, CancellationToken, ValueTask> _beforeAssemblyHookFactory;
+
     public TestExecutor(
         HookExecutor hookExecutor,
         TestLifecycleCoordinator lifecycleCoordinator,
@@ -41,6 +46,9 @@ internal class TestExecutor
         _afterHookPairTracker = afterHookPairTracker;
         _contextProvider = contextProvider;
         _eventReceiverOrchestrator = eventReceiverOrchestrator;
+
+        _beforeTestSessionHookFactory = ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct);
+        _beforeAssemblyHookFactory = (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct);
     }
 
 
@@ -53,7 +61,7 @@ internal class TestExecutor
     {
         // Get or create and cache Before hooks - these run only once
         await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
-            ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct),
+            _beforeTestSessionHookFactory,
             cancellationToken).ConfigureAwait(false);
 
         // Register After Session hook to run on cancellation (guarantees cleanup)
@@ -73,10 +81,9 @@ internal class TestExecutor
     public async ValueTask EnsureClassAndAssemblyHooksExecutedAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
     {
         var testClass = test.Metadata.TestClassType;
-        var testAssembly = testClass.Assembly;
 
         await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
-            ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct),
+            _beforeTestSessionHookFactory,
             cancellationToken).ConfigureAwait(false);
 
         // Flow AsyncLocals captured by BeforeTestSession into the BeforeAssembly hook, and likewise
@@ -86,8 +93,8 @@ internal class TestExecutor
         test.Context.ClassContext.AssemblyContext.TestSessionContext.RestoreExecutionContext();
 
         await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
-            testAssembly,
-            (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct),
+            testClass.Assembly,
+            _beforeAssemblyHookFactory,
             cancellationToken).ConfigureAwait(false);
 
         test.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
@@ -121,7 +128,7 @@ internal class TestExecutor
 
             await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
                 testAssembly,
-                (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct),
+                _beforeAssemblyHookFactory,
                 cancellationToken).ConfigureAwait(false);
 
             // Register After Assembly hook to run on cancellation (guarantees cleanup)

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -57,7 +57,7 @@ internal class TestExecutor
     /// This is called before creating test instances to ensure resources are available.
     /// Registers the corresponding After(TestSession) hook to run on cancellation.
     /// </summary>
-    public async Task EnsureTestSessionHooksExecutedAsync(CancellationToken cancellationToken)
+    public async ValueTask EnsureTestSessionHooksExecutedAsync(CancellationToken cancellationToken)
     {
         // Get or create and cache Before hooks - these run only once
         await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
@@ -100,6 +100,11 @@ internal class TestExecutor
         test.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
 
         await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+
+        // Note: the caller (TestCoordinator) restores ClassContext.RestoreExecutionContext() right
+        // before constructing the instance so AsyncLocals captured by BeforeAssembly/BeforeClass flow
+        // into the constructor. Restoring here wouldn't persist — the ambient ExecutionContext is
+        // reset when this async method returns to the caller.
     }
 
     /// <summary>

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -63,6 +63,39 @@ internal class TestExecutor
     }
 
     /// <summary>
+    /// Ensures Before(TestSession), Before(Assembly) and Before(Class) hooks (including their
+    /// BeforeEvery counterparts) have executed before the test class instance is constructed, so the
+    /// documented lifecycle contract (hooks run before instantiation) holds — see issue #6192.
+    /// The hook tasks are cached in <see cref="BeforeHookTaskCache"/>, so the matching awaits later in
+    /// <see cref="ExecuteAsync"/> are no-ops. Only the pure cached getters are invoked here; the
+    /// After-hook pair registration stays single-sourced in ExecuteAsync to avoid double-registration.
+    /// </summary>
+    public async ValueTask EnsureClassAndAssemblyHooksExecutedAsync(AbstractExecutableTest test, CancellationToken cancellationToken)
+    {
+        var testClass = test.Metadata.TestClassType;
+        var testAssembly = testClass.Assembly;
+
+        await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
+            ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct),
+            cancellationToken).ConfigureAwait(false);
+
+        // Flow AsyncLocals captured by BeforeTestSession into the BeforeAssembly hook, and likewise
+        // BeforeAssembly into BeforeClass. This mirrors the RestoreExecutionContext chain in
+        // ExecuteAsync (the assembly/class hook tasks are cached, so when ExecuteAsync re-awaits them
+        // it re-applies the same captured contexts).
+        test.Context.ClassContext.AssemblyContext.TestSessionContext.RestoreExecutionContext();
+
+        await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
+            testAssembly,
+            (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct),
+            cancellationToken).ConfigureAwait(false);
+
+        test.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
+
+        await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Creates a test executor delegate that wraps the provided executor with hook orchestration.
     /// Uses focused services that follow SRP to manage lifecycle and execution.
     /// </summary>

--- a/TUnit.TestProject/Bugs/6192/Bug6192Tests.cs
+++ b/TUnit.TestProject/Bugs/6192/Bug6192Tests.cs
@@ -1,20 +1,30 @@
+using System.Threading;
 using TUnit.TestProject.Attributes;
 
 namespace TUnit.TestProject.Bugs._6192;
 
 // Regression test for #6192: lifecycle hooks must run BEFORE the test class is constructed.
-// Previously the constructor ran before BeforeEvery(Assembly)/BeforeEvery(Class), so the
-// assertions in the constructor below would throw.
+// Previously the constructor ran before Before(Assembly)/Before(Class) (and their BeforeEvery
+// counterparts), so the assertions in the constructors below would throw.
 
 public class Bug6192HookOrderProbe
 {
-    public static bool BeforeEveryClassRan;
-    public static bool BeforeEveryAssemblyRan;
+    // volatile to make the happens-before intent explicit (the framework's task-caching already
+    // provides the edge between hook completion and the constructor that reads these).
+    public static volatile bool BeforeEveryClassRan;
+    public static volatile bool BeforeEveryAssemblyRan;
+    public static volatile bool BeforeClassRan;
+    public static volatile bool BeforeAssemblyRan;
+
+    // AsyncLocal set inside a [Before(Class)] hook (which opts in via context.AddAsyncLocalValues()).
+    // Its value must flow into the constructor, which proves ClassContext.RestoreExecutionContext()
+    // runs before construction in the pre-construction hook gate (#6192 / review feedback).
+    public static readonly AsyncLocal<string?> ClassHookAsyncLocal = new();
 
     [BeforeEvery(Class)]
     public static void BeforeEveryClass(ClassHookContext context)
     {
-        if (context.ClassType == typeof(Bug6192Tests))
+        if (context.ClassType == typeof(Bug6192Tests) || context.ClassType == typeof(Bug6192RetryTests))
         {
             BeforeEveryClassRan = true;
         }
@@ -33,6 +43,19 @@ public class Bug6192HookOrderProbe
 [EngineTest(ExpectedResult.Pass)]
 public class Bug6192Tests
 {
+    // Non-BeforeEvery hooks go through the same cache path; assert they precede the constructor too.
+    [Before(Assembly)]
+    public static void BeforeAssembly() => Bug6192HookOrderProbe.BeforeAssemblyRan = true;
+
+    [Before(Class)]
+    public static void BeforeClass(ClassHookContext context)
+    {
+        Bug6192HookOrderProbe.BeforeClassRan = true;
+        Bug6192HookOrderProbe.ClassHookAsyncLocal.Value = "set-by-before-class";
+        // Opt in to flowing this AsyncLocal forward (otherwise TUnit doesn't capture it).
+        context.AddAsyncLocalValues();
+    }
+
     public Bug6192Tests()
     {
         // The constructor must run AFTER the lifecycle hooks (issue #6192).
@@ -45,6 +68,23 @@ public class Bug6192Tests
         {
             throw new InvalidOperationException("Constructor ran before [BeforeEvery(Class)] hook");
         }
+
+        if (!Bug6192HookOrderProbe.BeforeAssemblyRan)
+        {
+            throw new InvalidOperationException("Constructor ran before [Before(Assembly)] hook");
+        }
+
+        if (!Bug6192HookOrderProbe.BeforeClassRan)
+        {
+            throw new InvalidOperationException("Constructor ran before [Before(Class)] hook");
+        }
+
+        // AsyncLocals captured by a class-level hook must flow into the constructor, otherwise the
+        // hook ran but ClassContext.RestoreExecutionContext() did not run before construction.
+        if (Bug6192HookOrderProbe.ClassHookAsyncLocal.Value != "set-by-before-class")
+        {
+            throw new InvalidOperationException("Before(Class) AsyncLocal did not flow into the constructor");
+        }
     }
 
     [Test]
@@ -54,6 +94,40 @@ public class Bug6192Tests
 
     [Test]
     public void TestB()
+    {
+    }
+}
+
+// Same contract must hold on the retry code path (ExecuteTestLifecycleAsync), which has its own
+// pre-construction hook gate separate from the no-retry fast path.
+[EngineTest(ExpectedResult.Pass)]
+public class Bug6192RetryTests
+{
+    public static readonly AsyncLocal<string?> ClassHookAsyncLocal = new();
+
+    [Before(Class)]
+    public static void BeforeClass(ClassHookContext context)
+    {
+        ClassHookAsyncLocal.Value = "set-by-before-class-retry";
+        context.AddAsyncLocalValues();
+    }
+
+    public Bug6192RetryTests()
+    {
+        if (!Bug6192HookOrderProbe.BeforeEveryClassRan)
+        {
+            throw new InvalidOperationException("Constructor ran before [BeforeEvery(Class)] hook (retry path)");
+        }
+
+        if (ClassHookAsyncLocal.Value != "set-by-before-class-retry")
+        {
+            throw new InvalidOperationException("Before(Class) AsyncLocal did not flow into the constructor (retry path)");
+        }
+    }
+
+    [Retry(1)]
+    [Test]
+    public void RetriedTest()
     {
     }
 }

--- a/TUnit.TestProject/Bugs/6192/Bug6192Tests.cs
+++ b/TUnit.TestProject/Bugs/6192/Bug6192Tests.cs
@@ -1,0 +1,59 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6192;
+
+// Regression test for #6192: lifecycle hooks must run BEFORE the test class is constructed.
+// Previously the constructor ran before BeforeEvery(Assembly)/BeforeEvery(Class), so the
+// assertions in the constructor below would throw.
+
+public class Bug6192HookOrderProbe
+{
+    public static bool BeforeEveryClassRan;
+    public static bool BeforeEveryAssemblyRan;
+
+    [BeforeEvery(Class)]
+    public static void BeforeEveryClass(ClassHookContext context)
+    {
+        if (context.ClassType == typeof(Bug6192Tests))
+        {
+            BeforeEveryClassRan = true;
+        }
+    }
+
+    [BeforeEvery(Assembly)]
+    public static void BeforeEveryAssembly(AssemblyHookContext context)
+    {
+        if (context.Assembly == typeof(Bug6192Tests).Assembly)
+        {
+            BeforeEveryAssemblyRan = true;
+        }
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public class Bug6192Tests
+{
+    public Bug6192Tests()
+    {
+        // The constructor must run AFTER the lifecycle hooks (issue #6192).
+        if (!Bug6192HookOrderProbe.BeforeEveryAssemblyRan)
+        {
+            throw new InvalidOperationException("Constructor ran before [BeforeEvery(Assembly)] hook");
+        }
+
+        if (!Bug6192HookOrderProbe.BeforeEveryClassRan)
+        {
+            throw new InvalidOperationException("Constructor ran before [BeforeEvery(Class)] hook");
+        }
+    }
+
+    [Test]
+    public void TestA()
+    {
+    }
+
+    [Test]
+    public void TestB()
+    {
+    }
+}


### PR DESCRIPTION
Fixes #6192.

## Problem

The documented lifecycle contract says hooks run **before** test-class instantiation, but the constructor was running **before** `BeforeEveryAssembly`/`BeforeEveryClass` (and `Before(Assembly)`/`Before(Class)`).

**Root cause:** `TestCoordinator` called `CreateInstanceAsync()` (the constructor) *before* `TestExecutor.ExecuteAsync()`, and the before-hooks live inside `ExecuteAsync` (`GetOrCreateBeforeAssemblyTask`/`GetOrCreateBeforeClassTask`). So construction always preceded the hooks. The repro has no data sources, so this is purely execution-time ordering — the "constructor twice" in the report is just the two tests, each constructed once before the hooks.

## Fix

The before-hook tasks are already cached/idempotent in `BeforeHookTaskCache`, so they can be awaited earlier without re-running. New `TestExecutor.EnsureClassAndAssemblyHooksExecutedAsync` runs the cached `Before(TestSession/Assembly/Class)` tasks, and `TestCoordinator` calls it immediately before `CreateInstanceAsync` on both the no-retry fast path and the retry path. `ExecuteAsync`'s subsequent hook awaits become no-ops; the non-cached `FirstTestIn*` event receivers and `RegisterAfter*` pairs stay exactly where they were.

The helper replays the `RestoreExecutionContext` chain between hook awaits (mirroring `ExecuteAsync`) so AsyncLocals still flow `BeforeTestSession` → `BeforeAssembly` → `BeforeClass`.

## Tests

- New self-validating regression test `Bugs/6192/Bug6192Tests.cs`: the constructor throws if `BeforeEvery(Assembly)`/`BeforeEvery(Class)` have not yet run. Fails before the fix, passes after.
- Verified no regression across the lifecycle/hook suites (`Bugs/1914` AsyncLocal flow, `BeforeTests/*`, `Bugs/4432` constructor injection, `Bugs/_2804` hook cleanup), in **both** source-generated and reflection modes.

Engine-only change — no source-generator or snapshot changes.
