### PR TITLE
fix: stop retrying artifact upload on non-retryable status codes

### DIFF
--- a/src/TUnit.Engine/Reporters/Html/GitHubArtifactUploader.cs
+++ b/src/TUnit.Engine/Reporters/Html/GitHubArtifactUploader.cs
@@ -14,7 +14,7 @@ internal static class GitHubArtifactUploader
     private const int BaseRetryMs = 3000;
     private const double RetryMultiplier = 1.5;
 
-    private static readonly HashSet<int> RetryableStatusCodes = [429, 500, 502, 503, 504];
+    private static readonly HashSet<int> RetryableStatusCodes = [408, 429, 500, 502, 503, 504];
     private static readonly HttpClient SharedHttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
 
     internal static async Task<string?> UploadAsync(
@@ -280,7 +280,7 @@ internal static class GitHubArtifactUploader
             {
                 return await action();
             }
-            catch (HttpRequestException ex) when (IsRetryable(ex))
+            catch (ArtifactUploadException ex) when (IsRetryable(ex.StatusCode))
             {
                 if (attempt == MaxRetries - 1)
                 {
@@ -312,29 +312,30 @@ internal static class GitHubArtifactUploader
 
         // Include response body in the exception message rather than logging per-attempt,
         // so only the final failure is surfaced by RetryAsync.
-#if NET
-        throw new HttpRequestException($"{step} returned {(int)response.StatusCode}: {body}", null, response.StatusCode);
-#else
-        throw new HttpRequestException($"{step} returned {(int)response.StatusCode}: {body}");
-#endif
+        var statusCode = (int)response.StatusCode;
+        var hint = statusCode is 404
+            // GitHub Enterprise Server / other non-github.com hosts don't implement the
+            // Actions Results artifact API, so retrying can only burn wall-clock time.
+            ? " (the artifact API is unavailable on this host — this is expected on GitHub Enterprise Server)"
+            : "";
+
+        throw new ArtifactUploadException($"{step} returned {statusCode}{hint}: {body}", statusCode);
     }
 
-    private static bool IsRetryable(HttpRequestException ex)
-    {
-#if NET
-        var statusCode = (int?)ex.StatusCode;
-        return statusCode is not null && RetryableStatusCodes.Contains(statusCode.Value);
-#else
-        // On netstandard2.0, HttpRequestException doesn't have StatusCode.
-        // Use message heuristic to avoid retrying non-retryable errors like 401/403.
-        var msg = ex.Message;
-        if (msg.Contains("401") || msg.Contains("403") ||
-            msg.Contains("Unauthorized") || msg.Contains("Forbidden"))
-        {
-            return false;
-        }
+    /// <summary>
+    /// Only transient failures are worth retrying. Anything else — an unavailable artifact API (404),
+    /// a bad token (401/403), a malformed request (400) — fails identically on every attempt, so
+    /// retrying just adds the full backoff schedule to the run time before the same error surfaces.
+    /// </summary>
+    internal static bool IsRetryable(int? statusCode) =>
+        statusCode is not null && RetryableStatusCodes.Contains(statusCode.Value);
 
-        return true;
-#endif
+    /// <summary>
+    /// Carries the HTTP status code across all target frameworks —
+    /// <see cref="HttpRequestException"/> only exposes <c>StatusCode</c> on .NET 5+.
+    /// </summary>
+    private sealed class ArtifactUploadException(string message, int statusCode) : Exception(message)
+    {
+        public int StatusCode { get; } = statusCode;
     }
 }

--- a/tests/TUnit.Engine.Tests/GitHubArtifactUploaderTests.cs
+++ b/tests/TUnit.Engine.Tests/GitHubArtifactUploaderTests.cs
@@ -47,6 +47,37 @@ public class GitHubArtifactUploaderTests
     }
 
     [Test]
+    [Arguments(408)]
+    [Arguments(429)]
+    [Arguments(500)]
+    [Arguments(502)]
+    [Arguments(503)]
+    [Arguments(504)]
+    public void IsRetryable_Is_True_For_Transient_Status_Codes(int statusCode)
+    {
+        GitHubArtifactUploader.IsRetryable(statusCode).ShouldBeTrue();
+    }
+
+    [Test]
+    [Arguments(400)]
+    [Arguments(401)]
+    [Arguments(403)]
+    // 404 is what GitHub Enterprise Server returns — the artifact API doesn't exist there
+    [Arguments(404)]
+    [Arguments(422)]
+    [Arguments(501)]
+    public void IsRetryable_Is_False_For_Non_Retryable_Status_Codes(int statusCode)
+    {
+        GitHubArtifactUploader.IsRetryable(statusCode).ShouldBeFalse();
+    }
+
+    [Test]
+    public void IsRetryable_Is_False_When_No_Status_Code()
+    {
+        GitHubArtifactUploader.IsRetryable(null).ShouldBeFalse();
+    }
+
+    [Test]
     public void ComputeExpiresAt_Ignores_NonPositive_Repository_Maximum()
     {
         var result = GitHubArtifactUploader.ComputeExpiresAt(10, maxRetentionDays: 0, FixedUtcNow);


### PR DESCRIPTION
## Description

Follow-up to discussion #6448 (GitHub Enterprise Server users waiting ~30s for the HTML report artifact upload to fail).

GHES doesn't implement the Actions Results artifact API that `actions/upload-artifact@v4+` — and TUnit's in-process uploader — depend on, so `CreateArtifact` returns **404**. That should fail immediately, but on `netstandard2.0` it didn't:

```csharp
// HttpRequestException has no StatusCode on netstandard2.0, so we guessed from the message
if (msg.Contains("401") || msg.Contains("403") || ...) return false;
return true;   // <-- 404 lands here
```

A 404 was therefore treated as retryable and burned the whole 5-attempt backoff schedule (3s → 4.5s → 6.75s → 10.1s, plus jitter ≈ 25-30s) before surfacing the identical error.

## Changes

- Added `ArtifactUploadException`, which carries the HTTP status code on **every** target framework. `EnsureSuccessAsync` throws it instead of `HttpRequestException`, removing both the `#if NET` split and the string heuristic.
- `IsRetryable(int?)` is now an allowlist of genuinely transient codes: `408, 429, 500, 502, 503, 504` (408 is new). Everything else — 404, 401, 403, 400, 422 — fails on the first attempt.
- 404 responses include a hint that the artifact API is unavailable on this host, which is expected on GitHub Enterprise Server.
- Non-retryable failures still propagate out of `UploadAsync`, so the `CreateArtifact` name-dedup loop doesn't re-issue the same doomed request three times. `HtmlReporter` catches and warns exactly as before.

Complements #6447 rather than replacing it — that flag is still the way to skip the upload entirely; this makes the un-flagged path cost one request instead of five.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

14 new `IsRetryable` cases in `TUnit.Engine.Tests/GitHubArtifactUploaderTests.cs` covering the transient allowlist, the non-retryable codes (incl. the GHES 404), and the no-status case. 20/20 pass on net10.0.

No source generator or public API surface touched, so no snapshot updates required.
