### PR TITLE
fix(aspire): fail fast on Finished-state crashes during startup (#6342)

### DIFF
--- a/TUnit.Aspire.Core/AspireFixture.cs
+++ b/TUnit.Aspire.Core/AspireFixture.cs
@@ -1099,7 +1099,10 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
                 failureCts.Cancel();
                 var failedName = await await anyFailureTask;
 
-                var headline = $"Resource '{failedName}' failed to start.";
+                // "failed during startup" (not "failed to start") because the trigger covers both a
+                // launch failure (FailedToStart) and a crash-exit that reached a terminal state
+                // (Exited/Finished with a non-zero code) — see IsFailureState.
+                var headline = $"Aspire startup aborted: resource '{failedName}' failed during startup.";
                 throw new InvalidOperationException(
                     await BuildDiagnosticsAndAttachAsync(
                         app, notificationService, headline, [failedName], readyResources.ToArray()));
@@ -1308,14 +1311,24 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         => StateEquals(state, KnownResourceStates.Running)
         || StateEquals(state, KnownResourceStates.Finished);
 
-    /// <summary>
-    /// Whether a snapshot represents a genuine startup failure. <c>FailedToStart</c> always counts;
-    /// <c>Exited</c> counts only with a non-zero exit code, so a one-shot resource (migration runner,
-    /// seeder) that exits cleanly with code 0 isn't mis-reported as a failure.
-    /// </summary>
     private static bool IsFailureState(CustomResourceSnapshot snapshot)
+        => IsFailureState(snapshot.State?.Text, snapshot.ExitCode);
+
+    /// <summary>
+    /// Whether a state + exit code represents a genuine startup failure. <c>FailedToStart</c> always
+    /// counts. A crash-exit lands in <c>Exited</c> (containers) or <c>Finished</c> (projects and
+    /// executables — e.g. a .NET process that throws an unhandled exception ends Finished with a
+    /// non-zero exit code, NOT Exited), so either terminal state with a non-zero exit code counts.
+    /// A clean (code 0) exit is excluded so a one-shot resource (migration runner, seeder) that
+    /// finishes successfully isn't mis-reported as a failure.
+    /// </summary>
+    /// <remarks>
+    /// Watching only <c>Exited</c> here was the root cause of #6342: a crashed project resource
+    /// reaches <c>Finished</c>, never becomes healthy, and — unseen by the fail-fast watcher — the
+    /// wait blocked for the entire <see cref="ResourceTimeout"/> instead of aborting immediately.
+    /// </remarks>
+    internal static bool IsFailureState(string? state, int? exitCode)
     {
-        var state = snapshot.State?.Text;
         if (state is null)
         {
             return false;
@@ -1326,7 +1339,8 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             return true;
         }
 
-        return StateEquals(state, KnownResourceStates.Exited) && snapshot.ExitCode is not (null or 0);
+        return (StateEquals(state, KnownResourceStates.Exited) || StateEquals(state, KnownResourceStates.Finished))
+            && exitCode is not (null or 0);
     }
 
     /// <summary>Scans recent log lines for high-confidence failure signatures. Heuristic; a miss
@@ -1430,11 +1444,43 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         _ => null,
     };
 
+    /// <summary>
+    /// Human-readable interpretation of a process exit code, or <c>null</c> when nothing specific is
+    /// known. Turns an opaque number like -532462766 (0xE0434352) into ".NET unhandled exception".
+    /// Covers the common Windows NTSTATUS/HRESULT crash codes (surfaced as the sign-extended 32-bit
+    /// value) and POSIX 128+signal codes.
+    /// </summary>
+    internal static string? DecodeExitCode(int exitCode) => exitCode switch
+    {
+        // Windows: DCP reports the raw 32-bit code sign-extended into an int, hence the negatives.
+        unchecked((int)0xE0434352) => ".NET unhandled exception",
+        unchecked((int)0xC0000005) => "access violation (native crash)",
+        unchecked((int)0xC00000FD) => "stack overflow",
+        unchecked((int)0xC000013A) => "terminated by Ctrl+C",
+        // POSIX: a process killed by signal N exits with 128 + N.
+        134 => "SIGABRT (abort)",
+        137 => "SIGKILL (often OOM)",
+        139 => "SIGSEGV (segmentation fault)",
+        143 => "SIGTERM",
+        _ => null,
+    };
+
+    /// <summary>Formats an exit code with its decoded meaning when known: "1", or "-532462766 (.NET unhandled exception)".</summary>
+    internal static string FormatExitCode(int? exitCode)
+    {
+        if (exitCode is not int code)
+        {
+            return "(unknown)";
+        }
+
+        return DecodeExitCode(code) is { } meaning ? $"{code} ({meaning})" : code.ToString();
+    }
+
     /// <summary>One-line human description of a resource's failure state for the concise exception message.</summary>
     internal static string DescribeState(in ResourceDiagnosis d) => d.Class switch
     {
         ResourceFailureClass.OutOfMemory => $"{d.State}, exit code {d.ExitCode} (OOM / SIGKILL)",
-        ResourceFailureClass.NonZeroExit => $"{d.State}, exit code {d.ExitCode}",
+        ResourceFailureClass.NonZeroExit => $"{d.State}, exit code {FormatExitCode(d.ExitCode)}",
         ResourceFailureClass.CrashedNoCode => $"{d.State} (no exit code)",
         ResourceFailureClass.HealthCheckFailing => d.Detail is { Length: > 0 } health
             ? $"Running but not Healthy ({health})"
@@ -1559,6 +1605,36 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         }
     }
 
