### PR TITLE
fix(analyzers): scope TUnit0031 async-void rule to tests and hooks (#6190)

### DIFF
--- a/TUnit.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -247,6 +247,42 @@ public class AsyncVoidAnalyzerTests
     }
 
     [Test]
+    public async Task Async_Void_Lambda_In_Local_Function_In_Test_Raises_Error()
+    {
+        // A local function is not a boundary: a lambda nested inside one within a test
+        // is still scoped to the test and must be flagged. See #6190 review.
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System;
+                using System.Threading.Tasks;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Test]
+                    public void Test()
+                    {
+                        void Helper()
+                        {
+                            Action action = {|#0:async () =>
+                            {
+                                await Task.Delay(1);
+                            }|};
+                        }
+
+                        Helper();
+                    }
+                }
+                """,
+
+                Verifier
+                    .Diagnostic(Rules.AsyncVoidMethod)
+                    .WithLocation(0)
+            );
+    }
+
+    [Test]
     public async Task Async_Void_Hook_Raises_Error()
     {
         await Verifier

--- a/TUnit.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -188,4 +188,86 @@ public class AsyncVoidAnalyzerTests
                     .WithLocation(0)
             );
     }
+
+    [Test]
+    public async Task Async_Void_NonTest_Method_Raises_No_Error()
+    {
+        // An async void method that is not a test or hook (e.g. an event handler)
+        // must not be flagged just because the project references TUnit. See #6190.
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System;
+                using System.Threading.Tasks;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    public event EventHandler? Ticked;
+
+                    public void Setup()
+                    {
+                        Ticked += OnTicked;
+                    }
+
+                    private async void OnTicked(object? sender, EventArgs e)
+                    {
+                        await Task.Delay(1);
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Async_Void_EventHandler_Lambda_In_NonTest_Method_Raises_No_Error()
+    {
+        // An async void lambda subscribed to an event from a non-test method is legitimate.
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System;
+                using System.Threading.Tasks;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    public event EventHandler? Ticked;
+
+                    public void Setup()
+                    {
+                        Ticked += async (sender, e) =>
+                        {
+                            await Task.Delay(1);
+                        };
+                    }
+                }
+                """
+            );
+    }
+
+    [Test]
+    public async Task Async_Void_Hook_Raises_Error()
+    {
+        await Verifier
+            .VerifyAnalyzerAsync(
+                """
+                using System.Threading.Tasks;
+                using TUnit.Core;
+
+                public class MyClass
+                {
+                    [Before(HookType.Test)]
+                    public async void {|#0:Setup|}()
+                    {
+                        await Task.Delay(1);
+                    }
+                }
+                """,
+
+                Verifier
+                    .Diagnostic(Rules.AsyncVoidMethod)
+                    .WithLocation(0)
+            );
+    }
 }

--- a/TUnit.Analyzers/AsyncVoidAnalyzer.cs
+++ b/TUnit.Analyzers/AsyncVoidAnalyzer.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using TUnit.Analyzers.Extensions;
 
 namespace TUnit.Analyzers;
 
@@ -28,12 +29,22 @@ public class AsyncVoidAnalyzer : ConcurrentDiagnosticAnalyzer
             return;
         }
 
-        if (methodSymbol is { IsAsync: true, ReturnsVoid: true })
+        if (methodSymbol is not { IsAsync: true, ReturnsVoid: true })
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rules.AsyncVoidMethod,
-                methodSymbol.Locations.FirstOrDefault())
-            );
+            return;
         }
+
+        // Only flag `async void` on TUnit test methods and hooks. Other `async void`
+        // methods (e.g. an event handler for System.Timers.Timer.Elapsed) are legitimate
+        // and must not be flagged just because the project references TUnit. See #6190.
+        if (!IsTestOrHookMethod(methodSymbol, context.Compilation))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rules.AsyncVoidMethod,
+            methodSymbol.Locations.FirstOrDefault())
+        );
     }
 
     private void AnalyzeLambda(SyntaxNodeAnalysisContext context)
