### PR TITLE
Add single-item assertion chaining

### DIFF
--- a/TUnit.Assertions.Tests/ListAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ListAssertionTests.cs
@@ -253,6 +253,36 @@ public class ListAssertionTests
     }
 
     [Test]
+    public async Task Test_List_HasSingleItem_Item_Rejects_Preceding_Or_Chain()
+    {
+        var action = async () => await Assert.That(Array.Empty<int>())
+            .IsEmpty().Or.HasSingleItem().Item.IsEqualTo(0);
+
+        await Assert.That(action).Throws<MixedAndOrAssertionsException>();
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_Item_Is_Not_Evaluated_After_Failure_In_Assert_Multiple()
+    {
+        var itemAssertionEvaluated = false;
+
+        var action = async () =>
+        {
+            using (Assert.Multiple())
+            {
+                await Assert.That(Array.Empty<int>()).HasSingleItem().Item.Satisfies(_ =>
+                {
+                    itemAssertionEvaluated = true;
+                    return true;
+                });
+            }
+        };
+
+        await Assert.That(action).ThrowsException();
+        await Assert.That(itemAssertionEvaluated).IsFalse();
+    }
+
+    [Test]
     public async Task Test_List_HasSingleItem_WithPredicate()
     {
         IList<int> list = new List<int> { 1, 2, 3, 4, 5 };

--- a/TUnit.Assertions.Tests/ListAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ListAssertionTests.cs
@@ -262,6 +262,15 @@ public class ListAssertionTests
     }
 
     [Test]
+    public async Task Test_List_HasSingleItem_Item_Or_Cannot_Bypass_Parent_Assertion()
+    {
+        var action = async () => await Assert.That(Array.Empty<int>())
+            .HasSingleItem().Item.IsEqualTo(1).Or.IsEqualTo(0);
+
+        await Assert.That(action).ThrowsException();
+    }
+
+    [Test]
     public async Task Test_List_HasSingleItem_Item_Is_Not_Evaluated_After_Failure_In_Assert_Multiple()
     {
         var itemAssertionEvaluated = false;

--- a/TUnit.Assertions.Tests/ListAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ListAssertionTests.cs
@@ -204,11 +204,68 @@ public class ListAssertionTests
     }
 
     [Test]
+    public async Task Test_List_HasSingleItem_Item_Allows_Chaining()
+    {
+        IList<int> list = new List<int> { 42 };
+
+        await Assert.That(list).HasSingleItem().Item.IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_Item_Preserves_Preceding_Chain()
+    {
+        IList<int> list = new List<int> { 42 };
+
+        await Assert.That(list).IsNotEmpty().And.HasSingleItem().Item.IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_Item_Does_Not_Reenumerate()
+    {
+        var enumerationCount = 0;
+
+        IEnumerable<int> GetItems()
+        {
+            enumerationCount++;
+            yield return 42;
+        }
+
+        await Assert.That(GetItems()).HasSingleItem().Item.IsEqualTo(42);
+        await Assert.That(enumerationCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_Item_Preserves_Collection_Shape()
+    {
+        IList<List<int>> list = [new List<int> { 1, 2, 3 }];
+
+        await Assert.That(list).HasSingleItem().Item.Count().IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_Item_Fails_Before_Item_Assertion()
+    {
+        IList<int> list = [];
+
+        var action = async () => await Assert.That(list).HasSingleItem().Item.IsEqualTo(0);
+
+        await Assert.That(action).ThrowsException();
+    }
+
+    [Test]
     public async Task Test_List_HasSingleItem_WithPredicate()
     {
         IList<int> list = new List<int> { 1, 2, 3, 4, 5 };
         var item = await Assert.That(list).HasSingleItem(x => x == 3);
         await Assert.That(item).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Test_List_HasSingleItem_WithPredicate_Item_Allows_Chaining()
+    {
+        IList<int> list = new List<int> { 1, 2, 3, 4, 5 };
+
+        await Assert.That(list).HasSingleItem(x => x == 3).Item.IsEqualTo(3);
     }
 
     [Test]

--- a/TUnit.Assertions.Tests/ListAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ListAssertionTests.cs
@@ -271,6 +271,17 @@ public class ListAssertionTests
     }
 
     [Test]
+    public async Task Test_List_HasSingleItem_Item_Preserves_Parent_Through_Mappings()
+    {
+        await Assert.That(new[] { "value" }).HasSingleItem().Item.Length().IsEqualTo(5);
+
+        var action = async () => await Assert.That(Array.Empty<string>())
+            .HasSingleItem().Item.Length().IsEqualTo(0);
+
+        await Assert.That(action).ThrowsException();
+    }
+
+    [Test]
     public async Task Test_List_HasSingleItem_Item_Is_Not_Evaluated_After_Failure_In_Assert_Multiple()
     {
         var itemAssertionEvaluated = false;

--- a/TUnit.Assertions.Tests/MemoryAssertionTests.cs
+++ b/TUnit.Assertions.Tests/MemoryAssertionTests.cs
@@ -56,6 +56,14 @@ public class MemoryAssertionTests
     }
 
     [Test]
+    public async Task Test_Memory_HasSingleItem_Item_Allows_Chaining()
+    {
+        Memory<int> memory = new[] { 42 };
+
+        await Assert.That(memory).HasSingleItem().Item.IsEqualTo(42);
+    }
+
+    [Test]
     public async Task Test_Memory_All()
     {
         Memory<int> memory = new[] { 2, 4, 6, 8 };

--- a/TUnit.Assertions.Tests/ParseAssertionTests.cs
+++ b/TUnit.Assertions.Tests/ParseAssertionTests.cs
@@ -161,8 +161,9 @@ public class ParseAssertionTests
             }
         }).ThrowsException();
 
-        // Should have recorded the length assertion failure
+        // Both the pre-work failure and mapped assertion failure must be recorded.
         await Assert.That(exception.Message).Contains("length");
+        await Assert.That(exception.Message).Contains("456");
     }
 
     [Test]

--- a/TUnit.Assertions/Collections/MemoryAssertions.cs
+++ b/TUnit.Assertions/Collections/MemoryAssertions.cs
@@ -273,6 +273,7 @@ public class MemoryHasSingleItemAssertion<TMemory, TItem> : MemoryAssertionBase<
     {
         get
         {
+            ThrowIfMixingCombiner<Chaining.OrAssertion<TMemory>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
             return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));

--- a/TUnit.Assertions/Collections/MemoryAssertions.cs
+++ b/TUnit.Assertions/Collections/MemoryAssertions.cs
@@ -276,7 +276,7 @@ public class MemoryHasSingleItemAssertion<TMemory, TItem> : MemoryAssertionBase<
             ThrowIfMixingCombiner<Chaining.OrAssertion<TMemory>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
-            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+            return SingleItemSource<TItem>.Create(Context, _ => _singleItem);
         }
     }
 }

