### PR TITLE
fix(engine): emit ECMA-335 metadata-format type names in TestMethodIdentifierProperty

### DIFF
--- a/TUnit.Engine.Tests/MetadataTypeNameFormatterTests.cs
+++ b/TUnit.Engine.Tests/MetadataTypeNameFormatterTests.cs
@@ -1,0 +1,71 @@
+using Shouldly;
+using TUnit.Engine.Helpers;
+
+namespace TUnit.Engine.Tests;
+
+public class MetadataTypeNameFormatterTests
+{
+    [Test]
+    [Arguments(typeof(string), "System.String")]
+    [Arguments(typeof(void), "System.Void")]
+    [Arguments(typeof(int[]), "System.Int32[]")]
+    [Arguments(typeof(int[][]), "System.Int32[][]")]
+    [Arguments(typeof(int[,]), "System.Int32[,]")]
+    [Arguments(typeof(List<string>), "System.Collections.Generic.List`1<System.String>")]
+    [Arguments(typeof(List<>), "System.Collections.Generic.List`1")]
+    [Arguments(typeof(Dictionary<string, List<int>>), "System.Collections.Generic.Dictionary`2<System.String,System.Collections.Generic.List`1<System.Int32>>")]
+    [Arguments(typeof(Task<int>), "System.Threading.Tasks.Task`1<System.Int32>")]
+    [Arguments(typeof(int?), "System.Nullable`1<System.Int32>")]
+    [Arguments(typeof(Outer.Inner), "TUnit.Engine.Tests.MetadataTypeNameFormatterTests+Outer+Inner")]
+    [Arguments(typeof(Outer.GenericInner<string>), "TUnit.Engine.Tests.MetadataTypeNameFormatterTests+Outer+GenericInner`1<System.String>")]
+    public void Formats_Types_In_Metadata_Format(Type type, string expected)
+    {
+        MetadataTypeNameFormatter.GetMetadataFullName(type).ShouldBe(expected);
+    }
+
+    [Test]
+    public void Formats_Generic_Method_Parameter_As_DoubleBang_Position()
+    {
+        var method = typeof(GenericMembers).GetMethod(nameof(GenericMembers.MethodWithGenericParameters))!;
+        var parameters = method.GetParameters();
+
+        MetadataTypeNameFormatter.GetMetadataFullName(parameters[0].ParameterType).ShouldBe("!!0");
+        MetadataTypeNameFormatter.GetMetadataFullName(parameters[1].ParameterType).ShouldBe("!!1[]");
+        MetadataTypeNameFormatter.GetMetadataFullName(parameters[2].ParameterType).ShouldBe("System.Collections.Generic.List`1<!!0>");
+    }
+
+    [Test]
+    public void Formats_Generic_Type_Parameter_As_SingleBang_Position()
+    {
+        var typeParameter = typeof(Dictionary<,>).GetGenericArguments()[1];
+
+        MetadataTypeNameFormatter.GetMetadataFullName(typeParameter).ShouldBe("!1");
+    }
+
+    [Test]
+    public void Formats_ByRef_Parameter_With_Ampersand()
+    {
+        var method = typeof(GenericMembers).GetMethod(nameof(GenericMembers.MethodWithRefParameter))!;
+        var parameterType = method.GetParameters()[0].ParameterType;
+
+        MetadataTypeNameFormatter.GetMetadataFullName(parameterType).ShouldBe("System.Int32&");
+    }
+
+    public static class Outer
+    {
+        public class Inner;
+
+        public class GenericInner<T>;
+    }
+
+    public static class GenericMembers
+    {
+        public static void MethodWithGenericParameters<T1, T2>(T1 first, T2[] second, List<T1> third)
+        {
+        }
+
+        public static void MethodWithRefParameter(ref int value)
+        {
+        }
+    }
+}

--- a/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/TUnit.Engine/Extensions/TestExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using TUnit.Core;
 using TUnit.Core.Extensions;
 using TUnit.Engine.Capabilities;
+using TUnit.Engine.Helpers;
 using TUnit.Engine.Reporters;
 #pragma warning disable TPEXP
 
@@ -61,7 +62,7 @@ internal static class TestExtensions
                 typeName: testContext.GetClassTypeName(),
                 methodName: testDetails.MethodName,
                 parameterTypeFullNames: CreateParameterTypeArray(testDetails.MethodMetadata.Parameters),
-                returnTypeFullName: testDetails.ReturnType.FullName ?? typeof(void).FullName!,
+                returnTypeFullName: MetadataTypeNameFormatter.GetMetadataFullName(testDetails.ReturnType),
                 methodArity: testDetails.MethodMetadata.GenericTypeCount
             );
 
