### PR TITLE
fix(mocks): forward asymmetric `new`-hidden property slots per-accessor (#6263)

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
+++ b/TUnit.Mocks.SourceGenerator.Tests/MockGeneratorTests.cs
@@ -2182,6 +2182,46 @@ public class MockGeneratorTests : SnapshotTestBase
     }
 
     [Test]
+    public void Interface_Hiding_Property_With_New_And_Different_Accessors_Forwards_Per_Slot_Accessors()
+    {
+        // Regression #6263: IDerived hides a base property with `new` AND a different accessor set.
+        // IBase.Prop (get-only) and IDerived.Prop (get+set) are distinct slots. The shared impl holds
+        // the merged accessors, but each explicit wrapper forward must emit only the accessors ITS
+        // slot declares — else the base forward adds a `set` IBase never had (CS0550). Both directions.
+        var source = """
+            using TUnit.Mocks;
+
+            public interface IBase { string Prop { get; } }
+            public interface IDerived : IBase { new string Prop { get; set; } }
+
+            public interface IRwBase { string Other { get; set; } }
+            public interface IRoDerived : IRwBase { new string Other { get; } }
+
+            public class TestUsage
+            {
+                void M()
+                {
+                    var a = Mock.Of<IDerived>();
+                    var b = Mock.Of<IRoDerived>();
+                }
+            }
+            """;
+
+        var output = GetGeneratedOutput(source);
+
+        // Derived slot keeps both accessors; the get-only base slot forward must NOT emit a setter.
+        AssertContains(output, "string global::IDerived.Prop { get => ((global::IDerived)Object).Prop; set => ((global::IDerived)Object).Prop = value; }");
+        AssertContains(output, "string global::IBase.Prop { get => ((global::IBase)Object).Prop; }");
+
+        // Reverse: derived drops the setter, base keeps it.
+        AssertContains(output, "string global::IRoDerived.Other { get => ((global::IRoDerived)Object).Other; }");
+        AssertContains(output, "string global::IRwBase.Other { get => ((global::IRwBase)Object).Other; set => ((global::IRwBase)Object).Other = value; }");
+
+        AssertNoGeneratedError(source, "CS0550");
+        AssertNoGeneratedError(source, "CS0535");
+    }
+
+    [Test]
     public void Interface_Inheriting_Identical_Member_From_Multiple_Interfaces_Forwards_Both_Slots()
     {
         // Regression #6252 (diamond): IDiamondC inherits an identically-signed Go() from two

--- a/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockWrapperTypeBuilder.cs
@@ -96,10 +96,10 @@ internal static class MockWrapperTypeBuilder
         // Additional explicit forwards for distinct interface slots this member also satisfies
         // (base members hidden by `new`, or inherited from multiple interfaces). Each slot needs
         // its own explicit impl, cast to that interface so the right slot is hit on Object (#6252).
-        foreach (var extra in method.AdditionalExplicitInterfaceNames)
+        foreach (var extra in method.AdditionalExplicitSlots)
         {
             writer.AppendLine();
-            EmitMethodForward(writer, method, extra, CastTarget(extra));
+            EmitMethodForward(writer, method, extra.InterfaceName, CastTarget(extra.InterfaceName));
         }
     }
 
@@ -132,16 +132,18 @@ internal static class MockWrapperTypeBuilder
     private static void GeneratePropertyForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
         var interfaceName = GetForwardingInterfaceName(prop, model);
-        EmitPropertyForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName));
+        // The primary forward emits the declaring slot's OWN accessors, not the merged set, so an
+        // asymmetric `new`-hidden slot doesn't gain an accessor it never declared (CS0550, #6263).
+        EmitPropertyForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName), prop.OwnHasGetter, prop.OwnHasSetter);
 
-        foreach (var extra in prop.AdditionalExplicitInterfaceNames)
+        foreach (var extra in prop.AdditionalExplicitSlots)
         {
             writer.AppendLine();
-            EmitPropertyForward(writer, prop, extra, CastTarget(extra));
+            EmitPropertyForward(writer, prop, extra.InterfaceName, CastTarget(extra.InterfaceName), extra.HasGetter, extra.HasSetter);
         }
     }
 