+    /// <summary>
+    /// Elapsed time (relative to the first recorded transition) at which <paramref name="name"/>
+    /// most recently entered a terminal state, or <c>null</c> when the timeline has no such
+    /// transition. Lets the concise message report "exited after 41.3s" by reusing the timeline the
+    /// background monitor already records, rather than separately instrumenting the wait.
+    /// </summary>
+    private TimeSpan? TerminalElapsedFor(string name)
+    {
+        lock (_timelineGate)
+        {
+            if (_timeline.Count == 0)
+            {
+                return null;
+            }
+
+            var origin = _timeline[0].Elapsed;
+            for (var i = _timeline.Count - 1; i >= 0; i--)
+            {
+                var transition = _timeline[i];
+                if (string.Equals(transition.Resource, name, StringComparison.Ordinal)
+                    && IsTerminalState(transition.To))
+                {
+                    return transition.Elapsed - origin;
+                }
+            }
+
+            return null;
+        }
+    }
+
     /// <summary>Renders the recorded transitions as a relative-time timeline; "" only when empty.
     /// A single transition (e.g. an immediate jump to FailedToStart) is still worth showing.</summary>
     internal static string FormatTimeline(StateTransition[] transitions)
@@ -1599,6 +1675,19 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         var concise = new StringBuilder().Append(headline);
         var full = new StringBuilder().AppendLine(headline);
 
+        // The reverse dependency graph — which resources declared a WaitFor on a failed one — lets
+        // the message name the downstream work that was blocked. Resolve the model defensively: a
+        // concurrently torn-down app throws ObjectDisposedException, in which case awaiters are
+        // simply omitted rather than masking the underlying failure.
+        DistributedApplicationModel? model = null;
+        try
+        {
+            model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
         // Collect every resource's logs in parallel — each has its own short timeout, so doing
         // them sequentially would compound the delay on an already-failed test's teardown.
         var collected = await Task.WhenAll(problemResources.Select(async name =>
@@ -1612,12 +1701,23 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
             var diagnosis = DiagnoseResource(notificationService, name, ev, logLines);
 
             concise.AppendLine().Append($"  {name}: {DescribeState(diagnosis)}");
+            if (TerminalElapsedFor(name) is { } elapsed)
+            {
+                concise.Append($" after {elapsed.TotalSeconds:0.0}s");
+            }
+
+            List<string> awaiters = model is null ? [] : FindAwaiters(model.Resources, name);
+            if (awaiters.Count > 0)
+            {
+                concise.AppendLine().Append($"     Awaited by: {string.Join(", ", awaiters)}");
+            }
+
             if (diagnosis.Hint is not null)
             {
                 concise.AppendLine().Append($"     Hint: {diagnosis.Hint}");
             }
 
-            AppendResourceDiagnosticBlock(full, notificationService, name, ev, diagnosis, logLines);
+            AppendResourceDiagnosticBlock(full, notificationService, name, ev, diagnosis, logLines, awaiters);
         }
 
         if (readyResources is { Count: > 0 })
@@ -1648,13 +1748,23 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
         string name,
         ResourceEvent? ev,
         in ResourceDiagnosis diagnosis,
-        IReadOnlyList<string> logLines)
+        IReadOnlyList<string> logLines,
+        IReadOnlyList<string> awaiters)
     {
         sb.AppendLine().AppendLine($"--- {name} diagnostics ---");
         sb.AppendLine($"  State:      {diagnosis.State}");
         if (diagnosis.ExitCode is int code)
         {
-            sb.AppendLine($"  Exit code:  {code}");
+            sb.Append($"  Exit code:  {code}");
+            if (DecodeExitCode(code) is { } meaning)
+            {
+                sb.Append($" ({meaning})");
+            }
+            sb.AppendLine();
+        }
+        if (awaiters.Count > 0)
+        {
+            sb.AppendLine($"  Awaited by: {string.Join(", ", awaiters)}");
         }
         if (diagnosis.Hint is not null)
         {
@@ -1745,6 +1855,28 @@ public class AspireFixture<TAppHost> : IAsyncInitializer, IAsyncDisposable, ITes
 
             sb.AppendLine($"    - {depName} [{wait.WaitType}] -> {description}");
         }
+    }
+
+    /// <summary>
+    /// Names of resources that declared a <see cref="WaitAnnotation"/> on <paramref name="target"/> —
+    /// the reverse of <see cref="AppendDependencyChain"/>. These are the downstream resources whose
+    /// own startup was gated on <paramref name="target"/> and were therefore blocked when it failed,
+    /// so the failure message can point at the work that didn't run ("Awaited by: media, web").
+    /// </summary>
+    internal static List<string> FindAwaiters(IEnumerable<IResource> resources, string target)
+    {
+        var awaiters = new List<string>();
+
+        foreach (var resource in resources)
+        {
+            if (resource.TryGetAnnotationsOfType<WaitAnnotation>(out var waits)
+                && waits.Any(w => string.Equals(w.Resource.Name, target, StringComparison.Ordinal)))
+            {
+                awaiters.Add(resource.Name);
+            }
+        }
+
+        return awaiters;
     }
 
     private async Task<string?> TryWriteDiagnosticsArtifactAsync(string content)