--- a/TUnit.Assertions/Collections/MemoryAssertions.cs
+++ b/TUnit.Assertions/Collections/MemoryAssertions.cs
@@ -1,6 +1,7 @@
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 using TUnit.Assertions.Abstractions;
+using TUnit.Assertions.Conditions;
 using TUnit.Assertions.Conditions.Helpers;
 using TUnit.Assertions.Core;
 using TUnit.Assertions.Enums;
@@ -235,6 +236,7 @@ public class MemoryIsEquivalentToAssertion<TMemory, TItem> : MemoryAssertionBase
 public class MemoryHasSingleItemAssertion<TMemory, TItem> : MemoryAssertionBase<TMemory, TItem>
 {
     private readonly Func<TMemory, ICollectionAdapter<TItem>> _adapterFactory;
+    private TItem? _singleItem;
 
     public MemoryHasSingleItemAssertion(
         AssertionContext<TMemory> context,
@@ -259,10 +261,23 @@ public class MemoryHasSingleItemAssertion<TMemory, TItem> : MemoryAssertionBase<
         }
 
         var adapter = _adapterFactory(metadata.Value);
-        return Task.FromResult(CollectionChecks.CheckHasSingleItem(adapter));
+        return Task.FromResult(CollectionChecks.CheckHasSingleItem(adapter, out _singleItem));
     }
 
     protected override string GetExpectation() => "to have a single item";
