### PR TITLE
Improve test framework migrations

### DIFF
--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
@@ -71,7 +71,7 @@ public class ConversionPlan
     public List<InvocationReplacement> InvocationReplacements { get; } = new();
 
     /// <summary>
-    /// Expressions to replace (e.g., TestContext.CurrentContext.TestDirectory → System.AppContext.BaseDirectory)
+    /// Expressions to replace (e.g., TestContext.CurrentContext.TestDirectory → TestContext.TestDirectory)
     /// </summary>
     public List<ExpressionReplacement> ExpressionReplacements { get; } = new();
 
@@ -483,12 +483,12 @@ public class InvocationReplacement : ConversionTarget
 }
 
 /// <summary>
-/// Represents an expression to replace (e.g., TestContext.CurrentContext.TestDirectory → System.AppContext.BaseDirectory)
+/// Represents an expression to replace (e.g., TestContext.CurrentContext.TestDirectory → TestContext.TestDirectory)
 /// </summary>
 public class ExpressionReplacement : ConversionTarget
 {
     /// <summary>
-    /// The new expression code (e.g., "System.AppContext.BaseDirectory")
+    /// The new expression code (e.g., "TestContext.TestDirectory")
     /// </summary>
     public required string ReplacementCode { get; init; }
 }

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
@@ -71,6 +71,11 @@ public class ConversionPlan
     public List<InvocationReplacement> InvocationReplacements { get; } = new();
 
     /// <summary>
+    /// Expressions to replace (e.g., TestContext.CurrentContext.TestDirectory → System.AppContext.BaseDirectory)
+    /// </summary>
+    public List<ExpressionReplacement> ExpressionReplacements { get; } = new();
+
+    /// <summary>
     /// TheoryData conversions (TheoryData&lt;T&gt; → IEnumerable&lt;T&gt;)
     /// </summary>
     public List<TheoryDataConversion> TheoryDataConversions { get; } = new();
@@ -111,6 +116,7 @@ public class ConversionPlan
         ConstructorParameterRemovals.Count > 0 ||
         RecordExceptionConversions.Count > 0 ||
         InvocationReplacements.Count > 0 ||
+        ExpressionReplacements.Count > 0 ||
         TheoryDataConversions.Count > 0 ||
         ParameterAttributes.Count > 0 ||
         UsingsToAdd.Count > 0 ||
@@ -472,6 +478,17 @@ public class InvocationReplacement : ConversionTarget
 {
     /// <summary>
     /// The new invocation code (e.g., "Console.WriteLine(args)")
+    /// </summary>
+    public required string ReplacementCode { get; init; }
+}
+
+/// <summary>
+/// Represents an expression to replace (e.g., TestContext.CurrentContext.TestDirectory → System.AppContext.BaseDirectory)
+/// </summary>
+public class ExpressionReplacement : ConversionTarget
+{
+    /// <summary>
+    /// The new expression code (e.g., "System.AppContext.BaseDirectory")
     /// </summary>
     public required string ReplacementCode { get; init; }
 }

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/ConversionPlan.cs
@@ -491,6 +491,11 @@ public class ExpressionReplacement : ConversionTarget
     /// The new expression code (e.g., "TestContext.TestDirectory")
     /// </summary>
     public required string ReplacementCode { get; init; }
+
+    /// <summary>
+    /// Optional TODO comment to add before the containing statement.
+    /// </summary>
+    public string? TodoComment { get; init; }
 }
 
 /// <summary>

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationAnalyzer.cs
@@ -530,14 +530,16 @@ public abstract class MigrationAnalyzer
         CompilationUnitSyntax root,
         ExpressionSyntax originalExpression,
         string replacementCode,