-    private static void EmitPropertyForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target)
+    private static void EmitPropertyForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target, bool hasGetter, bool hasSetter)
     {
         var returnType = prop.ReturnType;
 
@@ -150,8 +152,8 @@ internal static class MockWrapperTypeBuilder
         // Per-accessor [Obsolete] is injected inline so the property line stays a one-liner.
         var getterAttr = GetAccessorObsoletePrefix(prop.GetterObsoleteAttribute);
         var setterAttr = GetAccessorObsoletePrefix(prop.SetterObsoleteAttribute);
-        var getter = prop.HasGetter ? $"{getterAttr}get => {target}.{EscapeIdentifier(prop.Name)}; " : "";
-        var setter = prop.HasSetter ? $"{setterAttr}set => {target}.{EscapeIdentifier(prop.Name)} = value; " : "";
+        var getter = hasGetter ? $"{getterAttr}get => {target}.{EscapeIdentifier(prop.Name)}; " : "";
+        var setter = hasSetter ? $"{setterAttr}set => {target}.{EscapeIdentifier(prop.Name)} = value; " : "";
 
         writer.AppendLine($"{returnType} {interfaceName}.{EscapeIdentifier(prop.Name)} {{ {getter}{setter}}}");
     }
@@ -159,16 +161,16 @@ internal static class MockWrapperTypeBuilder
     private static void GenerateIndexerForwarding(CodeWriter writer, MockMemberModel prop, MockTypeModel model)
     {
         var interfaceName = GetForwardingInterfaceName(prop, model);
-        EmitIndexerForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName));
+        EmitIndexerForward(writer, prop, interfaceName, GetPrimaryTarget(prop, interfaceName), prop.OwnHasGetter, prop.OwnHasSetter);
 
-        foreach (var extra in prop.AdditionalExplicitInterfaceNames)
+        foreach (var extra in prop.AdditionalExplicitSlots)
         {
             writer.AppendLine();
-            EmitIndexerForward(writer, prop, extra, CastTarget(extra));
+            EmitIndexerForward(writer, prop, extra.InterfaceName, CastTarget(extra.InterfaceName), extra.HasGetter, extra.HasSetter);
         }
     }
 
-    private static void EmitIndexerForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target)
+    private static void EmitIndexerForward(CodeWriter writer, MockMemberModel prop, string interfaceName, string target, bool hasGetter, bool hasSetter)
     {
         var returnType = prop.ReturnType;
         var paramList = MockImplBuilder.GetParameterList(prop);
@@ -178,8 +180,8 @@ internal static class MockWrapperTypeBuilder
 
         var getterAttr = GetAccessorObsoletePrefix(prop.GetterObsoleteAttribute);
         var setterAttr = GetAccessorObsoletePrefix(prop.SetterObsoleteAttribute);
-        var getter = prop.HasGetter ? $"{getterAttr}get => {target}[{argPassList}]; " : "";
-        var setter = prop.HasSetter ? $"{setterAttr}set => {target}[{argPassList}] = value; " : "";
+        var getter = hasGetter ? $"{getterAttr}get => {target}[{argPassList}]; " : "";
+        var setter = hasSetter ? $"{setterAttr}set => {target}[{argPassList}] = value; " : "";
 
         writer.AppendLine($"{returnType} {interfaceName}.this[{paramList}] {{ {getter}{setter}}}");
     }
@@ -197,7 +199,7 @@ internal static class MockWrapperTypeBuilder
     // or when it also satisfies other slots — otherwise `Object.X` may be ambiguous (CS0121) or bind
     // to the wrong slot (#6252).
     private static string GetPrimaryTarget(MockMemberModel member, string interfaceName)
