### PR TITLE
fix(engine): reset test cancellation token before After hooks on timeout path (#6339)

### DIFF
--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -296,6 +296,15 @@ internal class TestExecutor
         }
         finally
         {
+            // The timeout path (TimeoutHelper) set Context.CancellationToken to a linked CTS token
+            // that is disposed the moment the test body returns. Restore the still-valid outer token
+            // before the test-end event receivers, After(Test)/AfterEvery(Test) hooks, and any retry
+            // back-off run, so they never observe a disposed CancellationTokenSource (fixes #6339).
+            if (testTimeout.HasValue)
+            {
+                executableTest.Context.CancellationToken = cancellationToken;
+            }
+
             // After hooks must use CancellationToken.None to ensure cleanup runs even when cancelled
             // This matches the pattern used for After Class/Assembly hooks in TestCoordinator
 

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -277,6 +277,16 @@ internal class TestExecutor
                 TUnitActivitySource.StopActivity(testBodyActivity);
 #endif
                 executableTest.Context.Execution.TestEnd ??= DateTimeOffset.UtcNow;
+
+                // The timeout path (TimeoutHelper) set Context.CancellationToken to a linked CTS
+                // token that is disposed the moment the test body returns. Restore the still-valid
+                // outer token — colocated here with the timeout call that mutated it — so the
+                // test-end event receivers, After(Test)/AfterEvery(Test) hooks, and any retry
+                // back-off never observe a disposed CancellationTokenSource (fixes #6339).
+                if (testTimeout.HasValue)
+                {
+                    executableTest.Context.CancellationToken = cancellationToken;
+                }
             }
 
             executableTest.SetResult(TestState.Passed);