-        string phase)
+        string phase,
+        string? todoComment = null)
     {
         try
         {
             var replacement = new ExpressionReplacement
             {
                 ReplacementCode = replacementCode,
-                OriginalText = originalExpression.ToString()
+                OriginalText = originalExpression.ToString(),
+                TodoComment = todoComment
             };
 
             Plan.ExpressionReplacements.Add(replacement);

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationAnalyzer.cs
@@ -488,6 +488,82 @@ public abstract class MigrationAnalyzer
         return root;
     }
 
+    protected CompilationUnitSyntax AddInvocationReplacement(
+        CompilationUnitSyntax root,
+        InvocationExpressionSyntax originalCall,
+        string replacementCode,
+        string phase)
+    {
+        try
+        {
+            var replacement = new InvocationReplacement
+            {
+                ReplacementCode = replacementCode,
+                OriginalText = originalCall.ToString()
+            };
+
+            Plan.InvocationReplacements.Add(replacement);
+
+            var nodeToAnnotate = root.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .FirstOrDefault(n => n.Span == originalCall.Span);
+
+            return nodeToAnnotate == null
+                ? root
+                : root.ReplaceNode(nodeToAnnotate, nodeToAnnotate.WithAdditionalAnnotations(replacement.Annotation));
+        }
+        catch (Exception ex)
+        {
+            Plan.Failures.Add(new ConversionFailure
+            {
+                Phase = phase,
+                Description = ex.Message,
+                OriginalCode = originalCall.ToString(),
+                Exception = ex
+            });
+
+            return root;
+        }
+    }
+
+    protected CompilationUnitSyntax AddExpressionReplacement(
+        CompilationUnitSyntax root,
+        ExpressionSyntax originalExpression,
+        string replacementCode,
+        string phase)
+    {
+        try
+        {
+            var replacement = new ExpressionReplacement
+            {
+                ReplacementCode = replacementCode,
+                OriginalText = originalExpression.ToString()
+            };
+
+            Plan.ExpressionReplacements.Add(replacement);
+
+            var nodeToAnnotate = root.DescendantNodes()
+                .OfType<ExpressionSyntax>()
+                .FirstOrDefault(n => n.Span == originalExpression.Span && n.Kind() == originalExpression.Kind());
+
+            return nodeToAnnotate == null
+                ? root
+                : root.ReplaceNode(nodeToAnnotate, nodeToAnnotate.WithAdditionalAnnotations(replacement.Annotation));
+        }
+        catch (Exception ex)
+        {
+            Plan.Failures.Add(new ConversionFailure
+            {
+                Phase = phase,
+                Description = ex.Message,
+                OriginalCode = originalExpression.ToString(),
+                Exception = ex
+            });
+
+            return root;
+        }
+    }
+
     /// <summary>
     /// Analyzes TheoryData fields/properties for conversion to IEnumerable.
     /// </summary>

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -32,52 +32,90 @@ public class MigrationTransformer
         // 1. Record.Exception conversions (before assertions - may affect structure)
         currentRoot = TransformRecordExceptionCalls(currentRoot);
 
-        // 2. Invocation replacements (ITestOutputHelper → Console)
+        // 2. Expression replacements (TestContext directory properties, etc.)
+        currentRoot = TransformExpressionReplacements(currentRoot);
+
+        // 3. Invocation replacements (ITestOutputHelper → Console)
         currentRoot = TransformInvocationReplacements(currentRoot);
 
-        // 3. TheoryData conversions (TheoryData<T> → IEnumerable<T>)
+        // 4. TheoryData conversions (TheoryData<T> → IEnumerable<T>)
         currentRoot = TransformTheoryData(currentRoot);
 
-        // 4. Assertions (may introduce await)
+        // 5. Assertions (may introduce await)
         currentRoot = TransformAssertions(currentRoot);
 
-        // 4. Method signatures (add async/Task based on new awaits)
+        // 6. Method signatures (add async/Task based on new awaits)
         currentRoot = TransformMethodSignatures(currentRoot);
 
-        // 5. Add method attributes (e.g., [Before(Test)])
+        // 7. Add method attributes (e.g., [Before(Test)])
         currentRoot = AddMethodAttributes(currentRoot);
 
-        // 6. Attributes
+        // 8. Attributes
         currentRoot = TransformAttributes(currentRoot);
 
-        // 6b. Parameter attributes (e.g., [Range] → [MatrixRange])
+        // 9. Parameter attributes (e.g., [Range] → [MatrixRange])
         currentRoot = TransformParameterAttributes(currentRoot);
 
-        // 7. Remove attributes
+        // 10. Remove attributes
         currentRoot = RemoveAttributes(currentRoot);
 
-        // 8. Remove base types
+        // 11. Remove base types
         currentRoot = RemoveBaseTypes(currentRoot);
 
-        // 9. Add base types (e.g., IAsyncInitializer)
+        // 12. Add base types (e.g., IAsyncInitializer)
         currentRoot = AddBaseTypes(currentRoot);
 
-        // 10. Add class attributes (e.g., ClassDataSource)
+        // 13. Add class attributes (e.g., ClassDataSource)
         currentRoot = AddClassAttributes(currentRoot);
 
-        // 11. Remove members
+        // 14. Remove members
         currentRoot = RemoveMembers(currentRoot);
 
-        // 12. Remove constructor parameters
+        // 15. Remove constructor parameters
         currentRoot = RemoveConstructorParameters(currentRoot);
 
-        // 13. Update usings (last, pure syntax)
+        // 16. Update usings (last, pure syntax)
         currentRoot = TransformUsings(currentRoot);
 
-        // 14. Add TODO comments for failures
+        // 17. Add TODO comments for failures
         if (_plan.HasFailures)
         {
             currentRoot = AddFailureComments(currentRoot);
+        }
+
+        return currentRoot;
+    }
+
+    private CompilationUnitSyntax TransformExpressionReplacements(CompilationUnitSyntax root)
+    {
+        var currentRoot = root;
+
+        foreach (var replacement in _plan.ExpressionReplacements)
+        {
+            try
+            {
+                var expression = currentRoot.DescendantNodes()
+                    .OfType<ExpressionSyntax>()
+                    .FirstOrDefault(i => i.HasAnnotation(replacement.Annotation));
+
+                if (expression == null) continue;
+
+                var newExpression = SyntaxFactory.ParseExpression(replacement.ReplacementCode);
+
+                currentRoot = currentRoot.ReplaceNode(expression, newExpression
+                    .WithLeadingTrivia(expression.GetLeadingTrivia())
+                    .WithTrailingTrivia(expression.GetTrailingTrivia()));
+            }
+            catch (Exception ex)
+            {
+                _plan.Failures.Add(new ConversionFailure
+                {
+                    Phase = "ExpressionReplacementTransformation",
+                    Description = ex.Message,
+                    OriginalCode = replacement.OriginalText,
+                    Exception = ex
+                });
+            }
         }
 
         return currentRoot;
@@ -400,7 +438,7 @@ public class MigrationTransformer
                 {
                     // Build the leading trivia, including TODO comment if present
                     var leadingTrivia = containingStatement.GetLeadingTrivia();
-                    if (!string.IsNullOrEmpty(assertion.TodoComment))
+                    if (assertion.TodoComment is { Length: > 0 } todoComment)
                     {
                         // Extract the indentation from existing trivia
                         var indentationTrivia = leadingTrivia
@@ -412,7 +450,7 @@ public class MigrationTransformer
                         {
                             todoTrivia.Add(indentationTrivia);
                         }
-                        todoTrivia.Add(SyntaxFactory.Comment(assertion.TodoComment));
+                        todoTrivia.Add(SyntaxFactory.Comment(todoComment));
                         todoTrivia.Add(SyntaxFactory.EndOfLine("\n"));
 
                         // Combine TODO comment with existing leading trivia
@@ -485,14 +523,15 @@ public class MigrationTransformer
                 }
 
                 // Wrap return type in Task<T> if needed (non-void, non-Task return type)
-                if (change.WrapReturnTypeInTask && !string.IsNullOrEmpty(change.OriginalReturnType))
+                if (change.WrapReturnTypeInTask &&
+                    change.OriginalReturnType is { Length: > 0 } originalReturnType)
                 {
                     // Build Task<OriginalReturnType>
                     var taskGenericType = SyntaxFactory.GenericName(
                         SyntaxFactory.Identifier("Task"),
                         SyntaxFactory.TypeArgumentList(
                             SyntaxFactory.SingletonSeparatedList(
-                                SyntaxFactory.ParseTypeName(change.OriginalReturnType))))
+                                SyntaxFactory.ParseTypeName(originalReturnType))))
                         .WithTrailingTrivia(SyntaxFactory.Space);
                     newMethod = newMethod.WithReturnType(taskGenericType);
                 }
