### PR TITLE
fix(aspire): publish TUnit.Aspire.Core package (#6246)

### DIFF
--- a/TUnit.Pipeline/Modules/GetPackageProjectsModule.cs
+++ b/TUnit.Pipeline/Modules/GetPackageProjectsModule.cs
@@ -24,6 +24,7 @@ public class GetPackageProjectsModule : Module<List<File>>
             Sourcy.DotNet.Projects.TUnit_AspNetCore,
             Sourcy.DotNet.Projects.TUnit_AspNetCore_Core,
             Sourcy.DotNet.Projects.TUnit_Aspire,
+            Sourcy.DotNet.Projects.TUnit_Aspire_Core,
             Sourcy.DotNet.Projects.TUnit_OpenTelemetry,
             Sourcy.DotNet.Projects.TUnit_FsCheck,
             Sourcy.DotNet.Projects.TUnit_Mocks,


### PR DESCRIPTION
Fixes #6246

## Problem
`TUnit.Aspire` 1.55.0 fails to restore:
```
<PackageReference Include="TUnit.Aspire" Version="1.55.0" />
```

## Root cause
PR #6243 split `TUnit.Aspire.Core` out of `TUnit.Aspire` and made the
`TUnit.Aspire` metapackage `ProjectReference` it — so the published
`TUnit.Aspire.nupkg` carries a `<dependency>` on `TUnit.Aspire.Core`.

But `GetPackageProjectsModule` (the explicit allowlist of projects the
pipeline packs and pushes to NuGet) was never updated to include
`TUnit.Aspire.Core`. The metapackage therefore shipped a dependency on a
package that doesn't exist on NuGet → restore 404.

The earlier `TUnit.AspNetCore` / `TUnit.AspNetCore.Core` split (which this
mirrored) correctly lists **both** projects; Aspire only listed the
metapackage.

## Fix
Add `Sourcy.DotNet.Projects.TUnit_Aspire_Core` to the pack/push list.
Verified `TUnit.Pipeline` builds (the Sourcy-generated symbol resolves).