### PR TITLE
docs: align docs homepage messaging with revamped README

### DIFF
--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -16,7 +16,7 @@ const FeatureList: FeatureItem[] = [
     icon: '🔧',
     description: (
       <>
-        Multiple ways to write, inject data, and control tests. Support for data-driven testing, matrix tests, and custom data sources.
+        Data-driven arguments, matrix tests, and custom data sources — plus injectable, shared fixtures with dependency injection and reference-counted disposal.
       </>
     ),
     codeExample: `[Test]
@@ -32,7 +32,7 @@ public async Task TestAdd(int a, int b, int expected)
     icon: '✨',
     description: (
       <>
-        Clean attribute-based syntax that's easy to read and write. Fluent assertions make tests expressive and self-documenting.
+        Clean, attribute-based tests with fluent async assertions that read like sentences — and pinpoint the exact difference when they fail, instead of dumping object graphs at you.
       </>
     ),
     codeExample: `[Test]
@@ -49,7 +49,7 @@ public async Task TestAsync()
     icon: '⚡',
     description: (
       <>
-        Source generated tests with Native AOT support. Built on Microsoft Testing Platform to reduce overhead and improve efficiency.
+        Source-generated tests with Native AOT support, built on the Microsoft Testing Platform. Work shifts from run time to build time, so every run after starts faster.
       </>
     ),
     codeExample: `// AOT Compatible

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -43,8 +43,10 @@ public async Task MyTest()
               <div className={styles.badge}>Modern .NET Testing</div>
             </div>
             <p className={styles.heroSubtitle}>
-              A modern testing framework for .NET built with performance in mind.
-              Leveraging source generation and AOT compilation for efficient test execution.
+              A modern .NET testing framework where tests are discovered at compile time, not
+              reflected at runtime. Source-generated and Native AOT ready, parallel by default,
+              batteries included — assertions, mocking, and first-class ASP.NET Core, Aspire,
+              and Playwright integrations.
             </p>
             <div className={styles.heroStats}>
               <div className={styles.stat}>
@@ -168,33 +170,33 @@ function WhyTUnit() {
   const features = [
     {
       icon: '⚡',
-      title: 'Performance Focused',
-      description: 'Source generated code eliminates reflection overhead. Built on the modern Microsoft Testing Platform.',
+      title: 'Compile-Time Discovery',
+      description: 'Tests are wired up by a source generator at build time, not found via reflection at runtime — faster startup, better IDE integration, and full Native AOT / trimming support.',
     },
     {
       icon: '🎯',
-      title: 'Compile-Time Validation',
-      description: 'Source generators provide early error detection and full IntelliSense support.',
+      title: 'Compile-Time Safety',
+      description: 'A suite of Roslyn analyzers ships in the box, so invalid hook signatures, broken data sources, and misused assertions fail your build — not your CI run.',
+    },
+    {
+      icon: '🔀',
+      title: 'Parallel by Default',
+      description: 'Tests run concurrently out of the box; [DependsOn], [NotInParallel], and [ParallelLimiter<T>] give you precise ordering and throttling when you need it.',
+    },
+    {
+      icon: '🧩',
+      title: 'Batteries Included',
+      description: 'Rich async assertions, shared fixtures with dependency injection, and lifecycle hooks at every scope — plus a source-generated mocking library.',
+    },
+    {
+      icon: '🔌',
+      title: 'First-Class Integrations',
+      description: 'Purpose-built support for ASP.NET Core, Aspire, and Playwright, so integration and end-to-end tests feel native to the framework.',
     },
     {
       icon: '🚀',
-      title: 'AOT Compatible',
-      description: 'Native AOT support enables faster startup times and reduced memory usage.',
-    },
-    {
-      icon: '🔧',
-      title: 'Extensible',
-      description: 'Rich extension points and customization options to fit your testing needs.',
-    },
-    {
-      icon: '📊',
-      title: 'Data Driven',
-      description: 'Powerful data source attributes for parameterized and matrix testing.',
-    },
-    {
-      icon: '🎨',
-      title: 'Modern API',
-      description: 'Fluent assertions, async-first design, and intuitive test organization.',
+      title: 'AOT & Trimming Ready',
+      description: 'Native AOT support enables dramatically faster startup and reduced memory usage, with no runtime reflection to trim away.',
     },
   ];
 


### PR DESCRIPTION
Follow-up to #6430 (README revamp). Brings the Docusaurus homepage in line with the README's positioning.

## What changed
- **Hero subtitle** — sharpened from the generic "built with performance in mind" to the README's angle: compile-time discovery (not runtime reflection), source-generated + Native AOT, parallel by default, batteries-included with first-class integrations.
- **`WhyTUnit` cards** — refreshed the six cards to mirror the README's pillars:
  - Compile-Time Discovery · Compile-Time Safety (Roslyn analyzers) · Parallel by Default (`[DependsOn]`/`[NotInParallel]`/`[ParallelLimiter<T>]`) · Batteries Included (source-generated mocking) · First-Class Integrations (ASP.NET Core / Aspire / Playwright) · AOT & Trimming Ready.
- **`HomepageFeatures` cards** — sharpened the three descriptions to surface injectable DI fixtures, self-explaining assertion failures, and the build-time/run-time tradeoff. Code examples left intact (they already use the non-obsolete `.And.Count().IsEqualTo(...)` pattern).

## What was intentionally left alone
- **Benchmark components** (`BenchmarkHighlight` / `BenchmarkChart`) already fetch `latest.json` — the same source the README table now consumes — so numbers stay in sync automatically. No hand-editing.

## Notes
- No behavioural/library changes — docs-only.
- `npm run typecheck` fails on a pre-existing `tsconfig.json` `baseUrl` incompatibility (present on `main`), unrelated to this diff.