### PR TITLE
fix(mocks): implement `new`-hidden base interface members in wrapper (#6252)

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
+++ b/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
@@ -2050,6 +2050,89 @@ public class MockGeneratorTests : SnapshotTestBase
         return VerifyGeneratorOutput(source);
     }
 
+    [Test]
+    public void Interface_Hiding_Base_Members_With_New_Forwards_All_Slots_In_Wrapper()
+    {
+        // Regression #6252: IDerived hides IBase members with `new`. IBase.X and IDerived.X are
+        // distinct interface slots; the wrapper forwards each member as an explicit impl, which
+        // satisfies only the slot it names — so each hidden base slot needs its own explicit
+        // forward (cast to that interface) or the build fails with CS0535.
+        var source = """
+            using TUnit.Mocks;
+
+            public interface IBase
+            {
+                void SomeMethod();
+                int Prop { get; }
+                event System.Action Evt;
+            }
+
+            public interface IDerived : IBase
+            {
+                new void SomeMethod();
+                new int Prop { get; }
+                new event System.Action Evt;
+            }
+
+            public class TestUsage
+            {
+                void M() { var mock = Mock.Of<IDerived>(); }
+            }
+            """;
+
+        var output = GetGeneratedOutput(source);
+
+        // Both the derived slot and the hidden base slot are forwarded explicitly.
+        AssertContains(output, "void global::IDerived.SomeMethod()");
+        AssertContains(output, "void global::IBase.SomeMethod()");
+        AssertContains(output, "((global::IBase)Object).SomeMethod()");
+        AssertContains(output, "int global::IDerived.Prop");
+        AssertContains(output, "int global::IBase.Prop");
+        AssertContains(output, "global::IDerived.Evt");
+        AssertContains(output, "global::IBase.Evt");
+
+        AssertNoGeneratedError(source, "CS0535");
+    }
+
+    [Test]
+    public void Interface_Inheriting_Identical_Member_From_Multiple_Interfaces_Forwards_Both_Slots()
+    {
+        // Regression #6252 (diamond): IDiamondC inherits an identically-signed Go() from two
+        // unrelated interfaces. One impl satisfies both slots, but the wrapper must forward both —
+        // and BOTH forwards (including the primary) must cast, else `Object.Go()` is ambiguous (CS0121).
+        var source = """
+            using TUnit.Mocks;
+
+            public interface IDiamondA { void Go(); }
+            public interface IDiamondB { void Go(); }
+            public interface IDiamondC : IDiamondA, IDiamondB { }
+
+            public class TestUsage
+            {
+                void M() { var mock = Mock.Of<IDiamondC>(); }
+            }
+            """;
+
+        var output = GetGeneratedOutput(source);
+
+        AssertContains(output, "((global::IDiamondA)Object).Go()");
+        AssertContains(output, "((global::IDiamondB)Object).Go()");
+
+        AssertNoGeneratedError(source, "CS0121");
+        AssertNoGeneratedError(source, "CS0535");
+    }
+
+    private static void AssertNoGeneratedError(string source, string errorId)
+    {
+        foreach (var diagnostic in GetGeneratedCompilationErrors(source))
+        {
+            if (string.Equals(diagnostic.Id, errorId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Generated code produced {errorId}: {diagnostic}");
+            }
+        }
+    }
+
     private static string GetGeneratedOutput(string source, IEnumerable<Microsoft.CodeAnalysis.MetadataReference>? additionalReferences = null)
         => string.Join(Environment.NewLine, RunGenerator(source, additionalReferences));
 

--- a/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
@@ -90,17 +90,32 @@ internal static class MockWrapperTypeBuilder
     private static void GenerateMethodForwarding(CodeWriter writer, MockMemberModel method, MockTypeModel model)
     {
         var interfaceName = method.ExplicitInterfaceName ?? method.DeclaringInterfaceName ?? model.FullyQualifiedName;
+
+        // When the method is an explicit interface impl on the underlying object,
+        // we must cast to call the correct method (e.g. ((IEnumerable)Object).GetEnumerator()).
+        var target = method.ExplicitInterfaceName is not null
+            ? CastTarget(method.ExplicitInterfaceName)
+            : "Object";
+
+        EmitMethodForward(writer, method, interfaceName, target);
+
+        // Additional explicit forwards for distinct interface slots this member also satisfies
+        // (base members hidden by `new`, or inherited from multiple interfaces). Each slot needs
+        // its own explicit impl, cast to that interface so the right slot is hit on Object (#6252).
+        foreach (var extra in method.AdditionalExplicitInterfaceNames)
+        {
+            writer.AppendLine();
+            EmitMethodForward(writer, method, extra, CastTarget(extra));
+        }
+    }
+
+    private static void EmitMethodForward(CodeWriter writer, MockMemberModel method, string interfaceName, string target)
+    {
         var paramList = MockImplBuilder.GetParameterList(method);
         var typeParams = MockImplBuilder.GetTypeParameterList(method);
         var constraints = MockImplBuilder.GetConstraintClauses(method, forExplicitImplementation: true);
         var argPassList = MockImplBuilder.GetArgPassList(method);
         var returnType = (method.IsVoid && !method.IsAsync) ? "void" : method.ReturnType;
-
-        // When the method is an explicit interface impl on the underlying object,
-        // we must cast to call the correct method (e.g. ((IEnumerable)Object).GetEnumerator()).
-        var target = method.ExplicitInterfaceName is not null
-            ? $"(({method.ExplicitInterfaceName})Object)"
-            : "Object";
 
         // Copy the source member's [Obsolete] attribute onto the forward so the call to
         // Object.{name}(...) inside this method is allowed by the compiler (a member
@@ -122,9 +137,18 @@ internal static class MockWrapperTypeBuilder
 
     private static void GeneratePropertyForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        var interfaceName = GetForwardingInterfaceName(prop, model);
+        EmitPropertyForward(writer, prop, GetForwardingInterfaceName(prop, model), GetForwardingTarget(prop));
+
+        foreach (var extra in prop.AdditionalExplicitInterfaceNames)
+        {
+            writer.AppendLine();
+            EmitPropertyForward(writer, prop, extra, CastTarget(extra));
+        }
+    }
+
+    private static void EmitPropertyForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target)
+    {
         var returnType = prop.ReturnType;
-        var target = GetForwardingTarget(prop);
 
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
 
@@ -139,11 +163,20 @@ internal static class MockWrapperTypeBuilder
 
     private static void GenerateIndexerForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        var interfaceName = GetForwardingInterfaceName(prop, model);
+        EmitIndexerForward(writer, prop, GetForwardingInterfaceName(prop, model), GetForwardingTarget(prop));
+
+        foreach (var extra in prop.AdditionalExplicitInterfaceNames)
+        {
+            writer.AppendLine();
+            EmitIndexerForward(writer, prop, extra, CastTarget(extra));
+        }
+    }
+
+    private static void EmitIndexerForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target)
+    {
         var returnType = prop.ReturnType;
         var paramList = MockImplBuilder.GetParameterList(prop);
         var argPassList = MockImplBuilder.GetArgPassList(prop);
-        var target = GetForwardingTarget(prop);
 
         writer.AppendLineIfNotEmpty(prop.ObsoleteAttribute);
 
@@ -154,6 +187,11 @@ internal static class MockWrapperTypeBuilder
 
         writer.AppendLine($"{returnType} {interfaceName}.this[{paramList}] {{ {getter}{setter}}}");
     }
