### PR TITLE
Remove EqualTo alias documentation

### DIFF
--- a/docs/docs/assertions/equality-and-comparison.md
+++ b/docs/docs/assertions/equality-and-comparison.md
@@ -43,22 +43,6 @@ public async Task Not_Equal()
 }
 ```
 
-### EqualTo (Alias)
-
-`EqualTo()` is an alias for `IsEqualTo()` for more natural chaining:
-
-```csharp
-[Test]
-public async Task Using_EqualTo_Alias()
-{
-    var numbers = new[] { 1, 2, 3 };
-
-    await Assert.That(numbers)
-        .Count().IsEqualTo(3)
-        .And.Contains(2);
-}
-```
-
 ## Reference Equality
 
 ### IsSameReferenceAs


### PR DESCRIPTION
## Summary
- remove the standalone `EqualTo` alias section from equality documentation
- retain `IsEqualTo` as the natural documented assertion syntax

## Root cause
The alias section described `EqualTo`, but its count-chaining example correctly used `Count().IsEqualTo(...)`. Replacing that call with `EqualTo(...)` would be invalid because `CollectionCountSource` only exposes `IsEqualTo(int)`.

## Impact
Users no longer see a confusing alias section whose example cannot naturally demonstrate the alias.

## Validation
- `yarn build` from `docs`
- `git diff --check`

Closes #6360