+
+    /// <summary>
+    /// Drills into the single item, allowing assertions to be chained directly against it.
+    /// </summary>
+    public SingleItemSource<TItem> Item
+    {
+        get
+        {
+            Context.ExpressionBuilder.Append(".Item");
+            Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
+            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+        }
+    }
 }
 
 /// <summary>

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -511,7 +511,7 @@ public class HasSingleItemAssertion<TCollection, TItem> : Sources.CollectionAsse
             ThrowIfMixingCombiner<Chaining.OrAssertion<TCollection>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
-            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+            return SingleItemSource<TItem>.Create(Context, _ => _singleItem);
         }
     }
 
@@ -584,7 +584,7 @@ public class HasSingleItemPredicateAssertion<TCollection, TItem> : Sources.Colle
             ThrowIfMixingCombiner<Chaining.OrAssertion<TCollection>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
-            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+            return SingleItemSource<TItem>.Create(Context, _ => _singleItem);
         }
     }
 

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -502,6 +502,19 @@ public class HasSingleItemAssertion<TCollection, TItem> : Sources.CollectionAsse
     protected override string GetExpectation() => "to have exactly one item";
 
     /// <summary>
+    /// Drills into the single item, allowing assertions to be chained directly against it.
+    /// </summary>
+    public SingleItemSource<TItem> Item
+    {
+        get
+        {
+            Context.ExpressionBuilder.Append(".Item");
+            Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
+            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+        }
+    }
+
+    /// <summary>
     /// Enables await syntax that returns the single item.
     /// This allows both chaining (.And) and item capture (await).
     /// </summary>
@@ -559,6 +572,19 @@ public class HasSingleItemPredicateAssertion<TCollection, TItem> : Sources.Colle
     }
 
     protected override string GetExpectation() => $"to have exactly one item matching {_predicateDescription}";
+
+    /// <summary>
+    /// Drills into the single matching item, allowing assertions to be chained directly against it.
+    /// </summary>
+    public SingleItemSource<TItem> Item
+    {
+        get
+        {
+            Context.ExpressionBuilder.Append(".Item");
+            Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
+            return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
+        }
+    }
 
     /// <summary>
     /// Enables await syntax that returns the matching item.

--- a/TUnit.Assertions/Conditions/CollectionAssertions.cs
+++ b/TUnit.Assertions/Conditions/CollectionAssertions.cs
@@ -508,6 +508,7 @@ public class HasSingleItemAssertion<TCollection, TItem> : Sources.CollectionAsse
     {
         get
         {
+            ThrowIfMixingCombiner<Chaining.OrAssertion<TCollection>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
             return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));
@@ -580,6 +581,7 @@ public class HasSingleItemPredicateAssertion<TCollection, TItem> : Sources.Colle
     {
         get
         {
+            ThrowIfMixingCombiner<Chaining.OrAssertion<TCollection>>();
             Context.ExpressionBuilder.Append(".Item");
             Context.SetPendingLink(InternalWrappedExecution ?? this, CombinerType.And);
             return new SingleItemSource<TItem>(Context.Map<TItem>(_ => _singleItem));

--- a/TUnit.Assertions/Conditions/SingleItemSource.cs
+++ b/TUnit.Assertions/Conditions/SingleItemSource.cs
@@ -14,4 +14,13 @@ public sealed class SingleItemSource<TItem> : ValueAssertion<TItem>
         : base(context)
     {
     }
+
+    internal static SingleItemSource<TItem> Create<TValue>(
+        AssertionContext<TValue> context,
+        Func<TValue?, TItem?> mapper)
+    {
+        var itemContext = context.Map(mapper);
+        itemContext.PreservePendingPreWorkOnMap = true;
+        return new SingleItemSource<TItem>(itemContext);
+    }
 }

--- a/TUnit.Assertions/Conditions/SingleItemSource.cs
+++ b/TUnit.Assertions/Conditions/SingleItemSource.cs
@@ -21,6 +21,7 @@ public sealed class SingleItemSource<TItem> : ValueAssertion<TItem>
     {
         var itemContext = context.Map(mapper);
         itemContext.PreservePendingPreWorkOnMap = true;
+        itemContext.SkipAssertionOnPreWorkFailure = true;
         return new SingleItemSource<TItem>(itemContext);
     }
 }

