### PR TITLE
feat(aspire): surface exception detail in routed OTLP logs (#6347)

### DIFF
--- a/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
+++ b/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
@@ -317,10 +317,11 @@ public class OtlpReceiverIngestionTests
     {
         var traceId = Guid.NewGuid().ToString("N");
         const string stackTrace = "System.InvalidOperationException: boom\n   at Sut.Fail()";
-        var body = BuildLogsExportRequestWithException(
+        var body = BuildLogsExportRequest(
             "my-service",
             traceId,
             "Could not say hello",
+            severityText: "ERROR",
             exceptionType: "System.InvalidOperationException",
             exceptionMessage: "boom",
             exceptionStackTrace: stackTrace);
@@ -333,7 +334,6 @@ public class OtlpReceiverIngestionTests
         await Assert.That(record.ExceptionType).IsEqualTo("System.InvalidOperationException");
         await Assert.That(record.ExceptionMessage).IsEqualTo("boom");
         await Assert.That(record.ExceptionStackTrace).IsEqualTo(stackTrace);
-        await Assert.That(record.HasException).IsTrue();
         // Full stack trace preferred over the discrete type/message fields.
         await Assert.That(record.FormatException()).IsEqualTo(stackTrace);
     }
@@ -348,7 +348,6 @@ public class OtlpReceiverIngestionTests
 
         await Assert.That(records.Count).IsEqualTo(1);
         var record = records[0];
-        await Assert.That(record.HasException).IsFalse();
         await Assert.That(record.FormatException()).IsNull();
     }
 
@@ -356,58 +355,20 @@ public class OtlpReceiverIngestionTests
     public async Task Parser_ExceptionTypeAndMessageOnly_FormatsAsTypeColonMessage()
     {
         var traceId = Guid.NewGuid().ToString("N");
-        var body = BuildLogsExportRequestWithException(
+        var body = BuildLogsExportRequest(
             "my-service",
             traceId,
             "boom happened",
+            severityText: "ERROR",
             exceptionType: "System.InvalidOperationException",
-            exceptionMessage: "boom",
-            exceptionStackTrace: "");
+            exceptionMessage: "boom");
 
         var records = OtlpLogParser.Parse(body);
 
         await Assert.That(records.Count).IsEqualTo(1);
         var record = records[0];
-        await Assert.That(record.HasException).IsTrue();
         // No stack trace available → fall back to "type: message".
         await Assert.That(record.FormatException()).IsEqualTo("System.InvalidOperationException: boom");
-    }
-
-    private static byte[] BuildLogsExportRequestWithException(
-        string serviceName,
-        string traceId,
-        string body,
-        string exceptionType,
-        string exceptionMessage,
-        string exceptionStackTrace)
-    {
-        // KeyValue { key = "service.name", value = AnyValue(serviceName) }
-        using var kvStream = new MemoryStream();
-        WriteStringField(kvStream, 1, "service.name");
-        WriteField(kvStream, 2, BuildAnyValue(serviceName));
-
-        using var resourceStream = new MemoryStream();
-        WriteField(resourceStream, 1, kvStream.ToArray());
-
-        // LogRecord { severity_text (3), body (5), attributes (6)*, trace_id (9) }
-        using var logRecordStream = new MemoryStream();
-        WriteStringField(logRecordStream, 3, "ERROR");
-        WriteField(logRecordStream, 5, BuildAnyValue(body));
-        WriteExceptionAttribute(logRecordStream, "exception.type", exceptionType);
-        WriteExceptionAttribute(logRecordStream, "exception.message", exceptionMessage);
-        WriteExceptionAttribute(logRecordStream, "exception.stacktrace", exceptionStackTrace);
-        WriteField(logRecordStream, 9, Convert.FromHexString(traceId));
-
-        using var scopeLogsStream = new MemoryStream();
-        WriteField(scopeLogsStream, 2, logRecordStream.ToArray());
-
-        using var resourceLogsStream = new MemoryStream();
-        WriteField(resourceLogsStream, 1, resourceStream.ToArray());
-        WriteField(resourceLogsStream, 2, scopeLogsStream.ToArray());
-
-        using var exportStream = new MemoryStream();
-        WriteField(exportStream, 1, resourceLogsStream.ToArray());
-        return exportStream.ToArray();
     }
 
     private static void WriteExceptionAttribute(MemoryStream logRecordStream, string key, string value)
@@ -424,7 +385,14 @@ public class OtlpReceiverIngestionTests
         WriteField(logRecordStream, 6, kvStream.ToArray());
     }
 
