### PR TITLE
fix(mocks): CS9262 in generated mock members on VS 17.14 (Roslyn 4.14)

### DIFF
--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_Implementing_Static_Abstract_Interface.verified.txt
@@ -98,13 +98,10 @@ public static class StaticAbstractImpl_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::StaticAbstractImpl> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Constructor_Parameters_Extension_Discovery.verified.txt
@@ -135,13 +135,10 @@ public static class MyService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::MyService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Required_Members.verified.txt
@@ -80,13 +80,10 @@ public static class ConfigBase_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ConfigBase> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Class_With_Same_Arity_Constructor_Overloads.verified.txt
@@ -144,13 +144,10 @@ public static class MyService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::MyService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Conflict_With_Existing_Type_Falls_Back_To_Generated_Namespace.verified.txt
@@ -131,13 +131,10 @@ namespace TUnit.Mocks.Generated.MyApp
 
         extension(global::TUnit.Mocks.Mock<global::MyApp.IGreeter> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/External_Interface_With_Indexer_Static_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/External_Interface_With_Indexer_Static_Extension_Discovery.verified.txt
@@ -151,13 +151,10 @@ namespace Microsoft.Extensions.Configuration
 
         extension(global::TUnit.Mocks.Mock<global::Microsoft.Extensions.Configuration.IConfiguration> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/GenerateMock_Attribute_With_Concrete_Class.verified.txt
@@ -110,13 +110,10 @@ public static class MyService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::MyService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_Extension_Discovery.verified.txt
@@ -140,13 +140,10 @@ public static class IRepository_T__MockMemberExtensions
 
     extension<T>(global::TUnit.Mocks.Mock<global::IRepository<T>> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Class_Type_Argument.verified.txt
@@ -141,13 +141,10 @@ namespace Sandbox
 
         extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Enum_Type_Argument.verified.txt
@@ -118,13 +118,10 @@ namespace Sandbox
 
         extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IFoo<T>> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Multiple_Non_Builtin_Type_Arguments.verified.txt
@@ -125,13 +125,10 @@ namespace Sandbox
 
         extension<TIn, TOut>(global::TUnit.Mocks.Mock<global::Sandbox.IMapper<TIn, TOut>> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Generic_Type_Argument.verified.txt
@@ -118,13 +118,10 @@ namespace Sandbox
 
         extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IProvider<T>> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Generic_Interface_With_Nested_Namespace_Type_Argument.verified.txt
@@ -141,13 +141,10 @@ namespace Sandbox
 
         extension<T>(global::TUnit.Mocks.Mock<global::Sandbox.IService<T>> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Directly_Inheriting_IEnumerable.verified.txt
@@ -156,13 +156,10 @@ public static class ICustomCollection_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ICustomCollection> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -129,13 +129,10 @@ public static class IDialogReference_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDialogReference> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
@@ -517,13 +514,10 @@ public static class IDialogService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDialogService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_IEnumerable_Generic.verified.txt
@@ -114,13 +114,10 @@ public static class ITestEnum_T__MockMemberExtensions
 
     extension<T>(global::TUnit.Mocks.Mock<global::ITestEnum<T>> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Multiple_Interfaces.verified.txt
@@ -155,13 +155,10 @@ public static class IReadWriter_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IReadWriter> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_Inheriting_Nested_Generic_IEnumerable.verified.txt
@@ -137,13 +137,10 @@ public static class IPagedResult_T__MockMemberExtensions
 
     extension<T>(global::TUnit.Mocks.Mock<global::IPagedResult<T>> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -228,13 +228,10 @@ public static class IAsyncService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IAsyncService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Events.verified.txt
@@ -185,13 +185,10 @@ public static class INotifier_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::INotifier> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Method_Constraints_On_Explicit_Impl.verified.txt
@@ -188,13 +188,10 @@ public static class IConstrained_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IConstrained> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Generic_Methods.verified.txt
@@ -166,13 +166,10 @@ public static class IRepository_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IRepository> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Inherited_Static_Abstract_Members.verified.txt
@@ -144,13 +144,10 @@ public static class IMyService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IMyServiceMockable> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Member_Names.verified.txt
@@ -194,13 +194,10 @@ public static class IEscapedNames_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IEscapedNames> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Keyword_Parameter_Names.verified.txt
@@ -168,13 +168,10 @@ public static class ITest_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ITest> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -242,13 +242,10 @@ public static class IService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Multiple_Multi_Parameter_Events.verified.txt
@@ -205,13 +205,10 @@ public static class IDualEvents_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDualEvents> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event.verified.txt
@@ -162,13 +162,10 @@ public static class IFoo_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_And_Nullable_Args.verified.txt
@@ -162,13 +162,10 @@ public static class IFoo_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Event_Args.verified.txt
@@ -162,13 +162,10 @@ public static class IFoo_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -292,13 +292,10 @@ public static class IFoo_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_DiagnosticId_NamedArgs.verified.txt
@@ -118,13 +118,10 @@ public static class IDeprecatedApi_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDeprecatedApi> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -103,13 +103,10 @@ public static class BaseDialog_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::BaseDialog> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);
@@ -538,13 +535,10 @@ public static class IDialogService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDialogService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Out_Ref_Parameters.verified.txt
@@ -152,13 +152,10 @@ public static class IDictionary_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IDictionary> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Overloaded_Methods.verified.txt
@@ -245,13 +245,10 @@ public static class IFormatter_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFormatter> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Params_Array_Parameter.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Params_Array_Parameter.verified.txt
@@ -273,13 +273,10 @@ public static class IParamsSink_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IParamsSink> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Properties.verified.txt
@@ -137,13 +137,10 @@ public static class IRepository_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IRepository> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_RefStruct_Parameters.verified.txt
@@ -171,13 +171,10 @@ public static class IBufferProcessor_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IBufferProcessor> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Members.verified.txt
@@ -166,13 +166,10 @@ public static class IServiceFactory_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IServiceFactoryMockable> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Static_Abstract_Transitive_Return_Type.verified.txt
@@ -142,13 +142,10 @@ public static class IMyService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IMyService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -155,13 +155,10 @@ public static class IFoo_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IFoo> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -136,13 +136,10 @@ public static class ILongMethodSignatures_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ILongMethodSignatures> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Class_Primary_And_Explicit_Impl.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Class_Primary_And_Explicit_Impl.verified.txt
@@ -191,13 +191,10 @@ public static class DataContext_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::DataContext> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Conflicting_Member_Names.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Conflicting_Member_Names.verified.txt
@@ -218,13 +218,10 @@ public static class IConflictA_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IConflictA> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Secondary_Setup_Surface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Interface_Mock_With_Secondary_Setup_Surface.verified.txt
@@ -258,13 +258,10 @@ public static class IMultiLogger_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IMultiLogger> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Multi_Method_Interface.verified.txt
@@ -199,13 +199,10 @@ public static class ICalculator_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ICalculator> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -147,13 +147,10 @@ namespace ExternalLib
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalClient> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Filters_Members_With_Internal_Signature_Types.verified.txt
@@ -107,13 +107,10 @@ namespace ExternalLib
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ServiceClient> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_Omits_Inaccessible_Property_Setters.verified.txt
@@ -140,13 +140,10 @@ namespace ExternalLib
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalResponse> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Partial_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -157,13 +157,10 @@ public static class BaseService_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::BaseService> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -136,13 +136,10 @@ public static class ILongReturningSignature_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::ILongReturningSignature> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/SelfEquatable_Generates_EqualsOf_GetHashCodeOf_ToStringOf.verified.txt
@@ -154,13 +154,10 @@ public static class SelfEquatableSnapshot_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::SelfEquatableSnapshot> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Simple_Interface_With_One_Method.verified.txt
@@ -123,13 +123,10 @@ public static class IGreeter_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::IGreeter> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Via_Qualified_Name.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Via_Qualified_Name.verified.txt
@@ -124,13 +124,10 @@ namespace MyNamespace
 
         extension(global::TUnit.Mocks.Mock<global::MyNamespace.ITestInterface> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Static_Extension_Discovery_Without_Mock_Of.verified.txt
@@ -139,13 +139,10 @@ public static class INotifier_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::INotifier> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Filters_Internal_Virtual_Members_From_External_Assembly.verified.txt
@@ -128,13 +128,10 @@ namespace ExternalLib
 
         extension(global::TUnit.Mocks.Mock<global::ExternalLib.ExternalService> mock)
         {
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-            [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
             public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
             {
                 get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_With_Generic_Constrained_Virtual_Methods.verified.txt
@@ -127,13 +127,10 @@ public static class Repository_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::Repository> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Without_Parameterless_Constructor.verified.txt
+++ b/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Wrap_Mock_Without_Parameterless_Constructor.verified.txt
@@ -98,13 +98,10 @@ public static class RealClass_MockMemberExtensions
 
     extension(global::TUnit.Mocks.Mock<global::RealClass> mock)
     {
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);
 
-        [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
         public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider
         {
             get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);

--- a/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -1492,6 +1492,10 @@ internal static class MockMembersBuilder
 
         // Property polyfills via C# 14 extension block so users write mock.Invocations rather
         // than mock.Invocations().
+        // No [OverloadResolutionPriority] here: older-but-supported compilers (VS 17.14 /
+        // Roslyn 4.14) reject the attribute on non-indexer extension properties with CS9262
+        // (#6370), and it ranks nothing anyway — the skip-emission above already guarantees no
+        // same-name member ever coexists in this containing type.
         if (emitInvocations || emitBehavior || emitDefaultValueProvider)
         {
             if (!first) writer.AppendLine();
@@ -1500,21 +1504,18 @@ internal static class MockMembersBuilder
                 bool firstProp = true;
                 if (emitInvocations)
                 {
-                    writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::System.Collections.Generic.IReadOnlyList<global::TUnit.Mocks.Verification.CallRecord> Invocations => global::TUnit.Mocks.Mock.Invocations(mock);");
                     firstProp = false;
                 }
                 if (emitBehavior)
                 {
                     if (!firstProp) writer.AppendLine();
-                    writer.AppendLine(PriorityMinusOneAttribute);
                     writer.AppendLine("public global::TUnit.Mocks.MockBehavior Behavior => global::TUnit.Mocks.Mock.Behavior(mock);");
                     firstProp = false;
                 }
                 if (emitDefaultValueProvider)
                 {
                     if (!firstProp) writer.AppendLine();
-                    writer.AppendLine(PriorityMinusOneAttribute);
                     using (writer.Block("public global::TUnit.Mocks.IDefaultValueProvider? DefaultValueProvider"))
                     {
                         writer.AppendLine("get => global::TUnit.Mocks.Mock.GetDefaultValueProvider(mock);");


### PR DESCRIPTION
## Summary
Fixes #6370 — since v1.44.0, any `Type.Mock()` usage failed to compile under Visual Studio 17.14 with:

> CS9262: Cannot use 'OverloadResolutionPriorityAttribute' on this member. (×3)

## Root cause
The `*_MockMembers.g.cs` polyfills introduced in #5881 apply `[OverloadResolutionPriority(-1)]` to the three **extension-block properties** (`Invocations`, `Behavior`, `DefaultValueProvider`) — hence exactly three errors. Roslyn 4.14 (VS 17.14) rejects the attribute on non-indexer extension properties with CS9262; the Roslyn shipped with the .NET 10 SDK accepts it, which is why CI and local builds never caught it.

## Fix
Remove the attribute from the property polyfills only. It was inert there: the polyfill is skipped whenever the mocked type declares a member of the same name, so no same-name member can coexist in the containing type for the attribute to rank against. Method polyfills keep it — the attribute is legal on ordinary static methods since Roslyn 4.12.

## Testing
- `TUnit.Mocks.SourceGenerator.Tests`: 76/76 pass; all 58 affected snapshots re-verified — every diff is purely the three attribute-line removals.
- `TUnit.Mocks.Tests` (net10.0): 1158/1158 pass — `mock.Invocations` / `mock.Behavior` / `mock.DefaultValueProvider` ergonomics unchanged.
- CS9262 itself is not reproducible in-repo (test infra compiles with latest Roslyn, which permits the attribute); the snapshots are the regression guard, with a code comment explaining the constraint.