### PR TITLE
fix(mocks): mock deep interface hierarchies (#6264)

### DIFF
--- a/TUnit.Mocks.SourceGenerator/Discovery/MockTypeDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MockTypeDiscovery.cs
@@ -241,11 +241,21 @@ internal static class MockTypeDiscovery
         INamedTypeSymbol type, HashSet<string> visited, IAssemblySymbol? compilationAssembly, Compilation compilation)
     {
         var results = new List<MockTypeModel>();
+        // Mark the entry type as visited so a member returning it (a self-cycle) is skipped.
+        visited.Add(NormalizeTransitiveInterfaceReturnType(type).GetFullyQualifiedName());
+        CollectTransitiveInterfaceTypes(type, visited, results, compilationAssembly, compilation);
+        return results;
+    }
 
-        var canonicalType = NormalizeTransitiveInterfaceReturnType(type);
-        var fqn = canonicalType.GetFullyQualifiedName();
-        visited.Add(fqn);
-
+    /// <summary>
+    /// Recursive worker for <see cref="DiscoverTransitiveInterfaceTypes"/>. Appends directly into
+    /// the shared <paramref name="results"/> accumulator (no per-frame list / merge) and records
+    /// each discovered type in <paramref name="visited"/> before recursing.
+    /// </summary>
+    private static void CollectTransitiveInterfaceTypes(
+        INamedTypeSymbol type, HashSet<string> visited, List<MockTypeModel> results,
+        IAssemblySymbol? compilationAssembly, Compilation compilation)
+    {
         // Collect all members from the type and its interfaces
         var members = new List<ISymbol>(type.GetMembers());
         foreach (var iface in type.AllInterfaces)
@@ -289,19 +299,16 @@ internal static class MockTypeDiscovery
             if (HasStaticAbstractMembers(namedReturn))
                 continue;
 
-            var returnFqn = namedReturn.GetFullyQualifiedName();
-            if (visited.Contains(returnFqn)) continue;
-            visited.Add(returnFqn);
+            // Add returns false if already discovered/visited — skip without re-walking.
+            if (!visited.Add(namedReturn.GetFullyQualifiedName())) continue;
 
             var model = BuildSingleTypeModel(namedReturn, isPartialMock: false, compilationAssembly, compilation);
             if (model is null) continue;
 
             results.Add(model);
-            // Recurse into the transitive type's members
-            results.AddRange(DiscoverTransitiveInterfaceTypes(namedReturn, visited, compilationAssembly, compilation));
+            // Recurse into the transitive type's members, accumulating into the same list.
+            CollectTransitiveInterfaceTypes(namedReturn, visited, results, compilationAssembly, compilation);
         }
-
-        return results;
     }
 
     /// <summary>

--- a/TUnit.Mocks.SourceGenerator/Discovery/MockTypeDiscovery.cs
+++ b/TUnit.Mocks.SourceGenerator/Discovery/MockTypeDiscovery.cs
@@ -151,10 +151,10 @@ internal static class MockTypeDiscovery
         // these, members returning user interfaces reference CreateAutoMock factories that are
         // never generated when only Mock.Of<T1,T2>() appears in the assembly.
         var visited = new HashSet<string>();
-        var transitiveModels = DiscoverTransitiveInterfaceTypes(namedType, visited, maxDepth: 3, compilationAssembly, compilation);
+        var transitiveModels = DiscoverTransitiveInterfaceTypes(namedType, visited, compilationAssembly, compilation);
         foreach (var additionalType in additionalTypes)
         {
-            transitiveModels.AddRange(DiscoverTransitiveInterfaceTypes(additionalType, visited, maxDepth: 3, compilationAssembly, compilation));
+            transitiveModels.AddRange(DiscoverTransitiveInterfaceTypes(additionalType, visited, compilationAssembly, compilation));
         }
 
         // Build multi-type model (generates impl + factory)
@@ -231,13 +231,16 @@ internal static class MockTypeDiscovery
 
     /// <summary>
     /// Walks the members of a type and discovers interface return types that need mock factories
-    /// generated for auto-mocking support. Recurses up to maxDepth levels.
+    /// generated for auto-mocking support. Recurses over the full transitive closure; the
+    /// <paramref name="visited"/> set both prevents cycles and bounds the walk to the finite set
+    /// of distinct reachable interfaces. The closure must be complete — every auto-mockable return
+    /// type that a generated impl references must itself be generated, otherwise the boundary type
+    /// references a factory that was never emitted (CS0400). See issue #6264.
     /// </summary>
     private static List<MockTypeModel> DiscoverTransitiveInterfaceTypes(
-        INamedTypeSymbol type, HashSet<string> visited, int maxDepth, IAssemblySymbol? compilationAssembly, Compilation compilation)
+        INamedTypeSymbol type, HashSet<string> visited, IAssemblySymbol? compilationAssembly, Compilation compilation)
     {
         var results = new List<MockTypeModel>();
-        if (maxDepth <= 0) return results;
 
         var canonicalType = NormalizeTransitiveInterfaceReturnType(type);
         var fqn = canonicalType.GetFullyQualifiedName();
@@ -295,7 +298,7 @@ internal static class MockTypeDiscovery
 
             results.Add(model);
             // Recurse into the transitive type's members
-            results.AddRange(DiscoverTransitiveInterfaceTypes(namedReturn, visited, maxDepth - 1, compilationAssembly, compilation));
+            results.AddRange(DiscoverTransitiveInterfaceTypes(namedReturn, visited, compilationAssembly, compilation));
         }
 
         return results;