@@ -296,15 +306,6 @@ internal class TestExecutor
         }
         finally
         {
-            // The timeout path (TimeoutHelper) set Context.CancellationToken to a linked CTS token
-            // that is disposed the moment the test body returns. Restore the still-valid outer token
-            // before the test-end event receivers, After(Test)/AfterEvery(Test) hooks, and any retry
-            // back-off run, so they never observe a disposed CancellationTokenSource (fixes #6339).
-            if (testTimeout.HasValue)
-            {
-                executableTest.Context.CancellationToken = cancellationToken;
-            }
-
             // After hooks must use CancellationToken.None to ensure cleanup runs even when cancelled
             // This matches the pattern used for After Class/Assembly hooks in TestCoordinator
 

--- a/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
+++ b/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
@@ -9,9 +9,9 @@ namespace TUnit.TestProject.Bugs._6339;
 /// When a test is subject to a timeout (an explicit <c>[Timeout]</c> or a configured
 /// <c>DefaultTestTimeout</c>), the engine ran the body with a linked <see cref="CancellationTokenSource"/>
 /// token stored on <c>TestContext.Execution.CancellationToken</c>. That source was disposed the moment the
-/// body returned, so an <c>[After(Test)]</c> hook that read the context token and did anything source-touching
-/// on it (e.g. <see cref="CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)"/>, common in
-/// ASP.NET Core integration cleanup via EF Core / Respawn / HttpClient) threw
+/// body returned, so an <c>[After(Test)]</c> hook that read the context token and touched the underlying
+/// source (e.g. accessing <see cref="CancellationToken.WaitHandle"/> — what a synchronous wait inside
+/// ASP.NET Core integration cleanup via EF Core / Respawn / SemaphoreSlim ends up doing) threw
 /// <see cref="ObjectDisposedException"/> "The CancellationTokenSource has been disposed."
 ///
 /// The body completes fast (no actual timeout) so this is a plain passing test — the regression is the
@@ -23,10 +23,7 @@ public class TimeoutAfterHookTokenTests
     [Test]
     [Timeout(30_000)]
     [EngineTest(ExpectedResult.Pass)]
-    public async Task Body_Completes_Then_After_Hook_Uses_Context_Token()
-    {
-        await Task.CompletedTask;
-    }
+    public Task Body_Completes_Then_After_Hook_Uses_Context_Token() => Task.CompletedTask;
 
     [After(Test)]
     public void After_Hook_Can_Use_Context_Cancellation_Token(TestContext context)

--- a/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
+++ b/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
@@ -1,0 +1,40 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6339;
+
+/// <summary>
+/// Reproduction for issue #6339: "After(Test) hook failed: The CancellationTokenSource has been disposed."
+/// https://github.com/thomhurst/TUnit/issues/6339
+///
+/// When a test is subject to a timeout (an explicit <c>[Timeout]</c> or a configured
+/// <c>DefaultTestTimeout</c>), the engine ran the body with a linked <see cref="CancellationTokenSource"/>
+/// token stored on <c>TestContext.Execution.CancellationToken</c>. That source was disposed the moment the
+/// body returned, so an <c>[After(Test)]</c> hook that read the context token and did anything source-touching
+/// on it (e.g. <see cref="CancellationTokenSource.CreateLinkedTokenSource(CancellationToken)"/>, common in
+/// ASP.NET Core integration cleanup via EF Core / Respawn / HttpClient) threw
+/// <see cref="ObjectDisposedException"/> "The CancellationTokenSource has been disposed."
+///
+/// The body completes fast (no actual timeout) so this is a plain passing test — the regression is the
+/// disposed-token leak into the After phase, not cancellation. Before the fix the After hook throws and the
+/// test is reported failed; after the fix the context token is the still-valid outer token and it passes.
+/// </summary>
+public class TimeoutAfterHookTokenTests
+{
+    [Test]
+    [Timeout(30_000)]
+    [EngineTest(ExpectedResult.Pass)]
+    public async Task Body_Completes_Then_After_Hook_Uses_Context_Token()
+    {
+        await Task.CompletedTask;
+    }
+
+    [After(Test)]
+    public void After_Hook_Can_Use_Context_Cancellation_Token(TestContext context)
+    {
+        // Pre-fix: threw ObjectDisposedException "The CancellationTokenSource has been disposed."
+        // because the timeout-scoped CTS backing this token was already disposed by TimeoutHelper.
+        // Accessing WaitHandle calls the source's ThrowIfDisposed unconditionally, mirroring what
+        // synchronous waits inside real cleanup code (EF Core, Respawn, SemaphoreSlim.Wait) hit.
+        _ = context.Execution.CancellationToken.WaitHandle;
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #6339. Users running ASP.NET Core integration tests hit random failures:

```
[Test Failure] After(Test) hook failed: The CancellationTokenSource has been disposed.
  at TestExecutor.ExecuteAsync -> TestCoordinator.ExecuteTestAsync
```

## Root cause

When a test is subject to a timeout (an explicit `[Timeout]` **or** a configured
`DefaultTestTimeout`), `TimeoutHelper.ExecuteWithTimeoutAsync` runs the body under a linked
`CancellationTokenSource` and `TestExecutor.ExecuteTestAsync` stores that token on
`TestContext.Execution.CancellationToken` (`TestExecutor.cs:428`). The linked CTS is disposed via
`using` the instant the body returns — but the context was left pointing at it.

The `finally` in `ExecuteAsync` then runs the test-end event receivers and
`After(Test)`/`AfterEvery(Test)` hooks. Those hooks are *invoked* with `CancellationToken.None`, but
any code that reads `context.Execution.CancellationToken` and touches the underlying source —
`.WaitHandle` (synchronous waits in EF Core / Respawn / `SemaphoreSlim.Wait`), `.Token`, `.Cancel`,
etc. — throws `ObjectDisposedException: The CancellationTokenSource has been disposed.` The same
disposed token also feeds `RetryHelper.ApplyBackoffDelay` (`RetryHelper.cs:118`).

It looks "random" because only timed tests whose After-hooks/retries actually touch the token in a
source-accessing way fail, and the no-timeout fast path is unaffected (it stores the still-valid
outer session token).

## Fix

Restore the still-valid outer token at the top of the `ExecuteAsync` `finally`, before the test-end
phase runs and before the exception unwinds into any retry back-off:

```csharp
if (testTimeout.HasValue)
{
    executableTest.Context.CancellationToken = cancellationToken;
}
```

- Gated on `testTimeout.HasValue` so the no-timeout fast path (and any user-added linked token via
  `TestContext.AddLinkedCancellationToken`) is untouched.
- Runs on every exit (pass / fail / skip / exception) and before the re-throw, so it also covers the
  retry back-off manifestation.
- Engine-only; identical in source-gen and reflection modes. No public API or snapshot changes.

## Test

`TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs` — a passing `[Timeout]` test whose
`[After(Test)]` hook reads the context token's `WaitHandle`. Verified it **fails** with
"The CancellationTokenSource has been disposed." before the fix and **passes** after.

## Note for the reporter

The companion `BeforeTest hook failed: ... transient failure ... EnableRetryOnFailure` message is a
plain EF Core SqlServer transient fault in your own seeding hook, not a TUnit defect — add
`options.UseSqlServer(cs, o => o.EnableRetryOnFailure())` to handle it.
