### PR TITLE
fix(benchmarks): make SetupTeardownTests JSON tests Native AOT compatible

### DIFF
--- a/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
+++ b/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
@@ -353,13 +353,8 @@ public class SetupTeardownTests
     public void JsonOperationTest()
     {
         // Simulate JSON serialization
-        var data = new
-        {
-            Id = 123,
-            Name = "Test Data",
-            Values = Enumerable.Range(0, 50).ToArray()
-        };
-        var json = System.Text.Json.JsonSerializer.Serialize(data);
+        var data = new JsonPayload(123, "Test Data", Enumerable.Range(0, 50).ToArray());
+        var json = System.Text.Json.JsonSerializer.Serialize(data, BenchmarkJsonContext.Default.JsonPayload);
         _logBuilder.AppendLine($"JSON length: {json.Length}");
     }
 
@@ -368,13 +363,15 @@ public class SetupTeardownTests
     {
         // Simulate async JSON operations
         await Task.Delay(10);
-        var data = new
-        {
-            Id = 123,
-            Name = "Test Data",
-            Values = Enumerable.Range(0, 50).ToArray()
-        };
-        var json = System.Text.Json.JsonSerializer.Serialize(data);
+        var data = new JsonPayload(123, "Test Data", Enumerable.Range(0, 50).ToArray());
+        var json = System.Text.Json.JsonSerializer.Serialize(data, BenchmarkJsonContext.Default.JsonPayload);
         _logBuilder.AppendLine($"Async JSON length: {json.Length}");
     }
 }
+
+// Concrete DTO + source-generated serializer context so JSON tests work under Native AOT,
+// where reflection-based System.Text.Json serialization is disabled.
+public sealed record JsonPayload(int Id, string Name, int[] Values);
+
+[System.Text.Json.Serialization.JsonSerializable(typeof(JsonPayload))]
+internal partial class BenchmarkJsonContext : System.Text.Json.Serialization.JsonSerializerContext;


### PR DESCRIPTION
## Problem

The README benchmark table shows `—` for **TUnit (AOT)** on the **Setup/teardown lifecycle** row. The AOT benchmark run for `SetupTeardownTests` crashes:

- `JsonOperationTest` / `AsyncJsonOperationTest` serialize an **anonymous type** with `System.Text.Json.JsonSerializer.Serialize(data)`.
- `PublishAot=true` sets `JsonSerializerIsReflectionEnabledByDefault=false`, so reflection-based STJ throws `InvalidOperationException` at runtime.
- 2 failing tests → non-zero exit → CliWrap `ExecuteBufferedAsync` throws in `RuntimeBenchmarks.TUnit_AOT` → BenchmarkDotNet records `NA` → README renders `—`.

This is a benchmark-suite bug, not a TUnit hooks bug — `[Before(Test)]`/`[After(Test)]` work fine under AOT.

## Fix

Replace the anonymous type with a concrete `JsonPayload` record serialized via a source-generated `JsonSerializerContext`. Works under Native AOT and compiles for all four framework variants (shared file).

## Verification

No MSVC linker on this machine, so full AOT link wasn''t possible locally. Instead, reproduced the exact AOT failure mode by building the TUnit variant with `-p:JsonSerializerIsReflectionEnabledByDefault=false` (the same feature switch `PublishAot` flips) and running `--treenode-filter "/*/*/SetupTeardownTests/*"`:

- Confirmed `"System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault": false` in runtimeconfig.json
- **22/22 tests pass**

Also compile-checked `XUNIT3`, `NUNIT`, `MSTEST` variants — all build clean.

After merge, the next weekly Speed Comparison run should fill in the missing AOT cell.