### PR TITLE
feat(aspire): dump resource error logs on test failure + warn on missing telemetry wiring

### DIFF
--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -218,6 +218,11 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
     /// Time budget for collecting a resource's buffered logs on test failure. The log stream
     /// never completes on its own (it tails live output), so this bounds the wait after the
     /// backlog replays. Default: 2 seconds.
+    /// <para>
+    /// Also bounds the per-resource console-output probe used by the missing-telemetry hint
+    /// (<see cref="WarnOnMissingTelemetry"/>) at session end, so raising it for slow log
+    /// collection also lengthens that teardown probe for any resource not seen exporting OTLP logs.
+    /// </para>
     /// </summary>
     protected virtual TimeSpan FailureLogCollectionTimeout => TimeSpan.FromSeconds(2);
 
@@ -451,6 +456,18 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
     {
         var app = _app;
         if (!DumpResourceLogsOnFailure || app is null || context.Execution.Result?.State != TestState.Failed)
+        {
+            return;
+        }
+
+        // OnTestEnd fires once per retry attempt — the end-event receivers run inside the retried
+        // test body (see RetryHelper.ExecuteWithRetry), and TestContext.Output is shared across all
+        // attempts. Dumping on a non-final attempt would leak that attempt's failure logs into the
+        // output of a test that ultimately passes on retry. Only dump on the final attempt. (A custom
+        // retry predicate that declines mid-way terminates as Failed before the limit; in that rarer
+        // case we forgo the dump rather than risk leaking it — the default per-exception retry, which
+        // always runs to the limit on failure, dumps exactly once on the terminal attempt.)
+        if (context.Execution.CurrentRetryAttempt < context.Metadata.TestDetails.RetryLimit)
         {
             return;
         }
@@ -697,6 +714,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             // an SUT using the default service name matches by resource name here; one that overrides
             // its service name may produce a false hint — hence the soft wording below.
             var candidates = model.Resources.OfType<ProjectResource>()
+                .Where(ShouldWaitForResource)
                 .Where(p => !receiver.HasSeenLogsFrom(p.Name))
                 .ToList();
             if (candidates.Count == 0)

--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -26,7 +26,7 @@ namespace TUnit.Aspire;
 /// or subclass to customize behavior via the virtual configuration hooks.
 /// </para>
 /// </remarks>
-public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
+public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITestEndEventReceiver
     where TAppHost : class
 {
     private DistributedApplication? _app;
@@ -201,6 +201,33 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     /// Resource wait timeout. Default: 60 seconds.
     /// </summary>
     protected virtual TimeSpan ResourceTimeout => TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// When <c>true</c> (default), if a test fails, recent error log lines from each waited-on
+    /// resource are appended to that test's output. These are raw console/stderr lines from the
+    /// resource (resource-scoped, NOT request-correlated) — a coarse fallback for resources that
+    /// don't export OpenTelemetry logs. Correlated per-request SUT logs already flow live to the
+    /// owning test via the OTLP receiver when <see cref="EnableTelemetryCollection"/> is on.
+    /// </summary>
+    protected virtual bool DumpResourceLogsOnFailure => true;
+
+    /// <summary>Maximum (most-recent) error log lines captured per resource for the on-failure dump. Default: 50.</summary>
+    protected virtual int MaxFailureLogLinesPerResource => 50;
+
+    /// <summary>
+    /// Time budget for collecting a resource's buffered logs on test failure. The log stream
+    /// never completes on its own (it tails live output), so this bounds the wait after the
+    /// backlog replays. Default: 2 seconds.
+    /// </summary>
+    protected virtual TimeSpan FailureLogCollectionTimeout => TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// When <c>true</c> (default), emits a one-time hint at session end for any project resource
+    /// that produced console output but never sent correlated OpenTelemetry logs to TUnit — the
+    /// usual symptom of missing OTLP log export in the SUT (e.g. Aspire ServiceDefaults not
+    /// wired). Only meaningful when <see cref="EnableTelemetryCollection"/> is on.
+    /// </summary>
+    protected virtual bool WarnOnMissingTelemetry => true;
 
     /// <summary>
     /// Which resources to wait for. Default: <see cref="ResourceWaitBehavior.AllHealthy"/>.
@@ -409,6 +436,123 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
     }
 
     /// <summary>
+    /// On test failure, appends recent error log lines from each waited-on resource to the test's
+    /// output. TUnit invokes this on every test that consumes the fixture (event receivers found
+    /// on injected data-source objects fire per test). Best-effort: it never throws into the test
+    /// result — a log-collection race against a torn-down app is swallowed.
+    /// </summary>
+    /// <remarks>
+    /// These lines are resource-scoped, not request-correlated: on a shared (session/class) fixture
+    /// the buffer spans the whole run, so output may include lines from earlier tests. For precise
+    /// per-request correlation, rely on the OTLP receiver (<see cref="EnableTelemetryCollection"/>),
+    /// which routes a SUT's logs to the originating test live, via trace context.
+    /// </remarks>
+    public async ValueTask OnTestEnd(TestContext context)
+    {
+        var app = _app;
+        if (!DumpResourceLogsOnFailure || app is null || context.Execution.Result?.State != TestState.Failed)
+        {
+            return;
+        }
+
+        try
+        {
+            var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+            var names = new List<string>();
+            foreach (var resource in model.Resources)
+            {
+                if (ShouldWaitForResource(resource))
+                {
+                    names.Add(resource.Name);
+                }
+            }
+
+            if (names.Count == 0)
+            {
+                return;
+            }
+
+            var timeout = FailureLogCollectionTimeout;
+            var max = MaxFailureLogLinesPerResource;
+
+            // Collect in parallel — each resource has its own short timeout, so collecting
+            // sequentially would compound the delay onto an already-failed test's teardown.
+            var collected = await Task.WhenAll(names.Select(async name =>
+                (name, errors: await CollectResourceErrorLinesAsync(app, name, timeout, max))));
+
+            foreach (var (name, errors) in collected)
+            {
+                if (errors.Count == 0)
+                {
+                    continue;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"--- [{name}] {errors.Count} recent error log line(s) (resource-scoped, not request-correlated) ---");
+                foreach (var line in errors)
+                {
+                    sb.Append("  ").AppendLine(line);
+                }
+
+                context.Output.WriteLine(sb.ToString());
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The Aspire application was torn down concurrently (e.g. a run abort raced this
+            // test's completion) — there is nothing left to collect.
+        }
+    }
+
+    /// <summary>
+    /// Collects up to <paramref name="max"/> of the most recent error (stderr) log lines from a
+    /// resource via the <see cref="ResourceLoggerService"/>. <see cref="ResourceLoggerService.WatchAsync(string)"/>
+    /// replays the buffered backlog before tailing live output, so lines from an already-exited
+    /// resource are still captured; the stream never completes on its own, so a short timeout
+    /// bounds the live-tail wait.
+    /// </summary>
+    private static async Task<List<string>> CollectResourceErrorLinesAsync(
+        DistributedApplication app,
+        string resourceName,
+        TimeSpan timeout,
+        int max)
+    {
+        var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+        var errors = new List<string>();
+
+        using var cts = new CancellationTokenSource(timeout);
+
+        try
+        {
+            await foreach (var batch in loggerService.WatchAsync(resourceName)
+                .WithCancellation(cts.Token))
+            {
+                foreach (var line in batch)
+                {
+                    if (line.IsErrorMessage)
+                    {
+                        errors.Add(line.Content);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — the short timeout fires once the backlog has replayed and the live
+            // tail goes quiet.
+        }
+
+        // Keep only the most recent `max` lines (the backlog can be large on a long run).
+        if (max >= 0 && errors.Count > max)
+        {
+            errors.RemoveRange(0, errors.Count - max);
+        }
+
+        return errors;
+    }
+
+    /// <summary>
     /// Registers the run-abort token so an aborted test run begins tearing down the Aspire
     /// application immediately, in parallel with the rest of session shutdown. The callback and
     /// the normal <see cref="DisposeAsync"/> path share a single teardown task, so the work runs
@@ -459,6 +603,15 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
             // last set of spans never reaches us.
             LogProgress("Draining OTLP receiver...");
             await _otlpReceiver.DrainAsync();
+
+            // After the drain the receiver's seen-services set is as complete as it will get,
+            // and the app is still up so console logs are collectable — the only window where
+            // both signals the missing-telemetry hint needs are available. Skip on a run abort:
+            // the telemetry picture is incomplete then, so the hint would be misleading noise.
+            if (WarnOnMissingTelemetry && !RunCancellationToken.IsCancellationRequested)
+            {
+                await EmitTelemetryWiringHintsAsync(_app, _otlpReceiver);
+            }
         }
 
         if (_app is not null)
@@ -578,6 +731,83 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable
                     }));
             }
         }
