### PR TITLE
fix(engine): keep per-test timeout token source alive through teardown (#6339)

### DIFF
--- a/TUnit.Core/TestContext.Execution.cs
+++ b/TUnit.Core/TestContext.Execution.cs
@@ -13,6 +13,13 @@ public partial class TestContext
     // Internal backing fields and properties
     internal CancellationToken CancellationToken { get; set; }
     internal CancellationTokenSource? LinkedCancellationTokens { get; set; }
+
+    // Linked source backing the per-test timeout token. Owned for the whole test lifecycle — the body
+    // plus every teardown phase (After(Test) hooks, instance/OnDispose, object cleanup, After(Class)/
+    // After(Assembly)) — and disposed once at the end in TestCoordinator. Keeping it alive that long
+    // means a token copy captured mid-body and later touched by a synchronous .WaitHandle wait never
+    // observes a disposed CancellationTokenSource (#6339). Only allocated for tests that have a timeout.
+    internal CancellationTokenSource? TimeoutCancellationSource { get; set; }
     internal TestPhase Phase { get; set; } = TestPhase.Execution;
     internal TestResult? Result { get; set; }
     internal string? SkipReason { get; set; }

--- a/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -13,8 +13,9 @@ internal static class TimeoutHelper
     private static readonly TimeSpan GracePeriod = EngineDefaults.TimeoutGracePeriod;
 
     /// <summary>
-    /// Executes a task with a timeout. If the timeout elapses before the task completes,
-    /// control is returned to the caller immediately with a TimeoutException.
+    /// Executes a task with a timeout, owning the linked cancellation source for the duration of
+    /// the call. If the timeout elapses before the task completes, control is returned to the
+    /// caller immediately with a TimeoutException.
     /// </summary>
     /// <param name="taskFactory">Factory function that creates the task to execute.</param>
     /// <param name="timeout">Timeout duration.</param>
@@ -30,8 +31,39 @@ internal static class TimeoutHelper
         string? timeoutMessage = null)
     {
         // Timeout path: create linked token so task can observe both timeout and external cancellation.
+        // Standalone callers have nothing observing the token after this returns, so we own its
+        // lifetime here. Callers that hand the token to code which may touch it after the body
+        // returns (e.g. TestExecutor's After-hook phase) must use the CTS-owning overload instead.
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        await ExecuteWithTimeoutAsync(taskFactory, timeout, timeoutCts, cancellationToken, timeoutMessage).ConfigureAwait(false);
+    }
 