--- a/TUnit.Aspire.Tests/AspireDiagnosticsTests.cs
+++ b/TUnit.Aspire.Tests/AspireDiagnosticsTests.cs
@@ -1,3 +1,5 @@
+using Aspire.Hosting.ApplicationModel;
+using TUnit.Aspire.Tests.Helpers;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
@@ -22,6 +24,43 @@ public class AspireDiagnosticsTests
     public async Task Classify_TerminalWithNonZeroExit_IsNonZeroExit()
         => await Assert.That(Classify("FailedToStart", 1, runningButUnhealthy: false, logLines: null))
             .IsEqualTo(ResourceFailureClass.NonZeroExit);
+
+    // A crashed .NET project reaches Finished (not Exited) with a non-zero exit code — #6342.
+    [Test]
+    public async Task Classify_FinishedWithNonZeroExit_IsNonZeroExit()
+        => await Assert.That(Classify("Finished", -532462766, runningButUnhealthy: false, logLines: null))
+            .IsEqualTo(ResourceFailureClass.NonZeroExit);
+
+    // --- IsFailureState: the fail-fast trigger. #6342 = Finished + non-zero was previously missed. ---
+
+    [Test]
+    public async Task IsFailureState_FinishedWithNonZeroExit_IsFailure()
+        => await Assert.That(IsFailureState("Finished", -532462766)).IsTrue();
+
+    [Test]
+    public async Task IsFailureState_ExitedWithNonZeroExit_IsFailure()
+        => await Assert.That(IsFailureState("Exited", 1)).IsTrue();
+
+    [Test]
+    public async Task IsFailureState_FailedToStart_IsFailure()
+        => await Assert.That(IsFailureState("FailedToStart", null)).IsTrue();
+
+    // A one-shot resource (migration runner, seeder) that finishes cleanly must NOT be a failure.
+    [Test]
+    public async Task IsFailureState_FinishedWithZeroExit_IsNotFailure()
+        => await Assert.That(IsFailureState("Finished", 0)).IsFalse();
+
+    [Test]
+    public async Task IsFailureState_ExitedWithZeroExit_IsNotFailure()
+        => await Assert.That(IsFailureState("Exited", 0)).IsFalse();
+
+    [Test]
+    public async Task IsFailureState_Running_IsNotFailure()
+        => await Assert.That(IsFailureState("Running", null)).IsFalse();
+
+    [Test]
+    public async Task IsFailureState_NullState_IsNotFailure()
+        => await Assert.That(IsFailureState(null, null)).IsFalse();
 
     [Test]
     public async Task Classify_TerminalWithNoExitCode_IsCrashedNoCode()