@@ -635,10 +674,10 @@ public class MigrationTransformer
                             var additionalAttr = SyntaxFactory.Attribute(
                                 SyntaxFactory.IdentifierName(additional.Name));
 
-                            if (!string.IsNullOrEmpty(additional.Arguments))
+                            if (additional.Arguments is { Length: > 0 } additionalArguments)
                             {
                                 additionalAttr = additionalAttr.WithArgumentList(
-                                    SyntaxFactory.ParseAttributeArgumentList(additional.Arguments));
+                                    SyntaxFactory.ParseAttributeArgumentList(additionalArguments));
                             }
 
                             // Use only indentation for additional attributes (no blank lines)
@@ -1091,10 +1130,10 @@ public class MigrationTransformer
                     .WithAttributeLists(SyntaxFactory.List(newAttributeLists));
 
                 // Change return type if specified
-                if (!string.IsNullOrEmpty(addition.NewReturnType))
+                if (addition.NewReturnType is { Length: > 0 } newReturnType)
                 {
                     newMethod = newMethod.WithReturnType(
-                        SyntaxFactory.ParseTypeName(addition.NewReturnType)
+                        SyntaxFactory.ParseTypeName(newReturnType)
                             .WithTrailingTrivia(SyntaxFactory.Space));
                 }
 

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -100,11 +100,22 @@ public class MigrationTransformer
 
                 if (expression == null) continue;
 
-                var newExpression = SyntaxFactory.ParseExpression(replacement.ReplacementCode);
-
-                currentRoot = currentRoot.ReplaceNode(expression, newExpression
+                var newExpression = SyntaxFactory.ParseExpression(replacement.ReplacementCode)
                     .WithLeadingTrivia(expression.GetLeadingTrivia())
-                    .WithTrailingTrivia(expression.GetTrailingTrivia()));
+                    .WithTrailingTrivia(expression.GetTrailingTrivia());
+
+                if (replacement.TodoComment is { Length: > 0 } todoComment
+                    && expression.FirstAncestorOrSelf<StatementSyntax>() is { } statement)
+                {
+                    var newStatement = statement.ReplaceNode(expression, newExpression)
+                        .WithLeadingTrivia(PrependTodoComment(statement.GetLeadingTrivia(), todoComment));
+
+                    currentRoot = currentRoot.ReplaceNode(statement, newStatement);
+                }
+                else
+                {
+                    currentRoot = currentRoot.ReplaceNode(expression, newExpression);
+                }
             }
             catch (Exception ex)
             {
@@ -440,21 +451,7 @@ public class MigrationTransformer
                     var leadingTrivia = containingStatement.GetLeadingTrivia();
                     if (assertion.TodoComment is { Length: > 0 } todoComment)
                     {
-                        // Extract the indentation from existing trivia
-                        var indentationTrivia = leadingTrivia
-                            .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia))
-                            .LastOrDefault();
-
-                        var todoTrivia = new List<SyntaxTrivia>();
-                        if (indentationTrivia != default)
-                        {
-                            todoTrivia.Add(indentationTrivia);
-                        }
-                        todoTrivia.Add(SyntaxFactory.Comment(todoComment));
-                        todoTrivia.Add(SyntaxFactory.EndOfLine("\n"));
-
-                        // Combine TODO comment with existing leading trivia
-                        leadingTrivia = SyntaxFactory.TriviaList(todoTrivia.Concat(leadingTrivia));
+                        leadingTrivia = PrependTodoComment(leadingTrivia, todoComment);
                     }
 
                     // Replace the entire statement with the new expression statement
@@ -485,6 +482,23 @@ public class MigrationTransformer
         }
 
         return currentRoot;
+    }
+
+    private static SyntaxTriviaList PrependTodoComment(SyntaxTriviaList leadingTrivia, string todoComment)
+    {
+        var indentationTrivia = leadingTrivia
+            .Where(t => t.IsKind(SyntaxKind.WhitespaceTrivia))
+            .LastOrDefault();
+
+        var todoTrivia = new List<SyntaxTrivia>();
+        if (indentationTrivia != default)
+        {
+            todoTrivia.Add(indentationTrivia);
+        }
+
+        todoTrivia.Add(SyntaxFactory.Comment(todoComment));
+        todoTrivia.Add(SyntaxFactory.EndOfLine("\n"));
+        return SyntaxFactory.TriviaList(todoTrivia.Concat(leadingTrivia));
     }
 
     private CompilationUnitSyntax TransformMethodSignatures(CompilationUnitSyntax root)

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -98,7 +98,10 @@ public class MigrationTransformer
                     .OfType<ExpressionSyntax>()
                     .FirstOrDefault(i => i.HasAnnotation(replacement.Annotation));
 
-                if (expression == null) continue;
+                if (expression == null)
+                {
+                    continue;
+                }
 
                 var newExpression = SyntaxFactory.ParseExpression(replacement.ReplacementCode)
                     .WithLeadingTrivia(expression.GetLeadingTrivia())

--- a/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
+++ b/TUnit.Analyzers.CodeFixers/Base/TwoPhase/MigrationTransformer.cs
@@ -242,8 +242,18 @@ public class MigrationTransformer
 
                 if (invocation == null) continue;
 
-                // Parse the replacement code
                 var newInvocation = SyntaxFactory.ParseExpression(replacement.ReplacementCode);
