### PR TITLE
fix(aspnetcore): serialize WithWebHostBuilder to stop _derivedFactories race (flaky disposal NRE)

### DIFF
--- a/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
+++ b/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
@@ -26,6 +26,16 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
     // belong to its own request pipeline vs. a sibling factory's.
     private readonly CorrelationScope _correlationScope = new();
 
+    // Serializes WithWebHostBuilder calls. The shared (e.g. PerTestSession) GlobalFactory
+    // has GetIsolatedFactory invoked from every test's parallel Before(Test) hook, and
+    // WithWebHostBuilder mutates the base factory's internal _derivedFactories List<T>
+    // with no synchronization of its own. Concurrent List.Add tears the backing array
+    // (lost entries / null slots), which surfaces much later as a NullReferenceException
+    // when the GlobalFactory is disposed and enumerates that list. WithWebHostBuilder is
+    // synchronous and the work inside is fast configuration, so a plain lock is enough;
+    // the expensive host build is throttled separately by ServerInitSemaphore.
+    private readonly object _isolationLock = new();
+
     public WebApplicationFactory<TEntryPoint> GetIsolatedFactory(
         TestContext testContext,
         WebApplicationTestOptions options,
@@ -33,43 +43,46 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
         Action<WebHostBuilderContext, IConfigurationBuilder> configureIsolatedAppConfiguration,
         Action<IWebHostBuilder>? configureWebHostBuilder = null)
     {
-        return WithWebHostBuilder(builder =>
+        lock (_isolationLock)
         {
-            var configurationBuilder = new ConfigurationManager();
-            ConfigureStartupConfiguration(configurationBuilder);
-
-            foreach (var keyValuePair in configurationBuilder.AsEnumerable())
+            return WithWebHostBuilder(builder =>
             {
-                builder.UseSetting(keyValuePair.Key, keyValuePair.Value);
-            }
+                var configurationBuilder = new ConfigurationManager();
+                ConfigureStartupConfiguration(configurationBuilder);
 
-            builder
-                .ConfigureAppConfiguration(configureIsolatedAppConfiguration)
-                .ConfigureTestServices(services =>
+                foreach (var keyValuePair in configurationBuilder.AsEnumerable())
                 {
-                    configureIsolatedServices(services);
-                    services.AddSingleton(testContext);
-                    services.AddTUnitLogging(testContext);
+                    builder.UseSetting(keyValuePair.Key, keyValuePair.Value);
+                }
 
-                    if (options.AutoPropagateHttpClientFactory)
+                builder
+                    .ConfigureAppConfiguration(configureIsolatedAppConfiguration)
+                    .ConfigureTestServices(services =>
                     {
-                        services.TryAddEnumerable(
-                            ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, TUnitHttpClientFilter>());
-                    }
+                        configureIsolatedServices(services);
+                        services.AddSingleton(testContext);
+                        services.AddTUnitLogging(testContext);
 
-                    if (options.AutoConfigureOpenTelemetry)
-                    {
-                        AddTUnitOpenTelemetry(services, _correlationScope);
-                    }
-                });
+                        if (options.AutoPropagateHttpClientFactory)
+                        {
+                            services.TryAddEnumerable(
+                                ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, TUnitHttpClientFilter>());
+                        }
 
-            if (options.EnableHttpExchangeCapture)
-            {
-                builder.ConfigureTestServices(services => services.AddHttpExchangeCapture());
-            }
+                        if (options.AutoConfigureOpenTelemetry)
+                        {
+                            AddTUnitOpenTelemetry(services, _correlationScope);
+                        }
+                    });
 
-            configureWebHostBuilder?.Invoke(builder);
-        });
+                if (options.EnableHttpExchangeCapture)
+                {
+                    builder.ConfigureTestServices(services => services.AddHttpExchangeCapture());
+                }
+
+                configureWebHostBuilder?.Invoke(builder);
+            });
+        }
     }
 
     protected virtual void ConfigureStartupConfiguration(IConfigurationBuilder configurationBuilder)