--- a/TUnit.Assertions/Conditions/SingleItemSource.cs
+++ b/TUnit.Assertions/Conditions/SingleItemSource.cs
@@ -1,0 +1,17 @@
+using TUnit.Assertions.Core;
+using TUnit.Assertions.Sources;
+
+namespace TUnit.Assertions.Conditions;
+
+/// <summary>
+/// Assertion source for the item captured by a successful <c>HasSingleItem</c> assertion.
+/// </summary>
+/// <typeparam name="TItem">The collection item type.</typeparam>
+[global::TUnit.Assertions.Attributes.GenerateCollectionShapeAssertions]
+public sealed class SingleItemSource<TItem> : ValueAssertion<TItem>
+{
+    internal SingleItemSource(AssertionContext<TItem> context)
+        : base(context)
+    {
+    }
+}

--- a/TUnit.Assertions/Core/Assertion.cs
+++ b/TUnit.Assertions/Core/Assertion.cs
@@ -114,6 +114,11 @@ public abstract class Assertion<TValue> : IAssertion
     /// </summary>
     public virtual async Task<TValue?> AssertAsync()
     {
+        if (!await ExecutePendingPreWorkAsync())
+        {
+            return default;
+        }
+
         // If part of an And/Or chain, delegate to the wrapper
         if (_wrappedExecution != null)
         {
@@ -129,21 +134,9 @@ public abstract class Assertion<TValue> : IAssertion
     /// </summary>
     internal async Task<TValue?> ExecuteCoreAsync()
     {
-        // Execute any pending cross-type assertions first (e.g., string assertions before WhenParsedInto<int>)
-        if (Context.PendingPreWork != null)
+        if (!await ExecutePendingPreWorkAsync())
         {
-            var preWork = Context.PendingPreWork;
-            Context.PendingPreWork = null; // Clear BEFORE execution to prevent re-entry
-            var currentScope = AssertionScope.GetCurrentAssertionScope();
-            var exceptionCountBefore = currentScope?.ExceptionCount ?? 0;
-            await preWork();
-
-            // Cross-type drill-ins must not evaluate when their parent assertion failed.
-            // Outside Assert.Multiple the failure throws; inside it the scope count is our signal.
-            if (currentScope?.ExceptionCount > exceptionCountBefore)
-            {
-                return default;
-            }
+            return default;
         }
 
         // If this is an And/OrAssertion (composite), delegate to AssertAsync which has custom logic
@@ -162,6 +155,23 @@ public abstract class Assertion<TValue> : IAssertion
         }
 
         return contextResult.Value;
+    }
+
+    private async Task<bool> ExecutePendingPreWorkAsync()
+    {
+        if (Context.PendingPreWork is not { } preWork)
+        {
+            return true;
+        }
+
+        Context.PendingPreWork = null; // Clear before execution to prevent re-entry.
+        var currentScope = AssertionScope.GetCurrentAssertionScope();
+        var exceptionCountBefore = currentScope?.ExceptionCount ?? 0;
+        await preWork();
+
+        // Cross-type drill-ins must not evaluate when their parent assertion failed.
+        // Outside Assert.Multiple the failure throws; inside it the scope count is our signal.
+        return currentScope is null || currentScope.ExceptionCount <= exceptionCountBefore;
     }
 
     // Create EvaluationMetadata in a separate scope to avoid creating additional

--- a/TUnit.Assertions/Core/Assertion.cs
+++ b/TUnit.Assertions/Core/Assertion.cs
@@ -169,9 +169,9 @@ public abstract class Assertion<TValue> : IAssertion
         var exceptionCountBefore = currentScope?.ExceptionCount ?? 0;
         await preWork();
 
-        // Cross-type drill-ins must not evaluate when their parent assertion failed.
-        // Outside Assert.Multiple the failure throws; inside it the scope count is our signal.
-        return currentScope is null || currentScope.ExceptionCount <= exceptionCountBefore;
+        return !Context.SkipAssertionOnPreWorkFailure
+               || currentScope is null
+               || currentScope.ExceptionCount <= exceptionCountBefore;
     }
 
     // Create EvaluationMetadata in a separate scope to avoid creating additional

