### PR TITLE
perf: reduce allocations in source-gen test building hot paths

### DIFF
--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -23,7 +23,8 @@ public static class DataSourceHelpers
             return null;
         }
 
-        if(value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(Func<>))
+        var type = value.GetType();
+        if(type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Func<>))
         {
             return ((Delegate)value).DynamicInvoke();
         }
@@ -426,30 +427,16 @@ public static class DataSourceHelpers
         // Try to use ITuple interface first for any ValueTuple type
         if (value is ITuple tuple)
         {
-            var result = new List<object?>();
-            var typeIndex = 0;
+            // Elements map 1:1 to expected parameters; nested tuples are kept as-is
+            var count = Math.Min(tuple.Length, expectedTypes.Length);
+            var result = new object?[count];
 
-            for (var i = 0; i < tuple.Length && typeIndex < expectedTypes.Length; i++)
+            for (var i = 0; i < count; i++)
             {
-                var element = tuple[i];
-                var expectedType = expectedTypes[typeIndex];
-
-                // Check if the expected type is a tuple type
-                if (TupleHelper.IsTupleType(expectedType) && IsTuple(element))
-                {
-                    // Keep nested tuple as-is
-                    result.Add(element);
-                    typeIndex++;
-                }
-                else
-                {
-                    // Add element normally
-                    result.Add(element);
-                    typeIndex++;
-                }
+                result[i] = tuple[i];
             }
 
-            return result.ToArray();
+            return result;
         }
 #endif
 

--- a/TUnit.Core/Helpers/DataSourceHelpers.cs
+++ b/TUnit.Core/Helpers/DataSourceHelpers.cs
@@ -75,6 +75,18 @@ public static class DataSourceHelpers
         return [() => Task.FromResult<object?>(value)];
     }
 
+#if NET5_0_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    private static object?[] CopyTupleElements(ITuple tuple, int count)
+    {
+        var result = new object?[count];
+        for (var i = 0; i < count; i++)
+        {
+            result[i] = tuple[i];
+        }
+        return result;
+    }
+#endif
+
     /// <summary>
     /// AOT-compatible tuple unwrapping that handles common tuple types without reflection
     /// </summary>
@@ -89,13 +101,7 @@ public static class DataSourceHelpers
         // Try to use ITuple interface first for any ValueTuple type (available in .NET Core 3.0+)
         if (value is ITuple tuple)
         {
-            var length = tuple.Length;
-            var result = new object?[length];
-            for (var i = 0; i < length; i++)
-            {
-                result[i] = tuple[i];
-            }
-            return result;
+            return CopyTupleElements(tuple, tuple.Length);
         }
 #endif
 
@@ -427,16 +433,8 @@ public static class DataSourceHelpers
         // Try to use ITuple interface first for any ValueTuple type
         if (value is ITuple tuple)
         {
-            // Elements map 1:1 to expected parameters; nested tuples are kept as-is
-            var count = Math.Min(tuple.Length, expectedTypes.Length);
-            var result = new object?[count];
-
-            for (var i = 0; i < count; i++)
-            {
-                result[i] = tuple[i];
-            }
-
-            return result;
+            // Elements are copied 1:1, capped at the expected parameter count
+            return CopyTupleElements(tuple, Math.Min(tuple.Length, expectedTypes.Length));
         }
 #endif
 

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -173,15 +173,7 @@ internal sealed class TestBuilder : ITestBuilder
             TestBuilderContext.Current = testBuilderContext;
 
             // Check for ClassConstructor attribute and set it early if present (reuse already created attributes)