-    private static byte[] BuildLogsExportRequest(string serviceName, string traceId, string body)
+    private static byte[] BuildLogsExportRequest(
+        string serviceName,
+        string traceId,
+        string body,
+        string severityText = "INFO",
+        string exceptionType = "",
+        string exceptionMessage = "",
+        string exceptionStackTrace = "")
     {
         // KeyValue { key = "service.name", value = AnyValue(serviceName) }
         using var kvStream = new MemoryStream();
@@ -435,10 +403,13 @@ public class OtlpReceiverIngestionTests
         using var resourceStream = new MemoryStream();
         WriteField(resourceStream, 1, kvStream.ToArray());
 
-        // LogRecord { severity_text (3), body (5), trace_id (9) }
+        // LogRecord { severity_text (3), body (5), attributes (6)*, trace_id (9) }
         using var logRecordStream = new MemoryStream();
-        WriteStringField(logRecordStream, 3, "INFO");
+        WriteStringField(logRecordStream, 3, severityText);
         WriteField(logRecordStream, 5, BuildAnyValue(body));
+        WriteExceptionAttribute(logRecordStream, "exception.type", exceptionType);
+        WriteExceptionAttribute(logRecordStream, "exception.message", exceptionMessage);
+        WriteExceptionAttribute(logRecordStream, "exception.stacktrace", exceptionStackTrace);
         WriteField(logRecordStream, 9, Convert.FromHexString(traceId));
 
         // ScopeLogs { log_records (field 2) = [logRecord] }

--- a/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
+++ b/TUnit.OpenTelemetry.Tests/OtlpReceiverIngestionTests.cs
@@ -312,6 +312,118 @@ public class OtlpReceiverIngestionTests
         await Assert.That(receiver.Diagnostics.LogsRecordsParsed).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task Parser_LogWithExceptionAttributes_ExtractsAndFormatsException()
+    {
+        var traceId = Guid.NewGuid().ToString("N");
+        const string stackTrace = "System.InvalidOperationException: boom\n   at Sut.Fail()";
+        var body = BuildLogsExportRequestWithException(
+            "my-service",
+            traceId,
+            "Could not say hello",
+            exceptionType: "System.InvalidOperationException",
+            exceptionMessage: "boom",
+            exceptionStackTrace: stackTrace);
+
+        var records = OtlpLogParser.Parse(body);
+
+        await Assert.That(records.Count).IsEqualTo(1);
+        var record = records[0];
+        await Assert.That(record.Body).IsEqualTo("Could not say hello");
+        await Assert.That(record.ExceptionType).IsEqualTo("System.InvalidOperationException");
+        await Assert.That(record.ExceptionMessage).IsEqualTo("boom");
+        await Assert.That(record.ExceptionStackTrace).IsEqualTo(stackTrace);
+        await Assert.That(record.HasException).IsTrue();
+        // Full stack trace preferred over the discrete type/message fields.
+        await Assert.That(record.FormatException()).IsEqualTo(stackTrace);
+    }
+
+    [Test]
+    public async Task Parser_LogWithoutException_HasNoExceptionDetail()
+    {
+        var traceId = Guid.NewGuid().ToString("N");
+        var body = BuildLogsExportRequest("my-service", traceId, "just a log line");
+
+        var records = OtlpLogParser.Parse(body);
+
+        await Assert.That(records.Count).IsEqualTo(1);
+        var record = records[0];
+        await Assert.That(record.HasException).IsFalse();
+        await Assert.That(record.FormatException()).IsNull();
+    }
+
+    [Test]
+    public async Task Parser_ExceptionTypeAndMessageOnly_FormatsAsTypeColonMessage()
+    {
+        var traceId = Guid.NewGuid().ToString("N");
+        var body = BuildLogsExportRequestWithException(
+            "my-service",
+            traceId,
+            "boom happened",
+            exceptionType: "System.InvalidOperationException",
+            exceptionMessage: "boom",
+            exceptionStackTrace: "");
+
+        var records = OtlpLogParser.Parse(body);
+
+        await Assert.That(records.Count).IsEqualTo(1);
+        var record = records[0];
+        await Assert.That(record.HasException).IsTrue();
+        // No stack trace available → fall back to "type: message".
+        await Assert.That(record.FormatException()).IsEqualTo("System.InvalidOperationException: boom");
+    }
+
+    private static byte[] BuildLogsExportRequestWithException(
+        string serviceName,
+        string traceId,
+        string body,
+        string exceptionType,
+        string exceptionMessage,
+        string exceptionStackTrace)
+    {
+        // KeyValue { key = "service.name", value = AnyValue(serviceName) }
+        using var kvStream = new MemoryStream();
+        WriteStringField(kvStream, 1, "service.name");
+        WriteField(kvStream, 2, BuildAnyValue(serviceName));
+
+        using var resourceStream = new MemoryStream();
+        WriteField(resourceStream, 1, kvStream.ToArray());
+
+        // LogRecord { severity_text (3), body (5), attributes (6)*, trace_id (9) }
+        using var logRecordStream = new MemoryStream();
+        WriteStringField(logRecordStream, 3, "ERROR");
+        WriteField(logRecordStream, 5, BuildAnyValue(body));
+        WriteExceptionAttribute(logRecordStream, "exception.type", exceptionType);
+        WriteExceptionAttribute(logRecordStream, "exception.message", exceptionMessage);
+        WriteExceptionAttribute(logRecordStream, "exception.stacktrace", exceptionStackTrace);
+        WriteField(logRecordStream, 9, Convert.FromHexString(traceId));
+
+        using var scopeLogsStream = new MemoryStream();
+        WriteField(scopeLogsStream, 2, logRecordStream.ToArray());
+
+        using var resourceLogsStream = new MemoryStream();
+        WriteField(resourceLogsStream, 1, resourceStream.ToArray());
+        WriteField(resourceLogsStream, 2, scopeLogsStream.ToArray());
+
+        using var exportStream = new MemoryStream();
+        WriteField(exportStream, 1, resourceLogsStream.ToArray());
+        return exportStream.ToArray();
+    }
+
+    private static void WriteExceptionAttribute(MemoryStream logRecordStream, string key, string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        // KeyValue { key (1), value = AnyValue (2) } written to LogRecord.attributes (field 6).
+        using var kvStream = new MemoryStream();
+        WriteStringField(kvStream, 1, key);
+        WriteField(kvStream, 2, BuildAnyValue(value));
+        WriteField(logRecordStream, 6, kvStream.ToArray());
+    }
+
     private static byte[] BuildLogsExportRequest(string serviceName, string traceId, string body)
     {
         // KeyValue { key = "service.name", value = AnyValue(serviceName) }

--- a/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
@@ -34,14 +34,6 @@ internal readonly record struct OtlpLogRecord(
     string ExceptionStackTrace = "")
 {
     /// <summary>
-    /// <c>true</c> when the record carries any OTel exception semantic-convention attribute.
-    /// </summary>
-    public bool HasException =>
-        !string.IsNullOrEmpty(ExceptionStackTrace)
-        || !string.IsNullOrEmpty(ExceptionType)
-        || !string.IsNullOrEmpty(ExceptionMessage);
-
-    /// <summary>
     /// Renders the exception attributes into a single human-readable block, or <c>null</c> when the
     /// record carries no exception. Prefers <see cref="ExceptionStackTrace"/> (the full
     /// <c>ToString()</c>); otherwise falls back to <c>type: message</c> from the discrete fields.
@@ -227,8 +219,7 @@ internal static class OtlpLogParser
                 // exception. Pull those three out so the exception can be surfaced alongside the body
                 // (the body alone is often just the log message, not the failure detail).
                 case 6 when wireType == WireType.LengthDelimited:
-                    var attribute = reader.ReadEmbeddedMessage();
-                    var (key, value) = ParseKeyValue(attribute);
+                    var (key, value) = ParseExceptionAttribute(reader.ReadEmbeddedMessage());
                     switch (key)
                     {
                         case "exception.type":
@@ -289,6 +280,34 @@ internal static class OtlpLogParser
         }
 
         return "";
+    }
+
+    // Like ParseKeyValue, but materialises the value string only for the exception.* keys the
+    // receiver renders. A log record can carry many attributes (scopes, custom fields); parsing
+    // every value — some large — just to discard it would waste allocations on the ingest hot
+    // path. Assumes key (field 1) precedes value (field 2), which holds for all known OTel encoders.
+    private static (string Key, string Value) ParseExceptionAttribute(ProtobufReader reader)
+    {
+        var key = "";
+
+        while (reader.TryReadTag(out var fieldNumber, out var wireType))
+        {
+            if (fieldNumber == 1 && wireType == WireType.LengthDelimited)
+            {
+                key = reader.ReadString();
+            }
+            else if (fieldNumber == 2 && wireType == WireType.LengthDelimited
+                && key is "exception.type" or "exception.message" or "exception.stacktrace")
+            {
+                return (key, ParseAnyValueString(reader.ReadEmbeddedMessage()));
+            }
+            else
+            {
+                reader.Skip(wireType);
+            }
+        }
+
+        return (key, "");
     }
 
     private static (string Key, string Value) ParseKeyValue(ProtobufReader reader)

--- a/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
@@ -13,12 +13,59 @@ namespace TUnit.OpenTelemetry.Receiver;
 /// other value types (int, bool, kvlist, array) are not currently extracted.
 /// </param>
 /// <param name="ResourceName">The <c>service.name</c> resource attribute, if present.</param>
+/// <param name="ExceptionType">
+/// The <c>exception.type</c> log attribute, if present. Populated by the OTLP log exporter
+/// (OpenTelemetry .NET 1.8.0+) whenever a log record carries an exception. Empty otherwise.
+/// </param>
+/// <param name="ExceptionMessage">The <c>exception.message</c> log attribute, if present. Empty otherwise.</param>
+/// <param name="ExceptionStackTrace">
+/// The <c>exception.stacktrace</c> log attribute, if present. In OpenTelemetry .NET this is the
+/// full <c>Exception.ToString()</c> (type, message, and stack), so it already subsumes the type
+/// and message fields. Empty otherwise.
+/// </param>
 internal readonly record struct OtlpLogRecord(
     string TraceId,
     string SeverityText,
     int SeverityNumber,
     string Body,
-    string ResourceName);
+    string ResourceName,
+    string ExceptionType = "",
+    string ExceptionMessage = "",
+    string ExceptionStackTrace = "")
+{
+    /// <summary>
+    /// <c>true</c> when the record carries any OTel exception semantic-convention attribute.
+    /// </summary>
+    public bool HasException =>
+        !string.IsNullOrEmpty(ExceptionStackTrace)
+        || !string.IsNullOrEmpty(ExceptionType)
+        || !string.IsNullOrEmpty(ExceptionMessage);
+
+    /// <summary>
+    /// Renders the exception attributes into a single human-readable block, or <c>null</c> when the
+    /// record carries no exception. Prefers <see cref="ExceptionStackTrace"/> (the full
+    /// <c>ToString()</c>); otherwise falls back to <c>type: message</c> from the discrete fields.
+    /// </summary>
+    public string? FormatException()
+    {
+        if (!string.IsNullOrEmpty(ExceptionStackTrace))
+        {
+            return ExceptionStackTrace;
+        }
+
+        if (!string.IsNullOrEmpty(ExceptionType) && !string.IsNullOrEmpty(ExceptionMessage))
+        {
+            return $"{ExceptionType}: {ExceptionMessage}";
+        }
+
+        if (!string.IsNullOrEmpty(ExceptionType))
+        {
+            return ExceptionType;
+        }
+
+        return string.IsNullOrEmpty(ExceptionMessage) ? null : ExceptionMessage;
+    }
+}
 
 /// <summary>
 /// Minimal parser for OTLP ExportLogsServiceRequest protobuf messages.
@@ -154,6 +201,9 @@ internal static class OtlpLogParser
         var severityNumber = 0;
         var severityText = "";
         var body = "";
+        var exceptionType = "";
+        var exceptionMessage = "";
+        var exceptionStackTrace = "";
 
         while (reader.TryReadTag(out var fieldNumber, out var wireType))
         {
@@ -170,6 +220,28 @@ internal static class OtlpLogParser
                 case 5 when wireType == WireType.LengthDelimited:
                     var bodyMsg = reader.ReadEmbeddedMessage();
                     body = ParseAnyValueString(bodyMsg);
+                    break;
+
+                // LogRecord.attributes (field 6) — OpenTelemetry's OTLP log exporter attaches the
+                // exception.* semantic-convention attributes here whenever a record carries an
+                // exception. Pull those three out so the exception can be surfaced alongside the body
+                // (the body alone is often just the log message, not the failure detail).
+                case 6 when wireType == WireType.LengthDelimited:
+                    var attribute = reader.ReadEmbeddedMessage();
+                    var (key, value) = ParseKeyValue(attribute);
+                    switch (key)
+                    {
+                        case "exception.type":
+                            exceptionType = value;
+                            break;
+                        case "exception.message":
+                            exceptionMessage = value;
+                            break;
+                        case "exception.stacktrace":
+                            exceptionStackTrace = value;
+                            break;
+                    }
+
                     break;
 
                 case 9 when wireType == WireType.LengthDelimited:
@@ -192,7 +264,15 @@ internal static class OtlpLogParser
             return null;
         }
 
-        return new OtlpLogRecord(traceId, severityText, severityNumber, body, resourceName);
+        return new OtlpLogRecord(
+            traceId,
+            severityText,
+            severityNumber,
+            body,
+            resourceName,
+            exceptionType,
+            exceptionMessage,
+            exceptionStackTrace);
     }
 
     private static string ParseAnyValueString(ProtobufReader reader)