+    /// <summary>
+    /// Executes a task with a timeout using a <b>caller-owned</b> linked cancellation source.
+    /// <para>
+    /// The caller is responsible for disposing <paramref name="timeoutCts"/>, and must keep it alive
+    /// until every consumer that may have captured <c>timeoutCts.Token</c> has finished — this includes
+    /// the test body <b>and</b> any teardown (After-hook / test-end) phase that runs afterwards.
+    /// Disposing the source while a captured token copy is still reachable makes a synchronous
+    /// <see cref="CancellationToken.WaitHandle"/> wait (EF Core / Respawn / SemaphoreSlim / host shutdown)
+    /// throw <see cref="ObjectDisposedException"/> "The CancellationTokenSource has been disposed." — the
+    /// randomly-surfacing After(Test) failure in issue #6339.
+    /// </para>
+    /// </summary>
+    /// <param name="taskFactory">Factory function that creates the task to execute.</param>
+    /// <param name="timeout">Timeout duration.</param>
+    /// <param name="timeoutCts">Caller-owned CTS, already linked to <paramref name="externalToken"/>. Not disposed here.</param>
+    /// <param name="externalToken">The external token the CTS is linked to; used to distinguish timeout from external cancellation.</param>
+    /// <param name="timeoutMessage">Optional custom timeout message. If null, uses default message.</param>
+    /// <exception cref="TimeoutException">Thrown when the timeout elapses before task completion.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when cancellation is requested.</exception>
+    public static async Task ExecuteWithTimeoutAsync(
+        Func<CancellationToken, Task> taskFactory,
+        TimeSpan timeout,
+        CancellationTokenSource timeoutCts,
+        CancellationToken externalToken,
+        string? timeoutMessage = null)
+    {
         // Set up cancellation detection BEFORE scheduling timeout to avoid race condition
         // where timeout fires before registration completes (with very small timeouts)
         var cancelledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -49,9 +81,9 @@ internal static class TimeoutHelper
         if (winner == cancelledTcs.Task)
         {
             // Determine if it was external cancellation or timeout
-            if (cancellationToken.IsCancellationRequested)
+            if (externalToken.IsCancellationRequested)
             {
-                throw new OperationCanceledException(cancellationToken);
+                throw new OperationCanceledException(externalToken);
             }
 
             // Timeout occurred - give the execution task a brief grace period to clean up

--- a/TUnit.Engine/Services/AfterHookPairTracker.cs
+++ b/TUnit.Engine/Services/AfterHookPairTracker.cs
@@ -32,8 +32,8 @@ internal sealed class AfterHookPairTracker
     //
     // Safety of single registration: The CancellationToken passed in is always the session-scoped
     // token (or a derivative from Parallel.ForEachAsync which is itself linked to the session CT).
-    // Per-test timeout tokens are applied inside TestExecutor via TimeoutHelper.CreateLinkedTokenSource
-    // scoped to the test body only — they never reach this method. Therefore when the session cancels,
+    // Per-test timeout tokens are applied inside TestExecutor via a linked source scoped to the test
+    // body only — they never reach this method. Therefore when the session cancels,
     // the first test's registered CT still fires regardless of whether that test has completed.
     private readonly ConcurrentHashSet<Assembly> _assemblyHookRegistered = new();
     private readonly ConcurrentHashSet<Type> _classHookRegistered = new();

--- a/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -332,6 +332,13 @@ internal sealed class TestCoordinator : ITestCoordinator
                     throw new ArgumentOutOfRangeException();
             }
 
+            // Dispose the per-test timeout source now that the body and every teardown phase — After(Test)
+            // hooks, instance/OnDispose, object cleanup, After(Class)/After(Assembly) and Last receivers —
+            // have all run. Keeping it alive this long means a token copy captured mid-body stayed backed
+            // by a live source throughout teardown instead of throwing ObjectDisposedException (#6339).
+            test.Context.TimeoutCancellationSource?.Dispose();
+            test.Context.TimeoutCancellationSource = null;
+
             test.Context.RemoveFromRegistry();
         }
     }