-            ClassConstructorAttribute? classConstructorAttribute = null;
-            foreach (var attr in attributes)
-            {
-                if (attr is ClassConstructorAttribute cca)
-                {
-                    classConstructorAttribute = cca;
-                    break;
-                }
-            }
+            var classConstructorAttribute = attributes.FirstOfType<ClassConstructorAttribute>();
             if (classConstructorAttribute != null)
             {
                 testBuilderContext.ClassConstructor = (IClassConstructor)Activator.CreateInstance(classConstructorAttribute.ClassConstructorType)!;
@@ -1605,15 +1597,7 @@ internal sealed class TestBuilder : ITestBuilder
         // Check for ClassConstructor attribute and set it early if present
         // Look for any attribute that inherits from ClassConstructorAttribute
         // This handles both ClassConstructorAttribute and ClassConstructorAttribute<T>
-        ClassConstructorAttribute? classConstructorAttribute = null;
-        foreach (var attribute in attributes)
-        {
-            if (attribute is ClassConstructorAttribute cca)
-            {
-                classConstructorAttribute = cca;
-                break;
-            }
-        }
+        var classConstructorAttribute = attributes.FirstOfType<ClassConstructorAttribute>();
 
         if (classConstructorAttribute != null)
         {

--- a/TUnit.Engine/Building/TestBuilder.cs
+++ b/TUnit.Engine/Building/TestBuilder.cs
@@ -1605,10 +1605,15 @@ internal sealed class TestBuilder : ITestBuilder
         // Check for ClassConstructor attribute and set it early if present
         // Look for any attribute that inherits from ClassConstructorAttribute
         // This handles both ClassConstructorAttribute and ClassConstructorAttribute<T>
-        var classConstructorAttribute = attributes
-            .Where(a => a is ClassConstructorAttribute)
-            .Cast<ClassConstructorAttribute>()
-            .FirstOrDefault();
+        ClassConstructorAttribute? classConstructorAttribute = null;
+        foreach (var attribute in attributes)
+        {
+            if (attribute is ClassConstructorAttribute cca)
+            {
+                classConstructorAttribute = cca;
+                break;
+            }
+        }
 
         if (classConstructorAttribute != null)
         {

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -7,6 +7,7 @@ using TUnit.Core.Helpers;
 using TUnit.Core.Interfaces;
 using TUnit.Core.Services;
 using TUnit.Engine.Building.Interfaces;
+using TUnit.Engine.Extensions;
 using TUnit.Engine.Services;
 using TUnit.Engine.Utilities;
 
@@ -56,15 +57,7 @@ internal sealed class TestBuilderPipeline
 
         // Look for any attribute that inherits from ClassConstructorAttribute
         // This handles both ClassConstructorAttribute and ClassConstructorAttribute<T>
-        ClassConstructorAttribute? classConstructorAttribute = null;
-        foreach (var attr in attributes)
-        {
-            if (attr is ClassConstructorAttribute cca)
-            {
-                classConstructorAttribute = cca;
-                break;
-            }
-        }
+        var classConstructorAttribute = attributes.FirstOfType<ClassConstructorAttribute>();
 
         if (classConstructorAttribute != null)
         {

--- a/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -210,6 +210,11 @@ internal sealed class TestBuilderPipeline
         // Get dynamic test metadata for DisplayName support
         var dynamicTestMetadata = metadata as IDynamicTestMetadata;
 
+        // Hoist loop-invariant state so repeat iterations share one attribute dictionary and factory delegate
+        var attributes = metadata.GetOrCreateAttributes();
+        var attributesByType = attributes.ToAttributeDictionary();
+        Func<Task<object>> instanceFactory = () => Task.FromResult(metadata.InstanceFactory(Type.EmptyTypes, []));
+
         return await Enumerable.Range(0, repeatCount + 1)
             .SelectAsync(async repeatIndex =>
         {
@@ -218,7 +223,7 @@ internal sealed class TestBuilderPipeline
             var dynamicTestIndex = dynamicTestMetadata?.DynamicTestIndex ?? 0;
             var testData = new TestBuilder.TestData
             {
-                TestClassInstanceFactory = () => Task.FromResult(metadata.InstanceFactory(Type.EmptyTypes, [])),
+                TestClassInstanceFactory = instanceFactory,
                 ClassDataSourceAttributeIndex = 0,
                 ClassDataLoopIndex = 0,
                 ClassData = [],
@@ -239,9 +244,6 @@ internal sealed class TestBuilderPipeline
                 ? $"{baseDisplayName} (Repeat {repeatIndex + 1}/{repeatCount + 1})"
                 : baseDisplayName;
 
-            // Get attributes first
-            var attributes = metadata.GetOrCreateAttributes();
-
             // Create TestDetails for dynamic tests
             var testDetails = new TestDetails(attributes)
             {
@@ -259,7 +261,7 @@ internal sealed class TestBuilderPipeline
                 TestEndColumnNumber = metadata.EndColumnNumber,
                 ReturnType = typeof(Task),
                 MethodMetadata = metadata.MethodMetadata,
-                AttributesByType = attributes.ToAttributeDictionary()
+                AttributesByType = attributesByType
             };
 
             var testBuilderContext = CreateTestBuilderContext(metadata);
@@ -339,6 +341,10 @@ internal sealed class TestBuilderPipeline
                 // Get attributes for test details
                 var attributes = resolvedMetadata.GetOrCreateAttributes();
 
+                // Hoist loop-invariant state so repeat iterations share one attribute dictionary and factory delegate
+                var attributesByType = attributes.ToAttributeDictionary();
+                Func<Task<object>> instanceFactory = () => Task.FromResult(resolvedMetadata.InstanceFactory(Type.EmptyTypes, []));
+
                 // Dynamic tests need to honor attributes like RepeatCount, RetryCount, etc.
                 // We'll create multiple test instances based on RepeatCount
                 // Use DynamicTestIndex from the metadata to ensure unique test IDs for multiple dynamic tests
@@ -348,7 +354,7 @@ internal sealed class TestBuilderPipeline
                     // Create a simple TestData for ID generation
                     var testData = new TestBuilder.TestData
                     {
-                        TestClassInstanceFactory = () => Task.FromResult(resolvedMetadata.InstanceFactory(Type.EmptyTypes, [])),
+                        TestClassInstanceFactory = instanceFactory,
                         ClassDataSourceAttributeIndex = 0,
                         ClassDataLoopIndex = 0,
                         ClassData = [],
@@ -385,7 +391,7 @@ internal sealed class TestBuilderPipeline
                         TestEndColumnNumber = resolvedMetadata.EndColumnNumber,
                         ReturnType = typeof(Task),
                         MethodMetadata = resolvedMetadata.MethodMetadata,
-                        AttributesByType = attributes.ToAttributeDictionary()
+                        AttributesByType = attributesByType
                     };
 
                     var context = _contextProvider.CreateTestContext(

--- a/TUnit.Engine/Extensions/AttributeArrayExtensions.cs
+++ b/TUnit.Engine/Extensions/AttributeArrayExtensions.cs
@@ -1,0 +1,21 @@
+namespace TUnit.Engine.Extensions;
+
+internal static class AttributeArrayExtensions
+{
+    /// <summary>
+    /// Returns the first attribute assignable to <typeparamref name="T"/>, or null.
+    /// Allocation-free alternative to OfType&lt;T&gt;().FirstOrDefault() for hot paths.
+    /// </summary>
+    public static T? FirstOfType<T>(this Attribute[] attributes) where T : Attribute
+    {
+        foreach (var attribute in attributes)
+        {
+            if (attribute is T typed)
+            {
+                return typed;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Trivial, behavior-preserving allocation reductions in the source-generated mode test-building pipeline (all code shared with reflection mode, verified in both):

- **TestBuilder.cs (streaming path)**: replaced the `Where(...).Cast<ClassConstructorAttribute>().FirstOrDefault()` LINQ chain with a `foreach` + pattern match, matching the fix already present in the non-streaming `BuildTestsFromMetadataAsync` path. Saves two iterator allocations per test metadata item during streaming discovery.
- **TestBuilderPipeline.cs (both dynamic-test paths)**: hoisted `attributes.ToAttributeDictionary()` and the `TestClassInstanceFactory` lambda out of the repeat loops. Previously each `[Repeat(N)]` iteration rebuilt the same attribute dictionary and allocated a new closure; now all iterations share one of each.
- **DataSourceHelpers.UnwrapTupleWithTypes**: the `ITuple` branch built a `List<object?>` (default capacity) then called `.ToArray()`, despite the length being known up front — and both branches of its inner `if` did the identical `result.Add(element)`. Now writes directly into a pre-sized array. One allocation instead of two-plus per tuple data row.
- **DataSourceHelpers.InvokeIfFunc**: `value.GetType()` was called twice per invocation; now captured once.

## Testing

- `dotnet build TUnit.Engine -c Release` clean
- TUnit.TestProject filtered runs (net10.0, Release):
  - `/*/*/*Tuple*/*` — 46/47 pass; the 1 failure (`ClassDataSourceTupleTests.Test_ClassDataSource_UnwrapsTuples`) reproduces identically on unmodified `main` (pre-existing, unrelated)
  - `/*/*/*Repeat*/*` — 27/27 pass (source-gen mode), 27/27 pass (reflection mode via `TUNIT_EXECUTION_MODE=Reflection`)
  - `/*/*/Dynamic*/*` — 16 pass / 2 skip
  - `/*/*/*ClassConstructor*/*` — 10/10 pass

No source generator output or public API changes, so no snapshot updates needed.