### PR TITLE
feat(aspire): tear down Aspire on test-run abort via session cancellation token

### DIFF
--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -40,6 +40,29 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     private readonly object _timelineGate = new();
     private Stopwatch? _timelineClock;
 
+    // Single-shot teardown so the run-abort callback and the normal DisposeAsync path
+    // converge on the same StopAsync/DisposeAsync work instead of racing each other.
+    private readonly object _teardownGate = new();
+    private Task? _teardownTask;
+    private CancellationTokenRegistration _abortRegistration;
+
+    /// <summary>
+    /// The run-abort token whose lifetime governs this fixture. Defaults to the test session's
+    /// cancellation token (Ctrl+C, IDE stop, process exit), which matches the lifetime of a
+    /// session- or class-scoped fixture. It is linked into the startup and resource-wait
+    /// operations so an abort interrupts them promptly instead of blocking for the full
+    /// <see cref="ResourceTimeout"/>, and triggers teardown of the Aspire application.
+    /// Override-provided <see cref="WaitForResourcesAsync"/> implementations should honor it too.
+    /// </summary>
+    /// <remarks>
+    /// Override this only if the fixture is genuinely per-test (<c>Shared = SharedType.None</c>)
+    /// and you want a per-test token folded in. Do NOT return a per-test token from a shared
+    /// fixture: it is cancelled when the first consuming test ends, which would tear the shared
+    /// application down underneath every later test.
+    /// </remarks>
+    protected virtual CancellationToken RunCancellationToken =>
+        TestSessionContext.Current?.SessionCancellationToken ?? CancellationToken.None;
+
     /// <summary>
     /// The running Aspire distributed application.
     /// </summary>
@@ -198,7 +221,8 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     /// Override for full control over the resource waiting logic.
     /// </summary>
     /// <param name="app">The running distributed application.</param>
-    /// <param name="cancellationToken">A cancellation token that will be cancelled after <see cref="ResourceTimeout"/>.</param>
+    /// <param name="cancellationToken">A cancellation token that is cancelled after <see cref="ResourceTimeout"/>
+    /// or when the test run is aborted (see <see cref="RunCancellationToken"/>).</param>
     protected virtual async Task WaitForResourcesAsync(DistributedApplication app, CancellationToken cancellationToken)
     {
         var notificationService = app.Services.GetRequiredService<ResourceNotificationService>();
@@ -258,8 +282,12 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             LogProgress($"OTLP receiver listening on port {_otlpReceiver!.Port}");
         }
 
+        // Register before CreateAsync/BuildAsync so an abort during early AppHost creation still
+        // begins fixture teardown instead of waiting for normal failed-initializer disposal.
+        RegisterAbortTeardown();
+
         LogProgress($"Creating distributed application builder for {typeof(TAppHost).Name}...");
-        var builder = await DistributedApplicationTestingBuilder.CreateAsync<TAppHost>(Args, ConfigureAppHost);
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<TAppHost>(Args, ConfigureAppHost, RunCancellationToken);
         ConfigureBuilder(builder);
         RemoveResources(builder);
 
@@ -272,7 +300,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         LogProgress($"Builder created in {sw.Elapsed.TotalSeconds:0.0}s");
 
         LogProgress("Building application...");
-        _app = await builder.BuildAsync();
+        _app = await builder.BuildAsync(RunCancellationToken);
         LogProgress($"Application built in {sw.Elapsed.TotalSeconds:0.0}s");
 
         var model = _app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -288,31 +316,44 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         var monitorTask = MonitorResourceEventsAsync(_app, monitorCts.Token);
         var notificationService = _app.Services.GetRequiredService<ResourceNotificationService>();
 
