### PR TITLE
fix: honor OverloadResolutionPriority on net8 consumers (#6276, #6280)

### DIFF
--- a/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
+++ b/TUnit.Assertions.Tests/Bugs/Issue5720Tests.cs
@@ -1,5 +1,3 @@
-// Gated to match ImplicitConversionEqualityExtensions.cs — see issue #5765.
-#if NET9_0_OR_GREATER
 namespace TUnit.Assertions.Tests.Bugs;
 
 /// <summary>
@@ -193,5 +191,3 @@ public class Issue5720Tests
             $"No implicit conversion operator from '{typeof(UnrelatedType)}' to '{typeof(string)}' was found.");
     }
 }
-
-#endif

--- a/TUnit.Assertions.Tests/CollectionOverloadResolutionTests.cs
+++ b/TUnit.Assertions.Tests/CollectionOverloadResolutionTests.cs
@@ -1,4 +1,3 @@
-#if NET9_0_OR_GREATER
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
@@ -393,4 +392,3 @@ public class CollectionOverloadResolutionTests
         await Assert.That(collection).Contains(1);
     }
 }
-#endif

--- a/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
+++ b/TUnit.Assertions/Extensions/ImplicitConversionEqualityExtensions.cs
@@ -1,8 +1,6 @@
-// Gated to .NET 9+ because these overloads rely on [OverloadResolutionPriority] to
-// lose to the source-generated single-generic IsEqualTo / IsNotEqualTo on same-type
-// calls, and that attribute is silently dropped on net8.0 / netstandard2.0 (Polyfill
-// does not supply it), causing CS0121. See issue #5765.
-#if NET9_0_OR_GREATER
+// These overloads rely on [OverloadResolutionPriority] (honored only by C# 13+) to lose to the
+// source-generated same-type IsEqualTo / IsNotEqualTo. TUnit raises consumer LangVersion so the
+// attribute is honored on every target (see TUnit.Assertions.props). Issues #5765, #6276, #6280.
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -151,4 +149,3 @@ internal static class ImplicitConversionCache
         return null;
     }
 }
-#endif