--- a/TUnit.Assertions/Core/Assertion.cs
+++ b/TUnit.Assertions/Core/Assertion.cs
@@ -134,7 +134,16 @@ public abstract class Assertion<TValue> : IAssertion
         {
             var preWork = Context.PendingPreWork;
             Context.PendingPreWork = null; // Clear BEFORE execution to prevent re-entry
+            var currentScope = AssertionScope.GetCurrentAssertionScope();
+            var exceptionCountBefore = currentScope?.ExceptionCount ?? 0;
             await preWork();
+
+            // Cross-type drill-ins must not evaluate when their parent assertion failed.
+            // Outside Assert.Multiple the failure throws; inside it the scope count is our signal.
+            if (currentScope?.ExceptionCount > exceptionCountBefore)
+            {
+                return default;
+            }
         }
 
         // If this is an And/OrAssertion (composite), delegate to AssertAsync which has custom logic

--- a/TUnit.Assertions/Core/AssertionContext.cs
+++ b/TUnit.Assertions/Core/AssertionContext.cs
@@ -67,6 +67,16 @@ public sealed class AssertionContext<TValue>
             newContext.PendingPreWork = async () => await pendingAssertion.ExecuteCoreAsync();
         }
 
+        if (PreservePendingPreWorkOnMap && PendingPreWork is { } preWork)
+        {
+            PendingPreWork = null;
+            var existing = newContext.PendingPreWork;
+            newContext.PendingPreWork = existing is null
+                ? preWork
+                : async () => { await preWork(); await existing(); };
+            newContext.PreservePendingPreWorkOnMap = true;
+        }
+
         return newContext;
     }
 
@@ -159,6 +169,11 @@ public sealed class AssertionContext<TValue>
     /// Used for cross-type assertion chaining (e.g., string assertions before WhenParsedInto&lt;int&gt;).
     /// </summary>
     internal Func<Task>? PendingPreWork { get; set; }
+
+    /// <summary>
+    /// Keeps pending pre-work attached while drill-in operations map through intermediate types.
+    /// </summary>
+    internal bool PreservePendingPreWorkOnMap { get; set; }
 
     /// <summary>
     /// Sets the pending link state for the next assertion to consume.

--- a/TUnit.Assertions/Core/AssertionContext.cs
+++ b/TUnit.Assertions/Core/AssertionContext.cs
@@ -75,6 +75,7 @@ public sealed class AssertionContext<TValue>
                 ? preWork
                 : async () => { await preWork(); await existing(); };
             newContext.PreservePendingPreWorkOnMap = true;
+            newContext.SkipAssertionOnPreWorkFailure = SkipAssertionOnPreWorkFailure;
         }
 
         return newContext;
@@ -174,6 +175,12 @@ public sealed class AssertionContext<TValue>
     /// Keeps pending pre-work attached while drill-in operations map through intermediate types.
     /// </summary>
     internal bool PreservePendingPreWorkOnMap { get; set; }
+
+    /// <summary>
+    /// Skips the mapped assertion when pending pre-work fails inside <see cref="Assert.Multiple"/>.
+    /// Used when the mapped value is only valid after the pre-work succeeds.
+    /// </summary>
+    internal bool SkipAssertionOnPreWorkFailure { get; set; }
 
     /// <summary>
     /// Sets the pending link state for the next assertion to consume.

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -562,6 +562,7 @@ namespace .Collections
     public class MemoryHasSingleItemAssertion<TMemory, TItem> : .<TMemory, TItem>
     {
         public MemoryHasSingleItemAssertion(.<TMemory> context, <TMemory, .<TItem>> adapterFactory) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TMemory> metadata) { }
         protected override .<TItem> CreateAdapter(TMemory value) { }
         protected override string GetExpectation() { }