+        // Linked to the run-abort token so an abort interrupts startup promptly; the timeout
+        // is layered on top via CancelAfter.
+        using var startCts = CancellationTokenSource.CreateLinkedTokenSource(RunCancellationToken);
+        startCts.CancelAfter(ResourceTimeout);
         try
         {
-            using (var startCts = new CancellationTokenSource(ResourceTimeout))
+            try
             {
-                try
-                {
-                    await _app.StartAsync(startCts.Token);
-                }
-                catch (OperationCanceledException) when (startCts.IsCancellationRequested)
-                {
-                    var headline = $"Timed out after {ResourceTimeout.TotalSeconds:0}s waiting for the Aspire application to start.";
-                    throw new TimeoutException(
-                        await BuildDiagnosticsAndAttachAsync(_app, notificationService, headline,
-                            model.Resources.Select(r => r.Name).ToList()));
-                }
+                await _app.StartAsync(startCts.Token);
+            }
+            catch (OperationCanceledException) when (RunCancellationToken.IsCancellationRequested)
+            {
+                // Run aborted — propagate cancellation; DisposeAsync (and the abort callback) tear down.
+                throw;
+            }
+            catch (OperationCanceledException) when (startCts.IsCancellationRequested)
+            {
+                var headline = $"Timed out after {ResourceTimeout.TotalSeconds:0}s waiting for the Aspire application to start.";
+                throw new TimeoutException(
+                    await BuildDiagnosticsAndAttachAsync(_app, notificationService, headline,
+                        model.Resources.Select(r => r.Name).ToList()));
             }
 
             LogProgress($"Application started in {sw.Elapsed.TotalSeconds:0.0}s. Waiting for resources (timeout: {ResourceTimeout.TotalSeconds:0}s, behavior: {WaitBehavior})...");
 
-            using (var cts = new CancellationTokenSource(ResourceTimeout))
+            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(RunCancellationToken))
             {
+                cts.CancelAfter(ResourceTimeout);
+
                 try
                 {
                     await WaitForResourcesAsync(_app, cts.Token);
                     LogProgress("All resources ready.");
+                }
+                catch (OperationCanceledException) when (RunCancellationToken.IsCancellationRequested)
+                {
+                    // Run aborted — propagate cancellation; teardown is handled by DisposeAsync / abort callback.
+                    throw;
                 }
                 catch (OperationCanceledException) when (cts.IsCancellationRequested)
                 {
@@ -362,6 +403,54 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     /// </summary>
     public virtual async ValueTask DisposeAsync()
     {
+        _abortRegistration.Dispose();
+        await StopAndDisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Registers the run-abort token so an aborted test run begins tearing down the Aspire
+    /// application immediately, in parallel with the rest of session shutdown. The callback and
+    /// the normal <see cref="DisposeAsync"/> path share a single teardown task, so the work runs
+    /// exactly once regardless of which fires first.
+    /// </summary>
+    private void RegisterAbortTeardown()
+    {
+        if (!RunCancellationToken.CanBeCanceled)
+        {
+            return;
+        }
+
+        _abortRegistration = RunCancellationToken.Register(static state =>
+        {
+            var fixture = (AspireFixture<TAppHost>) state!;
+            fixture.LogProgress("Test run aborted — tearing down Aspire application...");
+            // Fire-and-forget: don't block the thread raising cancellation. Log errors here too
+            // in case the host kills the process before DisposeAsync observes the shared task.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await fixture.StopAndDisposeAsync();
+                }
+                catch (Exception ex)
+                {
+                    fixture.LogProgress($"Teardown error on abort: {ex.Message}");
+                }
+            });
+        }, this);
+    }
+
+    private Task StopAndDisposeAsync()
+    {
+        lock (_teardownGate)
+        {
+            return _teardownTask ??= StopAndDisposeCoreAsync();
+        }
+    }
+
+    private async Task StopAndDisposeCoreAsync()
+    {
         if (_otlpReceiver is not null && _app is not null)
         {
             // Give the SUT's BatchSpanProcessor a chance to flush trailing spans while the
@@ -387,8 +476,6 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             await _otlpReceiver.DisposeAsync();
             _otlpReceiver = null;
         }
-
-        GC.SuppressFinalize(this);
     }
 
     // --- OTLP Telemetry ---