--- a/TUnit.Assertions/TUnit.Assertions.props
+++ b/TUnit.Assertions/TUnit.Assertions.props
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+    <!--
+      TUnit's Assert.That(...) overloads are disambiguated with [OverloadResolutionPriority],
+      which only C# 13+ honors. net8.0-and-earlier projects default to C# 12 and silently ignore
+      it, breaking overload resolution (CS0411/CS0121; issues #6276, #6280). This default MUST
+      live in .props, not .targets: the SDK sets the target-framework default LangVersion during
+      the .targets phase, so a .targets default (Condition="'$(LangVersion)' == ''") never wins.
+      Consumers can still override LangVersion explicitly.
+    -->
+    <PropertyGroup>
+        <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(TUnitAssertionsImplicitUsings)' == ''">
         <TUnitAssertionsImplicitUsings>true</TUnitAssertionsImplicitUsings>
     </PropertyGroup>

--- a/TUnit.Engine/TUnit.Engine.props
+++ b/TUnit.Engine/TUnit.Engine.props
@@ -20,6 +20,18 @@
         <TUnitReflectionScanner Condition="'$(IsVBProject)' == 'true' or '$(IsFSharpProject)' == 'true'">true</TUnitReflectionScanner>
     </PropertyGroup>
 
+    <!--
+      TUnit's Assert.That(...) overloads are disambiguated with [OverloadResolutionPriority],
+      which only C# 13+ honors. net8.0-and-earlier projects default to C# 12 and silently ignore
+      it, breaking overload resolution (CS0411/CS0121; issues #6276, #6280). This default MUST
+      live in .props, not .targets: the SDK sets the target-framework default LangVersion during
+      the .targets phase, so a .targets default (Condition="'$(LangVersion)' == ''") never wins.
+      Consumers can still override LangVersion explicitly.
+    -->
+    <PropertyGroup>
+        <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <!--
           !!! IMPORTANT !!!

--- a/TUnit.Engine/TUnit.Engine.targets
+++ b/TUnit.Engine/TUnit.Engine.targets
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-    <PropertyGroup>
-        <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
-    </PropertyGroup>
+    <!-- LangVersion default moved to TUnit.Engine.props: a .targets default never wins against
+         the SDK's target-framework LangVersion default (set during the .targets phase). See #6276/#6280. -->
 
     <ItemGroup Condition="'$(TUnitImplicitUsings)' == 'true'">
         <Using Include="TUnit.Core" />

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -4299,6 +4299,9 @@ namespace .Extensions
     {
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, [.("expected")] string? expectedExpression = null) { }
         public static .<TValue> IsEqualTo<TValue>(this .<TValue> source, TValue? expected, .<TValue> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        public static .<TOther> IsEqualTo<TValue, TOther>(this .<TValue> source, TOther? expected, [.("expected")] string? expectedExpression = null) { }
     }
     public static class EquatableAssertionExtensions
     {
@@ -5225,6 +5228,9 @@ namespace .Extensions
     public static class NotEqualsAssertionExtensions
     {
         public static .<TValue> IsNotEqualTo<TValue>(this .<TValue> source, TValue notExpected, .<TValue>? comparer = null, [.("notExpected")] string? notExpectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        [.("Looks up implicit conversion operators via reflection. Trimming may remove user-d" +
+            "efined operators.")]
+        public static .<TOther> IsNotEqualTo<TValue, TOther>(this .<TValue> source, TOther? notExpected, [.("notExpected")] string? notExpectedExpression = null) { }
     }
     public static class NotEquivalentToAssertionExtensions
     {

--- a/TUnit/TUnit.props
+++ b/TUnit/TUnit.props
@@ -17,6 +17,18 @@
         <TUnitAssertionsImplicitUsings Condition="'$(TUnitAssertionsImplicitUsings)' == ''">true</TUnitAssertionsImplicitUsings>
     </PropertyGroup>
 
+    <!--
+      TUnit's Assert.That(...) overloads are disambiguated with [OverloadResolutionPriority],
+      which only C# 13+ honors. net8.0-and-earlier projects default to C# 12 and silently ignore
+      it, breaking overload resolution (CS0411/CS0121; issues #6276, #6280). This default MUST
+      live in .props, not .targets: the SDK sets the target-framework default LangVersion during
+      the .targets phase, so a .targets default (Condition="'$(LangVersion)' == ''") never wins.
+      Consumers can still override LangVersion explicitly.
+    -->
+    <PropertyGroup>
+        <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <!--
           !!! IMPORTANT !!!

--- a/TUnit/TUnit.targets
+++ b/TUnit/TUnit.targets
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-    <PropertyGroup>
-        <LangVersion Condition="'$(LangVersion)' == ''">latest</LangVersion>
-    </PropertyGroup>
+    <!-- LangVersion default moved to TUnit.props: a .targets default never wins against the SDK's
+         target-framework LangVersion default (set during the .targets phase). See #6276/#6280. -->
 
 </Project>


### PR DESCRIPTION
## Problem

Closes #6276, closes #6280.

`Assert.That(...)` exposes many overloads (array, `IList<T>`, `ICollection<T>`, `IReadOnlyCollection<T>`, `IEnumerable<T>`, `IDictionary<,>`, `IReadOnlyDictionary<,>`, ... plus a generic `That<TValue>(TValue)` catch-all). They overlap by design — a `Dictionary<,>` satisfies several at once — and are disambiguated purely with `[OverloadResolutionPriority]`.

That attribute is **only honored by C# 13+**. Projects targeting **net8.0** (and earlier) default to **C# 12**, which silently ignores it. Overload resolution then falls back to the generic catch-all (`ValueAssertion<T>`), so the typed collection/dictionary surface — `All`, `Count`, `ContainsKey`, ... — disappears and calls fail to compile:

```
error CS0411: The type arguments for method 'ImmutableArrayExtensions.All<T>(...)' cannot be inferred ...
error CS0411: ... 'DictionaryValueSourceCollectionShapeAssertions.ContainsKey<TKey, TValue>(...)' ...
```

`net9.0`/`net10.0` default to C# 13/14, so they were unaffected — which is why this looked like "Count/ContainsKey/All only work on net9+".

## Root cause of the *non-fix*

PR #2437 already added `<LangVersion>latest</LangVersion>` to fix exactly this — but it lives in the package **`.targets`**. The SDK assigns the target-framework default `LangVersion` (e.g. `12.0` for net8.0) during the **`.targets` phase**, so a `.targets` default guarded by `Condition="'$(LangVersion)' == ''"` **never fires** (the property is already `12.0` by then). Measured effective `LangVersion` stayed `12.0`.

## Fix

- Move the `LangVersion` default from `.targets` → **`.props`** (imported early, before the SDK default) in `TUnit.props`, `TUnit.Engine.props`, `TUnit.Assertions.props`. It now wins, while still letting consumers override `LangVersion` explicitly. Per-package copies are required because each package can be referenced standalone.
- Remove the `#if NET9_0_OR_GREATER` gate from `ImplicitConversionEqualityExtensions` (a partial band-aid for the same root cause, #5765) and the matching test gates, restoring implicit-conversion `IsEqualTo` + collection-overload-resolution coverage on net8.0.

Deliberately **left gated** (not ORP-related): `JsonElement.DeepEquals` (genuine net9+ BCL API — users can upgrade S.T.Json if they want it on net8) and the Mocks source-generator `#if NET9_0_OR_GREATER` blocks (all `allows ref struct` / runtime-feature gates).

## Validation

- **Packed net8 consumer** (real package, no explicit `LangVersion`): forced `-p:LangVersion=12` reproduces `CS0411`; the props default **builds clean**.
- `TUnit.Assertions` builds: netstandard2.0 / net8.0 / net9.0 green.
- net8 test build green; un-gated tests pass on net8: `Issue5720Tests` 15/15, `CollectionOverloadResolutionTests` 47/47.

## Follow-up (separate)

Standalone `TUnit.Mocks` consumers on net8 have the same ORP-on-C#12 hazard; that package ships no `LangVersion` `.props`. A follow-up could add one there too (would churn the Mocks snapshot suite, so kept out of this PR).