@@ -388,7 +391,7 @@ internal static class MockTypeDiscovery
             return ImmutableArray<MockTypeModel>.Empty;
 
         var visited = new HashSet<string>();
-        var transitiveModels = DiscoverTransitiveInterfaceTypes(namedType, visited, maxDepth: 3, compilationAssembly, compilation);
+        var transitiveModels = DiscoverTransitiveInterfaceTypes(namedType, visited, compilationAssembly, compilation);
 
         if (transitiveModels.Count == 0)
             return ImmutableArray.Create(model);

--- a/TUnit.Mocks.Tests/Issue6264Tests.cs
+++ b/TUnit.Mocks.Tests/Issue6264Tests.cs
@@ -1,0 +1,81 @@
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6264
+// Mocking the top of a deep interface hierarchy (each level returns the next via a property)
+// failed to compile. Transitive auto-mock discovery was capped at a fixed depth, so the
+// deepest generated impl referenced the factory of the next level down — which was never
+// generated — producing CS0400 ("the type or namespace name 'IDepthNMockFactory' could not
+// be found"). The cap is removed; the full transitive closure of reachable interfaces is now
+// generated (bounded by the finite set of distinct types, cycle-safe via the visited set).
+
+#region Test interfaces — deeper than the old depth cap of 3
+
+public interface IDepth1
+{
+    IDepth2 Inner { get; }
+}
+
+public interface IDepth2
+{
+    IDepth3 Inner { get; }
+}
+
+public interface IDepth3
+{
+    IDepth4 Inner { get; }
+}
+
+public interface IDepth4
+{
+    IDepth5 Inner { get; }
+}
+
+public interface IDepth5
+{
+    IDepth6 Inner { get; }
+}
+
+public interface IDepth6
+{
+    int Value { get; }
+}
+
+#endregion
+
+public class Issue6264Tests
+{
+    [Test]
+    public async Task Mocking_Top_Of_Deep_Hierarchy_Compiles()
+    {
+        // Before the fix this file failed to compile with CS0400 on a generated
+        // IDepthN_MockImplFactory referencing an un-generated IDepthN+1MockFactory.
+        var mock = IDepth1.Mock();
+        await Assert.That(mock).IsNotNull();
+    }
+
+    [Test]
+    public async Task Auto_Mock_Chains_Through_The_Full_Depth()
+    {
+        var mock = IDepth1.Mock();
+
+        // Navigate the chain past the old depth-3 cap — each level auto-mocks the next, which is
+        // only possible because every level's factory is now generated.
+        var leaf = mock.Object.Inner.Inner.Inner.Inner.Inner;
+
+        await Assert.That(leaf).IsNotNull();
+        await Assert.That(leaf.Value).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Auto_Mock_At_Depth_Is_Configurable()
+    {
+        var mock = IDepth1.Mock();
+
+        var leaf = mock.Object.Inner.Inner.Inner.Inner.Inner;
+        Mock.Get(leaf).Value.Returns(99);
+
+        await Assert.That(leaf.Value).IsEqualTo(99);
+    }
+}


### PR DESCRIPTION
Fixes #6264

## Problem

Mocking the top of a deep interface hierarchy (each level returns the next via a property/method) failed to compile:

```
IDepth4_MockImplFactory.g.cs(19,156): error CS0400: The type or namespace name 'IDepth5MockFactory' could not be found
```

`MemberDiscovery` emits an auto-mock factory reference (`XMockFactory.CreateAutoMock`) for **every** non-framework interface-returning member, but `MockTypeDiscovery.DiscoverTransitiveInterfaceTypes` only **generated** those factories up to `maxDepth: 3`. The deepest generated impl (`IDepth4`) still referenced the next level's factory (`IDepth5`), which was never emitted → the whole assembly failed to build, breaking even the top-level mock.

## Fix

Remove the depth cap. The `visited` `HashSet` is the actual termination guard — it bounds the walk to the finite set of distinct reachable interfaces and is cycle-safe (already exercised by the existing circular-reference auto-mock tests). The closure's filters (interface kind, non-`System`/`Microsoft`/`Windows` namespace, no static-abstract members) match the factory-emission filters exactly, so every referenced factory is now generated.

## Verification

- New `Issue6264Tests` (6-level hierarchy, past the old cap): compiles + auto-mock chains and configures through the full depth.
- `TUnit.Mocks.SourceGenerator.Tests`: **74/74** pass — snapshots **byte-identical** (all existing fixtures were within depth 3).
- `TUnit.Mocks.Tests`: **1153/1153** pass — no regression (circular-ref, async, nested-chain auto-mock all green).