-        => member.ExplicitInterfaceName is not null || member.AdditionalExplicitInterfaceNames.Length > 0
+        => member.ExplicitInterfaceName is not null || member.AdditionalExplicitSlots.Length > 0
             ? CastTarget(interfaceName)
             : "Object";
 

--- a/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MemberDiscovery.cs
@@ -98,12 +98,27 @@ internal static class MemberDiscovery
     /// the interface already matches the member's own slot or is already recorded. Only meaningful
     /// for single-interface mocks — the only ones with a wrapper.
     /// </summary>
-    private static void RecordAdditionalWrapperInterface(List<MockMemberModel> members, int index, string interfaceFqn)
+    /// <param name="slotHasGetter">/<param name="slotHasSetter">: the accessors declared by the
+    /// shadowed slot itself, so the wrapper forward for it emits only those (asymmetric <c>new</c>
+    /// hiding — CS0550, #6263). Both true for methods, where accessor presence is irrelevant.</param>
+    private static void RecordAdditionalWrapperInterface(List<MockMemberModel> members, int index, string interfaceFqn,
+        bool slotHasGetter, bool slotHasSetter)
     {
         var existing = members[index];
-        var updated = AppendDistinctSlot(existing.AdditionalExplicitInterfaceNames,
-            existing.ExplicitInterfaceName ?? existing.DeclaringInterfaceName, interfaceFqn, out var changed);
-        if (changed) members[index] = existing with { AdditionalExplicitInterfaceNames = updated };
+        var ownSlot = existing.ExplicitInterfaceName ?? existing.DeclaringInterfaceName;
+        if (ownSlot == interfaceFqn) return;
+        var array = existing.AdditionalExplicitSlots.AsImmutableArray();
+        if (array.Any(s => s.InterfaceName == interfaceFqn)) return;
+        var slot = new MockExplicitInterfaceSlot
+        {
+            InterfaceName = interfaceFqn,
+            HasGetter = slotHasGetter,
+            HasSetter = slotHasSetter
+        };
+        members[index] = existing with
+        {
+            AdditionalExplicitSlots = new EquatableArray<MockExplicitInterfaceSlot>(array.Add(slot))
+        };
     }
 
     /// <summary>Event counterpart of <see cref="RecordAdditionalWrapperInterface"/>. Locates the
@@ -221,7 +236,7 @@ internal static class MemberDiscovery
                                     // forwards that slot, else the build fails with CS0535 (#6252).
                                     if (primaryClassSymbol is null && existing.Index >= 0)
                                     {
-                                        RecordAdditionalWrapperInterface(state.Methods, existing.Index, interfaceFqn);
+                                        RecordAdditionalWrapperInterface(state.Methods, existing.Index, interfaceFqn, slotHasGetter: true, slotHasSetter: true);
                                     }
                                     continue;
                                 }
@@ -277,8 +292,11 @@ internal static class MemberDiscovery
                                 {
                                     MergePropertyAccessors(state.Properties, existingIndex.Value, property, ref state.MemberIdCounter, compilationAssembly);
                                     // Distinct slot hidden by `new` (or inherited twice) — the wrapper
-                                    // needs its own explicit forward for it too (#6252).
-                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn);
+                                    // needs its own explicit forward for it too (#6252), emitting only
+                                    // the accessors this slot declares (#6263).
+                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn,
+                                        IsAccessorAccessible(property.GetMethod, compilationAssembly),
+                                        IsAccessorAccessible(property.SetMethod, compilationAssembly));
                                 }
                                 // else: class-primary walk and the existing member already covers
                                 // every accessor the interface needs — plain dedup.