--- a/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpLogParser.cs
@@ -231,6 +231,10 @@ internal static class OtlpLogParser
                         case "exception.stacktrace":
                             exceptionStackTrace = value;
                             break;
+                        default:
+                            // ParseExceptionAttribute already filters to the three exception.* keys;
+                            // any other attribute arrives with an empty value and is ignored.
+                            break;
                     }
 
                     break;

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -602,6 +602,15 @@ internal sealed class OtlpReceiver : IAsyncDisposable
                 : $"[{record.ResourceName}] ";
 
             testContext.Output.WriteLine($"{prefix}[{severity}] {record.Body}");
+
+            // When the SUT logged an exception, the OTLP body is usually just the message
+            // template — the actual stack trace lives in the exception.* attributes. Surface it
+            // so a failing test shows *why* it failed, not only that an error was logged.
+            if (record.HasException)
+            {
+                testContext.Output.WriteLine($"{prefix}{record.FormatException()}");
+            }
+
             Interlocked.Increment(ref _diagnostics.LogsRecordsRouted);
         }
     }

--- a/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
+++ b/TUnit.OpenTelemetry/Receiver/OtlpReceiver.cs
@@ -606,9 +606,10 @@ internal sealed class OtlpReceiver : IAsyncDisposable
             // When the SUT logged an exception, the OTLP body is usually just the message
             // template — the actual stack trace lives in the exception.* attributes. Surface it
             // so a failing test shows *why* it failed, not only that an error was logged.