--- a/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
+++ b/TUnit.AspNetCore.Core/TestWebApplicationFactory.cs
@@ -26,14 +26,11 @@ public abstract class TestWebApplicationFactory<TEntryPoint> : WebApplicationFac
     // belong to its own request pipeline vs. a sibling factory's.
     private readonly CorrelationScope _correlationScope = new();
 
-    // Serializes WithWebHostBuilder calls. The shared (e.g. PerTestSession) GlobalFactory
-    // has GetIsolatedFactory invoked from every test's parallel Before(Test) hook, and
-    // WithWebHostBuilder mutates the base factory's internal _derivedFactories List<T>
-    // with no synchronization of its own. Concurrent List.Add tears the backing array
-    // (lost entries / null slots), which surfaces much later as a NullReferenceException
-    // when the GlobalFactory is disposed and enumerates that list. WithWebHostBuilder is
-    // synchronous and the work inside is fast configuration, so a plain lock is enough;
-    // the expensive host build is throttled separately by ServerInitSemaphore.
+    // Serializes WithWebHostBuilder, which mutates the base factory's internal
+    // _derivedFactories List<T> with no synchronization. Concurrent calls (one per
+    // parallel Before(Test) hook on a shared factory) tear the backing array, surfacing
+    // later as a NullReferenceException when the disposed factory enumerates it. The call
+    // is synchronous fast configuration, so a plain lock suffices.
     private readonly object _isolationLock = new();
 
     public WebApplicationFactory<TEntryPoint> GetIsolatedFactory(

--- a/TUnit.AspNetCore.Tests/IsolatedFactoryConcurrencyTests.cs
+++ b/TUnit.AspNetCore.Tests/IsolatedFactoryConcurrencyTests.cs
@@ -27,12 +27,9 @@ public class IsolatedFactoryConcurrencyTests
         {
             var globalFactory = new TestWebAppFactory();
 
+            // WhenAll re-throws if any concurrent call hit a torn-array exception during Add.
             var derived = await CreateIsolatedFactoriesConcurrentlyAsync(globalFactory);
-
-            // Every call must have produced a distinct, non-null derived factory.
             await Assert.That(derived.Length).IsEqualTo(Concurrency);
-            await Assert.That(derived.All(f => f is not null)).IsTrue();
-            await Assert.That(derived.Distinct().Count()).IsEqualTo(Concurrency);
 
             // Disposing the shared factory enumerates _derivedFactories; a torn list NREs here.
             await Assert.That(async () => await globalFactory.DisposeAsync()).ThrowsNothing();

--- a/TUnit.AspNetCore.Tests/IsolatedFactoryConcurrencyTests.cs
+++ b/TUnit.AspNetCore.Tests/IsolatedFactoryConcurrencyTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using TUnit.AspNetCore;
+
+namespace TUnit.AspNetCore.Tests;
+
+/// <summary>
+/// Regression tests for the race in <see cref="TestWebApplicationFactory{TEntryPoint}.GetIsolatedFactory"/>.
+/// <para>
+/// A shared (e.g. <c>SharedType.PerTestSession</c>) factory has <c>GetIsolatedFactory</c> invoked from
+/// every test's parallel <c>Before(Test)</c> hook. Internally that calls
+/// <see cref="WebApplicationFactory{TEntryPoint}.WithWebHostBuilder"/>, which appends to the base
+/// factory's private <c>_derivedFactories</c> <see cref="List{T}"/> with no synchronization. Concurrent
+/// <c>List.Add</c> calls tear the backing array (lost entries / null slots); the damage only surfaces
+/// later as a <see cref="NullReferenceException"/> when the shared factory is disposed and enumerates
+/// that list. These tests hammer the call concurrently and then dispose, reproducing that crash.
+/// </para>
+/// </summary>
+public class IsolatedFactoryConcurrencyTests
+{
+    private const int Concurrency = 64;
+    private const int Rounds = 8;
+
+    [Test]
+    public async Task Concurrent_GetIsolatedFactory_Then_Dispose_Does_Not_Throw()
+    {
+        for (var round = 0; round < Rounds; round++)
+        {
+            var globalFactory = new TestWebAppFactory();
+
+            var derived = await CreateIsolatedFactoriesConcurrentlyAsync(globalFactory);
+
+            // Every call must have produced a distinct, non-null derived factory.
+            await Assert.That(derived.Length).IsEqualTo(Concurrency);
+            await Assert.That(derived.All(f => f is not null)).IsTrue();
+            await Assert.That(derived.Distinct().Count()).IsEqualTo(Concurrency);
+
+            // Disposing the shared factory enumerates _derivedFactories; a torn list NREs here.
+            await Assert.That(async () => await globalFactory.DisposeAsync()).ThrowsNothing();
+        }
+    }
+
+    private static async Task<WebApplicationFactory<Program>[]> CreateIsolatedFactoriesConcurrentlyAsync(
+        TestWebAppFactory globalFactory)
+    {
+        var testContext = TestContext.Current!;
+        var options = new WebApplicationTestOptions();
+
+        // Release all workers at once to maximise the window for a concurrent List.Add tear.
+        var gate = new TaskCompletionSource();
+
+        var tasks = Enumerable.Range(0, Concurrency)
+            .Select(_ => Task.Run(async () =>
+            {
+                await gate.Task;
+                return globalFactory.GetIsolatedFactory(
+                    testContext,
+                    options,
+                    static _ => { },
+                    static (_, _) => { },
+                    static _ => { });
+            }))
+            .ToArray();
+
+        gate.SetResult();
+
+        return await Task.WhenAll(tasks);
+    }
+}


### PR DESCRIPTION
## Problem

Users running ASP.NET Core integration tests in parallel with `TUnit.AspNetCore` hit a flaky crash during disposal:

```
[Null Reference] Object reference not set to an instance of an object.
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
   at TUnit.Core.Helpers.Disposer.DisposeAsync(Object obj)
   at TUnit.Core.Tracking.ObjectTracker.UntrackObject(Object obj)
   at TUnit.Core.Tracking.ObjectTracker.UntrackObjectsAsync(SortedList`2 trackedObjects)
```

## Root cause

`WebApplicationTest<TFactory, TEntryPoint>` exposes a single shared factory:

```csharp
[ClassDataSource(Shared = [SharedType.PerTestSession])]
public TFactory GlobalFactory { get; set; }
```

Every test's `[Before(HookType.Test)]` hook runs in parallel and calls
`GlobalFactory.GetIsolatedFactory(...)`, which calls
`WebApplicationFactory.WithWebHostBuilder`. That method appends to the base
factory's **private `_derivedFactories` `List<T>` with no synchronization**
(confirmed against the ASP.NET Core source):

```csharp
private readonly List<WebApplicationFactory<TEntryPoint>> _derivedFactories = new();
// WithWebHostBuilderCore:
_derivedFactories.Add(factory);          // unsynchronized
// DisposeAsync:
foreach (var factory in _derivedFactories)
    await ((IAsyncDisposable)factory).DisposeAsync();   // null slot -> NRE
```

Concurrent `List.Add` tears the backing array, leaving a `null` slot. Tests
pass. At session end the last test untracks the shared `GlobalFactory`, whose
`DisposeAsync` enumerates the corrupted list and dereferences the null slot →
`NullReferenceException`. The race only sometimes tears the array, hence the
flakiness. `ServerInitSemaphore` did not cover this — it guards only the
`Server` host build, which happens *after* the unsynchronized
`GetIsolatedFactory` call.

## Fix

Wrap the `WithWebHostBuilder` call in a per-factory `lock`. It is synchronous
and only does fast configuration, so a plain lock suffices; the expensive host
build remains throttled separately by `ServerInitSemaphore`.

## Regression test

`IsolatedFactoryConcurrencyTests` fires 64 concurrent `GetIsolatedFactory`
calls (released together via a gate) against one shared factory across 8
rounds, then disposes. Verified it **reproduces the exact NRE** with the lock
removed and **passes** with the fix. Full `TUnit.AspNetCore.Tests` suite (36
tests) green.

## Note for users not on the base class

If you manage your own shared `WebApplicationFactory` and call
`.WithWebHostBuilder()` from parallel tests yourself, the same ASP.NET Core
race applies in your code — serialize that call.