@@ -1329,6 +1330,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemAssertion(.<TCollection> context) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1338,6 +1340,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemPredicateAssertion(.<TCollection> context, <TItem, bool> predicate, string predicateDescription) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1988,6 +1991,7 @@ namespace .Conditions
     [.<float>("IsSubnormal", CustomName="IsNotSubnormal", ExpectationMessage="be subnormal", NegateLogic=true)]
     [.<float>("IsSubnormal", ExpectationMessage="be subnormal")]
     public static class SingleAssertionExtensions { }
+    public sealed class SingleItemSource<TItem> : .<TItem> { }
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
     [.(typeof(<!0>), "IsEmpty", ExpectationMessage="be empty")]
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
@@ -5607,6 +5611,481 @@ namespace .Extensions
         public static . IsNotSubnormal(this .<float> source) { }
         public static . IsPositiveInfinity(this .<float> source) { }
         public static . IsSubnormal(this .<float> source) { }
+    }
+    public static class SingleItemSourceCollectionShapeAssertions
+    {
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Any<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> ContainsOnly<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtLeast<TItem>(this .<TItem[]> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtMost<TItem>(this .<TItem[]> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<TItem[], TItem> HasCountBetween<TItem>(this .<TItem[]> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInDescendingOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsNotEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? indexExpression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
     }
     public static class SpanAssertionExtensions { }
     public static class StreamAssertionExtensions

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -545,6 +545,7 @@ namespace .Collections
     public class MemoryHasSingleItemAssertion<TMemory, TItem> : .<TMemory, TItem>
     {
         public MemoryHasSingleItemAssertion(.<TMemory> context, <TMemory, .<TItem>> adapterFactory) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TMemory> metadata) { }
         protected override .<TItem> CreateAdapter(TMemory value) { }
         protected override string GetExpectation() { }
@@ -1312,6 +1313,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemAssertion(.<TCollection> context) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1321,6 +1323,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemPredicateAssertion(.<TCollection> context, <TItem, bool> predicate, string predicateDescription) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1971,6 +1974,7 @@ namespace .Conditions
     [.<float>("IsSubnormal", CustomName="IsNotSubnormal", ExpectationMessage="be subnormal", NegateLogic=true)]
     [.<float>("IsSubnormal", ExpectationMessage="be subnormal")]
     public static class SingleAssertionExtensions { }
+    public sealed class SingleItemSource<TItem> : .<TItem> { }
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
     [.(typeof(<!0>), "IsEmpty", ExpectationMessage="be empty")]
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
@@ -5527,6 +5531,470 @@ namespace .Extensions
         public static . IsNotSubnormal(this .<float> source) { }
         public static . IsPositiveInfinity(this .<float> source) { }
         public static . IsSubnormal(this .<float> source) { }
+    }
+    public static class SingleItemSourceCollectionShapeAssertions
+    {
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Any<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> ContainsOnly<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtLeast<TItem>(this .<TItem[]> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtMost<TItem>(this .<TItem[]> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<TItem[], TItem> HasCountBetween<TItem>(this .<TItem[]> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInDescendingOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsNotEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? indexExpression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
     }
     public static class SpanAssertionExtensions { }
     public static class StreamAssertionExtensions

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -562,6 +562,7 @@ namespace .Collections
     public class MemoryHasSingleItemAssertion<TMemory, TItem> : .<TMemory, TItem>
     {
         public MemoryHasSingleItemAssertion(.<TMemory> context, <TMemory, .<TItem>> adapterFactory) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TMemory> metadata) { }
         protected override .<TItem> CreateAdapter(TMemory value) { }
         protected override string GetExpectation() { }
@@ -1329,6 +1330,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemAssertion(.<TCollection> context) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1338,6 +1340,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemPredicateAssertion(.<TCollection> context, <TItem, bool> predicate, string predicateDescription) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1988,6 +1991,7 @@ namespace .Conditions
     [.<float>("IsSubnormal", CustomName="IsNotSubnormal", ExpectationMessage="be subnormal", NegateLogic=true)]
     [.<float>("IsSubnormal", ExpectationMessage="be subnormal")]
     public static class SingleAssertionExtensions { }
+    public sealed class SingleItemSource<TItem> : .<TItem> { }
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
     [.(typeof(<!0>), "IsEmpty", ExpectationMessage="be empty")]
     [.(typeof(<!0>), "IsEmpty", CustomName="IsNotEmpty", ExpectationMessage="be empty", NegateLogic=true)]
@@ -5607,6 +5611,481 @@ namespace .Extensions
         public static . IsNotSubnormal(this .<float> source) { }
         public static . IsPositiveInfinity(this .<float> source) { }
         public static . IsSubnormal(this .<float> source) { }
+    }
+    public static class SingleItemSourceCollectionShapeAssertions
+    {
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Any<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> ContainsOnly<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        [.(-1)]
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        [.(-1)]
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtLeast<TItem>(this .<TItem[]> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtMost<TItem>(this .<TItem[]> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<TItem[], TItem> HasCountBetween<TItem>(this .<TItem[]> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInDescendingOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsNotEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? indexExpression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
     }
     public static class SpanAssertionExtensions { }
     public static class StreamAssertionExtensions

--- a/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/TUnit.PublicAPI/Tests.Assertions_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1151,6 +1151,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemAssertion(.<TCollection> context) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1160,6 +1161,7 @@ namespace .Conditions
         where TCollection : .<TItem>
     {
         public HasSingleItemPredicateAssertion(.<TCollection> context, <TItem, bool> predicate, string predicateDescription) { }
+        public .<TItem> Item { get; }
         protected override .<.> CheckAsync(.<TCollection> metadata) { }
         public .<TItem> GetAwaiter() { }
         protected override string GetExpectation() { }
@@ -1761,6 +1763,7 @@ namespace .Conditions
     [.<float>("IsPositiveInfinity", CustomName="IsNotPositiveInfinity", ExpectationMessage="be positive infinity", NegateLogic=true)]
     [.<float>("IsPositiveInfinity", ExpectationMessage="be positive infinity")]
     public static class SingleAssertionExtensions { }
+    public sealed class SingleItemSource<TItem> : .<TItem> { }
     [.("Contains")]
     public class StringContainsAssertion : .<string>
     {
@@ -4791,6 +4794,435 @@ namespace .Extensions
         public static . IsNotNegativeInfinity(this .<float> source) { }
         public static . IsNotPositiveInfinity(this .<float> source) { }
         public static . IsPositiveInfinity(this .<float> source) { }
+    }
+    public static class SingleItemSourceCollectionShapeAssertions
+    {
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> All<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> All<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> All<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllKeys<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AllValues<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Any<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Any<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Any<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyKey<TKey, TValue>(this .<.<TKey, TValue>> source, <TKey, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> AnyValue<TKey, TValue>(this .<.<TKey, TValue>> source, <TValue, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> Contains<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> Contains<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Contains<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, .<TKey>? comparer, [.("expectedKey")] string? keyExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsKeyWithValue<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, TValue expectedValue, [.("expectedKey")] string? keyExpression = null, [.("expectedValue")] string? valueExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ContainsOnly<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> ContainsOnly<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> ContainsOnly<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> ContainsValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Count<TItem>(this .<.<TItem>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<TItem>, .?> itemAssertion, [.("itemAssertion")] string? expression = null) { }
+        public static .<TItem[], TItem> Count<TItem>(this .<TItem[]> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> Count<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<.<TKey, TValue>>, .?> itemAssertion, [.("itemAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> Count<TKey, TValue>(this .<.<TKey, TValue>> source, <.<int>, .<int>?> countAssertion, [.("countAssertion")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, [.("expected")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> DoesNotContain<TItem>(this .<.<TItem>> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> DoesNotContain<TItem>(this .<TItem[]> source, TItem expected, .<TItem> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, [.("expected")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> DoesNotContain<TKey, TValue>(this .<.<TKey, TValue>> source, .<TKey, TValue> expected, .<.<TKey, TValue>> comparer, [.("expected")] string? expectedExpression = null, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainKey<TKey, TValue>(this .<.<TKey, TValue>> source, TKey expectedKey, [.("expectedKey")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> DoesNotContainValue<TKey, TValue>(this .<.<TKey, TValue>> source, TValue expectedValue, [.("expectedValue")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> DoesNotOverlap<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> FirstItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtLeast<TItem>(this .<.<TItem>> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtLeast<TItem>(this .<TItem[]> source, int minCount, [.("minCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtLeast<TKey, TValue>(this .<.<TKey, TValue>> source, int minCount, [.("minCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasAtMost<TItem>(this .<.<TItem>> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<TItem[], TItem> HasAtMost<TItem>(this .<TItem[]> source, int maxCount, [.("maxCount")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasAtMost<TKey, TValue>(this .<.<TKey, TValue>> source, int maxCount, [.("maxCount")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TItem>, TItem> HasCountBetween<TItem>(this .<.<TItem>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<TItem[], TItem> HasCountBetween<TItem>(this .<TItem[]> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasCountBetween<TKey, TValue>(this .<.<TKey, TValue>> source, int min, int max, [.("min")] string? minExpression = null, [.("max")] string? maxExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> HasDistinctItems<TItem>(this .<.<TItem>> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem> HasDistinctItems<TItem>(this .<TItem[]> source, .<TItem> comparer, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> HasDistinctItems<TKey, TValue>(this .<.<TKey, TValue>> source, .<.<TKey, TValue>> comparer, [.("comparer")] string? comparerExpression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasItemAt<TItem>(this .<.<TItem>> source, int index, TItem expected, .<TItem>? comparer = null, [.("index")] string? indexExpression = null, [.("expected")] string? expectedExpression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TItem>, TItem> HasSingleItem<TItem>(this .<.<TItem>> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<TItem[], TItem> HasSingleItem<TItem>(this .<TItem[]> source, <TItem, bool> predicate, [.("predicate")] string? expression = null) { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> HasSingleItem<TKey, TValue>(this .<.<TKey, TValue>> source, <.<TKey, TValue>, bool> predicate, [.("predicate")] string? expression = null)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInDescendingOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInDescendingOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInDescendingOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsInOrder<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsInOrder<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, .<TKey, TValue>> IsInOrder<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> IsNotEmpty<TItem>(this .<.<TItem>> source) { }
+        public static .<TItem[], TItem> IsNotEmpty<TItem>(this .<TItem[]> source) { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TKey, TValue>, TKey, TValue> IsNotEmpty<TKey, TValue>(this .<.<TKey, TValue>> source)
+            where TKey :  notnull { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedBy<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedBy<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, [.("keySelector")] string? expression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<.<TItem>> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<TItem[], TItem, TKey> IsOrderedByDescending<TItem, TKey>(this .<TItem[]> source, <TItem, TKey> keySelector, .<TKey>? comparer, [.("keySelector")] string? selectorExpression = null, [.("comparer")] string? comparerExpression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsProperSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSubsetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> IsSupersetOf<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? indexExpression = null) { }
+        public static .<.<TItem>, TItem> ItemAt<TItem>(this .<.<TItem>> source, int index, [.("index")] string? expression = null) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> LastItem<TItem>(this .<.<TItem>> source) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> Overlaps<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
+        public static .<.<TItem>, TItem> SetEquals<TItem>(this .<.<TItem>> source, .<TItem> other, [.("other")] string? expression = null) { }
     }
     public static class StreamAssertionExtensions
     {

--- a/docs/docs/assertions/collections.md
+++ b/docs/docs/assertions/collections.md
@@ -239,6 +239,14 @@ public async Task Collection_Has_Single_Item()
 }
 ```
 
+Use `.Item` to continue assertions directly against the single item:
+
+```csharp
+await Assert.That(users)
+    .HasSingleItem()
+    .Item.Member(user => user.Name, name => name.IsEqualTo("Alice"));
+```
+
 ## Ordering Assertions
 
 ### IsInOrder


### PR DESCRIPTION
## Summary

- add `.Item` drill-in after `HasSingleItem()` and its predicate overload
- preserve the captured item so one-shot enumerables are not enumerated twice
- support collection-shaped items and memory assertions
- document direct item chaining

## Validation

- `dotnet test TUnit.Assertions.Tests/TUnit.Assertions.Tests.csproj` — 6,541 passed across net8.0, net9.0, and net10.0
- `dotnet test TUnit.PublicAPI --no-build` — 18 passed across net472, net8.0, net9.0, and net10.0

Closes #6221