+                if (newInvocation is InvocationExpressionSyntax replacementInvocation &&
+                    replacementInvocation.ArgumentList.Arguments.Count == invocation.ArgumentList.Arguments.Count)
+                {
+                    var currentArguments = invocation.ArgumentList.Arguments;
+                    var refreshedArguments = replacementInvocation.ArgumentList.Arguments
+                        .Select((argument, index) => argument.WithExpression(currentArguments[index].Expression));
+
+                    newInvocation = replacementInvocation.WithArgumentList(
+                        replacementInvocation.ArgumentList.WithArguments(
+                            SyntaxFactory.SeparatedList(refreshedArguments)));
+                }
 
                 currentRoot = currentRoot.ReplaceNode(invocation, newInvocation
                     .WithLeadingTrivia(invocation.GetLeadingTrivia())

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
@@ -933,7 +933,10 @@ public class MSTestTwoPhaseAnalyzer : MigrationAnalyzer
                 currentRoot,
                 originalExpression,
                 "TUnit.Core.TestContext.TestDirectory",
-                "MSTestTestContextDirectoryAnalysis");
+                "MSTestTestContextDirectoryAnalysis",
+                originalExpression.Name.Identifier.Text == "DeploymentDirectory"
+                    ? "// TODO: TUnit migration - MSTest DeploymentDirectory can differ from TUnit TestDirectory. Verify the migrated path."
+                    : null);
         }
 
         return currentRoot;

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
@@ -932,7 +932,7 @@ public class MSTestTwoPhaseAnalyzer : MigrationAnalyzer
             currentRoot = AddExpressionReplacement(
                 currentRoot,
                 originalExpression,
-                "System.AppContext.BaseDirectory",
+                "TUnit.Core.TestContext.TestDirectory",
                 "MSTestTestContextDirectoryAnalysis");
         }
 

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
@@ -878,6 +878,106 @@ public class MSTestTwoPhaseAnalyzer : MigrationAnalyzer
         return false;
     }
 
+    protected override CompilationUnitSyntax AnalyzeSpecialInvocations(CompilationUnitSyntax root)
+    {
+        var currentRoot = AnalyzeMSTestTestContextInvocations(root);
+        return AnalyzeMSTestTestContextDirectoryProperties(currentRoot);
+    }
+
+    private CompilationUnitSyntax AnalyzeMSTestTestContextInvocations(CompilationUnitSyntax root)
+    {
+        var currentRoot = root;
+        var testContextCalls = OriginalRoot.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Select(call => (Call: call, ReplacementCode: GetMSTestTestContextInvocationReplacement(call)))
+            .Where(x => x.ReplacementCode != null);
+
+        foreach (var (originalCall, replacementCode) in testContextCalls)
+        {
+            currentRoot = AddInvocationReplacement(
+                currentRoot,
+                originalCall,
+                replacementCode!,
+                "MSTestTestContextInvocationAnalysis");
+        }
+
+        return currentRoot;
+    }
+
+    private string? GetMSTestTestContextInvocationReplacement(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess ||
+            !IsMSTestTestContextExpression(memberAccess.Expression))
+        {
+            return null;
+        }
+
+        return memberAccess.Name.Identifier.Text switch
+        {
+            "WriteLine" => $"Console.WriteLine{invocation.ArgumentList}",
+            "AddResultFile" => BuildAttachArtifactCall(invocation.ArgumentList.Arguments),
+            _ => null
+        };
+    }
+
+    private CompilationUnitSyntax AnalyzeMSTestTestContextDirectoryProperties(CompilationUnitSyntax root)
+    {
+        var currentRoot = root;
+        var directoryProperties = OriginalRoot.DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Where(IsMSTestTestContextDirectoryProperty);
+
+        foreach (var originalExpression in directoryProperties)
+        {
+            currentRoot = AddExpressionReplacement(
+                currentRoot,
+                originalExpression,
+                "System.AppContext.BaseDirectory",
+                "MSTestTestContextDirectoryAnalysis");
+        }
+
+        return currentRoot;
+    }
+
+    private bool IsMSTestTestContextDirectoryProperty(MemberAccessExpressionSyntax memberAccess)
+    {
+        if (memberAccess.Name.Identifier.Text is not ("TestDir" or "DeploymentDirectory"))
+            return false;
+
+        return IsMSTestTestContextExpression(memberAccess.Expression);
+    }
+
+    private bool IsMSTestTestContextExpression(ExpressionSyntax expression)
+    {
+        try
+        {
+            var type = SemanticModel.GetTypeInfo(expression).Type;
+            if (IsMSTestTestContextType(type))
+            {
+                return true;
+            }
+        }
+        catch
+        {
+            // Fall back to syntax below.
+        }
+
+        return expression.ToString() == "TestContext";
+    }
+
+    private static bool IsMSTestTestContextType(ITypeSymbol? type)
+    {
+        return type?.ToDisplayString() == "Microsoft.VisualStudio.TestTools.UnitTesting.TestContext";
+    }
+
+    private static string? BuildAttachArtifactCall(SeparatedSyntaxList<ArgumentSyntax> args)
+    {
+        if (args.Count < 1)
+            return null;
+
+        return $"TUnit.Core.TestContext.Current!.Output.AttachArtifact{SyntaxFactory.ArgumentList(args)}";
+    }
+
     protected override void AnalyzeUsings()
     {
         Plan.UsingPrefixesToRemove.Add("Microsoft.VisualStudio.TestTools");

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/MSTestTwoPhaseAnalyzer.cs
@@ -945,7 +945,9 @@ public class MSTestTwoPhaseAnalyzer : MigrationAnalyzer
     private bool IsMSTestTestContextDirectoryProperty(MemberAccessExpressionSyntax memberAccess)
     {
         if (memberAccess.Name.Identifier.Text is not ("TestDir" or "DeploymentDirectory"))
+        {
             return false;
+        }
 
         return IsMSTestTestContextExpression(memberAccess.Expression);
     }

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
@@ -319,7 +319,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
     private bool IsMessageArgument(ArgumentSyntax arg)
     {
         if (arg.NameColon?.Name.Identifier.Text is "message")
+        {
             return true;
+        }
 
         if (arg.Expression is LiteralExpressionSyntax literal &&
             literal.IsKind(SyntaxKind.StringLiteralExpression))
@@ -328,7 +330,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
         }
 
         if (arg.Expression is InterpolatedStringExpressionSyntax)
+        {
             return true;
+        }
 
         try
         {

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
@@ -2089,11 +2089,18 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
             currentRoot = AddExpressionReplacement(
                 currentRoot,
                 originalExpression,
-                "System.AppContext.BaseDirectory",
+                GetNUnitTestContextDirectoryReplacement(originalExpression),
                 "NUnitTestContextDirectoryAnalysis");
         }
 
         return currentRoot;
+    }
+
+    private static string GetNUnitTestContextDirectoryReplacement(MemberAccessExpressionSyntax memberAccess)
+    {
+        return memberAccess.Name.Identifier.Text == "WorkDirectory"
+            ? "TestContext.WorkingDirectory"
+            : "TestContext.TestDirectory";
     }
 
     private bool IsNUnitTestContextDirectoryProperty(MemberAccessExpressionSyntax memberAccess)

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
@@ -1979,7 +1979,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
 
         var argumentList = attr.ArgumentList;
         if (argumentList is null || argumentList.Arguments.Count < 2)