+
+    // Cast the underlying Object to a specific interface so an explicit forward dispatches to
+    // that interface's slot (necessary when distinct slots share a signature — e.g. a `new`-hidden
+    // base member, or wrapping a real object whose explicit impls differ per interface).
+    private static string CastTarget(string interfaceFqn) => $"(({interfaceFqn})Object)";
 
     private static string GetForwardingInterfaceName(MockMemberModel member, MockTypeModel model)
         => member.ExplicitInterfaceName ?? member.DeclaringInterfaceName ?? model.FullyQualifiedName;
@@ -170,10 +208,19 @@ internal static class MockWrapperTypeBuilder
 
     private static void GenerateEventForwarding(CodeWriter writer, MockEventModel evt, MockTypeModel model)
     {
-        var interfaceName = evt.ExplicitInterfaceName ?? evt.DeclaringInterfaceName ?? model.FullyQualifiedName;
+        EmitEventForward(writer, evt, evt.ExplicitInterfaceName ?? evt.DeclaringInterfaceName ?? model.FullyQualifiedName, "Object");
 
+        foreach (var extra in evt.AdditionalExplicitInterfaceNames)
+        {
+            writer.AppendLine();
+            EmitEventForward(writer, evt, extra, CastTarget(extra));
+        }
+    }
+
+    private static void EmitEventForward(CodeWriter writer, MockEventModel evt, string interfaceName, string target)
+    {
         writer.AppendLineIfNotEmpty(evt.ObsoleteAttribute);
-        writer.AppendLine($"event {evt.EventHandlerType} {interfaceName}.{EscapeIdentifier(evt.Name)} {{ add => Object.{EscapeIdentifier(evt.Name)} += value; remove => Object.{EscapeIdentifier(evt.Name)} -= value; }}");
+        writer.AppendLine($"event {evt.EventHandlerType} {interfaceName}.{EscapeIdentifier(evt.Name)} {{ add => {target}.{EscapeIdentifier(evt.Name)} += value; remove => {target}.{EscapeIdentifier(evt.Name)} -= value; }}");
     }
 
 }

--- a/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
@@ -93,8 +93,11 @@ internal static class MockWrapperTypeBuilder
 
         // When the method is an explicit interface impl on the underlying object,
         // we must cast to call the correct method (e.g. ((IEnumerable)Object).GetEnumerator()).