@@ -354,7 +355,7 @@ internal static class TestExtensions
         var array = new string[parameters.Length];
         for (var i = 0; i < parameters.Length; i++)
         {
-            array[i] = parameters[i].Type.FullName!;
+            array[i] = MetadataTypeNameFormatter.GetMetadataFullName(parameters[i].Type);
         }
         return array;
     }

--- a/TUnit.Engine/Helpers/MetadataTypeNameFormatter.cs
+++ b/TUnit.Engine/Helpers/MetadataTypeNameFormatter.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using System.Text;
+using TUnit.Core.Helpers;
+
+namespace TUnit.Engine.Helpers;
+
+/// <summary>
+/// Formats <see cref="Type"/> instances as ECMA-335 metadata-format full names, as required by
+/// <c>TestMethodIdentifierProperty</c> in Microsoft.Testing.Platform. This matches the managed
+/// name format (vstest RFC 0017) that platform consumers parse: constructed generics as
+/// <c>List`1&lt;System.String&gt;</c>, generic method parameters as <c>!!0</c>, generic type
+/// parameters as <c>!0</c>, and nested types separated by <c>+</c>.
+/// </summary>
+internal static class MetadataTypeNameFormatter
+{
+    private static readonly ConcurrentDictionary<Type, string> Cache = new();
+
+    public static string GetMetadataFullName(Type type)
+    {
+        return Cache.GetOrAdd(type, static t =>
+        {
+            var builder = StringBuilderPool.Get();
+            try
+            {
+                AppendMetadataName(builder, t);
+                return builder.ToString();
+            }
+            finally
+            {
+                StringBuilderPool.Return(builder);
+            }
+        });
+    }
+
+    private static void AppendMetadataName(StringBuilder builder, Type type)
+    {
+        if (type.IsGenericParameter)
+        {
+            builder.Append(type.DeclaringMethod is null ? "!" : "!!");
+            builder.Append(type.GenericParameterPosition);
+            return;
+        }
+
+        if (type.HasElementType)
+        {
+            AppendMetadataName(builder, type.GetElementType()!);
+
+            if (type.IsArray)
+            {
+                builder.Append('[');
+                builder.Append(',', type.GetArrayRank() - 1);
+                builder.Append(']');
+            }
+            else if (type.IsPointer)
+            {
+                builder.Append('*');
+            }
+            else if (type.IsByRef)
+            {
+                builder.Append('&');
+            }
+
+            return;
+        }
+
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            AppendMetadataName(builder, type.GetGenericTypeDefinition());
+
+            builder.Append('<');
+            var genericArguments = type.GetGenericArguments();
+            for (var i = 0; i < genericArguments.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendMetadataName(builder, genericArguments[i]);
+            }
+            builder.Append('>');
+            return;
+        }
+
+        // Non-generic types and generic type definitions: FullName is already metadata format
+        // (namespace-qualified, '+' for nested types, backtick arity for generics).
+        builder.Append(type.FullName ?? type.Name);
+    }
+}


### PR DESCRIPTION
## Problem

Microsoft.Testing.Platform specifies that `TestMethodIdentifierProperty` values are **ECMA-335 compliant** (managed name format, [vstest RFC 0017](https://github.com/microsoft/vstest/blob/main/docs/RFCs/0017-Managed-TestCase-Properties.md)). TUnit was passing raw reflection `Type.FullName` for `ParameterTypeFullNames` and `ReturnTypeFullName`, which produces:

- Assembly-qualified generic arguments: `System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=...]]`
- `null` (via `FullName!`) for open generic method parameters (`T`)

## Fix

New `MetadataTypeNameFormatter` (cached per `Type`) emits the spec format, matching what MSTest's `ManagedNameParser` produces:

- Constructed generics: `System.Collections.Generic.List`1<System.String>`
- Generic method parameters: `!!0`; generic type parameters: `!0`
- Arrays (`[]`, `[,]`, jagged), byref `&`, pointer `*`
- Nested types via `+`

## Deliberately unchanged

`TypeName` keeps TUnit's class-argument decoration (`MyTests(arg1, arg2)`) for parameterized test classes — this keeps class-data-source instances distinguishable in Test Explorer. Nested-type `+` joining, namespace split, and generic backtick arity were already spec-conformant.

No internal consumers read `ParameterTypeFullNames`/`ReturnTypeFullName` (reporters only read `TypeName`/`MethodName`/`Namespace`), so no downstream output changes.

## Tests

15 new tests in `MetadataTypeNameFormatterTests` covering simple types, constructed/open generics, nested generics, arrays, nullable, nested types, `!!n`/`!n` placeholders, byref.