+        {
             return null;
+        }
 
         // Determine the type from the first argument literal or the parameter type
         var firstArg = argumentList.Arguments[0].Expression.ToString();
@@ -2057,7 +2059,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
     private string? GetNUnitTestContextInvocationReplacement(InvocationExpressionSyntax invocation)
     {
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
             return null;
+        }
 
         var methodName = memberAccess.Name.Identifier.Text;
         var arguments = invocation.ArgumentList.ToString();
@@ -2114,7 +2118,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
     private bool IsNUnitTestContextDirectoryProperty(MemberAccessExpressionSyntax memberAccess)
     {
         if (memberAccess.Name.Identifier.Text is not ("TestDirectory" or "WorkDirectory"))
+        {
             return false;
+        }
 
         return IsNUnitTestContextExpression(memberAccess.Expression);
     }
@@ -2124,7 +2130,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
         try
         {
             if (IsNUnitTestContextType(SemanticModel.GetTypeInfo(expression).Type))
+            {
                 return true;
+            }
 
             if (SemanticModel.GetSymbolInfo(expression).Symbol is INamedTypeSymbol namedType &&
                 IsNUnitTestContextType(namedType))

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
@@ -234,8 +234,11 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
         SeparatedSyntaxList<ArgumentSyntax> args,
         MemberAccessExpressionSyntax memberAccess)
     {
-        if (args.Count < 2)
-            return null;
+        if (args.Count == 1)
+            return ConvertBooleanAssertThat(node, args[0], null);
+
+        if (args.Count >= 2 && IsMessageArgument(args[1]) && IsBooleanExpression(args[0].Expression))
+            return ConvertBooleanAssertThat(node, args[0], GetMessageArgument(args[1]));
 
         var actualValue = args[0].Expression.ToString();
         var constraintArg = args[1].Expression;
@@ -271,6 +274,69 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
             IntroducesAwait = true,
             TodoComment = todoComment
         };