-        var target = method.ExplicitInterfaceName is not null
-            ? CastTarget(method.ExplicitInterfaceName)
+        // When the member also satisfies other interface slots, cast as well — otherwise
+        // `Object.M()` can be ambiguous (CS0121) where Object's type inherits M() from
+        // multiple interfaces (e.g. a diamond), or could bind to the wrong slot (#6252).
+        var target = method.ExplicitInterfaceName is not null || method.AdditionalExplicitInterfaceNames.Length > 0
+            ? CastTarget(interfaceName)
             : "Object";
 
         EmitMethodForward(writer, method, interfaceName, target);
@@ -137,7 +140,8 @@ internal static class MockWrapperTypeBuilder
 
     private static void GeneratePropertyForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        EmitPropertyForward(writer, prop, GetForwardingInterfaceName(prop, model), GetForwardingTarget(prop));
+        var interfaceName = GetForwardingInterfaceName(prop, model);
+        EmitPropertyForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName));
 
         foreach (var extra in prop.AdditionalExplicitInterfaceNames)
         {
@@ -163,7 +167,8 @@ internal static class MockWrapperTypeBuilder
 
     private static void GenerateIndexerForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
-        EmitIndexerForward(writer, prop, GetForwardingInterfaceName(prop, model), GetForwardingTarget(prop));
+        var interfaceName = GetForwardingInterfaceName(prop, model);
+        EmitIndexerForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName));
 
         foreach (var extra in prop.AdditionalExplicitInterfaceNames)
         {
@@ -196,11 +201,13 @@ internal static class MockWrapperTypeBuilder
     private static string GetForwardingInterfaceName(MockMemberModel member, MockTypeModel model)
         => member.ExplicitInterfaceName ?? member.DeclaringInterfaceName ?? model.FullyQualifiedName;
 
-    // When the member is an explicit interface impl on the underlying object,
-    // we must cast to access the correct member.
-    private static string GetForwardingTarget(MockMemberModel member)
-        => member.ExplicitInterfaceName is not null
-            ? $"(({member.ExplicitInterfaceName})Object)"
+    // The forwarding target for a member's *primary* slot. Normally the untyped `Object`, but cast
+    // to the slot's interface when the member is an explicit interface impl on the underlying object,
+    // or when it also satisfies other slots — otherwise `Object.X` may be ambiguous (CS0121) or bind
+    // to the wrong slot (#6252).
+    private static string GetPrimaryTarget(MockMemberModel member, string interfaceName)
+        => member.ExplicitInterfaceName is not null || member.AdditionalExplicitInterfaceNames.Length > 0
+            ? CastTarget(interfaceName)
             : "Object";
 
     private static string GetAccessorObsoletePrefix(string obsoleteAttribute)
@@ -208,7 +215,12 @@ internal static class MockWrapperTypeBuilder
 
     private static void GenerateEventForwarding(CodeWriter writer, MockEventModel evt, MockTypeModel model)
     {
-        EmitEventForward(writer, evt, evt.ExplicitInterfaceName ?? evt.DeclaringInterfaceName ?? model.FullyQualifiedName, "Object");
+        var interfaceName = evt.ExplicitInterfaceName ?? evt.DeclaringInterfaceName ?? model.FullyQualifiedName;
+        // Event forwards historically target the untyped `Object`; only cast when the event also
+        // satisfies other slots, to avoid an ambiguous `Object.Evt` (diamond) while keeping output
+        // unchanged for the common single-slot case (#6252).
+        var target = evt.AdditionalExplicitInterfaceNames.Length > 0 ? CastTarget(interfaceName) : "Object";
+        EmitEventForward(writer, evt, interfaceName, target);
 
         foreach (var extra in evt.AdditionalExplicitInterfaceNames)
         {

--- a/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
@@ -91,16 +91,7 @@ internal static class MockWrapperTypeBuilder
     {
         var interfaceName = method.ExplicitInterfaceName ?? method.DeclaringInterfaceName ?? model.FullyQualifiedName;
 
-        // When the method is an explicit interface impl on the underlying object,
-        // we must cast to call the correct method (e.g. ((IEnumerable)Object).GetEnumerator()).
-        // When the member also satisfies other interface slots, cast as well — otherwise
-        // `Object.M()` can be ambiguous (CS0121) where Object's type inherits M() from
-        // multiple interfaces (e.g. a diamond), or could bind to the wrong slot (#6252).
-        var target = method.ExplicitInterfaceName is not null || method.AdditionalExplicitInterfaceNames.Length > 0
-            ? CastTarget(interfaceName)
-            : "Object";
-
-        EmitMethodForward(writer, method, interfaceName, target);
+        EmitMethodForward(writer, method, interfaceName, GetPrimaryTarget(method, interfaceName));
 
         // Additional explicit forwards for distinct interface slots this member also satisfies
         // (base members hidden by `new`, or inherited from multiple interfaces). Each slot needs

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -101,14 +101,9 @@ internal static class MemberDiscovery
     private static void RecordAdditionalWrapperInterface(List<MockMemberModel> members, int index, string interfaceFqn)
     {
         var existing = members[index];
-        var ownSlot = existing.ExplicitInterfaceName ?? existing.DeclaringInterfaceName;
-        if (ownSlot == interfaceFqn) return;
-        var current = existing.AdditionalExplicitInterfaceNames.AsImmutableArray();
-        if (current.Contains(interfaceFqn)) return;
-        members[index] = existing with
-        {
-            AdditionalExplicitInterfaceNames = new EquatableArray<string>(current.Add(interfaceFqn))
-        };
+        var updated = AppendDistinctSlot(existing.AdditionalExplicitInterfaceNames,
+            existing.ExplicitInterfaceName ?? existing.DeclaringInterfaceName, interfaceFqn, out var changed);
+        if (changed) members[index] = existing with { AdditionalExplicitInterfaceNames = updated };
     }
 
     /// <summary>Event counterpart of <see cref="RecordAdditionalWrapperInterface"/>. Locates the
@@ -119,16 +114,26 @@ internal static class MemberDiscovery
         {
             var e = events[i];
             if (e.IsStaticAbstract || e.Name != eventName) continue;
-            var ownSlot = e.ExplicitInterfaceName ?? e.DeclaringInterfaceName;
-            if (ownSlot == interfaceFqn) return;
-            var current = e.AdditionalExplicitInterfaceNames.AsImmutableArray();
-            if (current.Contains(interfaceFqn)) return;
-            events[i] = e with
-            {
-                AdditionalExplicitInterfaceNames = new EquatableArray<string>(current.Add(interfaceFqn))
-            };
+            var updated = AppendDistinctSlot(e.AdditionalExplicitInterfaceNames,
+                e.ExplicitInterfaceName ?? e.DeclaringInterfaceName, interfaceFqn, out var changed);
+            if (changed) events[i] = e with { AdditionalExplicitInterfaceNames = updated };
             return;
         }
+    }
+
+    /// <summary>Returns <paramref name="slots"/> with <paramref name="interfaceFqn"/> appended,
+    /// setting <paramref name="changed"/>. No-op (returns the input) when <paramref name="interfaceFqn"/>
+    /// already is the member's own slot (<paramref name="ownSlot"/>) or is already recorded — so the
+    /// caller can skip allocating a new model record.</summary>
+    private static EquatableArray<string> AppendDistinctSlot(
+        EquatableArray<string> slots, string? ownSlot, string interfaceFqn, out bool changed)
+    {
+        changed = false;
+        if (ownSlot == interfaceFqn) return slots;
+        var array = slots.AsImmutableArray();
+        if (array.Contains(interfaceFqn)) return slots;
+        changed = true;
+        return new EquatableArray<string>(array.Add(interfaceFqn));
     }
 
     private static MockMemberModel Tag(MockMemberModel model, int ownerTypeIndex)

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -88,6 +88,49 @@ internal static class MemberDiscovery
         => primaryClassSymbol is not null
             && primaryClassSymbol.FindImplementationForInterfaceMember(interfaceMember) is not null;
 
+    /// <summary>
+    /// Records that the member at <paramref name="index"/> must additionally be forwarded as an
+    /// explicit implementation of <paramref name="interfaceFqn"/> in the generated wrapper type.
+    /// Used when an identically-signed member is dropped during dedup but represents a distinct
+    /// interface slot (a base member hidden by <c>new</c>, or one inherited from multiple
+    /// interfaces): the shared impl satisfies every slot implicitly, but the wrapper forwards
+    /// explicitly and an explicit impl satisfies only the one slot it names (#6252). No-op when
+    /// the interface already matches the member's own slot or is already recorded. Only meaningful
+    /// for single-interface mocks — the only ones with a wrapper.
+    /// </summary>
+    private static void RecordAdditionalWrapperInterface(List<MockMemberModel> members, int index, string interfaceFqn)
+    {
+        var existing = members[index];
+        var ownSlot = existing.ExplicitInterfaceName ?? existing.DeclaringInterfaceName;
+        if (ownSlot == interfaceFqn) return;
+        var current = existing.AdditionalExplicitInterfaceNames.AsImmutableArray();
+        if (current.Contains(interfaceFqn)) return;
+        members[index] = existing with
+        {
+            AdditionalExplicitInterfaceNames = new EquatableArray<string>(current.Add(interfaceFqn))
+        };
+    }
+
+    /// <summary>Event counterpart of <see cref="RecordAdditionalWrapperInterface"/>. Locates the
+    /// surviving (non-static) event model by name, since the event seen-set is keyed by name only.</summary>
+    private static void RecordAdditionalWrapperInterfaceForEvent(List<MockEventModel> events, string eventName, string interfaceFqn)
+    {
+        for (int i = 0; i < events.Count; i++)
+        {
+            var e = events[i];
+            if (e.IsStaticAbstract || e.Name != eventName) continue;
+            var ownSlot = e.ExplicitInterfaceName ?? e.DeclaringInterfaceName;
+            if (ownSlot == interfaceFqn) return;
+            var current = e.AdditionalExplicitInterfaceNames.AsImmutableArray();
+            if (current.Contains(interfaceFqn)) return;
+            events[i] = e with
+            {
+                AdditionalExplicitInterfaceNames = new EquatableArray<string>(current.Add(interfaceFqn))
+            };
+            return;
+        }
+    }
+
     private static MockMemberModel Tag(MockMemberModel model, int ownerTypeIndex)
         => ownerTypeIndex == 0 ? model : model with { OwnerTypeIndex = ownerTypeIndex };
 
@@ -164,7 +207,19 @@ internal static class MemberDiscovery
                                 // the prior sighting is a non-mockable class member (NonMockableEntry)
                                 // and we're walking an additional interface, re-implement explicitly
                                 // so the mock intercepts interface dispatch anyway.
-                                if (primaryClassSymbol is null || existing.Index != NonMockableEntry.Index) continue;
+                                if (primaryClassSymbol is null || existing.Index != NonMockableEntry.Index)
+                                {
+                                    // Single-interface mocks generate a wrapper that forwards each member
+                                    // as an explicit interface impl, which satisfies only the slot it names.
+                                    // This duplicate is a distinct slot (base member hidden by `new`, or one
+                                    // inherited from multiple interfaces) — record it so the wrapper also
+                                    // forwards that slot, else the build fails with CS0535 (#6252).
+                                    if (primaryClassSymbol is null && existing.Index >= 0)
+                                    {
+                                        RecordAdditionalWrapperInterface(state.Methods, existing.Index, interfaceFqn);
+                                    }
+                                    continue;
+                                }
                                 if (!state.SeenExplicitImpls.Add($"{interfaceFqn}|{fullKey}")) continue;
                                 state.Methods.Add(Tag(CreateMethodModel(method, ref state.MemberIdCounter, interfaceFqn, interfaceFqn, explicitInterfaceCanDelegate: false, compilation: compilation), ownerTypeIndex));
                                 break;
@@ -216,6 +271,9 @@ internal static class MemberDiscovery
                                 else if (primaryClassSymbol is null)
                                 {
                                     MergePropertyAccessors(state.Properties, existingIndex.Value, property, ref state.MemberIdCounter, compilationAssembly);
+                                    // Distinct slot hidden by `new` (or inherited twice) — the wrapper
+                                    // needs its own explicit forward for it too (#6252).
+                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn);
                                 }
                                 // else: class-primary walk and the existing member already covers
                                 // every accessor the interface needs — plain dedup.
@@ -244,6 +302,12 @@ internal static class MemberDiscovery
                             if (existingIndex.HasValue)
                             {
                                 MergePropertyAccessors(state.Properties, existingIndex.Value, indexer, ref state.MemberIdCounter, compilationAssembly);
+                                // Distinct indexer slot hidden by `new` (or inherited twice) — the
+                                // wrapper needs its own explicit forward for it too (#6252).
+                                if (primaryClassSymbol is null)
+                                {
+                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn);
+                                }
                             }
                             else if (primaryClassSymbol is not null && state.SeenExplicitImpls.Add($"{interfaceFqn}|{key}"))
                             {
@@ -262,7 +326,16 @@ internal static class MemberDiscovery
                     case IEventSymbol evt:
                     {
                         var key = $"E:{evt.Name}";
-                        if (!state.SeenEvents.Add(key)) continue;
+                        if (!state.SeenEvents.Add(key))
+                        {
+                            // Distinct event slot hidden by `new` (or inherited twice) — the wrapper
+                            // needs its own explicit forward for it too (#6252).
+                            if (primaryClassSymbol is null)
+                            {
+                                RecordAdditionalWrapperInterfaceForEvent(state.Events, evt.Name, interfaceFqn);
+                            }
+                            continue;
+                        }
 
                         var explicitName = RequiresExplicitImpl(primaryClassSymbol, evt) ? interfaceFqn : null;
                         state.Events.Add(Tag(CreateEventModel(evt, explicitName, interfaceFqn), ownerTypeIndex));

--- a/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
@@ -35,6 +35,14 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
     /// Used by the wrapper type builder for correct explicit interface forwarding.
     /// </summary>
     public string? DeclaringInterfaceName { get; init; }
+
+    /// <summary>
+    /// Extra interface FQNs whose identically-named event slot this event also satisfies but
+    /// which the generated wrapper must forward explicitly. Populated when a base-interface
+    /// event is hidden by a <c>new</c> event (or inherited from multiple interfaces). See
+    /// <see cref="MockMemberModel.AdditionalExplicitInterfaceNames"/> (#6252).
+    /// </summary>
+    public EquatableArray<string> AdditionalExplicitInterfaceNames { get; init; } = EquatableArray<string>.Empty;
     public string OverrideAccessModifier { get; init; } = "public";
     public bool IsStaticAbstract { get; init; }
 
@@ -63,6 +71,7 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
             && EventArgsType == other.EventArgsType
             && ExplicitInterfaceName == other.ExplicitInterfaceName
             && DeclaringInterfaceName == other.DeclaringInterfaceName
+            && AdditionalExplicitInterfaceNames.Equals(other.AdditionalExplicitInterfaceNames)
             && OverrideAccessModifier == other.OverrideAccessModifier
             && IsStaticAbstract == other.IsStaticAbstract
             && OwnerTypeIndex == other.OwnerTypeIndex
@@ -80,6 +89,7 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
             hash = hash * 31 + RaiseParameterList.GetHashCode();
             hash = hash * 31 + (ExplicitInterfaceName?.GetHashCode() ?? 0);
             hash = hash * 31 + (DeclaringInterfaceName?.GetHashCode() ?? 0);
+            hash = hash * 31 + AdditionalExplicitInterfaceNames.GetHashCode();
             hash = hash * 31 + OverrideAccessModifier.GetHashCode();
             hash = hash * 31 + ObsoleteAttribute.GetHashCode();
             hash = hash * 31 + OwnerTypeIndex;

--- a/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
@@ -36,6 +36,18 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
     /// Used by the wrapper type builder for correct explicit interface forwarding.
     /// </summary>
     public string? DeclaringInterfaceName { get; init; }
+
+    /// <summary>
+    /// Extra interface FQNs whose identically-signed member slot this single member also
+    /// satisfies, but which the generated wrapper type must implement with its own explicit
+    /// interface forward. Populated when a base-interface member is hidden by a <c>new</c>
+    /// member, or when identical members are inherited from multiple interfaces: the shared
+    /// impl implements every slot implicitly, but the wrapper forwards explicitly, and an
+    /// explicit impl satisfies only the one slot it names — so each shadowed base slot needs
+    /// its own forward or the build fails with CS0535 (#6252). Empty in the common case and
+    /// consumed only by <see cref="Builders.MockWrapperTypeBuilder"/> (single-interface mocks).
+    /// </summary>
+    public EquatableArray<string> AdditionalExplicitInterfaceNames { get; init; } = EquatableArray<string>.Empty;
     public string NullableAnnotation { get; init; } = "None";
     public string SmartDefault { get; init; } = "default!";
     public string UnwrappedSmartDefault { get; init; } = "default!";
@@ -135,6 +147,7 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             && ExplicitInterfaceName == other.ExplicitInterfaceName
             && ExplicitInterfaceCanDelegate == other.ExplicitInterfaceCanDelegate
             && DeclaringInterfaceName == other.DeclaringInterfaceName
+            && AdditionalExplicitInterfaceNames.Equals(other.AdditionalExplicitInterfaceNames)
             && NullableAnnotation == other.NullableAnnotation
             && SmartDefault == other.SmartDefault
             && UnwrappedSmartDefault == other.UnwrappedSmartDefault
@@ -173,6 +186,7 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             hash = hash * 31 + (ExplicitInterfaceName?.GetHashCode() ?? 0);
             hash = hash * 31 + ExplicitInterfaceCanDelegate.GetHashCode();
             hash = hash * 31 + (DeclaringInterfaceName?.GetHashCode() ?? 0);
+            hash = hash * 31 + AdditionalExplicitInterfaceNames.GetHashCode();
             hash = hash * 31 + ObsoleteAttribute.GetHashCode();
             hash = hash * 31 + GetterObsoleteAttribute.GetHashCode();
             hash = hash * 31 + SetterObsoleteAttribute.GetHashCode();

--- a/TUnit.Mocks.Tests/Issue6252Tests.cs
+++ b/TUnit.Mocks.Tests/Issue6252Tests.cs
@@ -6,7 +6,11 @@ namespace TUnit.Mocks.Tests;
 // An interface that hides a base member with `new` declares two distinct interface slots
 // (IBase.SomeMethod and IDerived.SomeMethod). The generated wrapper forwards each member as an
 // explicit interface impl, which satisfies only the slot it names — so the hidden base slot was
-// left unimplemented and the build failed with CS0535. The wrapper must now forward both slots.
+// left unimplemented and the build failed with CS0535. The wrapper must now forward both slots,
+// for every member kind, and through every level of hiding / multiple-inheritance.
+
+#region Test interfaces
+
 public interface IShadowBase
 {
     void Ping();
@@ -21,6 +25,74 @@ public interface IShadowDerived : IShadowBase
     new event System.Action Tick;
 }
 
+// Method with parameters and a non-void return — exercises argument + return forwarding.
+public interface ICalcBase
+{
+    int Compute(int x);
+}
+
+public interface ICalcDerived : ICalcBase
+{
+    new int Compute(int x);
+}
+
+// Read/write property — both accessors must be forwarded for both slots.
+public interface IRwPropBase
+{
+    string Name { get; set; }
+}
+
+public interface IRwPropDerived : IRwPropBase
+{
+    new string Name { get; set; }
+}
+
+// Indexer hiding.
+public interface IIndexerBase
+{
+    int this[int index] { get; }
+}
+
+public interface IIndexerDerived : IIndexerBase
+{
+    new int this[int index] { get; }
+}
+
+// Three-level hiding — three distinct slots for one signature.
+public interface ILevel1
+{
+    void Run();
+}
+
+public interface ILevel2 : ILevel1
+{
+    new void Run();
+}
+
+public interface ILevel3 : ILevel2
+{
+    new void Run();
+}
+
+// Diamond: two unrelated interfaces declare an identically-signed member; the combining
+// interface inherits both. Same root cause (one impl satisfies both slots, wrapper must
+// forward both) even though no `new` keyword is involved.
+public interface IDiamondA
+{
+    void Go();
+}
+
+public interface IDiamondB
+{
+    void Go();
+}
+
+public interface IDiamondC : IDiamondA, IDiamondB
+{
+}
+
+#endregion
+
 public class Issue6252Tests
 {
     [Test]
@@ -33,11 +105,22 @@ public class Issue6252Tests
     }
 
     [Test]
-    public async Task Wrapper_Forwards_Hidden_Method_Through_Both_Interface_Slots()
+    public async Task Wrapper_Is_Assignable_To_Both_Interfaces()
     {
         var mock = IShadowDerived.Mock();
 
-        // Drive the wrapper's explicit forwards via each interface slot.
+        IShadowDerived asDerived = mock;
+        IShadowBase asBase = mock;
+
+        await Assert.That(asDerived).IsNotNull();
+        await Assert.That(asBase).IsNotNull();
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_Void_Method_Through_Both_Slots()
+    {
+        var mock = IShadowDerived.Mock();
+
         ((IShadowDerived)mock).Ping();
         ((IShadowBase)mock).Ping();
 
@@ -47,12 +130,95 @@ public class Issue6252Tests
     }
 
     [Test]
-    public async Task Wrapper_Forwards_Hidden_Property_Through_Both_Interface_Slots()
+    public async Task Wrapper_Forwards_Hidden_Method_With_Args_And_Return_Through_Both_Slots()
+    {
+        var mock = ICalcDerived.Mock();
+        mock.Compute(5).Returns(50);
+
+        var viaDerived = ((ICalcDerived)mock).Compute(5);
+        var viaBase = ((ICalcBase)mock).Compute(5);
+
+        await Assert.That(viaDerived).IsEqualTo(50);
+        await Assert.That(viaBase).IsEqualTo(50);
+        mock.Compute(5).WasCalled(Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_GetOnly_Property_Through_Both_Slots()
     {
         var mock = IShadowDerived.Mock();
         mock.Value.Returns(42);
 
         await Assert.That(((IShadowDerived)mock).Value).IsEqualTo(42);
         await Assert.That(((IShadowBase)mock).Value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_ReadWrite_Property_Through_Both_Slots()
+    {
+        var mock = IRwPropDerived.Mock();
+        mock.Name.Returns("configured");
+
+        // Getter forwarded for both slots.
+        await Assert.That(((IRwPropDerived)mock).Name).IsEqualTo("configured");
+        await Assert.That(((IRwPropBase)mock).Name).IsEqualTo("configured");
+
+        // Setter forwarded for both slots (the explicit impl must declare both accessors,
+        // or this would not compile / would throw).
+        ((IRwPropDerived)mock).Name = "x";
+        ((IRwPropBase)mock).Name = "y";
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_Indexer_Through_Both_Slots()
+    {
+        var mock = IIndexerDerived.Mock();
+        mock.Item(0).Returns(100);
+
+        await Assert.That(((IIndexerDerived)mock)[0]).IsEqualTo(100);
+        await Assert.That(((IIndexerBase)mock)[0]).IsEqualTo(100);
+        mock.Item(0).WasCalled(Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_Event_Through_Both_Slots()
+    {
+        var mock = IShadowDerived.Mock();
+        var derivedFired = 0;
+        var baseFired = 0;
+
+        // Subscribe through each slot — both add/remove forwards target the same backing event.
+        ((IShadowDerived)mock).Tick += () => derivedFired++;
+        ((IShadowBase)mock).Tick += () => baseFired++;
+
+        mock.RaiseTick();
+
+        await Assert.That(derivedFired).IsEqualTo(1);
+        await Assert.That(baseFired).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Method_Hidden_Across_Three_Levels()
+    {
+        var mock = ILevel3.Mock();
+
+        ((ILevel3)mock).Run();
+        ((ILevel2)mock).Run();
+        ((ILevel1)mock).Run();
+
+        mock.Run().WasCalled(Times.Exactly(3));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Identical_Member_From_Multiple_Base_Interfaces()
+    {
+        var mock = IDiamondC.Mock();
+
+        ((IDiamondA)mock).Go();
+        ((IDiamondB)mock).Go();
+
+        mock.Go().WasCalled(Times.Exactly(2));
+        await Task.CompletedTask;
     }
 }

--- a/TUnit.Mocks.Tests/Issue6252Tests.cs
+++ b/TUnit.Mocks.Tests/Issue6252Tests.cs
@@ -1,0 +1,58 @@
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6252
+// An interface that hides a base member with `new` declares two distinct interface slots
+// (IBase.SomeMethod and IDerived.SomeMethod). The generated wrapper forwards each member as an
+// explicit interface impl, which satisfies only the slot it names — so the hidden base slot was
+// left unimplemented and the build failed with CS0535. The wrapper must now forward both slots.
+public interface IShadowBase
+{
+    void Ping();
+    int Value { get; }
+    event System.Action Tick;
+}
+
+public interface IShadowDerived : IShadowBase
+{
+    new void Ping();
+    new int Value { get; }
+    new event System.Action Tick;
+}
+
+public class Issue6252Tests
+{
+    [Test]
+    public async Task Mocking_Interface_That_Hides_Base_Members_With_New_Compiles()
+    {
+        // Before the fix this file failed to compile: CS0535 'IShadowDerivedMock' does not
+        // implement interface member 'IShadowBase.Ping()' (and Value / Tick).
+        var mock = IShadowDerived.Mock();
+        await Assert.That(mock).IsNotNull();
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_Method_Through_Both_Interface_Slots()
+    {
+        var mock = IShadowDerived.Mock();
+
+        // Drive the wrapper's explicit forwards via each interface slot.
+        ((IShadowDerived)mock).Ping();
+        ((IShadowBase)mock).Ping();
+
+        // Both slots dispatch to the single mocked member.
+        mock.Ping().WasCalled(Times.Exactly(2));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Wrapper_Forwards_Hidden_Property_Through_Both_Interface_Slots()
+    {
+        var mock = IShadowDerived.Mock();
+        mock.Value.Returns(42);
+
+        await Assert.That(((IShadowDerived)mock).Value).IsEqualTo(42);
+        await Assert.That(((IShadowBase)mock).Value).IsEqualTo(42);
+    }
+}


### PR DESCRIPTION
Fixes #6252

## Problem

Mocking an interface that hides a base member with `new` fails to compile:

```csharp
public interface IBase { void SomeMethod(); }
public interface IDerived : IBase { new void SomeMethod(); }

var mock = IDerived.Mock(); // error CS0535: 'IDerivedMock' does not implement 'IBase.SomeMethod()'
```

## Root cause

`IDerived.SomeMethod()` and `IBase.SomeMethod()` are **two distinct interface slots**.

- The backing impl `IDerivedMockImpl` implements them *implicitly* with one `public void SomeMethod()` — a single implicit method satisfies both slots, so it compiled fine.
- The generated **wrapper** `IDerivedMock : Mock<IDerived>, IDerived` forwards every member as an **explicit** interface impl (`void IDerived.SomeMethod() => Object.SomeMethod();`). An explicit impl satisfies only the slot it names. Member discovery deduped the base slot away, so the wrapper never emitted `void IBase.SomeMethod()` → CS0535.

The same flaw affected properties, indexers, and events.

## Fix

When discovery drops an identically-signed member from a *different* interface (a `new`-hidden base member, or one inherited from multiple interfaces) in the single-interface path, record that interface on the surviving member via a new `AdditionalExplicitInterfaceNames` field. The wrapper then emits one extra explicit forward per recorded slot, cast to that interface (`((IBase)Object).SomeMethod()`) so the correct slot is hit — which also keeps `Mock.Wrap` of a real object with differing explicit impls correct.

The comprehensive tests surfaced a **second defect** in the diamond case (`IC : IA, IB` where both declare `void Go()`): the *primary* forward `Object.Go()` is **ambiguous (CS0121)** because `Object`'s static type inherits `Go()` from two interfaces. So the primary forward is now also cast to its own slot whenever the member spans multiple slots.

Only the wrapper consumes the new field (single-interface mocks); the impl class and setup extensions are unchanged, so the dense member-ID invariant holds and snapshot output is **byte-identical** for the common single-slot case.

## Testing

- **`Issue6252Tests`** (runtime, 10 tests): void method, method with args+return, get-only property, read/write property, indexer, event (subscribe + raise through both slots), three-level hiding, wrapper assignability, and the diamond case — each verifying dispatch through **both** interface slots.
- **2 generator-level regression tests** in `MockGeneratorTests`: lock the generated wrapper shape (both forwards + cast targets) and assert CS0535/CS0121 are gone.
- Full `TUnit.Mocks.Tests`: **1116 passed** (net10.0); Issue6252 subset **10 passed** on net8.0 (cross-TFM).
- Full `TUnit.Mocks.SourceGenerator.Tests`: **71 passed** (69 existing snapshots unchanged + 2 new).

## Known remaining gap (pre-existing, not a regression)

Asymmetric-accessor `new` hiding (base `{get;set;}`, derived `new {get;}`) still fails to build (CS0550) — it was already broken before this PR and needs per-slot accessor tracking to fix. Out of scope here.