+    }
+
+    /// <summary>
+    /// Emits a one-time hint for any project resource that produced console output but never sent
+    /// correlated OpenTelemetry logs to TUnit — the typical symptom of an SUT missing OTLP log
+    /// export (e.g. it doesn't call <c>AddServiceDefaults()</c>/<c>ConfigureOpenTelemetry()</c>).
+    /// Without it, the resource's logs can't be routed to the owning test and the gap is silent.
+    /// </summary>
+    private async Task EmitTelemetryWiringHintsAsync(DistributedApplication app, OtlpReceiver receiver)
+    {
+        try
+        {
+            var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+            var projects = model.Resources.OfType<ProjectResource>().ToList();
+            if (projects.Count == 0)
+            {
+                return;
+            }
+
+            // Probe console output in parallel — each probe has its own short timeout.
+            var probed = await Task.WhenAll(projects.Select(async p =>
+                (p.Name, hasConsoleOutput: await ResourceProducedConsoleOutputAsync(app, p.Name))));
+
+            foreach (var (name, hasConsoleOutput) in probed)
+            {
+                // The fixture injects OTEL_SERVICE_NAME = resource name (see ConfigureOtlpEndpoints),
+                // so an SUT using the default service name matches by resource name here. An SUT
+                // that overrides its service name may produce a false hint — hence the soft wording.
+                if (hasConsoleOutput && !receiver.HasSeenLogsFrom(name))
+                {
+                    LogProgress(
+                        $"Resource '{name}' produced console output but sent no correlated OpenTelemetry logs to TUnit, " +
+                        "so its logs can't be routed to the owning test. If you expect correlated SUT logs, ensure the " +
+                        "service calls AddServiceDefaults()/ConfigureOpenTelemetry() and exports OTLP logs (UseOtlpExporter). " +
+                        "Set WarnOnMissingTelemetry => false to silence this.");
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // App torn down concurrently — skip the hint rather than fail teardown.
+        }
+        catch (Exception ex)
+        {
+            // A diagnostic hint must never break teardown.
+            LogProgress($"(failed to evaluate telemetry wiring hints: {ex.Message})");
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> as soon as a resource has produced any console/stderr output, or
+    /// <c>false</c> if none arrives within a short window. Short-circuits on the first line so it
+    /// doesn't pull the full backlog.
+    /// </summary>
+    private static async Task<bool> ResourceProducedConsoleOutputAsync(DistributedApplication app, string resourceName)
+    {
+        var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try
+        {
+            await foreach (var batch in loggerService.WatchAsync(resourceName)
+                .WithCancellation(cts.Token))
+            {
+                if (batch.Count > 0)
+                {
+                    return true;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // No output within the window.
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -704,9 +704,11 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
                 return;
             }
 
-            // Probe console output in parallel — each probe has its own short timeout.
+            // Probe console output in parallel — each probe has its own short timeout, reusing the
+            // same bound as the on-failure dump so extending one extends both.
+            var probeTimeout = FailureLogCollectionTimeout;
             var probed = await Task.WhenAll(candidates.Select(async p =>
-                (p.Name, hasConsoleOutput: await ResourceProducedConsoleOutputAsync(app, p.Name))));
+                (p.Name, hasConsoleOutput: await ResourceProducedConsoleOutputAsync(app, p.Name, probeTimeout))));
 
             foreach (var (name, hasConsoleOutput) in probed)
             {
@@ -736,11 +738,11 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
     /// <c>false</c> if none arrives within a short window. Short-circuits on the first line so it
     /// doesn't pull the full backlog.
     /// </summary>
-    private static async Task<bool> ResourceProducedConsoleOutputAsync(DistributedApplication app, string resourceName)
+    private static async Task<bool> ResourceProducedConsoleOutputAsync(DistributedApplication app, string resourceName, TimeSpan timeout)
     {
         var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var cts = new CancellationTokenSource(timeout);
 
         try
         {
@@ -1026,7 +1028,13 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         int max = -1)
     {
         var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
-        var lines = new List<string>();
+
+        // When a cap is set, keep only the most recent `max` lines in a sliding window so memory
+        // stays proportional to `max` — the backlog can be large on a long run with a shared fixture,
+        // and buffering it all just to discard the head would allocate it twice over.
+        var bounded = max >= 0;
+        var window = bounded ? new Queue<string>(max + 1) : null;
+        var all = bounded ? null : new List<string>();
 
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
 
@@ -1037,16 +1045,26 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             {
                 foreach (var line in batch)
                 {
-                    if (errorsOnly)
+                    if (errorsOnly && !line.IsErrorMessage)
                     {
-                        if (line.IsErrorMessage)
+                        continue;
+                    }
+
+                    var content = errorsOnly || !line.IsErrorMessage
+                        ? line.Content
+                        : $"E> {line.Content}";
+
+                    if (bounded)
+                    {
+                        window!.Enqueue(content);
+                        if (window.Count > max)
                         {
-                            lines.Add(line.Content);
+                            window.Dequeue();
                         }
                     }
                     else
                     {
-                        lines.Add(line.IsErrorMessage ? $"E> {line.Content}" : line.Content);
+                        all!.Add(content);
                     }
                 }
             }
@@ -1056,13 +1074,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             // Expected - we use a short timeout to collect buffered logs.
         }
 
-        // Keep only the most recent `max` lines (the backlog can be large on a long run).
-        if (max >= 0 && lines.Count > max)
-        {
-            lines.RemoveRange(0, lines.Count - max);
-        }
-
-        return lines;
+        return bounded ? window!.ToList() : all!;
     }
 
     /// <summary>

--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -714,8 +714,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             // an SUT using the default service name matches by resource name here; one that overrides
             // its service name may produce a false hint — hence the soft wording below.
             var candidates = model.Resources.OfType<ProjectResource>()
-                .Where(ShouldWaitForResource)
-                .Where(p => !receiver.HasSeenLogsFrom(p.Name))
+                .Where(p => ShouldWaitForResource(p) && !receiver.HasSeenLogsFrom(p.Name))
                 .ToList();
             if (candidates.Count == 0)
             {
@@ -1068,9 +1067,9 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
                         continue;
                     }
 
-                    var content = errorsOnly || !line.IsErrorMessage
-                        ? line.Content
-                        : $"E> {line.Content}";
+                    var content = !errorsOnly && line.IsErrorMessage
+                        ? $"E> {line.Content}"
+                        : line.Content;
 
                     if (bounded)
                     {

--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -459,15 +459,8 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         {
             var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-            var names = new List<string>();
-            foreach (var resource in model.Resources)
-            {
-                if (ShouldWaitForResource(resource))
-                {
-                    names.Add(resource.Name);
-                }
-            }
-
+            // Inline (not GetWaitableResourceNames) to avoid its LogProgress side effect at test-end.
+            var names = model.Resources.Where(ShouldWaitForResource).Select(r => r.Name).ToList();
             if (names.Count == 0)
             {
                 return;
@@ -479,7 +472,7 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             // Collect in parallel — each resource has its own short timeout, so collecting
             // sequentially would compound the delay onto an already-failed test's teardown.
             var collected = await Task.WhenAll(names.Select(async name =>
-                (name, errors: await CollectResourceErrorLinesAsync(app, name, timeout, max))));
+                (name, errors: await CollectResourceLogLinesAsync(app, name, timeout, errorsOnly: true, max: max))));
 
             foreach (var (name, errors) in collected)
             {
@@ -503,53 +496,6 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             // The Aspire application was torn down concurrently (e.g. a run abort raced this
             // test's completion) — there is nothing left to collect.
         }
-    }
-
-    /// <summary>
-    /// Collects up to <paramref name="max"/> of the most recent error (stderr) log lines from a
-    /// resource via the <see cref="ResourceLoggerService"/>. <see cref="ResourceLoggerService.WatchAsync(string)"/>
-    /// replays the buffered backlog before tailing live output, so lines from an already-exited
-    /// resource are still captured; the stream never completes on its own, so a short timeout
-    /// bounds the live-tail wait.
-    /// </summary>
-    private static async Task<List<string>> CollectResourceErrorLinesAsync(
-        DistributedApplication app,
-        string resourceName,
-        TimeSpan timeout,
-        int max)
-    {
-        var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
-        var errors = new List<string>();
-
-        using var cts = new CancellationTokenSource(timeout);
-
-        try
-        {
-            await foreach (var batch in loggerService.WatchAsync(resourceName)
-                .WithCancellation(cts.Token))
-            {
-                foreach (var line in batch)
-                {
-                    if (line.IsErrorMessage)
-                    {
-                        errors.Add(line.Content);
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected — the short timeout fires once the backlog has replayed and the live
-            // tail goes quiet.
-        }
-
-        // Keep only the most recent `max` lines (the backlog can be large on a long run).
-        if (max >= 0 && errors.Count > max)
-        {
-            errors.RemoveRange(0, errors.Count - max);
-        }
-
-        return errors;
     }
 
     /// <summary>
@@ -744,22 +690,27 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         try
         {
             var model = app.Services.GetRequiredService<DistributedApplicationModel>();
-            var projects = model.Resources.OfType<ProjectResource>().ToList();
-            if (projects.Count == 0)
+
+            // Only resources we've NOT already seen export OTLP logs are hint candidates. Filtering
+            // first means a correctly-wired SUT (every resource seen) opens zero console probes.
+            // The fixture injects OTEL_SERVICE_NAME = resource name (see ConfigureOtlpEndpoints), so
+            // an SUT using the default service name matches by resource name here; one that overrides
+            // its service name may produce a false hint — hence the soft wording below.
+            var candidates = model.Resources.OfType<ProjectResource>()
+                .Where(p => !receiver.HasSeenLogsFrom(p.Name))
+                .ToList();
+            if (candidates.Count == 0)
             {
                 return;
             }
 
             // Probe console output in parallel — each probe has its own short timeout.
-            var probed = await Task.WhenAll(projects.Select(async p =>
+            var probed = await Task.WhenAll(candidates.Select(async p =>
                 (p.Name, hasConsoleOutput: await ResourceProducedConsoleOutputAsync(app, p.Name))));
 
             foreach (var (name, hasConsoleOutput) in probed)
             {
-                // The fixture injects OTEL_SERVICE_NAME = resource name (see ConfigureOtlpEndpoints),
-                // so an SUT using the default service name matches by resource name here. An SUT
-                // that overrides its service name may produce a false hint — hence the soft wording.
-                if (hasConsoleOutput && !receiver.HasSeenLogsFrom(name))
+                if (hasConsoleOutput)
                 {
                     LogProgress(
                         $"Resource '{name}' produced console output but sent no correlated OpenTelemetry logs to TUnit, " +
@@ -1057,20 +1008,27 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
     }
 
     /// <summary>
-    /// Collects buffered log lines from a resource via the <see cref="ResourceLoggerService"/>.
-    /// Returns the raw line content (error/stderr lines prefixed with <c>E&gt;</c>), or an empty
-    /// list if none are available. Uses a short timeout to avoid hanging if the log service is
-    /// unresponsive; <see cref="ResourceLoggerService.WatchAsync(string)"/> replays the buffered
-    /// backlog first, so logs from an already-exited resource are still captured.
+    /// Collects buffered log lines from a resource via the <see cref="ResourceLoggerService"/>,
+    /// or an empty list if none are available. <see cref="ResourceLoggerService.WatchAsync(string)"/>
+    /// replays the buffered backlog before tailing live output (so logs from an already-exited
+    /// resource are still captured) and never completes on its own, so <paramref name="timeout"/>
+    /// bounds the wait.
     /// </summary>
+    /// <param name="timeout">Time budget for collection. Defaults to 5 seconds.</param>
+    /// <param name="errorsOnly">When <c>true</c>, keeps only stderr lines (raw content). When
+    /// <c>false</c> (default), keeps every line, prefixing stderr lines with <c>E&gt;</c>.</param>
+    /// <param name="max">When &gt;= 0, keeps only the most recent <paramref name="max"/> lines.</param>
     private static async Task<List<string>> CollectResourceLogLinesAsync(
         DistributedApplication app,
-        string resourceName)
+        string resourceName,
+        TimeSpan? timeout = null,
+        bool errorsOnly = false,
+        int max = -1)
     {
         var loggerService = app.Services.GetRequiredService<ResourceLoggerService>();
         var lines = new List<string>();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
 
         try
         {
@@ -1079,13 +1037,29 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             {
                 foreach (var line in batch)
                 {
-                    lines.Add(line.IsErrorMessage ? $"E> {line.Content}" : line.Content);
+                    if (errorsOnly)
+                    {
+                        if (line.IsErrorMessage)
+                        {
+                            lines.Add(line.Content);
+                        }
+                    }
+                    else
+                    {
+                        lines.Add(line.IsErrorMessage ? $"E> {line.Content}" : line.Content);
+                    }
                 }
             }
         }
         catch (OperationCanceledException)
         {
             // Expected - we use a short timeout to collect buffered logs.
+        }
+
+        // Keep only the most recent `max` lines (the backlog can be large on a long run).
+        if (max >= 0 && lines.Count > max)
+        {
+            lines.RemoveRange(0, lines.Count - max);
         }
 
         return lines;

--- a/TUnit.Aspire.Tests/OtlpLogParserTests.cs
+++ b/TUnit.Aspire.Tests/OtlpLogParserTests.cs
@@ -69,6 +69,27 @@ public class OtlpLogParserTests
     }
 
     [Test]
+    public async Task Parse_UntracedLogRecord_StillReportsSeenService()
+    {
+        // A resource that exports OTLP logs but emits only untraced records (e.g. startup/background
+        // logs with no active Activity) is correctly wired — the missing-telemetry hint must not
+        // flag it. The seen-service callback fires even though the record is dropped from results.
+        var data = OtlpProtobufBuilder.BuildExportLogsServiceRequest(
+            "background-worker",
+            new LogRecordSpec
+            {
+                SeverityNumber = 9,
+                Body = "Startup log with no trace context",
+            });
+
+        var seen = new List<string>();
+        var records = OtlpLogParser.Parse(data, name => seen.Add(name));
+
+        await Assert.That(records).IsEmpty();
+        await Assert.That(seen).Contains("background-worker");
+    }
+
+    [Test]
     public async Task Parse_MixOfTracedAndUntracedLogs_OnlyReturnsTraced()
     {
         var traceId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
+++ b/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
@@ -287,6 +287,70 @@ public class OtlpReceiverIngestionTests
         await Assert.That(TraceRegistry.GetContextId(derivedTraceId)).IsEqualTo(TestContext.Current!.Id);
     }
 
+    [Test]
+    public async Task Receiver_LogWithServiceName_RecordsSeenService()
+    {
+        await using var receiver = new OtlpReceiver();
+        receiver.Start();
+
+        // Deliberately use an unregistered trace id — the service name must still be recorded,
+        // since its presence (not trace correlation) is what the Aspire wiring hint checks.
+        var traceId = Guid.NewGuid().ToString("N");
+        var body = BuildLogsExportRequest("my-service", traceId, "hello from sut");
+
+        using var client = new HttpClient();
+        using var content = new ByteArrayContent(body);
+        content.Headers.ContentType = new("application/x-protobuf");
+        await client.PostAsync($"http://127.0.0.1:{receiver.Port}/v1/logs", content);
+
+        await receiver.WhenIdle();
+
+        await Assert.That(receiver.HasSeenLogsFrom("my-service")).IsTrue();
+        await Assert.That(receiver.HasSeenLogsFrom("MY-SERVICE")).IsTrue(); // case-insensitive
+        await Assert.That(receiver.HasSeenLogsFrom("other-service")).IsFalse();
+        await Assert.That(receiver.SeenLogServiceNames).Contains("my-service");
+        await Assert.That(receiver.Diagnostics.LogsRecordsParsed).IsEqualTo(1);
+    }
+
+    private static byte[] BuildLogsExportRequest(string serviceName, string traceId, string body)
+    {
+        // KeyValue { key = "service.name", value = AnyValue(serviceName) }
+        using var kvStream = new MemoryStream();
+        WriteStringField(kvStream, 1, "service.name");
+        WriteField(kvStream, 2, BuildAnyValue(serviceName));
+
+        // Resource { attributes (field 1) = [kv] }
+        using var resourceStream = new MemoryStream();
+        WriteField(resourceStream, 1, kvStream.ToArray());
+
+        // LogRecord { severity_text (3), body (5), trace_id (9) }
+        using var logRecordStream = new MemoryStream();
+        WriteStringField(logRecordStream, 3, "INFO");
+        WriteField(logRecordStream, 5, BuildAnyValue(body));
+        WriteField(logRecordStream, 9, Convert.FromHexString(traceId));
+
+        // ScopeLogs { log_records (field 2) = [logRecord] }
+        using var scopeLogsStream = new MemoryStream();
+        WriteField(scopeLogsStream, 2, logRecordStream.ToArray());
+
+        // ResourceLogs { resource (1), scope_logs (2) }
+        using var resourceLogsStream = new MemoryStream();
+        WriteField(resourceLogsStream, 1, resourceStream.ToArray());
+        WriteField(resourceLogsStream, 2, scopeLogsStream.ToArray());
+
+        // ExportLogsServiceRequest { resource_logs (field 1) = [resourceLogs] }
+        using var exportStream = new MemoryStream();
+        WriteField(exportStream, 1, resourceLogsStream.ToArray());
+        return exportStream.ToArray();
+    }
+
+    private static byte[] BuildAnyValue(string stringValue)
+    {
+        using var stream = new MemoryStream();
+        WriteStringField(stream, 1, stringValue); // AnyValue.string_value = field 1
+        return stream.ToArray();
+    }
+
     private static byte[] BuildMultiSpanBatch(string traceId, int spanCount)
     {
         // Build N sibling spans that all share traceId but have distinct spanIds. This

--- a/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
@@ -32,7 +32,13 @@ internal readonly record struct OtlpLogRecord(
 /// </summary>
 internal static class OtlpLogParser
 {
-    public static List<OtlpLogRecord> Parse(ReadOnlySpan<byte> data)
+    /// <param name="onResourceSeen">
+    /// Invoked with each non-empty <c>service.name</c> that produced a log record, <em>before</em>
+    /// the trace-id filter drops untraced records. Lets a consumer record that OTLP logging reached
+    /// it at all — independent of whether any record carried a usable trace id (records without one
+    /// are still excluded from the returned list, per the correlation contract).
+    /// </param>
+    public static List<OtlpLogRecord> Parse(ReadOnlySpan<byte> data, Action<string>? onResourceSeen = null)
     {
         var results = new List<OtlpLogRecord>();
         var reader = new ProtobufReader(data);
@@ -43,7 +49,7 @@ internal static class OtlpLogParser
             if (fieldNumber == 1 && wireType == WireType.LengthDelimited)
             {
                 var embedded = reader.ReadEmbeddedMessage();
-                ParseResourceLogs(embedded, results);
+                ParseResourceLogs(embedded, results, onResourceSeen);
             }
             else
             {
@@ -56,7 +62,7 @@ internal static class OtlpLogParser
 
     // Assumes Resource (field 1) precedes ScopeLogs (field 2) in the wire format,
     // which is true for all known OTel SDK implementations.
-    private static void ParseResourceLogs(ProtobufReader reader, List<OtlpLogRecord> results)
+    private static void ParseResourceLogs(ProtobufReader reader, List<OtlpLogRecord> results, Action<string>? onResourceSeen)
     {
         var resourceName = "";
 
@@ -72,7 +78,7 @@ internal static class OtlpLogParser
             {
                 // ScopeLogs
                 var embedded = reader.ReadEmbeddedMessage();
-                ParseScopeLogs(embedded, resourceName, results);
+                ParseScopeLogs(embedded, resourceName, results, onResourceSeen);
             }
             else
             {
@@ -104,7 +110,7 @@ internal static class OtlpLogParser
         return "";
     }
 
-    private static void ParseScopeLogs(ProtobufReader reader, string resourceName, List<OtlpLogRecord> results)
+    private static void ParseScopeLogs(ProtobufReader reader, string resourceName, List<OtlpLogRecord> results, Action<string>? onResourceSeen)
     {
         // ScopeLogs: field 2 = repeated LogRecord
         while (reader.TryReadTag(out var fieldNumber, out var wireType))
@@ -112,6 +118,14 @@ internal static class OtlpLogParser
             if (fieldNumber == 2 && wireType == WireType.LengthDelimited)
             {
                 var embedded = reader.ReadEmbeddedMessage();
+
+                // Signal that this resource emitted a log record before ParseLogRecord can drop it
+                // for lacking a trace id — presence is what the missing-telemetry hint checks for.
+                if (!string.IsNullOrEmpty(resourceName))
+                {
+                    onResourceSeen?.Invoke(resourceName);
+                }
+
                 var record = ParseLogRecord(embedded, resourceName);
                 if (record is not null)
                 {

--- a/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
@@ -65,6 +65,7 @@ internal static class OtlpLogParser
     private static void ParseResourceLogs(ProtobufReader reader, List<OtlpLogRecord> results, Action<string>? onResourceSeen)
     {
         var resourceName = "";
+        var sawLogRecord = false;
 
         while (reader.TryReadTag(out var fieldNumber, out var wireType))
         {
@@ -78,12 +79,21 @@ internal static class OtlpLogParser
             {
                 // ScopeLogs
                 var embedded = reader.ReadEmbeddedMessage();
-                ParseScopeLogs(embedded, resourceName, results, onResourceSeen);
+                sawLogRecord |= ParseScopeLogs(embedded, resourceName, results);
             }
             else
             {
                 reader.Skip(wireType);
             }
+        }
+
+        // Signal the source service once — independent of the trace-id filter that drops untraced
+        // records from `results` — as long as it emitted at least one log record. Presence (not
+        // correlation) is what the missing-telemetry hint checks for. Done once per resource rather
+        // than per record to avoid redundant work for a noisy resource.
+        if (sawLogRecord && !string.IsNullOrEmpty(resourceName))
+        {
+            onResourceSeen?.Invoke(resourceName);
         }
     }
 
@@ -110,22 +120,19 @@ internal static class OtlpLogParser
         return "";
     }
 
-    private static void ParseScopeLogs(ProtobufReader reader, string resourceName, List<OtlpLogRecord> results, Action<string>? onResourceSeen)
+    // Returns whether any LogRecord was present, so the caller can signal the source service once
+    // per resource (even when every record is dropped by the trace-id filter).
+    private static bool ParseScopeLogs(ProtobufReader reader, string resourceName, List<OtlpLogRecord> results)
     {
+        var sawLogRecord = false;
+
         // ScopeLogs: field 2 = repeated LogRecord
         while (reader.TryReadTag(out var fieldNumber, out var wireType))
         {
             if (fieldNumber == 2 && wireType == WireType.LengthDelimited)
             {
+                sawLogRecord = true;
                 var embedded = reader.ReadEmbeddedMessage();
-
-                // Signal that this resource emitted a log record before ParseLogRecord can drop it
-                // for lacking a trace id — presence is what the missing-telemetry hint checks for.
-                if (!string.IsNullOrEmpty(resourceName))
-                {
-                    onResourceSeen?.Invoke(resourceName);
-                }
-
                 var record = ParseLogRecord(embedded, resourceName);
                 if (record is not null)
                 {
@@ -137,6 +144,8 @@ internal static class OtlpLogParser
                 reader.Skip(wireType);
             }
         }
+
+        return sawLogRecord;
     }
 
     private static OtlpLogRecord? ParseLogRecord(ProtobufReader reader, string resourceName)

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -42,6 +42,9 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     // wrote raw console output, so it can hint at missing OpenTelemetry log export in the SUT.
     private readonly ConcurrentDictionary<string, byte> _seenLogServiceNames = new(StringComparer.OrdinalIgnoreCase);
 
+    // Cached so passing it to the parser doesn't allocate a delegate per /v1/logs request.
+    private readonly Action<string> _recordSeenLogService;
+
     private string? _upstreamEndpoint;
     private IReadOnlyDictionary<string, string>? _upstreamHeaders;
     private Task? _listenTask;
@@ -88,6 +91,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     {
         (_listener, Port) = CreateListener();
         UpstreamEndpoint = upstreamEndpoint;
+        _recordSeenLogService = name => _seenLogServiceNames.TryAdd(name, 0);
     }
 
     /// <summary>
@@ -554,7 +558,10 @@ internal sealed class OtlpReceiver : IAsyncDisposable
         List<OtlpLogRecord> records;
         try
         {
-            records = OtlpLogParser.Parse(body);
+            // The callback records the source service for *every* incoming log record — including
+            // ones the parser drops for lacking a trace id — so the Aspire missing-telemetry hint
+            // sees that OTLP logging reached us even from a resource that only emits untraced logs.
+            records = OtlpLogParser.Parse(body, _recordSeenLogService);
         }
         catch (Exception ex)
         {
@@ -567,14 +574,6 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
         foreach (var record in records)
         {
-            // Record the source service even when the record has no usable trace id — its
-            // presence proves OTLP logging is wired, which is exactly what the Aspire
-            // missing-telemetry hint checks for.
-            if (!string.IsNullOrEmpty(record.ResourceName))
-            {
-                _seenLogServiceNames.TryAdd(record.ResourceName, 0);
-            }
-
             if (string.IsNullOrEmpty(record.TraceId))
             {
                 Interlocked.Increment(ref _diagnostics.LogsRecordsNoTraceId);

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -35,6 +35,13 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly ConcurrentDictionary<int, Task> _inflightTasks = new();
     private readonly OtlpReceiverDiagnostics _diagnostics = new();
+
+    // service.name values seen on incoming OTLP *log* records. Recorded for every parsed log
+    // record regardless of trace-id match — presence here means OTLP logging reached us at all.
+    // TUnit.Aspire uses it to tell a resource that exported correlated logs from one that only
+    // wrote raw console output, so it can hint at missing OpenTelemetry log export in the SUT.
+    private readonly ConcurrentDictionary<string, byte> _seenLogServiceNames = new(StringComparer.OrdinalIgnoreCase);
+
     private string? _upstreamEndpoint;
     private IReadOnlyDictionary<string, string>? _upstreamHeaders;
     private Task? _listenTask;
@@ -58,6 +65,17 @@ internal sealed class OtlpReceiver : IAsyncDisposable
     /// silent drops in user environments via <see cref="WriteDiagnosticsSummary"/>.
     /// </summary>
     internal OtlpReceiverDiagnostics Diagnostics => _diagnostics;
+
+    /// <summary>
+    /// Returns <c>true</c> if at least one OTLP log record carrying the given <c>service.name</c>
+    /// resource attribute has been received (whether or not its trace id matched a registered
+    /// test). Used by TUnit.Aspire to distinguish a resource that exported telemetry from one
+    /// that only wrote to the console, so it can hint at missing OpenTelemetry log export.
+    /// </summary>
+    internal bool HasSeenLogsFrom(string serviceName) => _seenLogServiceNames.ContainsKey(serviceName);
+
+    /// <summary>Snapshot of all <c>service.name</c> values seen on incoming OTLP log records.</summary>
+    internal IReadOnlyCollection<string> SeenLogServiceNames => _seenLogServiceNames.Keys.ToArray();
 
     /// <summary>
     /// Creates a new OTLP receiver.
@@ -324,7 +342,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
             if (path == "/v1/logs")
             {
                 Interlocked.Increment(ref _diagnostics.LogsRequests);
-                ProcessLogs(body, _diagnostics);
+                ProcessLogs(body);
             }
             else if (path == "/v1/traces")
             {
@@ -531,8 +549,9 @@ internal sealed class OtlpReceiver : IAsyncDisposable
             ? ((ActivityStatusCode)code).ToString()
             : nameof(ActivityStatusCode.Unset);
 
-    private static void ProcessLogs(byte[] body, OtlpReceiverDiagnostics diag)
+    private void ProcessLogs(byte[] body)
     {
+        var diag = _diagnostics;
         List<OtlpLogRecord> records;
         try
         {
@@ -549,6 +568,14 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
         foreach (var record in records)
         {
+            // Record the source service even when the record has no usable trace id — its
+            // presence proves OTLP logging is wired, which is exactly what the Aspire
+            // missing-telemetry hint checks for.
+            if (!string.IsNullOrEmpty(record.ResourceName))
+            {
+                _seenLogServiceNames.TryAdd(record.ResourceName, 0);
+            }
+
             if (string.IsNullOrEmpty(record.TraceId))
             {
                 Interlocked.Increment(ref diag.LogsRecordsNoTraceId);

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -551,7 +551,6 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
     private void ProcessLogs(byte[] body)
     {
-        var diag = _diagnostics;
         List<OtlpLogRecord> records;
         try
         {
@@ -559,12 +558,12 @@ internal sealed class OtlpReceiver : IAsyncDisposable
         }
         catch (Exception ex)
         {
-            Interlocked.Increment(ref diag.LogsParseFailures);
+            Interlocked.Increment(ref _diagnostics.LogsParseFailures);
             Trace.WriteLine($"[TUnit.OpenTelemetry] Failed to parse /v1/logs body: {ex.GetType().Name}: {ex.Message}");
             return;
         }
 
-        Interlocked.Add(ref diag.LogsRecordsParsed, records.Count);
+        Interlocked.Add(ref _diagnostics.LogsRecordsParsed, records.Count);
 
         foreach (var record in records)
         {
@@ -578,7 +577,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
 
             if (string.IsNullOrEmpty(record.TraceId))
             {
-                Interlocked.Increment(ref diag.LogsRecordsNoTraceId);
+                Interlocked.Increment(ref _diagnostics.LogsRecordsNoTraceId);
                 continue;
             }
 
@@ -586,14 +585,14 @@ internal sealed class OtlpReceiver : IAsyncDisposable
             var contextId = TraceRegistry.GetContextId(record.TraceId);
             if (contextId is null)
             {
-                Interlocked.Increment(ref diag.LogsRecordsTraceNotRegistered);
+                Interlocked.Increment(ref _diagnostics.LogsRecordsTraceNotRegistered);
                 continue;
             }
 
             var testContext = TestContext.GetById(contextId);
             if (testContext is null)
             {
-                Interlocked.Increment(ref diag.LogsRecordsTestContextMissing);
+                Interlocked.Increment(ref _diagnostics.LogsRecordsTestContextMissing);
                 continue;
             }
 
@@ -604,7 +603,7 @@ internal sealed class OtlpReceiver : IAsyncDisposable
                 : $"[{record.ResourceName}] ";
 
             testContext.Output.WriteLine($"{prefix}[{severity}] {record.Body}");
-            Interlocked.Increment(ref diag.LogsRecordsRouted);
+            Interlocked.Increment(ref _diagnostics.LogsRecordsRouted);
         }
     }
 


### PR DESCRIPTION
## What

Two opt-out DX features so a failing Aspire test surfaces SUT logs without any manual wiring.

### 1. Dump resource error logs on test failure (default on)
`AspireFixture<T>` now implements `ITestEndEventReceiver`. When a test that consumes the fixture fails, each waited-on resource's recent **stderr** lines are appended to that test's output.

- Reuses the existing `ResourceLoggerService.WatchAsync` pattern; collected in parallel with a short per-resource timeout.
- Resource-scoped, **not** request-correlated — on a shared (session/class) fixture the log buffer spans the whole run, so output can include lines from earlier tests. Precise per-request correlation already flows live via the OTLP receiver (trace-context based). This is the coarse fallback for resources that don't export OpenTelemetry logs.
- Knobs: `DumpResourceLogsOnFailure` (default `true`), `MaxFailureLogLinesPerResource` (50), `FailureLogCollectionTimeout` (2s).

### 2. Warn on missing telemetry wiring (default on)
`OtlpReceiver` now records the `service.name` of every incoming OTLP **log** record (before the trace-id filter — presence means OTLP logging reached us at all). At session end the fixture emits a one-time hint for any project resource that produced console output but never sent correlated OTLP logs — the usual symptom of an SUT missing OpenTelemetry log export (e.g. Aspire ServiceDefaults not wired). Turns a silent gap into an actionable nudge.

- Emitted after the receiver drain (seen-set complete) but before `StopAsync` (app still up to probe console output); skipped on a run-abort (incomplete data).
- Name match relies on the fixture-injected `OTEL_SERVICE_NAME=<resourceName>`; an SUT that overrides its own service name may produce a false hint, hence the soft wording. Knob: `WarnOnMissingTelemetry` (default `true`).

## Why

For a SUT wired with standard ServiceDefaults, correlated per-request logs already reach the owning test live. These two changes cover the two remaining gaps with zero user code: failure visibility for uncorrelated **console** logs, and a hint when correlation silently can't work because OTLP log export isn't on.

## Tests

- New `Receiver_LogWithServiceName_RecordsSeenService` (hand-built OTLP logs protobuf, unregistered trace id, asserts case-insensitive `HasSeenLogsFrom` + `SeenLogServiceNames`).
- `OtlpReceiverIngestionTests` 8/8; pure Aspire `TraceRegistryTests` / `ResourcesToRemoveTests` pass; clean build on net10.0.
- Docker-backed integration path is not covered here (no container runtime in this environment) — same gap as the existing Aspire startup-diagnostics tests.

## Notes / landmines for reviewers

- `TestContext.Result` is internal; the public read path is `context.Execution.Result?.State`.
- `OtlpReceiver.ProcessLogs` changed from `static` to an instance method (needs the seen-services field).
- Event receivers fire for `[ClassDataSource]`-injected fixtures because `BuildEligibleEventObjects` scans test class arguments / injected properties.