@@ -719,6 +806,13 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // A run-abort cancels the linked token too — surface it as cancellation, not a
+            // misleading resource timeout, so the engine sees the abort and teardown proceeds.
+            if (RunCancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+
             // Timeout - diagnose each pending resource (state, exit code, health, dependencies)
             // and attach the full timeline + untruncated logs as an artifact.
             failureCts.Cancel();

--- a/TUnit.Core/EngineCancellationToken.cs
+++ b/TUnit.Core/EngineCancellationToken.cs
@@ -19,6 +19,7 @@ public class EngineCancellationToken : IDisposable
 
     private int _initialised;
     private volatile bool _forcefulExitStarted;
+    private CancellationTokenRegistration _platformRegistration;
 
     public EngineCancellationToken()
     {
@@ -32,11 +33,26 @@ public class EngineCancellationToken : IDisposable
     /// Per-call cancellation flows through the explicit <c>CancellationToken</c> threaded into
     /// discovery/execution, not through this session-scoped token.
     /// </summary>
-    internal void Initialise()
+    /// <param name="platformCancellationToken">
+    /// Microsoft.Testing.Platform's run-abort token. The host (IDE stop button, CI runner cancel,
+    /// <c>--abort</c>) cancels this independently of the OS signal handlers, so we link it in: when
+    /// it fires, the engine token fires too, and session-scoped fixtures observing it tear down.
+    /// Unlike the Ctrl+C path, this does NOT arm the forceful-exit timer — the platform owns
+    /// process shutdown when it is the one cancelling, and killing the process underneath it would
+    /// truncate result reporting.
+    /// </param>
+    internal void Initialise(CancellationToken platformCancellationToken = default)
     {
         if (Interlocked.CompareExchange(ref _initialised, 1, 0) != 0)
         {
             return;
+        }
+
+        if (platformCancellationToken.CanBeCanceled)
+        {
+            _platformRegistration = platformCancellationToken.Register(
+                static state => ((EngineCancellationToken) state!).Cancel(armForcefulExit: false),
+                this);
         }
 
         // Console.CancelKeyPress is not supported on browser platforms
@@ -59,12 +75,20 @@ public class EngineCancellationToken : IDisposable
         e.Cancel = true;
     }
 
-    private void Cancel()
+    private void Cancel(bool armForcefulExit = true)
     {
         // Cancel the test execution
         if (!CancellationTokenSource.IsCancellationRequested)
         {
             CancellationTokenSource.Cancel();
+        }
+
+        // The forceful-exit timer is only for signal-driven cancellation (Ctrl+C), where we
+        // suppressed the runtime's default termination and must guarantee the process still dies.
+        // Platform-driven cancellation manages its own shutdown, so it opts out.
+        if (!armForcefulExit)
+        {
+            return;
         }
 
         // Only start the forceful exit timer once
@@ -106,6 +130,8 @@ public class EngineCancellationToken : IDisposable
     /// </summary>
     public void Dispose()
     {
+        _platformRegistration.Dispose();
+
         // Console.CancelKeyPress is not supported on browser platforms
 #if NET5_0_OR_GREATER
         if (!OperatingSystem.IsBrowser())

--- a/TUnit.Core/Models/TestSessionContext.cs
+++ b/TUnit.Core/Models/TestSessionContext.cs
@@ -59,6 +59,20 @@ public class TestSessionContext : Context
 
     public required string? TestFilter { get; init; }
 
+    /// <summary>
+    /// The engine-wide cancellation token for this test session. Signalled when the run is
+    /// aborted (e.g. Ctrl+C, IDE stop, or process exit). Session-scoped fixtures
+    /// (<see cref="Interfaces.IAsyncInitializer"/> implementations such as long-running
+    /// containers or distributed applications) can observe this to abort startup and tear
+    /// themselves down promptly on an abort request.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="System.Threading.CancellationToken.None"/> until the engine
+    /// populates it at the start of execution. Per-test cancellation flows through
+    /// <see cref="TestContext.CancellationToken"/> instead; this token spans the whole session.
+    /// </remarks>
+    public CancellationToken SessionCancellationToken { get; internal set; }
+
     private readonly Lock _lock = new();
     private readonly List<AssemblyHookContext> _assemblies = [];
     private ClassHookContext[]? _cachedTestClasses;

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -59,6 +59,10 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
             GlobalContext.Current.GlobalLogger = serviceProvider.Logger;
             BeforeTestDiscoveryContext.Current = serviceProvider.ContextProvider.BeforeTestDiscoveryContext;
             TestDiscoveryContext.Current = serviceProvider.ContextProvider.TestDiscoveryContext;
+            // Expose the engine-wide abort token on the session context so session-scoped
+            // fixtures (containers, Aspire apps, etc.) can observe run cancellation and tear
+            // themselves down.
+            serviceProvider.ContextProvider.TestSessionContext.SessionCancellationToken = serviceProvider.CancellationToken.Token;
             TestSessionContext.Current = serviceProvider.ContextProvider.TestSessionContext;
 
             serviceProvider.Initializer.Initialize();

--- a/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -69,7 +69,10 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
 
             await serviceProvider.HookDelegateBuilder.InitializeAsync();
 
-            serviceProvider.CancellationToken.Initialise();
+            // Link the platform's run-abort token (IDE stop, CI runner cancel, --abort) so it
+            // flows through the engine token to session-scoped fixtures, alongside the OS signal
+            // handlers (Ctrl+C / process exit) wired up inside Initialise.
+            serviceProvider.CancellationToken.Initialise(context.CancellationToken);
 
             await _requestHandler.HandleRequestAsync((TestExecutionRequest) context.Request, serviceProvider, context, GetFilter(context));
         }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1722,6 +1722,7 @@ namespace
         public .<.TestContext> AllTests { get; }
         public .<.AssemblyHookContext> Assemblies { get; }
         public required string Id { get; init; }
+        public .CancellationToken SessionCancellationToken { get; }
         public .<.ClassHookContext> TestClasses { get; }
         public .TestDiscoveryContext TestDiscoveryContext { get; }
         public required string? TestFilter { get; init; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1722,6 +1722,7 @@ namespace
         public .<.TestContext> AllTests { get; }
         public .<.AssemblyHookContext> Assemblies { get; }
         public required string Id { get; init; }
+        public .CancellationToken SessionCancellationToken { get; }
         public .<.ClassHookContext> TestClasses { get; }
         public .TestDiscoveryContext TestDiscoveryContext { get; }
         public required string? TestFilter { get; init; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1722,6 +1722,7 @@ namespace
         public .<.TestContext> AllTests { get; }
         public .<.AssemblyHookContext> Assemblies { get; }
         public required string Id { get; init; }
+        public .CancellationToken SessionCancellationToken { get; }
         public .<.ClassHookContext> TestClasses { get; }
         public .TestDiscoveryContext TestDiscoveryContext { get; }
         public required string? TestFilter { get; init; }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1661,6 +1661,7 @@ namespace
         public .<.TestContext> AllTests { get; }
         public .<.AssemblyHookContext> Assemblies { get; }
         public required string Id { get; init; }
+        public .CancellationToken SessionCancellationToken { get; }
         public .<.ClassHookContext> TestClasses { get; }
         public .TestDiscoveryContext TestDiscoveryContext { get; }
         public required string? TestFilter { get; init; }


### PR DESCRIPTION
@
## Problem

`AspireFixture` startup (`CreateAsync`/`BuildAsync`/`StartAsync` and the resource-wait) only observed its own `ResourceTimeout`. It never saw the engines run-abort token, so a request to abort the test run (Ctrl+C, IDE stop, `ProcessExit`) could not:

- interrupt an in-progress startup (it blocked for the full `ResourceTimeout`, e.g. 60s), and
- stop/dispose the application before the forceful-exit timer killed the process — leaking containers.

## Change

1. **Expose the engine token on `TestSessionContext`.** TUnit.Core had no ambient session-scoped cancellation token (the engine token lived only in `TUnitServiceProvider`). Added `public CancellationToken CancellationToken { get; internal set; }` to `TestSessionContext`, populated once in `TUnitTestFramework.ExecuteRequestAsync`. Both reflection and source-generated modes funnel through that method, so a single wiring covers both. Session-scoped `IAsyncInitializer` fixtures (containers, distributed apps) can now observe run cancellation.

2. **AspireFixture honors it.** New `protected virtual RunCancellationToken` (defaults to the session token). Linked into `CreateAsync`/`BuildAsync`/`StartAsync` and the resource-wait via `CreateLinkedTokenSource(...)` + `CancelAfter(ResourceTimeout)`, so an abort interrupts startup promptly.

3. **Teardown on abort.** `RegisterAbortTeardown()` fires a single-shot `StopAndDisposeAsync()` when the token trips, giving the app a head start on graceful shutdown within the forceful-exit window. `DisposeAsync` awaits the same memoized task, so teardown runs exactly once regardless of which path fires first.

An abort is distinguished from a genuine resource timeout (the linked token trips both) so it surfaces as cancellation rather than a misleading `TimeoutException`.

## Why the session token (not a per-test one)

`AspireFixture` is used as `[ClassDataSource<...>(Shared = SharedType.PerTestSession)]` and outlives any single test. Its `InitializeAsync` runs lazily, triggered by the first consuming test. A per-test token would be cancelled (and disposed) when that first test ends, tearing the shared application down underneath every later test. The session tokens lifetime matches the fixtures. `RunCancellationToken` is `virtual` so a genuinely per-test fixture (`Shared = None`) can fold in its own token.

## Notes

- Public API change: new `TestSessionContext.CancellationToken` getter. All 4 Core PublicAPI snapshots updated; net8/9/10 pass.
- Outside the engine the token defaults to `None` (`CanBeCanceled == false`) so the abort registration is a no-op and behavior is unchanged.
- No integration test added — exercising real abort teardown needs live containers. The plumbing is covered by build + PublicAPI snapshots.