--- a/TUnit.Engine/TestExecutor.cs
+++ b/TUnit.Engine/TestExecutor.cs
@@ -247,11 +247,25 @@ internal class TestExecutor
             {
                 if (testTimeout.HasValue)
                 {
-                    var timeoutMessage = $"Test '{executableTest.Context.Metadata.TestDetails.TestName}' timed out after {testTimeout.Value}";
+                    // Own the linked timeout source across the whole test lifecycle rather than letting
+                    // TimeoutHelper dispose it on return. The body can hand Context.CancellationToken to
+                    // app/user code (EF Core, Respawn, an ASP.NET host) that only touches it during
+                    // teardown; disposing it the moment the body returned left those captured copies
+                    // pointing at a disposed source, so a synchronous .WaitHandle wait in an After(Test)
+                    // hook / OnDispose threw ObjectDisposedException (fixes #6339). It lives on the context
+                    // and is disposed once by TestCoordinator after every teardown phase has run. A prior
+                    // retry attempt's source (if any) is released here before the new one replaces it.
+                    var context = executableTest.Context;
+                    context.TimeoutCancellationSource?.Dispose();
+                    var testBodyTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    context.TimeoutCancellationSource = testBodyTimeoutCts;
+
+                    var timeoutMessage = $"Test '{context.Metadata.TestDetails.TestName}' timed out after {testTimeout.Value}";
 
                     await TimeoutHelper.ExecuteWithTimeoutAsync(
                         ct => ExecuteTestAsync(executableTest, ct).AsTask(),
                         testTimeout.Value,
+                        testBodyTimeoutCts,
                         cancellationToken,
                         timeoutMessage).ConfigureAwait(false);
                 }
@@ -278,11 +292,12 @@ internal class TestExecutor
 #endif
                 executableTest.Context.Execution.TestEnd ??= DateTimeOffset.UtcNow;
 
-                // The timeout path (TimeoutHelper) set Context.CancellationToken to a linked CTS
-                // token that is disposed the moment the test body returns. Restore the still-valid
-                // outer token — colocated here with the timeout call that mutated it — so the
-                // test-end event receivers, After(Test)/AfterEvery(Test) hooks, and any retry
-                // back-off never observe a disposed CancellationTokenSource (fixes #6339).
+                // The timeout path set Context.CancellationToken to the linked timeout token, which
+                // is cancelled once the timeout fires. Restore the still-valid, non-cancelled outer
+                // token — colocated here with the timeout call that mutated it — so the test-end event
+                // receivers, After(Test)/AfterEvery(Test) hooks, and any retry back-off observe a live
+                // token via the context property. (The source itself is kept alive on the context and
+                // disposed later by TestCoordinator, so token copies captured mid-body stay valid — #6339.)
                 if (testTimeout.HasValue)
                 {
                     executableTest.Context.CancellationToken = cancellationToken;
@@ -335,9 +350,6 @@ internal class TestExecutor
             {
                 hookException = new TestExecutionException(null, hookExceptions, eventReceiverExceptions);
             }
-
-#if NET
-#endif
         }
 
         if (capturedException is SkipTestException)

--- a/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
+++ b/TUnit.TestProject/Bugs/_6339/TimeoutAfterHookTokenTests.cs
@@ -7,31 +7,50 @@ namespace TUnit.TestProject.Bugs._6339;
 /// https://github.com/thomhurst/TUnit/issues/6339
 ///
 /// When a test is subject to a timeout (an explicit <c>[Timeout]</c> or a configured
-/// <c>DefaultTestTimeout</c>), the engine ran the body with a linked <see cref="CancellationTokenSource"/>
-/// token stored on <c>TestContext.Execution.CancellationToken</c>. That source was disposed the moment the
-/// body returned, so an <c>[After(Test)]</c> hook that read the context token and touched the underlying
-/// source (e.g. accessing <see cref="CancellationToken.WaitHandle"/> — what a synchronous wait inside
-/// ASP.NET Core integration cleanup via EF Core / Respawn / SemaphoreSlim ends up doing) threw
+/// <c>DefaultTestTimeout</c>), the engine runs the body with a linked <see cref="CancellationTokenSource"/>
+/// token exposed on <c>TestContext.Execution.CancellationToken</c>. That source used to be disposed the
+/// moment the body returned, so an <c>[After(Test)]</c> hook that touched the underlying source
+/// (e.g. accessing <see cref="CancellationToken.WaitHandle"/> — what a synchronous wait inside ASP.NET Core
+/// integration cleanup via EF Core / Respawn / SemaphoreSlim / host shutdown ends up doing) threw
 /// <see cref="ObjectDisposedException"/> "The CancellationTokenSource has been disposed."
 ///
-/// The body completes fast (no actual timeout) so this is a plain passing test — the regression is the
-/// disposed-token leak into the After phase, not cancellation. Before the fix the After hook throws and the
-/// test is reported failed; after the fix the context token is the still-valid outer token and it passes.
+/// Two leaks are covered here, both requiring the timeout source to stay alive through teardown:
+/// <list type="number">
+/// <item>the After hook reading the context token property directly, and</item>
+/// <item>the After hook using a token <b>copy captured during the body</b> — the realistic case, since app
+/// code (EF Core, an ASP.NET host) snapshots the ambient token mid-test and only touches it during teardown.
+/// Restoring the context property alone does not fix this; the backing source must outlive the hooks.</item>
+/// </list>
+/// The fix keeps the source alive for the whole per-test lifecycle (disposed once in TestCoordinator after
+/// every teardown phase), so later surfacing phases such as tracked-object cleanup are covered too, not just
+/// the After(Test) hooks exercised below. The body completes fast (no actual timeout) so this is a plain
+/// passing test — the regression is the disposed-token leak into teardown, not cancellation.
 /// </summary>
 public class TimeoutAfterHookTokenTests
 {
+    // Snapshot of the ambient timeout token taken during the body, mirroring how app/user code
+    // (EF Core, Respawn, an ASP.NET host) captures the token mid-test and touches it later.
+    private CancellationToken _capturedDuringBody;
+
     [Test]
     [Timeout(30_000)]
     [EngineTest(ExpectedResult.Pass)]
-    public Task Body_Completes_Then_After_Hook_Uses_Context_Token() => Task.CompletedTask;
+    public Task Body_Captures_Timeout_Token_Then_After_Hook_Waits_On_It()
+    {
+        _capturedDuringBody = TestContext.Current!.Execution.CancellationToken;
+        return Task.CompletedTask;
+    }
 
     [After(Test)]
     public void After_Hook_Can_Use_Context_Cancellation_Token(TestContext context)
     {
-        // Pre-fix: threw ObjectDisposedException "The CancellationTokenSource has been disposed."
-        // because the timeout-scoped CTS backing this token was already disposed by TimeoutHelper.
-        // Accessing WaitHandle calls the source's ThrowIfDisposed unconditionally, mirroring what
-        // synchronous waits inside real cleanup code (EF Core, Respawn, SemaphoreSlim.Wait) hit.
+        // (1) The context property — restored to the still-valid outer token by the fix.
         _ = context.Execution.CancellationToken.WaitHandle;
+
+        // (2) The copy captured during the body — the source behind it must still be alive.
+        // Pre-fix this threw ObjectDisposedException because the timeout-scoped source was disposed
+        // the instant the body returned. Accessing WaitHandle calls the source's ThrowIfDisposed
+        // unconditionally, mirroring a synchronous wait inside real cleanup code.
+        _ = _capturedDuringBody.WaitHandle;
     }
 }


### PR DESCRIPTION
## Problem

Issue #6339 — `[After(Test)] hook failed: The CancellationTokenSource has been disposed.` surfacing randomly in ASP.NET Core integration suites. The reporter confirmed it still reproduces on **1.57.17**, which already contains the earlier narrow fix (#6340).

## Root cause

When a test has a timeout (explicit `[Timeout]` or `DefaultTestTimeout`), the body runs under a linked `CancellationTokenSource` exposed on `TestContext.Execution.CancellationToken`. The earlier fix restored that **property** to the outer token before After hooks — but `TimeoutHelper` still **disposed the source** the instant the body returned. Any token *copy* captured during the body (EF Core, Respawn, an ASP.NET host all snapshot the ambient token mid-test and touch it during teardown) then pointed at a disposed source.

Verified .NET behaviour: on a disposed-but-not-cancelled CTS, only `token.WaitHandle` throws `ObjectDisposedException` — exactly what a synchronous wait inside EF Core / `SemaphoreSlim` / host shutdown hits during an `[After(Test)]` hook.

## Fix

Repair the source **lifetime**, not just the token identity: own the linked timeout CTS across the whole per-test lifecycle instead of inside `TimeoutHelper`'s `using` scope.

- `TimeoutHelper` gains a **CTS-owning overload** — the caller passes an already-linked source (+ the external token for the timeout-vs-cancel check) and owns disposal. The original 4-arg overload delegates to it and still disposes its own source for standalone callers (e.g. the existing unit test).
- `TestExecutor` stores the source on a new internal `TestContext.TimeoutCancellationSource` (sibling of `LinkedCancellationTokens`) and no longer disposes it locally; a prior retry attempt's source is released before the next replaces it.
- `TestCoordinator` disposes it **once** at the end of the per-test `finally` — after After(Test) hooks, instance/OnDispose, object cleanup and After(Class/Assembly) — so a mid-body token copy stays backed by a live source throughout teardown.

The inner-finally `Context.CancellationToken = <outer>` restore stays: it fixes token *identity* (hooks/retry back-off observe a live, non-cancelled token); this change fixes source *liveness*. The two are complementary.

The no-timeout **fast path is untouched** — no new allocation, no extra state machine (one `CancellationTokenSource` per *timed* test, same as before, just re-owned).

## Tests

- Strengthened the `#6339` regression test: it now asserts both on the context property **and** on a token copy captured during the body (the realistic failure mode). Verified it **fails** without the fix (After hook throws `ObjectDisposedException`) and **passes** with it.
- `TUnitSettingsTests` (exercises `TimeoutHelper` directly) — green.
- `TimeoutCancellationTokenTests` / `CancellationTokenTriggeredTests` direct-run counts match baseline exactly (timeout still fires correctly).
- `TUnit.Engine` builds across all TFMs.

Closes #6339.