### PR TITLE
feat: Allow disabling the automatic html report upload to upload-artifacts@v7

### DIFF
--- a/docs/docs/guides/html-report.md
+++ b/docs/docs/guides/html-report.md
@@ -114,6 +114,27 @@ The value must be a positive integer. If it exceeds your repository/organization
 TUnit clamps it to that maximum. This applies only to the automatic upload (Option A); the
 manual `upload-artifact` step (Option B) has its own [`retention-days`](https://github.com/actions/upload-artifact#retention-period) input.
 
+### Disabling the Automatic Artifact Upload
+
+To keep generating the html report file but skip the automatic artifact upload, set the
+`TUNIT_DISABLE_ARTIFACT_UPLOAD` environment variable:
+
+```yaml
+- name: Run Tests
+  run: dotnet run --project MyTests
+  env:
+    TUNIT_DISABLE_ARTIFACT_UPLOAD: true
+```
+This is useful if you:
+
+* Run a GitHub-actions compatible CI system that cant handle `upload-artifact/v7`
+  like [forgejo](https://forgejo.org/), [gitea](https://about.gitea.com/)
+  or anything other based on [GHES](https://docs.github.com/en/enterprise-server@latest/admin/overview/about-github-enterprise-server)
+* Upload the report to another endpoint anyway
+
+
+The report file and the `GITHUB_STEP_SUMMARY` are still generated.
+
 ### Viewing the Report
 
 After the workflow run completes:

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -60,6 +60,23 @@ Accepts truthy values: `true`, `1`, `yes` (case-insensitive).
 
 **Use case:** When you don't need the HTML report or want to reduce disk I/O. The report is written to `TestResults/{AssemblyName}-report.html` by default.
 
+### TUNIT_DISABLE_ARTIFACT_UPLOAD
+
+Skips the autmoatic upload of the html report but still generates the files.
+
+```bash
+export TUNIT_DISABLE_ARTIFACT_UPLOAD=true
+```
+
+Accepts truthy values: `true`, `1`, `yes` (case-insensitive).
+
+#### Use case
+
+CI Systems like [forgejo-actions](https://forgejo.org/docs/next/user/actions/reference/) are based on GitHub Enterprise Server.
+GitHub changed the server-side behaviour of `upload-artifacts` since v4 and hasn't updated updated ghes since that.
+Forgejo and gitea don't implement this new artifact endpoint but the runners set `GITHUB_ACTIONS=true`.
+In this case it attempts to upload the report a few times until it eventually backs off after 30s.
+
 ### TUNIT_DISABLE_JUNIT_REPORTER
 
 Disables the JUnit XML reporter.
@@ -268,6 +285,7 @@ When the same setting is configured in multiple places, TUnit follows this prior
 | `TUNIT_DISABLE_JUNIT_REPORTER` | - | Disables JUnit reporter |
 | `TUNIT_ENABLE_JUNIT_REPORTER` | - | Enables JUnit reporter |
 | `TUNIT_DISABLE_HTML_REPORTER` | - | Disables HTML report generation |
+| `TUNIT_DISABLE_ARTIFACT_UPLOAD` | - | Keeps the HTML report file but skips the GitHub Actions artifact upload |
 | `JUNIT_XML_OUTPUT_PATH` | - | JUnit output path |
 | `TUNIT_MAX_PARALLEL_TESTS` | `--maximum-parallel-tests` | Max parallel tests |
 | `TUNIT_EXECUTION_MODE` | `--reflection` | Selects source-generation (`sourcegeneration`/`aot`) or `reflection` execution mode |

--- a/src/TUnit.Engine/Configuration/EnvironmentConstants.cs
+++ b/src/TUnit.Engine/Configuration/EnvironmentConstants.cs
@@ -12,6 +12,9 @@ internal static class EnvironmentConstants
     // TUnit-specific: how long (in days) the auto-uploaded HTML report artifact is kept
     public const string ArtifactRetentionDays = "TUNIT_ARTIFACT_RETENTION_DAYS";
 
+    // TUnit-specific: keep generating the html report, but skip the automatic GitHub Actions artifact-upload.
+    public const string DisableArtifactUpload = "TUNIT_DISABLE_ARTIFACT_UPLOAD";
+
     // TUnit-specific: cross-process report aggregation (issue #4522).
     // ON by default wherever a shared directory is resolvable (GitHub Actions, or explicit
     // TUNIT_AGGREGATE_DIR). Values: off/false/0/no/disabled/none = disable;

--- a/src/TUnit.Engine/Reporters/Html/HtmlReporter.cs
+++ b/src/TUnit.Engine/Reporters/Html/HtmlReporter.cs
@@ -857,6 +857,11 @@ internal sealed class HtmlReporter(IExtension extension) : IDataConsumer, IDataP
             return null;
         }
 
+        if (IsTruthyEnv(Environment.GetEnvironmentVariable(EnvironmentConstants.DisableArtifactUpload)))
+        {
+            return null;
+        }
+
         var repo = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRepository);
         var runId = Environment.GetEnvironmentVariable(EnvironmentConstants.GitHubRunId);
 


### PR DESCRIPTION
## Description

Adds the environment variable `TUNIT_DISABLE_ARTIFACT_UPLOAD` to control whether the html report is uploaded to the artifacts endpoint

## Related Issue

<!-- Link to the issue this PR addresses (use "Fixes #123" or "Closes #123" to auto-close) -->
none

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [x] All existing tests pass (`dotnet test`)
- [ ] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->
* No additional test as `IsTruthyEnv` existed already