@@ -308,10 +326,13 @@ internal static class MemberDiscovery
                             {
                                 MergePropertyAccessors(state.Properties, existingIndex.Value, indexer, ref state.MemberIdCounter, compilationAssembly);
                                 // Distinct indexer slot hidden by `new` (or inherited twice) — the
-                                // wrapper needs its own explicit forward for it too (#6252).
+                                // wrapper needs its own explicit forward for it too (#6252), emitting
+                                // only the accessors this slot declares (#6263).
                                 if (primaryClassSymbol is null)
                                 {
-                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn);
+                                    RecordAdditionalWrapperInterface(state.Properties, existingIndex.Value, interfaceFqn,
+                                        IsAccessorAccessible(indexer.GetMethod, compilationAssembly),
+                                        IsAccessorAccessible(indexer.SetMethod, compilationAssembly));
                                 }
                             }
                             else if (primaryClassSymbol is not null && state.SeenExplicitImpls.Add($"{interfaceFqn}|{key}"))
@@ -781,6 +802,8 @@ internal static class MemberDiscovery
             IsProperty = true,
             HasGetter = hasGetter,
             HasSetter = hasSetter,
+            OwnHasGetter = hasGetter,
+            OwnHasSetter = hasSetter,
             SetterMemberId = setterId,
             ExplicitInterfaceName = explicitInterfaceName,
             DeclaringInterfaceName = declaringInterfaceName,
@@ -874,6 +897,8 @@ internal static class MemberDiscovery
             IsIndexer = true,
             HasGetter = hasGetter,
             HasSetter = hasSetter,