+    }
+
+    private AssertionConversion ConvertBooleanAssertThat(InvocationExpressionSyntax node, ArgumentSyntax actualArgument, string? message)
+    {
+        var actualValue = actualArgument.Expression.ToString();
+        var assertion = message != null
+            ? $"await Assert.That({actualValue}).IsTrue().Because({message})"
+            : $"await Assert.That({actualValue}).IsTrue()";
+
+        return new AssertionConversion
+        {
+            Kind = AssertionConversionKind.True,
+            OriginalText = node.ToString(),
+            ReplacementCode = assertion,
+            IntroducesAwait = true
+        };
+    }
+
+    private bool IsBooleanExpression(ExpressionSyntax expression)
+    {
+        try
+        {
+            var type = SemanticModel.GetTypeInfo(expression).ConvertedType
+                ?? SemanticModel.GetTypeInfo(expression).Type;
+
+            if (type != null)
+            {
+                return type.SpecialType == SpecialType.System_Boolean;
+            }
+        }
+        catch
+        {
+            // Fall back to NUnit's Assert.That(bool) syntax when semantic info is unavailable.
+        }
+
+        return true;
+    }
+
+    private bool IsMessageArgument(ArgumentSyntax arg)
+    {
+        if (arg.NameColon?.Name.Identifier.Text is "message")
+            return true;
+
+        if (arg.Expression is LiteralExpressionSyntax literal &&
+            literal.IsKind(SyntaxKind.StringLiteralExpression))
+        {
+            return true;
+        }
+
+        if (arg.Expression is InterpolatedStringExpressionSyntax)
+            return true;
+
+        try
+        {
+            var type = SemanticModel.GetTypeInfo(arg.Expression).ConvertedType
+                ?? SemanticModel.GetTypeInfo(arg.Expression).Type;
+
+            return type?.SpecialType == SpecialType.System_String;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private (AssertionConversionKind, string?, string?) AnalyzeConstraint(ExpressionSyntax constraint)
@@ -1903,11 +1969,12 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
         // [Range(1L, 100L)] -> [MatrixRange<long>(1L, 100L)]
         // [Range(1.0f, 5.0f)] -> [MatrixRange<float>(1.0f, 5.0f)]
 
-        if (attr.ArgumentList?.Arguments.Count < 2)
+        var argumentList = attr.ArgumentList;
+        if (argumentList is null || argumentList.Arguments.Count < 2)
             return null;
 
         // Determine the type from the first argument literal or the parameter type
-        var firstArg = attr.ArgumentList.Arguments[0].Expression.ToString();
+        var firstArg = argumentList.Arguments[0].Expression.ToString();
         var typeArg = InferRangeType(firstArg, parameter);
 
         return new ParameterAttributeConversion
@@ -1951,6 +2018,131 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
     {
         // NUnit doesn't have common base types to remove like xUnit's IClassFixture
         return false;
+    }
+
+    protected override CompilationUnitSyntax AnalyzeSpecialInvocations(CompilationUnitSyntax root)
+    {
+        var currentRoot = AnalyzeNUnitTestContextInvocations(root);
+        return AnalyzeNUnitTestContextDirectoryProperties(currentRoot);
+    }
+
+    private CompilationUnitSyntax AnalyzeNUnitTestContextInvocations(CompilationUnitSyntax root)
+    {
+        var currentRoot = root;
+        var testContextCalls = OriginalRoot.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Select(call => (Call: call, ReplacementCode: GetNUnitTestContextInvocationReplacement(call)))
+            .Where(x => x.ReplacementCode != null);
+
+        foreach (var (originalCall, replacementCode) in testContextCalls)
+        {
+            currentRoot = AddInvocationReplacement(
+                currentRoot,
+                originalCall,
+                replacementCode!,
+                "NUnitTestContextInvocationAnalysis");
+        }
+
+        return currentRoot;
+    }
+
+    private string? GetNUnitTestContextInvocationReplacement(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return null;
+
+        var methodName = memberAccess.Name.Identifier.Text;
+        var arguments = invocation.ArgumentList.ToString();
+
+        if (methodName == "WriteLine")
+        {
+            if (memberAccess.Expression is MemberAccessExpressionSyntax outAccess &&
+                outAccess.Name.Identifier.Text == "Out" &&
+                IsNUnitTestContextExpression(outAccess.Expression))
+            {
+                return $"Console.Out.WriteLine{arguments}";
+            }
+
+            if (IsNUnitTestContextExpression(memberAccess.Expression))
+            {
+                return $"Console.WriteLine{arguments}";
+            }
+        }
+
+        if (methodName == "AddTestAttachment" && IsNUnitTestContextExpression(memberAccess.Expression))
+        {
+            return BuildAttachArtifactCall(invocation.ArgumentList.Arguments);
+        }
+
+        return null;
+    }
+
+    private CompilationUnitSyntax AnalyzeNUnitTestContextDirectoryProperties(CompilationUnitSyntax root)
+    {
+        var currentRoot = root;
+        var directoryProperties = OriginalRoot.DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Where(IsNUnitTestContextDirectoryProperty);
+
+        foreach (var originalExpression in directoryProperties)
+        {
+            currentRoot = AddExpressionReplacement(
+                currentRoot,
+                originalExpression,
+                "System.AppContext.BaseDirectory",
+                "NUnitTestContextDirectoryAnalysis");
+        }
+
+        return currentRoot;
+    }
+
+    private bool IsNUnitTestContextDirectoryProperty(MemberAccessExpressionSyntax memberAccess)
+    {
+        if (memberAccess.Name.Identifier.Text is not ("TestDirectory" or "WorkDirectory"))
+            return false;
+
+        return IsNUnitTestContextExpression(memberAccess.Expression);
+    }
+
+    private bool IsNUnitTestContextExpression(ExpressionSyntax expression)
+    {
+        try
+        {
+            if (IsNUnitTestContextType(SemanticModel.GetTypeInfo(expression).Type))
+                return true;
+
+            if (SemanticModel.GetSymbolInfo(expression).Symbol is INamedTypeSymbol namedType &&
+                IsNUnitTestContextType(namedType))
+            {
+                return true;
+            }
+        }
+        catch
+        {
+            // Fall back to syntax below.
+        }
+
+        return expression.ToString() is "TestContext" or "TestContext.CurrentContext";
+    }
+
+    private static bool IsNUnitTestContextType(ITypeSymbol? type)
+    {
+        return type?.ToDisplayString() == "NUnit.Framework.TestContext";
+    }
+
+    private static string? BuildAttachArtifactCall(SeparatedSyntaxList<ArgumentSyntax> args)
+    {
+        if (args.Count < 1)
+            return null;
+
+        if (args.Count < 2)
+        {
+            return $"TestContext.Current!.Output.AttachArtifact{SyntaxFactory.ArgumentList(args)}";
+        }
+
+        var filePath = args[0].Expression.ToString();
+        var description = args[1].Expression.ToString();
+        return $"TestContext.Current!.Output.AttachArtifact({filePath}, description: {description})";
     }
 
     protected override void AnalyzeUsings()

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/NUnitTwoPhaseAnalyzer.cs
@@ -235,10 +235,14 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
         MemberAccessExpressionSyntax memberAccess)
     {
         if (args.Count == 1)
+        {
             return ConvertBooleanAssertThat(node, args[0], null);
+        }
 
         if (args.Count >= 2 && IsMessageArgument(args[1]) && IsBooleanExpression(args[0].Expression))
+        {
             return ConvertBooleanAssertThat(node, args[0], GetMessageArgument(args[1]));
+        }
 
         var actualValue = args[0].Expression.ToString();
         var constraintArg = args[1].Expression;
@@ -2140,7 +2144,9 @@ public class NUnitTwoPhaseAnalyzer : MigrationAnalyzer
     private static string? BuildAttachArtifactCall(SeparatedSyntaxList<ArgumentSyntax> args)
     {
         if (args.Count < 1)
+        {
             return null;
+        }
 
         if (args.Count < 2)
         {

--- a/TUnit.Analyzers.CodeFixers/TwoPhase/XUnitTwoPhaseAnalyzer.cs
+++ b/TUnit.Analyzers.CodeFixers/TwoPhase/XUnitTwoPhaseAnalyzer.cs
@@ -1754,41 +1754,11 @@ public class XUnitTwoPhaseAnalyzer : MigrationAnalyzer
 
         foreach (var originalCall in testOutputHelperCalls)
         {
-            try
-            {
-                // Build the Console.WriteLine replacement
-                var arguments = originalCall.ArgumentList.ToString();
-                var replacementCode = $"Console.WriteLine{arguments}";
-
-                var replacement = new InvocationReplacement
-                {
-                    ReplacementCode = replacementCode,
-                    OriginalText = originalCall.ToString()
-                };
-
-                Plan.InvocationReplacements.Add(replacement);
-
-                // Find corresponding node in current tree
-                var nodeToAnnotate = currentRoot.DescendantNodes()
-                    .OfType<InvocationExpressionSyntax>()
-                    .FirstOrDefault(n => n.Span == originalCall.Span);
-
-                if (nodeToAnnotate != null)
-                {
-                    var annotatedNode = nodeToAnnotate.WithAdditionalAnnotations(replacement.Annotation);
-                    currentRoot = currentRoot.ReplaceNode(nodeToAnnotate, annotatedNode);
-                }
-            }
-            catch (Exception ex)
-            {
-                Plan.Failures.Add(new ConversionFailure
-                {
-                    Phase = "TestOutputHelperAnalysis",
-                    Description = ex.Message,
-                    OriginalCode = originalCall.ToString(),
-                    Exception = ex
-                });
-            }
+            currentRoot = AddInvocationReplacement(
+                currentRoot,
+                originalCall,
+                $"Console.WriteLine{originalCall.ArgumentList}",
+                "TestOutputHelperAnalysis");
         }
 
         return currentRoot;

--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -368,6 +368,7 @@ public class MSTestMigrationAnalyzerTests
                         var testDirectory = TestContext.TestDir;
                         var deploymentDirectory = TestContext.DeploymentDirectory;
                         TestContext.WriteLine("standard output");
+                        TestContext.WriteLine($"Directory: {TestContext.TestDir}");
                         TestContext.AddResultFile("artifact.txt");
                     }
                 }
@@ -386,6 +387,7 @@ public class MSTestMigrationAnalyzerTests
                         // TODO: TUnit migration - MSTest DeploymentDirectory can differ from TUnit TestDirectory. Verify the migrated path.
                         var deploymentDirectory = TUnit.Core.TestContext.TestDirectory;
                         Console.WriteLine("standard output");
+                        Console.WriteLine($"Directory: {TUnit.Core.TestContext.TestDirectory}");
                         TUnit.Core.TestContext.Current!.Output.AttachArtifact("artifact.txt");
                     }
                 }

