### PR TITLE
feat: expose data source attributes on TestContext

### DIFF
--- a/docs/docs/writing-tests/test-context.md
+++ b/docs/docs/writing-tests/test-context.md
@@ -103,6 +103,46 @@ public class MyTestClass
 }
 ```
 
+## Data Source Attributes
+
+The context exposes the data source attribute instances that generated the current test's arguments:
+
+- `ClassDataSource` — the attribute that generated the test class's constructor arguments
+- `MethodDataSource` — the attribute that generated the test method's arguments
+
+Both are never null: for tests without a data source they return a no-op `NoDataSource` singleton, so you can pattern-match without null checks.
+
+This is useful when a fixture needs to know how it was shared. For example, a fixture can read its own `Shared` scope and `Key` during `InitializeAsync`:
+
+```csharp
+public class MyFixture : IAsyncInitializer
+{
+    public Task InitializeAsync()
+    {
+        if (TestContext.Current?.MethodDataSource is ClassDataSourceAttribute<MyFixture> attribute)
+        {
+            var sharedType = attribute.Shared; // e.g. SharedType.Keyed
+            var key = attribute.Key;           // e.g. "MyKey"
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public class MyTests
+{
+    [Test]
+    [ClassDataSource<MyFixture>(Shared = SharedType.Keyed, Key = "MyKey")]
+    public void MyTest(MyFixture fixture)
+    {
+    }
+}
+```
+
+Note that shared fixtures (`PerTestSession`, `PerClass`, `Keyed`, etc.) are initialized once, by the first test that uses them — inside `InitializeAsync`, `TestContext.Current` refers to that first test.
+
+If you only need the sharing key, implementing `IKeyedDataSource` on the fixture is a simpler alternative: TUnit sets its `Key` property before `InitializeAsync` is called.
+
 ## Dependency Injection
 
 **Note**: `TestContext` does NOT provide direct access to dependency injection services. The internal service provider in `TestContext` is exclusively for TUnit framework services and is not meant for user-provided dependencies.

--- a/docs/docs/writing-tests/test-context.md
+++ b/docs/docs/writing-tests/test-context.md
@@ -107,8 +107,8 @@ public class MyTestClass
 
 The context exposes the data source attribute instances that generated the current test's arguments:
 
-- `ClassDataSource` — the attribute that generated the test class's constructor arguments
-- `MethodDataSource` — the attribute that generated the test method's arguments
+- `Metadata.ClassDataSource` — the attribute that generated the test class's constructor arguments
+- `Metadata.MethodDataSource` — the attribute that generated the test method's arguments
 
 Both are never null: for tests without a data source they return a no-op `NoDataSource` singleton, so you can pattern-match without null checks.
 
@@ -119,7 +119,7 @@ public class MyFixture : IAsyncInitializer
 {
     public Task InitializeAsync()
     {
-        if (TestContext.Current?.MethodDataSource is ClassDataSourceAttribute<MyFixture> attribute)
+        if (TestContext.Current?.Metadata.MethodDataSource is ClassDataSourceAttribute<MyFixture> attribute)
         {
             var sharedType = attribute.Shared; // e.g. SharedType.Keyed
             var key = attribute.Key;           // e.g. "MyKey"

--- a/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
+++ b/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
@@ -14,7 +14,7 @@ public sealed class NoDataSource : IDataSourceAttribute
     private static readonly Task<object?[]?> _emptyRowTask = Task.FromResult<object?[]?>([]);
 
     /// <summary>
-    /// Gets the singleton instance.
+    /// Gets the singleton instance, shared process-wide across all tests.
     /// </summary>
     public static readonly NoDataSource Instance = new();
 
@@ -23,10 +23,12 @@ public sealed class NoDataSource : IDataSourceAttribute
     }
 
     /// <inheritdoc />
-    public bool SkipIfEmpty { get; set; }
+    /// <remarks>Always <c>false</c>. The setter is a no-op — this type is a shared singleton, so writes must not leak across tests.</remarks>
+    public bool SkipIfEmpty { get => false; set { } }
 
     /// <inheritdoc />
-    public bool DeferEnumeration { get; set; }
+    /// <remarks>Always <c>false</c>. The setter is a no-op — this type is a shared singleton, so writes must not leak across tests.</remarks>
+    public bool DeferEnumeration { get => false; set { } }
 
     public async IAsyncEnumerable<Func<Task<object?[]?>>> GetDataRowsAsync(DataGeneratorMetadata dataGeneratorMetadata)
     {

--- a/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
+++ b/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
@@ -1,9 +1,26 @@
-﻿namespace TUnit.Core;
+namespace TUnit.Core;
 
-internal class NoDataSource : IDataSourceAttribute
+/// <summary>
+/// No-op data source used for tests that have no data source. Yields a single empty data row
+/// so non-parameterized tests flow through the same building pipeline as data-driven tests.
+/// </summary>
+/// <remarks>
+/// <see cref="TestContext.ClassDataSource"/> and <see cref="TestContext.MethodDataSource"/> return
+/// <see cref="Instance"/> when the test has no class or method data source respectively, so callers
+/// can pattern-match with <c>is NoDataSource</c> instead of null-checking.
+/// </remarks>
+public sealed class NoDataSource : IDataSourceAttribute
 {
     private static readonly Task<object?[]?> _emptyRowTask = Task.FromResult<object?[]?>([]);
+
+    /// <summary>
+    /// Gets the singleton instance.
+    /// </summary>
     public static readonly NoDataSource Instance = new();
+
+    private NoDataSource()
+    {
+    }
 
     /// <inheritdoc />
     public bool SkipIfEmpty { get; set; }

--- a/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
+++ b/src/TUnit.Core/Attributes/TestData/NoDataSource.cs
@@ -5,9 +5,9 @@ namespace TUnit.Core;
 /// so non-parameterized tests flow through the same building pipeline as data-driven tests.
 /// </summary>
 /// <remarks>
-/// <see cref="TestContext.ClassDataSource"/> and <see cref="TestContext.MethodDataSource"/> return
-/// <see cref="Instance"/> when the test has no class or method data source respectively, so callers
-/// can pattern-match with <c>is NoDataSource</c> instead of null-checking.
+/// <see cref="Interfaces.ITestMetadata.ClassDataSource"/> and <see cref="Interfaces.ITestMetadata.MethodDataSource"/>
+/// (via <c>TestContext.Current.Metadata</c>) return <see cref="Instance"/> when the test has no class or
+/// method data source respectively, so callers can pattern-match with <c>is NoDataSource</c> instead of null-checking.
 /// </remarks>
 public sealed class NoDataSource : IDataSourceAttribute
 {

--- a/src/TUnit.Core/Interfaces/ITestMetadata.cs
+++ b/src/TUnit.Core/Interfaces/ITestMetadata.cs
@@ -34,4 +34,19 @@ public interface ITestMetadata
     /// Must implement IDisplayNameFormatter interface.
     /// </summary>
     Type? DisplayNameFormatter { get; set; }
+
+    /// <summary>
+    /// Gets the data source attribute instance that generated this test's class (constructor) arguments,
+    /// e.g. a <c>[ClassDataSource&lt;T&gt;]</c> applied to the test class. Never null — returns
+    /// <see cref="NoDataSource.Instance"/> when the test class has no constructor data source.
+    /// </summary>
+    IDataSourceAttribute ClassDataSource { get; }
+
+    /// <summary>
+    /// Gets the data source attribute instance that generated this test's method arguments,
+    /// e.g. an <c>[Arguments]</c>, <c>[MethodDataSource]</c> or <c>[ClassDataSource&lt;T&gt;]</c> applied
+    /// to the test method. Never null — returns <see cref="NoDataSource.Instance"/> when the test
+    /// method has no data source.
+    /// </summary>
+    IDataSourceAttribute MethodDataSource { get; }
 }

--- a/src/TUnit.Core/TestBuilderContext.cs
+++ b/src/TUnit.Core/TestBuilderContext.cs
@@ -93,7 +93,7 @@ public record TestBuilderContext
             Events = testContext.InternalEvents,
             TestMetadata = testContext.Metadata.TestDetails.MethodMetadata,
             DataSourceAttribute = dataSourceAttribute,
-            ClassDataSourceAttribute = testContext.ClassDataSource,
+            ClassDataSourceAttribute = testContext.Metadata.ClassDataSource,
             StateBag = testContext.StateBag.Items,
             ClassConstructor = testContext.ClassConstructor,
         };

--- a/src/TUnit.Core/TestBuilderContext.cs
+++ b/src/TUnit.Core/TestBuilderContext.cs
@@ -55,7 +55,15 @@ public record TestBuilderContext
         set => _events = value;
     }
 
+    /// <summary>
+    /// Gets or sets the data source attribute that generated the test's method arguments, if any.
+    /// </summary>
     public IDataSourceAttribute? DataSourceAttribute { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data source attribute that generated the test's class (constructor) arguments, if any.
+    /// </summary>
+    public IDataSourceAttribute? ClassDataSourceAttribute { get; set; }
 
     /// <summary>
     /// Gets the test method information, if available during source generation.
@@ -85,6 +93,7 @@ public record TestBuilderContext
             Events = testContext.InternalEvents,
             TestMetadata = testContext.Metadata.TestDetails.MethodMetadata,
             DataSourceAttribute = dataSourceAttribute,
+            ClassDataSourceAttribute = testContext.ClassDataSource,
             StateBag = testContext.StateBag.Items,
             ClassConstructor = testContext.ClassConstructor,
         };

--- a/src/TUnit.Core/TestContext.Metadata.cs
+++ b/src/TUnit.Core/TestContext.Metadata.cs
@@ -74,6 +74,21 @@ public partial class TestContext
         _cachedDisplayName = null;
     }
 
+    /// <summary>
+    /// Gets the data source attribute instance that generated this test's class (constructor) arguments,
+    /// e.g. a <c>[ClassDataSource&lt;T&gt;]</c> applied to the test class. Never null — returns
+    /// <see cref="NoDataSource.Instance"/> when the test class has no constructor data source.
+    /// </summary>
+    public IDataSourceAttribute ClassDataSource => _testBuilderContext.ClassDataSourceAttribute ?? NoDataSource.Instance;
+
+    /// <summary>
+    /// Gets the data source attribute instance that generated this test's method arguments,
+    /// e.g. an <c>[Arguments]</c>, <c>[MethodDataSource]</c> or <c>[ClassDataSource&lt;T&gt;]</c> applied
+    /// to the test method. Never null — returns <see cref="NoDataSource.Instance"/> when the test
+    /// method has no data source.
+    /// </summary>
+    public IDataSourceAttribute MethodDataSource => _testBuilderContext.DataSourceAttribute ?? NoDataSource.Instance;
+
     string ITestMetadata.DefinitionId => _testBuilderContext.DefinitionId;
     TestDetails ITestMetadata.TestDetails
     {

--- a/src/TUnit.Core/TestContext.Metadata.cs
+++ b/src/TUnit.Core/TestContext.Metadata.cs
@@ -74,22 +74,11 @@ public partial class TestContext
         _cachedDisplayName = null;
     }
 
-    /// <summary>
-    /// Gets the data source attribute instance that generated this test's class (constructor) arguments,
-    /// e.g. a <c>[ClassDataSource&lt;T&gt;]</c> applied to the test class. Never null — returns
-    /// <see cref="NoDataSource.Instance"/> when the test class has no constructor data source.
-    /// </summary>
-    public IDataSourceAttribute ClassDataSource => _testBuilderContext.ClassDataSourceAttribute ?? NoDataSource.Instance;
-
-    /// <summary>
-    /// Gets the data source attribute instance that generated this test's method arguments,
-    /// e.g. an <c>[Arguments]</c>, <c>[MethodDataSource]</c> or <c>[ClassDataSource&lt;T&gt;]</c> applied
-    /// to the test method. Never null — returns <see cref="NoDataSource.Instance"/> when the test
-    /// method has no data source.
-    /// </summary>
-    public IDataSourceAttribute MethodDataSource => _testBuilderContext.DataSourceAttribute ?? NoDataSource.Instance;
-
     string ITestMetadata.DefinitionId => _testBuilderContext.DefinitionId;
+
+    IDataSourceAttribute ITestMetadata.ClassDataSource => _testBuilderContext.ClassDataSourceAttribute ?? NoDataSource.Instance;
+
+    IDataSourceAttribute ITestMetadata.MethodDataSource => _testBuilderContext.DataSourceAttribute ?? NoDataSource.Instance;
     TestDetails ITestMetadata.TestDetails
     {
         get => TestDetails;

--- a/src/TUnit.Engine/Building/TestBuilder.cs
+++ b/src/TUnit.Engine/Building/TestBuilder.cs
@@ -283,6 +283,7 @@ internal sealed class TestBuilder : ITestBuilder
                                     {
                                         TestMetadata = metadata.MethodMetadata,
                                         DataSourceAttribute = methodDataSource,
+                                        ClassDataSourceAttribute = classDataSource,
                                         InitializedAttributes = testBuilderContext.InitializedAttributes,
                                         ClassConstructor = testBuilderContext.ClassConstructor
                                     };
@@ -418,6 +419,7 @@ internal sealed class TestBuilder : ITestBuilder
                                         StateBag = contextAccessor.Current.StateBag,
                                         ClassConstructor = testBuilderContext.ClassConstructor,
                                         DataSourceAttribute = contextAccessor.Current.DataSourceAttribute,
+                                        ClassDataSourceAttribute = classDataSource,
                                         InitializedAttributes = attributes
                                     };
 
@@ -481,6 +483,7 @@ internal sealed class TestBuilder : ITestBuilder
                                         TestMetadata = metadata.MethodMetadata,
                                         ClassConstructor = testBuilderContext.ClassConstructor,
                                         DataSourceAttribute = methodDataSource,
+                                        ClassDataSourceAttribute = classDataSource,
                                         InitializedAttributes = attributes
                                     };
 
@@ -546,6 +549,7 @@ internal sealed class TestBuilder : ITestBuilder
                             TestMetadata = metadata.MethodMetadata,
                             ClassConstructor = testBuilderContext.ClassConstructor,
                             DataSourceAttribute = classDataSource,
+                            ClassDataSourceAttribute = classDataSource,
                             InitializedAttributes = attributes
                         };
 
@@ -1956,7 +1960,8 @@ internal sealed class TestBuilder : ITestBuilder
                 TestMetadata = metadata.MethodMetadata,
                 StateBag = contextAccessor.Current.StateBag,
                 ClassConstructor = contextAccessor.Current.ClassConstructor,
-                DataSourceAttribute = contextAccessor.Current.DataSourceAttribute,
+                DataSourceAttribute = methodDataSource ?? contextAccessor.Current.DataSourceAttribute,
+                ClassDataSourceAttribute = classDataSource ?? contextAccessor.Current.ClassDataSourceAttribute,
                 InitializedAttributes = attributes
             };
 

--- a/src/TUnit.Engine/Building/TestBuilder.cs
+++ b/src/TUnit.Engine/Building/TestBuilder.cs
@@ -544,11 +544,14 @@ internal sealed class TestBuilder : ITestBuilder
                             ResolvedMethodGenericArguments = Type.EmptyTypes
                         };
 
+                        // The class data source yielded no rows, so no method data source was ever
+                        // enumerated — only ClassDataSourceAttribute is populated. The class attribute
+                        // is already present in the initialized attributes (it is declared on the class),
+                        // so nothing is lost by leaving the method slot empty.
                         var testSpecificContext = new TestBuilderContext
                         {
                             TestMetadata = metadata.MethodMetadata,
                             ClassConstructor = testBuilderContext.ClassConstructor,
-                            DataSourceAttribute = classDataSource,
                             ClassDataSourceAttribute = classDataSource,
                             InitializedAttributes = attributes
                         };

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -205,6 +205,12 @@ internal class TestExecutor
             }
 #endif
 
+            // The session/assembly/class RestoreExecutionContext calls above replay AsyncLocals
+            // captured while the FIRST test in that scope ran its hooks — including that test's
+            // TestContext.Current. Re-point Current at this test before initializing objects so
+            // IAsyncInitializer implementations observe the correct test context.
+            TestContext.Current = executableTest.Context;
+
             // Initialize test objects (IAsyncInitializer) AFTER BeforeClass hooks
             // and after the test case activity starts. Per-test objects are traced
             // under the test case; shared objects under session/assembly/class.

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1052,6 +1052,14 @@ namespace
         [.("ReflectionAnalysis", "IL2067", Justification="Factory is only called from generated code that always passes concrete types")]
         public static .MethodMetadata Create(string name,  type,  returnType, .ClassMetadata classMetadata, int genericTypeCount = 0, .ParameterMetadata[]? parameters = null) { }
     }
+    public sealed class NoDataSource : .IDataSourceAttribute
+    {
+        public static readonly .NoDataSource Instance;
+        public bool DeferEnumeration { get; set; }
+        public bool SkipIfEmpty { get; set; }
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
+    }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]
     public class NotDiscoverableAttribute : .TUnitAttribute, ., .
     {
@@ -1362,6 +1370,7 @@ namespace
     public class TestBuilderContext : <.TestBuilderContext>
     {
         public TestBuilderContext() { }
+        public .IDataSourceAttribute? ClassDataSourceAttribute { get; set; }
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
@@ -1396,6 +1405,7 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
+        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1403,6 +1413,7 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
+        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1405,7 +1405,6 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
-        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1413,7 +1412,6 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
-        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }
@@ -2730,9 +2728,11 @@ namespace .Interfaces
     }
     public interface ITestMetadata
     {
+        .IDataSourceAttribute ClassDataSource { get; }
         string DefinitionId { get; }
         string DisplayName { get; set; }
         ? DisplayNameFormatter { get; set; }
+        .IDataSourceAttribute MethodDataSource { get; }
         .TestDetails TestDetails { get; }
         string TestName { get; }
     }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1057,7 +1057,7 @@ namespace
         public static readonly .NoDataSource Instance;
         public bool DeferEnumeration { get; set; }
         public bool SkipIfEmpty { get; set; }
-        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__9))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1052,6 +1052,14 @@ namespace
         [.("ReflectionAnalysis", "IL2067", Justification="Factory is only called from generated code that always passes concrete types")]
         public static .MethodMetadata Create(string name,  type,  returnType, .ClassMetadata classMetadata, int genericTypeCount = 0, .ParameterMetadata[]? parameters = null) { }
     }
+    public sealed class NoDataSource : .IDataSourceAttribute
+    {
+        public static readonly .NoDataSource Instance;
+        public bool DeferEnumeration { get; set; }
+        public bool SkipIfEmpty { get; set; }
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
+    }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]
     public class NotDiscoverableAttribute : .TUnitAttribute, ., .
     {
@@ -1362,6 +1370,7 @@ namespace
     public class TestBuilderContext : <.TestBuilderContext>
     {
         public TestBuilderContext() { }
+        public .IDataSourceAttribute? ClassDataSourceAttribute { get; set; }
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
@@ -1396,6 +1405,7 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
+        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1403,6 +1413,7 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
+        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1405,7 +1405,6 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
-        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1413,7 +1412,6 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
-        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }
@@ -2730,9 +2728,11 @@ namespace .Interfaces
     }
     public interface ITestMetadata
     {
+        .IDataSourceAttribute ClassDataSource { get; }
         string DefinitionId { get; }
         string DisplayName { get; set; }
         ? DisplayNameFormatter { get; set; }
+        .IDataSourceAttribute MethodDataSource { get; }
         .TestDetails TestDetails { get; }
         string TestName { get; }
     }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1057,7 +1057,7 @@ namespace
         public static readonly .NoDataSource Instance;
         public bool DeferEnumeration { get; set; }
         public bool SkipIfEmpty { get; set; }
-        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__9))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1052,6 +1052,14 @@ namespace
         [.("ReflectionAnalysis", "IL2067", Justification="Factory is only called from generated code that always passes concrete types")]
         public static .MethodMetadata Create(string name,  type,  returnType, .ClassMetadata classMetadata, int genericTypeCount = 0, .ParameterMetadata[]? parameters = null) { }
     }
+    public sealed class NoDataSource : .IDataSourceAttribute
+    {
+        public static readonly .NoDataSource Instance;
+        public bool DeferEnumeration { get; set; }
+        public bool SkipIfEmpty { get; set; }
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
+    }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]
     public class NotDiscoverableAttribute : .TUnitAttribute, ., .
     {
@@ -1362,6 +1370,7 @@ namespace
     public class TestBuilderContext : <.TestBuilderContext>
     {
         public TestBuilderContext() { }
+        public .IDataSourceAttribute? ClassDataSourceAttribute { get; set; }
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
@@ -1396,6 +1405,7 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
+        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1403,6 +1413,7 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
+        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1405,7 +1405,6 @@ namespace
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public new .Activity? Activity { get; }
         public .ClassHookContext ClassContext { get; }
-        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1413,7 +1412,6 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
-        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }
@@ -2730,9 +2728,11 @@ namespace .Interfaces
     }
     public interface ITestMetadata
     {
+        .IDataSourceAttribute ClassDataSource { get; }
         string DefinitionId { get; }
         string DisplayName { get; set; }
         ? DisplayNameFormatter { get; set; }
+        .IDataSourceAttribute MethodDataSource { get; }
         .TestDetails TestDetails { get; }
         string TestName { get; }
     }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1057,7 +1057,7 @@ namespace
         public static readonly .NoDataSource Instance;
         public bool DeferEnumeration { get; set; }
         public bool SkipIfEmpty { get; set; }
-        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__9))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1014,6 +1014,14 @@ namespace
     {
         public static .MethodMetadata Create(string name,  type,  returnType, .ClassMetadata classMetadata, int genericTypeCount = 0, .ParameterMetadata[]? parameters = null) { }
     }
+    public sealed class NoDataSource : .IDataSourceAttribute
+    {
+        public static readonly .NoDataSource Instance;
+        public bool DeferEnumeration { get; set; }
+        public bool SkipIfEmpty { get; set; }
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
+    }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]
     public class NotDiscoverableAttribute : .TUnitAttribute, ., .
     {
@@ -1307,6 +1315,7 @@ namespace
     public class TestBuilderContext : <.TestBuilderContext>
     {
         public TestBuilderContext() { }
+        public .IDataSourceAttribute? ClassDataSourceAttribute { get; set; }
         public .IDataSourceAttribute? DataSourceAttribute { get; set; }
         public string DefinitionId { get; }
         public .TestContextEvents Events { get; set; }
@@ -1340,6 +1349,7 @@ namespace
     {
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public .ClassHookContext ClassContext { get; }
+        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1347,6 +1357,7 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
+        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1019,7 +1019,7 @@ namespace
         public static readonly .NoDataSource Instance;
         public bool DeferEnumeration { get; set; }
         public bool SkipIfEmpty { get; set; }
-        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__11))]
+        [.(typeof(.NoDataSource.<GetDataRowsAsync>d__9))]
         public .<<.<object?[]?>>> GetDataRowsAsync(.DataGeneratorMetadata dataGeneratorMetadata) { }
     }
     [(.Assembly | .Class | .Method, AllowMultiple=false, Inherited=true)]

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1349,7 +1349,6 @@ namespace
     {
         public TestContext(string testName,  serviceProvider, .ClassHookContext classContext, .TestBuilderContext testBuilderContext, .CancellationToken cancellationToken) { }
         public .ClassHookContext ClassContext { get; }
-        public .IDataSourceAttribute ClassDataSource { get; }
         public . Dependencies { get; }
         public . Events { get; }
         public . Execution { get; }
@@ -1357,7 +1356,6 @@ namespace
         public . Isolation { get; }
         public object Lock { get; }
         public . Metadata { get; }
-        public .IDataSourceAttribute MethodDataSource { get; }
         public . Output { get; }
         public . Parallelism { get; }
         public . StateBag { get; }
@@ -2661,9 +2659,11 @@ namespace .Interfaces
     }
     public interface ITestMetadata
     {
+        .IDataSourceAttribute ClassDataSource { get; }
         string DefinitionId { get; }
         string DisplayName { get; set; }
         ? DisplayNameFormatter { get; set; }
+        .IDataSourceAttribute MethodDataSource { get; }
         .TestDetails TestDetails { get; }
         string TestName { get; }
     }

--- a/tests/TUnit.TestProject/TestContextDataSourceAttributeTests.cs
+++ b/tests/TUnit.TestProject/TestContextDataSourceAttributeTests.cs
@@ -9,23 +9,23 @@ public class TestContextDataSourceAttributeTests
     [Test]
     public async Task NonDataTest_Returns_NoOp_Singletons()
     {
-        await Assert.That(TestContext.Current!.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
-        await Assert.That(TestContext.Current!.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(TestContext.Current!.Metadata.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(TestContext.Current!.Metadata.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
     }
 
     [Test]
     [Arguments(1)]
     public async Task ArgumentsTest_Exposes_ArgumentsAttribute(int value)
     {
-        await Assert.That(TestContext.Current!.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
-        await Assert.That(TestContext.Current!.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(TestContext.Current!.Metadata.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
+        await Assert.That(TestContext.Current!.Metadata.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
     }
 
     [Test]
     [ClassDataSource<KeyedFixture>(Shared = SharedType.Keyed, Key = "MyKey")]
     public async Task MethodLevel_ClassDataSource_Exposes_Shared_And_Key(KeyedFixture fixture)
     {
-        var attribute = TestContext.Current!.MethodDataSource as ClassDataSourceAttribute<KeyedFixture>;
+        var attribute = TestContext.Current!.Metadata.MethodDataSource as ClassDataSourceAttribute<KeyedFixture>;
 
         await Assert.That(attribute).IsNotNull();
         await Assert.That(attribute!.Shared).IsEqualTo(SharedType.Keyed);
@@ -49,7 +49,7 @@ public class TestContextDataSourceAttributeTests
 
         public Task InitializeAsync()
         {
-            var attribute = TestContext.Current?.MethodDataSource as ClassDataSourceAttribute<SharedTypeAwareFixture>;
+            var attribute = TestContext.Current?.Metadata.MethodDataSource as ClassDataSourceAttribute<SharedTypeAwareFixture>;
 
             ObservedShared = attribute?.Shared;
             ObservedKey = attribute?.Key;
@@ -66,11 +66,11 @@ public class TestContextConstructorDataSourceTests(TestContextConstructorDataSou
     [Test]
     public async Task ConstructorInjected_Exposes_ClassDataSource()
     {
-        var attribute = TestContext.Current!.ClassDataSource as ClassDataSourceAttribute<ConstructorFixture>;
+        var attribute = TestContext.Current!.Metadata.ClassDataSource as ClassDataSourceAttribute<ConstructorFixture>;
 
         await Assert.That(attribute).IsNotNull();
         await Assert.That(attribute!.Shared).IsEqualTo(SharedType.PerClass);
-        await Assert.That(TestContext.Current!.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(TestContext.Current!.Metadata.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
         await Assert.That(fixture).IsNotNull();
     }
 
@@ -78,8 +78,8 @@ public class TestContextConstructorDataSourceTests(TestContextConstructorDataSou
     [Arguments(42)]
     public async Task ConstructorInjected_With_MethodArguments_Exposes_Both(int value)
     {
-        await Assert.That(TestContext.Current!.ClassDataSource).IsTypeOf<ClassDataSourceAttribute<ConstructorFixture>>();
-        await Assert.That(TestContext.Current!.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
+        await Assert.That(TestContext.Current!.Metadata.ClassDataSource).IsTypeOf<ClassDataSourceAttribute<ConstructorFixture>>();
+        await Assert.That(TestContext.Current!.Metadata.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
     }
 
     public class ConstructorFixture;

--- a/tests/TUnit.TestProject/TestContextDataSourceAttributeTests.cs
+++ b/tests/TUnit.TestProject/TestContextDataSourceAttributeTests.cs
@@ -1,0 +1,86 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Pass)]
+public class TestContextDataSourceAttributeTests
+{
+    [Test]
+    public async Task NonDataTest_Returns_NoOp_Singletons()
+    {
+        await Assert.That(TestContext.Current!.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(TestContext.Current!.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
+    }
+
+    [Test]
+    [Arguments(1)]
+    public async Task ArgumentsTest_Exposes_ArgumentsAttribute(int value)
+    {
+        await Assert.That(TestContext.Current!.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
+        await Assert.That(TestContext.Current!.ClassDataSource).IsSameReferenceAs(NoDataSource.Instance);
+    }
+
+    [Test]
+    [ClassDataSource<KeyedFixture>(Shared = SharedType.Keyed, Key = "MyKey")]
+    public async Task MethodLevel_ClassDataSource_Exposes_Shared_And_Key(KeyedFixture fixture)
+    {
+        var attribute = TestContext.Current!.MethodDataSource as ClassDataSourceAttribute<KeyedFixture>;
+
+        await Assert.That(attribute).IsNotNull();
+        await Assert.That(attribute!.Shared).IsEqualTo(SharedType.Keyed);
+        await Assert.That(attribute.Key).IsEqualTo("MyKey");
+    }
+
+    [Test]
+    [ClassDataSource<SharedTypeAwareFixture>(Shared = SharedType.Keyed, Key = "InitKey")]
+    public async Task Fixture_Can_Read_Own_Sharing_Scope_In_InitializeAsync(SharedTypeAwareFixture fixture)
+    {
+        await Assert.That(fixture.ObservedShared).IsEqualTo(SharedType.Keyed);
+        await Assert.That(fixture.ObservedKey).IsEqualTo("InitKey");
+    }
+
+    public class KeyedFixture;
+
+    public class SharedTypeAwareFixture : IAsyncInitializer
+    {
+        public SharedType? ObservedShared { get; private set; }
+        public string? ObservedKey { get; private set; }
+
+        public Task InitializeAsync()
+        {
+            var attribute = TestContext.Current?.MethodDataSource as ClassDataSourceAttribute<SharedTypeAwareFixture>;
+
+            ObservedShared = attribute?.Shared;
+            ObservedKey = attribute?.Key;
+
+            return Task.CompletedTask;
+        }
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[ClassDataSource<TestContextConstructorDataSourceTests.ConstructorFixture>(Shared = SharedType.PerClass)]
+public class TestContextConstructorDataSourceTests(TestContextConstructorDataSourceTests.ConstructorFixture fixture)
+{
+    [Test]
+    public async Task ConstructorInjected_Exposes_ClassDataSource()
+    {
+        var attribute = TestContext.Current!.ClassDataSource as ClassDataSourceAttribute<ConstructorFixture>;
+
+        await Assert.That(attribute).IsNotNull();
+        await Assert.That(attribute!.Shared).IsEqualTo(SharedType.PerClass);
+        await Assert.That(TestContext.Current!.MethodDataSource).IsSameReferenceAs(NoDataSource.Instance);
+        await Assert.That(fixture).IsNotNull();
+    }
+
+    [Test]
+    [Arguments(42)]
+    public async Task ConstructorInjected_With_MethodArguments_Exposes_Both(int value)
+    {
+        await Assert.That(TestContext.Current!.ClassDataSource).IsTypeOf<ClassDataSourceAttribute<ConstructorFixture>>();
+        await Assert.That(TestContext.Current!.MethodDataSource).IsTypeOf<ArgumentsAttribute>();
+    }
+
+    public class ConstructorFixture;
+}


### PR DESCRIPTION
## Summary

Implements the ask from discussion #6476: data source metadata is now reachable from `TestContext`.

- **`TestContext.Metadata.ClassDataSource`** — the data source attribute instance that generated the test class's constructor arguments
- **`TestContext.Metadata.MethodDataSource`** — the data source attribute instance that generated the test method's arguments
- Both are **never null**: tests without a data source get the `NoDataSource` no-op singleton (now `public sealed` with a private constructor), so callers can pattern-match instead of null-checking

This lets a fixture discover its own sharing scope from `IAsyncInitializer.InitializeAsync`:

```csharp
if (TestContext.Current?.Metadata.MethodDataSource is ClassDataSourceAttribute<MyFixture> attr)
{
    var shared = attr.Shared; // SharedType.Keyed
    var key = attr.Key;       // "MyKey"
}
```

## Engine bug found & fixed along the way

While validating, the new `Fixture_Can_Read_Own_Sharing_Scope_In_InitializeAsync` test was flaky: the fixture's `InitializeAsync` intermittently observed a **sibling test's** `TestContext.Current`.

Root cause (pre-existing): in `TestExecutor.ExecuteAsync`, the session/assembly/class `RestoreExecutionContext()` calls replay AsyncLocals captured while the *first* test in that scope ran its hooks — including that test's `TestContext.Current`. Object initialization (`InitializeTestObjectsAsync`) ran *before* the test's own `RestoreExecutionContext()`, so `IAsyncInitializer` implementations reading `TestContext.Current` could see whichever test triggered the class hooks. Fixed by re-pointing `TestContext.Current` at the executing test before initialization. Stress-ran the suite 10x with zero failures (was failing ~1 in 3 runs before).

## Plumbing

- `TestBuilderContext` gains `ClassDataSourceAttribute`; `TestBuilder` populates it at all context-creation sites (batch, streaming, and skip paths). The existing `DataSourceAttribute` slot (method-level) is unchanged.
- The streaming `BuildSingleTestAsync` path now uses its explicit `classDataSource`/`methodDataSource` parameters (previously the context slot was left null there).

## Testing

- New `TestContextDataSourceAttributeTests` + `TestContextConstructorDataSourceTests` (6 tests) — pass in **both source-gen and reflection modes**, stress-ran 10x
- `/*/*/TestContext*/*` slice (48 tests): pass in both modes
- `/*/*/*Hook*/*` slice (115 tests): identical results to main (26 intentional failures, byte-for-byte same counts)
- `/*/*/ClassDataSource*/*` slice: identical results to main (3 pre-existing order-dependent failures under this filter, reproduced on main)
- Public API snapshots regenerated for all 4 TFMs (additions only)

## Docs

Added a "Data Source Attributes" section to `docs/docs/writing-tests/test-context.md`, including the shared-fixture caveat (shared fixtures initialize once, under the first consuming test's context) and a pointer to `IKeyedDataSource` for the key-only case.

Closes #6476