+            OwnHasGetter = hasGetter,
+            OwnHasSetter = hasSetter,
             Parameters = new EquatableArray<MockParameterModel>(
                 indexer.Parameters.Select(p => new MockParameterModel
                 {

--- a/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockEventModel.cs
@@ -40,7 +40,8 @@ internal sealed record MockEventModel : IEquatable<MockEventModel>
     /// Extra interface FQNs whose identically-named event slot this event also satisfies but
     /// which the generated wrapper must forward explicitly. Populated when a base-interface
     /// event is hidden by a <c>new</c> event (or inherited from multiple interfaces). See
-    /// <see cref="MockMemberModel.AdditionalExplicitInterfaceNames"/> (#6252).
+    /// <see cref="MockMemberModel.AdditionalExplicitSlots"/> (#6252). Events have no asymmetric
+    /// accessors, so this stays a plain name list (unlike the property/method slot model).
     /// </summary>
     public EquatableArray<string> AdditionalExplicitInterfaceNames { get; init; } = EquatableArray<string>.Empty;
     public string OverrideAccessModifier { get; init; } = "public";

--- a/TUnit.Mocks.SourceGenerator/Models/MockExplicitInterfaceSlot.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockExplicitInterfaceSlot.cs
@@ -1,0 +1,17 @@
+namespace TUnit.Mocks.SourceGenerator.Models;
+
+/// <summary>
+/// A distinct interface slot that a single shared member also satisfies, but which the generated
+/// wrapper type must implement with its own explicit interface forward (#6252). Carries the slot's
+/// own accessor presence so the forward emits only the accessors that <i>this</i> interface declares:
+/// when a base property is hidden by a <c>new</c> member with a different accessor set (e.g. base
+/// <c>{ get; }</c>, derived <c>new { get; set; }</c>), the shared model holds the <em>merged</em>
+/// accessors for the implicit impl, but each explicit forward must match its own slot exactly or the
+/// build fails with CS0550 (#6263). For methods these flags are unused.
+/// </summary>
+internal sealed record MockExplicitInterfaceSlot
+{
+    public string InterfaceName { get; init; } = "";
+    public bool HasGetter { get; init; }
+    public bool HasSetter { get; init; }
+}

--- a/TUnit.Mocks.SourceGenerator/Models/MockExplicitInterfaceSlot.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockExplicitInterfaceSlot.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace TUnit.Mocks.SourceGenerator.Models;
 
 /// <summary>
@@ -9,9 +11,29 @@ namespace TUnit.Mocks.SourceGenerator.Models;
 /// accessors for the implicit impl, but each explicit forward must match its own slot exactly or the
 /// build fails with CS0550 (#6263). For methods these flags are unused.
 /// </summary>
-internal sealed record MockExplicitInterfaceSlot
+internal sealed record MockExplicitInterfaceSlot : IEquatable<MockExplicitInterfaceSlot>
 {
     public string InterfaceName { get; init; } = "";
     public bool HasGetter { get; init; }
     public bool HasSetter { get; init; }
+
+    public bool Equals(MockExplicitInterfaceSlot? other)
+    {
+        if (other is null) return false;
+        return InterfaceName == other.InterfaceName
+            && HasGetter == other.HasGetter
+            && HasSetter == other.HasSetter;
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 31 + InterfaceName.GetHashCode();
+            hash = hash * 31 + HasGetter.GetHashCode();
+            hash = hash * 31 + HasSetter.GetHashCode();
+            return hash;
+        }
+    }
 }

--- a/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
+++ b/TUnit.Mocks.SourceGenerator/Models/MockMemberModel.cs
@@ -38,16 +38,28 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
     public string? DeclaringInterfaceName { get; init; }
 
     /// <summary>
-    /// Extra interface FQNs whose identically-signed member slot this single member also
-    /// satisfies, but which the generated wrapper type must implement with its own explicit
-    /// interface forward. Populated when a base-interface member is hidden by a <c>new</c>
-    /// member, or when identical members are inherited from multiple interfaces: the shared
-    /// impl implements every slot implicitly, but the wrapper forwards explicitly, and an
-    /// explicit impl satisfies only the one slot it names — so each shadowed base slot needs
-    /// its own forward or the build fails with CS0535 (#6252). Empty in the common case and
-    /// consumed only by <see cref="Builders.MockWrapperTypeBuilder"/> (single-interface mocks).
+    /// Extra interface slots whose identically-signed member this single member also satisfies,
+    /// but which the generated wrapper type must implement with its own explicit interface forward.
+    /// Populated when a base-interface member is hidden by a <c>new</c> member, or when identical
+    /// members are inherited from multiple interfaces: the shared impl implements every slot
+    /// implicitly, but the wrapper forwards explicitly, and an explicit impl satisfies only the one
+    /// slot it names — so each shadowed base slot needs its own forward or the build fails with
+    /// CS0535 (#6252). Each slot carries its own accessor presence so the forward emits only the
+    /// accessors that interface declares (asymmetric <c>new</c> hiding — CS0550, #6263). Empty in the
+    /// common case and consumed only by <see cref="Builders.MockWrapperTypeBuilder"/> (single-interface mocks).
     /// </summary>
-    public EquatableArray<string> AdditionalExplicitInterfaceNames { get; init; } = EquatableArray<string>.Empty;
+    public EquatableArray<MockExplicitInterfaceSlot> AdditionalExplicitSlots { get; init; } = EquatableArray<MockExplicitInterfaceSlot>.Empty;
+
+    /// <summary>
+    /// The accessors declared by this member's <em>own</em> primary slot
+    /// (<see cref="DeclaringInterfaceName"/>), before <c>MergePropertyAccessors</c> widened
+    /// <see cref="HasGetter"/>/<see cref="HasSetter"/> to the union across all shadowed slots.
+    /// The wrapper's primary explicit forward emits from these so it doesn't add an accessor the
+    /// declaring interface lacks (CS0550, #6263). Equal to <see cref="HasGetter"/>/<see cref="HasSetter"/>
+    /// in the common (non-shadowing) case, keeping generated output byte-identical. Unused for methods.
+    /// </summary>
+    public bool OwnHasGetter { get; init; }
+    public bool OwnHasSetter { get; init; }
     public string NullableAnnotation { get; init; } = "None";
     public string SmartDefault { get; init; } = "default!";
     public string UnwrappedSmartDefault { get; init; } = "default!";
@@ -147,7 +159,9 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             && ExplicitInterfaceName == other.ExplicitInterfaceName
             && ExplicitInterfaceCanDelegate == other.ExplicitInterfaceCanDelegate
             && DeclaringInterfaceName == other.DeclaringInterfaceName
-            && AdditionalExplicitInterfaceNames.Equals(other.AdditionalExplicitInterfaceNames)
+            && AdditionalExplicitSlots.Equals(other.AdditionalExplicitSlots)
+            && OwnHasGetter == other.OwnHasGetter
+            && OwnHasSetter == other.OwnHasSetter
             && NullableAnnotation == other.NullableAnnotation
             && SmartDefault == other.SmartDefault
             && UnwrappedSmartDefault == other.UnwrappedSmartDefault
@@ -186,7 +200,9 @@ internal sealed record MockMemberModel : IEquatable<MockMemberModel>
             hash = hash * 31 + (ExplicitInterfaceName?.GetHashCode() ?? 0);
             hash = hash * 31 + ExplicitInterfaceCanDelegate.GetHashCode();
             hash = hash * 31 + (DeclaringInterfaceName?.GetHashCode() ?? 0);
-            hash = hash * 31 + AdditionalExplicitInterfaceNames.GetHashCode();
+            hash = hash * 31 + AdditionalExplicitSlots.GetHashCode();
+            hash = hash * 31 + OwnHasGetter.GetHashCode();
+            hash = hash * 31 + OwnHasSetter.GetHashCode();
             hash = hash * 31 + ObsoleteAttribute.GetHashCode();
             hash = hash * 31 + GetterObsoleteAttribute.GetHashCode();
             hash = hash * 31 + SetterObsoleteAttribute.GetHashCode();

--- a/TUnit.Mocks.Tests/Issue6263Tests.cs
+++ b/TUnit.Mocks.Tests/Issue6263Tests.cs
@@ -1,0 +1,100 @@
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6263
+// When a derived interface hides a base property/indexer with `new` and a DIFFERENT accessor set
+// (e.g. base { get; }, derived new { get; set; }), the two slots are distinct. The shared impl holds
+// the merged accessors, but each explicit wrapper forward must emit only the accessors ITS slot
+// declares — otherwise the forward adds an accessor the interface lacks and the build fails with
+// CS0550. Both asymmetry directions are covered (adding and dropping an accessor in the derived slot).
+
+#region Test interfaces
+
+// Issue's exact case: base get-only, derived adds a setter.
+public interface IGetOnlyBase
+{
+    string SomeProperty { get; }
+}
+
+public interface IAddSetterDerived : IGetOnlyBase
+{
+    new string SomeProperty { get; set; }
+}
+
+// Reverse asymmetry: base read/write, derived drops the setter.
+public interface IReadWriteBase
+{
+    string Prop { get; set; }
+}
+
+public interface IDropSetterDerived : IReadWriteBase
+{
+    new string Prop { get; }
+}
+
+// Asymmetric indexer: base get-only, derived adds a setter.
+public interface IGetOnlyIndexerBase
+{
+    int this[int index] { get; }
+}
+
+public interface IAddSetterIndexerDerived : IGetOnlyIndexerBase
+{
+    new int this[int index] { get; set; }
+}
+
+#endregion
+
+public class Issue6263Tests
+{
+    [Test]
+    public async Task Mocking_Asymmetric_New_Hidden_Property_Compiles()
+    {
+        // Before the fix this file failed to compile: CS0550 'IAddSetterDerivedMock.IGetOnlyBase
+        // .SomeProperty.set' adds an accessor not found in interface member 'IGetOnlyBase.SomeProperty'.
+        var mock = IAddSetterDerived.Mock();
+        await Assert.That(mock).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddedSetter_Getter_Forwards_Through_Both_Slots()
+    {
+        var mock = IAddSetterDerived.Mock();
+        mock.SomeProperty.Returns("configured");
+
+        // The base slot is get-only; only the derived slot exposes the setter.
+        await Assert.That(((IAddSetterDerived)mock).SomeProperty).IsEqualTo("configured");
+        await Assert.That(((IGetOnlyBase)mock).SomeProperty).IsEqualTo("configured");
+
+        // Setter exists on the derived slot only — must not throw / must compile.
+        ((IAddSetterDerived)mock).SomeProperty = "x";
+    }
+
+    [Test]
+    public async Task DroppedSetter_Setter_Still_Reachable_Through_Base_Slot()
+    {
+        // Reverse direction: derived slot is get-only, base slot keeps the setter.
+        var mock = IDropSetterDerived.Mock();
+        mock.Prop.Returns("configured");
+
+        await Assert.That(((IDropSetterDerived)mock).Prop).IsEqualTo("configured");
+        await Assert.That(((IReadWriteBase)mock).Prop).IsEqualTo("configured");
+
+        // Setter exists on the base slot only.
+        ((IReadWriteBase)mock).Prop = "y";
+    }
+
+    [Test]
+    public async Task Asymmetric_New_Hidden_Indexer_Forwards_Through_Both_Slots()
+    {
+        var mock = IAddSetterIndexerDerived.Mock();
+        mock.Item(0).Returns(100);
+
+        await Assert.That(((IAddSetterIndexerDerived)mock)[0]).IsEqualTo(100);
+        await Assert.That(((IGetOnlyIndexerBase)mock)[0]).IsEqualTo(100);
+
+        // Setter on the derived slot only.
+        ((IAddSetterIndexerDerived)mock)[0] = 5;
+    }
+}


### PR DESCRIPTION
Fixes #6263

## Problem

Mocking an interface where a derived member hides a base property with `new` **and a different accessor set** fails to compile:

```csharp
public interface IBase    { string SomeProperty { get; } }
public interface IDerived : IBase { new string SomeProperty { get; set; } }

var mock = IDerived.Mock();
// error CS0550: 'IDerivedMock.IBase.SomeProperty.set' adds an accessor
//               not found in interface member 'IBase.SomeProperty'
```

This is the asymmetric-accessor gap left open by #6252/#6256 (which handled `new`-hiding only when both slots share the same accessors).

## Root cause

`IBase.SomeProperty` (get-only) and `IDerived.SomeProperty` (get+set) are two distinct interface slots. Discovery merges them into one model holding the **union** of accessors so the backing impl can satisfy every slot with a single implicit `public { get; set; }` — that's why only the wrapper errored. But the wrapper forwards each slot as an **explicit** impl, and it emitted *every* forward (primary + each `new`-hidden slot) using those merged flags. So the get-only `IBase` forward gained a `set` the interface never declared → **CS0550**.

The reverse asymmetry (base `{ get; set; }`, derived `new { get; }`) is the symmetric case, where it's the *primary* forward that gains a spurious accessor.

## Fix

Each explicit forward now emits only the accessors **its** slot declares:

- New `MockExplicitInterfaceSlot` record carries each shadowed slot's `HasGetter`/`HasSetter` (the old `AdditionalExplicitInterfaceNames` string list becomes `AdditionalExplicitSlots`).
- New `OwnHasGetter`/`OwnHasSetter` on the member model capture the declaring slot's **pre-merge** accessors; the primary forward emits from those.
- `MockWrapperTypeBuilder` emits each property/indexer forward from its slot's accessors instead of the merged flags.

Wrapper-only change (single-interface mocks). The impl and configurable setup surface keep using the merged flags, and `Own* == merged` in every non-asymmetric case, so generated output is **byte-identical** there.

## Testing

- **`Issue6263Tests`** (runtime, 4 tests): the issue's exact case (base `{get;}` / derived `new {get;set;}`), the reverse direction (base `{get;set;}` / derived `new {get;}`), and an asymmetric indexer — each verifying dispatch through both slots and that the asymmetric accessor lives only on the slot that declares it.
- **1 generator regression test** in `MockGeneratorTests`: locks the per-slot forward shapes and asserts CS0550/CS0535 are gone, both directions.
- `TUnit.Mocks.SourceGenerator.Tests`: **225 passed** (all existing snapshots unchanged, no `.received.txt`).
- `TUnit.Mocks.Tests`: **1154 passed** (net10.0); Issue6263 subset **4 passed** on net8.0 (cross-TFM).