--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -382,8 +382,8 @@ public class MSTestMigrationAnalyzerTests
                     [Test]
                     public void MyMethod()
                     {
-                        var testDirectory = System.AppContext.BaseDirectory;
-                        var deploymentDirectory = System.AppContext.BaseDirectory;
+                        var testDirectory = TUnit.Core.TestContext.TestDirectory;
+                        var deploymentDirectory = TUnit.Core.TestContext.TestDirectory;
                         Console.WriteLine("standard output");
                         TUnit.Core.TestContext.Current!.Output.AttachArtifact("artifact.txt");
                     }

--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -358,11 +358,11 @@ public class MSTestMigrationAnalyzerTests
             """
                 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-                {|#0:public class MyClass|}
+                public class MyClass
                 {
                     public TestContext TestContext { get; set; }
 
-                    [TestMethod]
+                    {|#0:[TestMethod]|}
                     public void MyMethod()
                     {
                         var testDirectory = TestContext.TestDir;
@@ -383,6 +383,7 @@ public class MSTestMigrationAnalyzerTests
                     public void MyMethod()
                     {
                         var testDirectory = TUnit.Core.TestContext.TestDirectory;
+                        // TODO: TUnit migration - MSTest DeploymentDirectory can differ from TUnit TestDirectory. Verify the migrated path.
                         var deploymentDirectory = TUnit.Core.TestContext.TestDirectory;
                         Console.WriteLine("standard output");
                         TUnit.Core.TestContext.Current!.Output.AttachArtifact("artifact.txt");

--- a/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/MSTestMigrationAnalyzerTests.cs
@@ -352,6 +352,48 @@ public class MSTestMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task MSTest_TestContext_Output_And_Directory_Converted()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                {|#0:public class MyClass|}
+                {
+                    public TestContext TestContext { get; set; }
+
+                    [TestMethod]
+                    public void MyMethod()
+                    {
+                        var testDirectory = TestContext.TestDir;
+                        var deploymentDirectory = TestContext.DeploymentDirectory;
+                        TestContext.WriteLine("standard output");
+                        TestContext.AddResultFile("artifact.txt");
+                    }
+                }
+                """,
+            Verifier.Diagnostic(Rules.MSTestMigration).WithLocation(0),
+            """
+
+                public class MyClass
+                {
+                    public TestContext TestContext { get; set; }
+
+                    [Test]
+                    public void MyMethod()
+                    {
+                        var testDirectory = System.AppContext.BaseDirectory;
+                        var deploymentDirectory = System.AppContext.BaseDirectory;
+                        Console.WriteLine("standard output");
+                        TUnit.Core.TestContext.Current!.Output.AttachArtifact("artifact.txt");
+                    }
+                }
+                """,
+            ConfigureMSTestTest
+        );
+    }
+
+    [Test]
     public async Task MSTest_Nested_Class_Converted()
     {
         await CodeFixer.VerifyCodeFixAsync(

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -227,8 +227,10 @@ public class NUnitMigrationAnalyzerTests
                     public void MyMethod()
                     {
                         var condition = true;
+                        System.Func<bool> deferredCondition = () => true;
                         Assert.That(condition);
                         Assert.That(condition, "Condition should be true");
+                        Assert.That(deferredCondition);
                     }
                 }
                 """,
@@ -242,8 +244,10 @@ public class NUnitMigrationAnalyzerTests
                     public async Task MyMethod()
                     {
                         var condition = true;
+                        System.Func<bool> deferredCondition = () => true;
                         await Assert.That(condition).IsTrue();
                         await Assert.That(condition).IsTrue().Because("Condition should be true");
+                        await Assert.That(deferredCondition).IsTrue();
                     }
                 }
                 """,

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -215,6 +215,85 @@ public class NUnitMigrationAnalyzerTests
     }
 
     [Test]