-            if (record.HasException)
+            var exceptionDetail = record.FormatException();
+            if (exceptionDetail is not null)
             {
-                testContext.Output.WriteLine($"{prefix}{record.FormatException()}");
+                testContext.Output.WriteLine($"{prefix}[{severity}] {exceptionDetail}");
             }
 
             Interlocked.Increment(ref _diagnostics.LogsRecordsRouted);


### PR DESCRIPTION
## Fixes #6347

### Problem
When an SUT test fails, TUnit routes the correlated OTLP log record to the test's output as `[resource] [ERROR] <body>`. But `<body>` is usually just the log **message template** — the actual exception/stack trace is dropped, so the output rarely explains *why* the test failed.

### Fix
The OpenTelemetry .NET OTLP log exporter (1.8.0+) attaches the exception as `exception.type` / `exception.message` / `exception.stacktrace` **log attributes** (`LogRecord.attributes`, protobuf field 6). The receiver previously skipped field 6 entirely.

- **`OtlpLogParser`** now reads field 6 and extracts those three attributes into new `OtlpLogRecord` fields. `FormatException()` renders them, preferring the full stack trace (which in OTel .NET is `Exception.ToString()`, so it already subsumes type+message) and falling back to `type: message`.
- **`OtlpReceiver.ProcessLogs`** prints the exception block right after the body line when present:

```
[resource] [ERROR] Could not say hello
[resource] System.InvalidOperationException: boom
   at Sut.Fail()
```

### Notes
- No behaviour change when a record carries no exception (`HasException` false → nothing extra printed).
- Complements the AspireFixture post-mortem stderr dump (#6323) and live log forwarding (#6341), which cover a different path (raw resource output, not OTLP-correlated records).

### Tests
Added 3 parser tests to `OtlpReceiverIngestionTests` (full-block extraction, no-exception, type+message-only fallback). Full `OtlpReceiverIngestionTests` suite green (11/11).
