### PR TITLE
fix(engine): apply --treenode-filter to --list-tests

### DIFF
--- a/TUnit.Engine.Tests/ListTestsFilterTests.cs
+++ b/TUnit.Engine.Tests/ListTestsFilterTests.cs
@@ -1,0 +1,80 @@
+using CliWrap;
+using CliWrap.Buffered;
+using Shouldly;
+
+namespace TUnit.Engine.Tests;
+
+/// <summary>
+/// Verifies that the built-in <c>--list-tests</c> flag honours <c>--treenode-filter</c>.
+/// Listing routes through <see cref="TUnit.Engine.TestDiscoveryService"/> as a discovery request,
+/// so this exercises the same engine code path in both reflection and source-generated modes.
+///
+/// Note: this drives the built test-project executable directly rather than using
+/// <see cref="InvokableTestBase"/>, because that harness always attaches <c>--report-trx</c> and
+/// asserts a TRX, which <c>--list-tests</c> does not produce. We assert on stdout instead.
+/// </summary>
+public class ListTestsFilterTests
+{
+    private static readonly string NetVersion = Environment.GetEnvironmentVariable("NET_VERSION") ?? "net10.0";
+
+    // true => reflection mode (--reflection), false => default source-generated mode.
+    public static IEnumerable<bool> Modes()
+    {
+        yield return false;
+        yield return true;
+    }
+
+    [Test]
+    [MethodDataSource(nameof(Modes))]
+    public async Task ListTests_With_Filter_Lists_Only_Matching_Tests(bool reflection)
+    {
+        var result = await RunListTestsAsync(reflection, "/*/*/PassFailTests/*[Category=Pass]");
+
+        // Pass* tests match the filter and should be listed...
+        result.StandardOutput.ShouldContain("Pass1");
+        // ...while Fail* tests (Category=Fail) are excluded and must NOT appear.
+        result.StandardOutput.ShouldNotContain("Fail1");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(Modes))]
+    public async Task ListTests_Without_Filter_Lists_Everything(bool reflection)
+    {
+        // Guards the no-filter branch: bare --list-tests (null/NopFilter) must keep listing
+        // every test, so both Pass* and Fail* appear.
+        var result = await RunListTestsAsync(reflection, filter: null);
+
+        result.StandardOutput.ShouldContain("Pass1");
+        result.StandardOutput.ShouldContain("Fail1");
+    }
+
+    private static async Task<BufferedCommandResult> RunListTestsAsync(bool reflection, string? filter)
+    {
+        var testProject = Sourcy.DotNet.Projects.TUnit_TestProject;
+        var projectName = Path.GetFileNameWithoutExtension(testProject.Name);
+        var binDir = new DirectoryInfo(Path.Combine(testProject.DirectoryName!, "bin", "Release", NetVersion));
+
+        var executable = binDir.EnumerateFiles(projectName).FirstOrDefault()
+                      ?? binDir.EnumerateFiles(projectName + ".exe").First();
+
+        var arguments = new List<string> { "--list-tests" };
+
+        if (filter is not null)
+        {
+            arguments.Add("--treenode-filter");
+            arguments.Add(filter);
+        }
+
+        if (reflection)
+        {
+            arguments.Add("--reflection");
+        }
+
+        return await Cli.Wrap(executable.FullName)
+            .WithArguments(arguments)
+            .WithWorkingDirectory(testProject.DirectoryName!)
+            .WithEnvironmentVariables(new Dictionary<string, string?> { ["TUNIT_DISABLE_HTML_REPORTER"] = "true" })
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync();
+    }
+}

--- a/TUnit.Engine/TestDiscoveryService.cs
+++ b/TUnit.Engine/TestDiscoveryService.cs
@@ -80,7 +80,18 @@ internal sealed class TestDiscoveryService : IDataProducer
         // ITestRegisteredEventReceiver can access dependency information and any state set by After(TestDiscovery) hooks
         await InvokePostResolutionEventsInParallelAsync(allTests).ConfigureAwait(false);
 
-        var filteredTests = isForExecution ? _testFilterService.FilterTests(filter, allTests) : allTests;
+        // Apply the filter during discovery too — not just execution — so `--list-tests
+        // --treenode-filter X` lists exactly the tests a run with X would execute. Only filter
+        // when a real filter is present: bare `--list-tests` and IDE Test Explorer discovery send
+        // null/NopFilter and must keep listing everything (including [Explicit] tests, which
+        // FilterTests would otherwise strip). Filtering is side-effect-free (MatchesTest only
+        // compares paths/properties), so unlike argument registration it is safe outside execution.
+#pragma warning disable TPEXP
+        var hasRealFilter = filter is not (null or NopFilter);
+#pragma warning restore TPEXP
+        var filteredTests = (isForExecution || hasRealFilter)
+            ? _testFilterService.FilterTests(filter, allTests)
+            : allTests;
 
         if (isForExecution)
         {


### PR DESCRIPTION
## Problem

`--list-tests` ignored `--treenode-filter` and listed **every** test in the assembly. Users expect `app --list-tests --treenode-filter X` to list only the tests filter `X` selects — the same set a real run would execute.

## Root cause

MTP routes `--list-tests` to a `DiscoverTestExecutionRequest`, which flows through `TestDiscoveryService.DiscoverTests` with `isForExecution: false`. The filter was applied only when `isForExecution` was true:

```csharp
var filteredTests = isForExecution ? _testFilterService.FilterTests(filter, allTests) : allTests;
```

`isForExecution` legitimately gates *side-effecting* work — argument registration / fixture creation (#6151) and dependency-closure expansion. But filtering itself is pure (`MatchesTest` only compares the test's path/properties against the filter), so running it during discovery was always safe; it just was never wired up. Filtering got conflated with the side-effect gate.

## Fix

Apply the filter during discovery too, but **only when a real filter is present**:

```csharp
var hasRealFilter = filter is not (null or NopFilter);
var filteredTests = (isForExecution || hasRealFilter)
    ? _testFilterService.FilterTests(filter, allTests)
    : allTests;
```

- **No filter (bare `--list-tests`, IDE Test Explorer)** → `null`/`NopFilter` → returns all tests unchanged, including `[Explicit]` ones (which `FilterTests` would otherwise strip). No behavior change.
- **Filter present** → reuse `FilterTests`, so the listing mirrors exactly what a run with that filter would execute.
- **No fixture leaks** — `RegisterTestsAsync` is still called with `isForExecution: false`, so `RegisterTestArgumentsAsync` stays skipped.
- **No dependency pull-in** — the dependency-closure block stays guarded by `isForExecution`.

Engine-runtime only; works identically in reflection and source-generated modes since both flow through `TestDiscoveryService`. No snapshot/source-gen output changes.

## Tests

Adds `ListTestsFilterTests` (reflection + source-generated modes):
- filter lists only matching tests,
- bare `--list-tests` still lists everything (guards the no-filter path).

Manually verified against `TUnit.TestProject`:

| Check | Result |
|---|---|
| source-gen + `[Category=Pass]` filter | only `Pass*`, 0 `Fail*` |
| reflection + filter | 86 Pass / 0 Fail |
| no filter | full 18,138 listed, `Pass1`+`Fail1` present |
| new engine test (4 cases) | all pass |