@@ -114,6 +153,83 @@ public class AspireDiagnosticsTests
             Detail: "'migrations' (Exited, exit code 1)", Hint: null);
 
         await Assert.That(DescribeState(diagnosis)).Contains("waiting on 'migrations'");
+    }
+
+    // --- Exit-code decoding (#6342): turn opaque numbers into human-readable causes. ---
+
+    [Test]
+    public async Task DecodeExitCode_DotNetUnhandledException_IsDescribed()
+        => await Assert.That(DecodeExitCode(-532462766)).Contains(".NET unhandled exception");
+
+    [Test]
+    public async Task DecodeExitCode_AccessViolation_IsDescribed()
+        => await Assert.That(DecodeExitCode(unchecked((int)0xC0000005))).Contains("access violation");
+
+    [Test]
+    public async Task DecodeExitCode_Sigkill_MentionsOom()
+        => await Assert.That(DecodeExitCode(137)).Contains("SIGKILL");
+
+    [Test]
+    public async Task DecodeExitCode_UnknownCode_IsNull()
+        => await Assert.That(DecodeExitCode(1)).IsNull();
+
+    [Test]
+    public async Task FormatExitCode_KnownCode_IncludesNumberAndMeaning()
+    {
+        var formatted = FormatExitCode(-532462766);
+
+        await Assert.That(formatted).Contains("-532462766");
+        await Assert.That(formatted).Contains(".NET unhandled exception");
+    }
+
+    [Test]
+    public async Task FormatExitCode_UnknownCode_IsBareNumber()
+        => await Assert.That(FormatExitCode(1)).IsEqualTo("1");
+
+    [Test]
+    public async Task FormatExitCode_Null_IsUnknown()
+        => await Assert.That(FormatExitCode(null)).IsEqualTo("(unknown)");
+
+    [Test]
+    public async Task DescribeState_NonZeroExit_DecodesExitCode()
+    {
+        var diagnosis = new ResourceDiagnosis(
+            "chat", "Finished", -532462766, ResourceFailureClass.NonZeroExit, null, null);
+
+        var description = DescribeState(diagnosis);
+
+        await Assert.That(description).Contains("Finished");
+        await Assert.That(description).Contains(".NET unhandled exception");
+    }
+
+    // --- Reverse dependency graph (#6342): who was awaiting the failed resource. ---
+
+    [Test]
+    public async Task FindAwaiters_ReturnsResourcesThatWaitOnTarget()
+    {
+        var chat = new FakeComputeResource("chat");
+        var media = new FakeComputeResource("media");
+        var web = new FakeComputeResource("web");
+        var unrelated = new FakeComputeResource("db");
+
+        media.Annotations.Add(new WaitAnnotation(chat, WaitType.WaitUntilHealthy, 0));
+        web.Annotations.Add(new WaitAnnotation(chat, WaitType.WaitUntilHealthy, 0));
+
+        var awaiters = FindAwaiters([chat, media, web, unrelated], "chat");
+
+        await Assert.That(awaiters).Contains("media");
+        await Assert.That(awaiters).Contains("web");
+        await Assert.That(awaiters).DoesNotContain("db");
+        await Assert.That(awaiters).DoesNotContain("chat");
+    }
+
+    [Test]
+    public async Task FindAwaiters_NoWaiters_IsEmpty()
+    {
+        var chat = new FakeComputeResource("chat");
+        var db = new FakeComputeResource("db");
+
+        await Assert.That(FindAwaiters([chat, db], "chat")).IsEmpty();
     }
 
     [Test]

--- a/TUnit.Aspire.Tests/AspireDiagnosticsTests.cs
+++ b/TUnit.Aspire.Tests/AspireDiagnosticsTests.cs
@@ -31,36 +31,19 @@ public class AspireDiagnosticsTests
         => await Assert.That(Classify("Finished", -532462766, runningButUnhealthy: false, logLines: null))
             .IsEqualTo(ResourceFailureClass.NonZeroExit);
 
-    // --- IsFailureState: the fail-fast trigger. #6342 = Finished + non-zero was previously missed. ---
-
+    // The fail-fast trigger. #6342 = Finished + non-zero was previously missed (a crashed .NET
+    // project reaches Finished, not Exited). Clean (code 0) exits stay non-failures so a one-shot
+    // resource (migration runner, seeder) that finishes successfully isn't mis-reported.
     [Test]