@@ -50,11 +61,44 @@ public class AsyncVoidAnalyzer : ConcurrentDiagnosticAnalyzer
 
         var symbol = context.SemanticModel.GetSymbolInfo(anonymousFunction).Symbol;
 
-        if (symbol is IMethodSymbol { ReturnsVoid: true })
+        if (symbol is not IMethodSymbol { ReturnsVoid: true })
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rules.AsyncVoidMethod,
-                anonymousFunction.GetLocation())
-            );
+            return;
         }
+
+        // Only flag `async void` lambdas declared inside a TUnit test method or hook,
+        // so legitimate async void event-handler lambdas elsewhere aren't flagged. See #6190.
+        var enclosingMethod = GetEnclosingMethod(symbol);
+
+        if (enclosingMethod is null || !IsTestOrHookMethod(enclosingMethod, context.Compilation))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rules.AsyncVoidMethod,
+            anonymousFunction.GetLocation())
+        );
+    }
+
+    private static bool IsTestOrHookMethod(IMethodSymbol methodSymbol, Compilation compilation)
+    {
+        return methodSymbol.HasTestAttribute(compilation)
+               || methodSymbol.IsHookMethod(compilation, out _, out _, out _);
+    }
+
+    private static IMethodSymbol? GetEnclosingMethod(ISymbol? symbol)
+    {
+        // Walk out of nested lambdas/anonymous methods to the real enclosing method.
+        while (symbol is IMethodSymbol method)
+        {
+            if (method.MethodKind != MethodKind.AnonymousFunction)
+            {
+                return method;
+            }
+
+            symbol = method.ContainingSymbol;
+        }
+
+        return null;
     }
 }

--- a/TUnit.Analyzers/AsyncVoidAnalyzer.cs
+++ b/TUnit.Analyzers/AsyncVoidAnalyzer.cs
@@ -88,10 +88,12 @@ public class AsyncVoidAnalyzer : ConcurrentDiagnosticAnalyzer
 
     private static IMethodSymbol? GetEnclosingMethod(ISymbol? symbol)
     {
-        // Walk out of nested lambdas/anonymous methods to the real enclosing method.
+        // Walk out of nested lambdas, anonymous methods, and local functions to the
+        // real enclosing method, so a lambda nested inside a local function of a test
+        // is still scoped to that test rather than treating the local function as a boundary.
         while (symbol is IMethodSymbol method)
         {
-            if (method.MethodKind != MethodKind.AnonymousFunction)
+            if (method.MethodKind is not (MethodKind.AnonymousFunction or MethodKind.LocalFunction))
             {
                 return method;
             }


### PR DESCRIPTION
## Problem

[Discussion #6190](https://github.com/thomhurst/TUnit/discussions/6190): `TUnit0031` (AsyncVoidAnalyzer) flags **every** `async void` method and lambda in any project that references TUnit — with no test/hook scoping. Because the rule's severity is **Error** (`Rules.cs`), legitimate async void code becomes a build break.

Reported case: a `System.Timers.Timer.Elapsed` event handler (which requires a void signature) made `async` → flagged as an error, despite having nothing to do with testing. The thread's "fix" (move tests to a separate project) is only a workaround — the rule ships transitively, so any TUnit-referencing project keeps hitting it.

## Fix

Scope the analyzer to its intended target:

- **Methods** — only flag `async void` when the method carries a TUnit test attribute (`HasTestAttribute`, covers `[Test]`/`[DynamicTestBuilder]`) or a hook attribute (`IsHookMethod`, Before/After).
- **Lambdas** — only flag `async void` lambdas declared inside such a method (walks out of nested lambdas via `ContainingSymbol`).

Event handlers and other async void code elsewhere in a test project are left alone.

## Tests

Existing tests still pass (async void test method / lambda inside `[Test]` still error). Added:

- non-test `async void` event-handler method → no diagnostic
- `async void` event-handler lambda in a non-test method → no diagnostic
- `async void` hook (`[Before(HookType.Test)]`) → still errors

All 10 `AsyncVoidAnalyzerTests` pass (net10.0).