+    public async Task NUnit_Assert_That_Boolean_Overload_Converted()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using NUnit.Framework;
+
+                {|#0:public class MyClass|}
+                {
+                    [Test]
+                    public void MyMethod()
+                    {
+                        var condition = true;
+                        Assert.That(condition);
+                        Assert.That(condition, "Condition should be true");
+                    }
+                }
+                """,
+            Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
+            """
+                using System.Threading.Tasks;
+
+                public class MyClass
+                {
+                    [Test]
+                    public async Task MyMethod()
+                    {
+                        var condition = true;
+                        await Assert.That(condition).IsTrue();
+                        await Assert.That(condition).IsTrue().Because("Condition should be true");
+                    }
+                }
+                """,
+            ConfigureNUnitTest
+        );
+    }
+
+    [Test]
+    public async Task NUnit_TestContext_Shortcuts_Converted()
+    {
+        await CodeFixer.VerifyCodeFixAsync(
+            """
+                using NUnit.Framework;
+
+                {|#0:public class MyClass|}
+                {
+                    [Test]
+                    public void MyMethod()
+                    {
+                        var testDirectory = TestContext.CurrentContext.TestDirectory;
+                        var workDirectory = TestContext.CurrentContext.WorkDirectory;
+                        TestContext.WriteLine("standard output");
+                        TestContext.Out.WriteLine("out writer");
+                        TestContext.AddTestAttachment("artifact.txt");
+                        TestContext.CurrentContext.AddTestAttachment("described.txt", "description");
+                    }
+                }
+                """,
+            Verifier.Diagnostic(Rules.NUnitMigration).WithLocation(0),
+            """
+
+                public class MyClass
+                {
+                    [Test]
+                    public void MyMethod()
+                    {
+                        var testDirectory = System.AppContext.BaseDirectory;
+                        var workDirectory = System.AppContext.BaseDirectory;
+                        Console.WriteLine("standard output");
+                        Console.Out.WriteLine("out writer");
+                        TestContext.Current!.Output.AttachArtifact("artifact.txt");
+                        TestContext.Current!.Output.AttachArtifact("described.txt", description: "description");
+                    }
+                }
+                """,
+            ConfigureNUnitTest
+        );
+    }
+
+    [Test]
     public async Task NUnit_Classic_Assertions_Converted()
     {
         await CodeFixer.VerifyCodeFixAsync(

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -270,6 +270,7 @@ public class NUnitMigrationAnalyzerTests
                         var testDirectory = TestContext.CurrentContext.TestDirectory;
                         var workDirectory = TestContext.CurrentContext.WorkDirectory;
                         TestContext.WriteLine("standard output");
+                        TestContext.WriteLine($"Directory: {TestContext.CurrentContext.TestDirectory}");
                         TestContext.Out.WriteLine("out writer");
                         TestContext.AddTestAttachment("artifact.txt");
                         TestContext.CurrentContext.AddTestAttachment("described.txt", "description");
@@ -287,6 +288,7 @@ public class NUnitMigrationAnalyzerTests
                         var testDirectory = TestContext.TestDirectory;
                         var workDirectory = TestContext.WorkingDirectory;
                         Console.WriteLine("standard output");
+                        Console.WriteLine($"Directory: {TestContext.TestDirectory}");
                         Console.Out.WriteLine("out writer");
                         TestContext.Current!.Output.AttachArtifact("artifact.txt");
                         TestContext.Current!.Output.AttachArtifact("described.txt", description: "description");

--- a/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
+++ b/TUnit.Analyzers.Tests/NUnitMigrationAnalyzerTests.cs
@@ -280,8 +280,8 @@ public class NUnitMigrationAnalyzerTests
                     [Test]
                     public void MyMethod()
                     {
-                        var testDirectory = System.AppContext.BaseDirectory;
-                        var workDirectory = System.AppContext.BaseDirectory;
+                        var testDirectory = TestContext.TestDirectory;
+                        var workDirectory = TestContext.WorkingDirectory;
                         Console.WriteLine("standard output");
                         Console.Out.WriteLine("out writer");
                         TestContext.Current!.Output.AttachArtifact("artifact.txt");

--- a/TUnit.Core/TestContext.cs
+++ b/TUnit.Core/TestContext.cs
@@ -271,6 +271,11 @@ public partial class TestContext : Context,
     }
 
     /// <summary>
+    /// Gets the directory containing the test assembly, or <c>null</c> if it cannot be determined.
+    /// </summary>
+    public static string? TestDirectory => OutputDirectory;
+
+    /// <summary>
     /// Gets or sets the current working directory for the test process.
     /// </summary>
     public static string WorkingDirectory

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1410,6 +1410,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }
         public override string GetStandardOutput() { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1410,6 +1410,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }
         public override string GetStandardOutput() { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1410,6 +1410,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }
         public override string GetStandardOutput() { }

--- a/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1354,6 +1354,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }
         public override string GetStandardOutput() { }


### PR DESCRIPTION
## Summary
- Add expression replacements to the two-phase migration pipeline for framework context properties.
- Add `TestContext.TestDirectory` as the TUnit test assembly directory API.
- Migrate NUnit `Assert.That(bool)`, `TestContext` output, directory, and attachment APIs.
- Migrate MSTest `TestContext` output, result-file, and directory APIs; keep xUnit output-helper migration on the shared invocation replacement path.

## Tests
- `dotnet test TUnit.Analyzers.Tests\TUnit.Analyzers.Tests.csproj --treenode-filter "/*/*/NUnitMigrationAnalyzerTests/*|/*/*/MSTestMigrationAnalyzerTests/*|/*/*/XUnitMigrationAnalyzerTests/*"`
- `dotnet test TUnit.PublicAPI\TUnit.PublicAPI.csproj --treenode-filter "/*/*/Tests/Core_Library_Has_No_API_Changes"`

Closes #6338