-    public async Task IsFailureState_FinishedWithNonZeroExit_IsFailure()
-        => await Assert.That(IsFailureState("Finished", -532462766)).IsTrue();
-
-    [Test]
-    public async Task IsFailureState_ExitedWithNonZeroExit_IsFailure()
-        => await Assert.That(IsFailureState("Exited", 1)).IsTrue();
-
-    [Test]
-    public async Task IsFailureState_FailedToStart_IsFailure()
-        => await Assert.That(IsFailureState("FailedToStart", null)).IsTrue();
-
-    // A one-shot resource (migration runner, seeder) that finishes cleanly must NOT be a failure.
-    [Test]
-    public async Task IsFailureState_FinishedWithZeroExit_IsNotFailure()
-        => await Assert.That(IsFailureState("Finished", 0)).IsFalse();
-
-    [Test]
-    public async Task IsFailureState_ExitedWithZeroExit_IsNotFailure()
-        => await Assert.That(IsFailureState("Exited", 0)).IsFalse();
-
-    [Test]
-    public async Task IsFailureState_Running_IsNotFailure()
-        => await Assert.That(IsFailureState("Running", null)).IsFalse();
-
-    [Test]
-    public async Task IsFailureState_NullState_IsNotFailure()
-        => await Assert.That(IsFailureState(null, null)).IsFalse();
+    [Arguments("Finished", -532462766, true)] // #6342: the crashed-project case
+    [Arguments("Exited", 1, true)]
+    [Arguments("FailedToStart", null, true)]  // launch failure fails regardless of exit code
+    [Arguments("Finished", 0, false)]         // one-shot finished cleanly
+    [Arguments("Exited", 0, false)]
+    [Arguments("Running", null, false)]
+    [Arguments(null, null, false)]
+    public async Task IsFailureState_ClassifiesStateAndExitCode(string? state, int? exitCode, bool expected)
+        => await Assert.That(IsFailureState(state, exitCode)).IsEqualTo(expected);
 
     [Test]
     public async Task Classify_TerminalWithNoExitCode_IsCrashedNoCode()


### PR DESCRIPTION
Fixes #6342.

## Root cause
`AspireFixture`'s fail-fast watcher (`IsFailureState`) only treated `Exited` + non-zero exit as a failure. But a crashed **.NET project/executable** reaches **`Finished`**, not `Exited` (confirmed against Aspire.Hosting: `Finished` is the DCP project/exe terminal state, `Exited` is the container path). So the crash went unseen — the resource never became healthy and the readiness wait blocked for the **entire `ResourceTimeout`** instead of aborting immediately (the report showed 480s for a resource that died at ~41s).

## Changes
- **`IsFailureState`** now also flags `Finished` + non-zero exit. Clean (code 0) exits stay excluded so one-shot migration/seeder resources aren't mis-reported. Refactored to a pure `(string? state, int? exitCode)` overload so it's unit-testable.
- **`DecodeExitCode` / `FormatExitCode`** turn opaque codes into human-readable causes: `0xE0434352` → ".NET unhandled exception", `0xC0000005` → access violation, `137` → SIGKILL/OOM, `139` SIGSEGV, `134` SIGABRT, etc. Surfaced in both the concise message and the diagnostics block.
- **`FindAwaiters`** reports the reverse `WaitFor` graph — the downstream resources that were blocked ("Awaited by: media, web").
- The concise message now reports **elapsed-to-exit** ("after 41.3s") by reusing the timeline the background monitor already records.

## Decision: code-0 exits
The issue's acceptance criteria also asked for clean (code 0) exits to be flagged as failures during startup. This was **intentionally not done** — the existing code excludes code 0 precisely so one-shot resources (migration runners, seeders) that finish successfully aren't mis-reported. Flipping that would regress those scenarios. Only non-zero terminal exits fail fast.

## Tests
Added pure (no-Docker) unit tests to `AspireDiagnosticsTests`: `IsFailureState` (Finished/Exited × zero/non-zero, FailedToStart, null), `DecodeExitCode`/`FormatExitCode`, `DescribeState` decoding, and `FindAwaiters`. All 39 tests in the class pass locally; `TUnit.Aspire.Core` builds clean across net8/net9/net10.

## Example message
```
Aspire startup aborted: resource 'chat' failed during startup.
  chat: Finished, exit code -532462766 (.NET unhandled exception) after 41.3s
     Awaited by: media, web
     Hint: The process exited with a non-zero code on startup. The logs usually show the cause...
```