### PR TITLE
fix(docs): make Mermaid lifecycle diagrams readable

### DIFF
--- a/docs/docs/writing-tests/lifecycle.md
+++ b/docs/docs/writing-tests/lifecycle.md
@@ -9,78 +9,54 @@ TUnit provides multiple mechanisms for hooking into the test lifecycle:
 
 ## Complete Lifecycle Diagram
 
+Discovery runs first, then every test executes inside nested scopes:
+
+```mermaid
+flowchart LR
+    Discovery["Discovery"] --> Session["Test Session"] --> Assembly["Assembly"] --> Class["Class"] --> Test["Test"]
+```
+
+`[Before]` hooks run outermost first (session → assembly → class → test), and `[After]` hooks
+unwind in the opposite order:
+
 ```mermaid
 flowchart TB
-    subgraph Discovery["1. Discovery Phase"]
-        direction TB
-        D1["[Before(TestDiscovery)]"]
-        D2["Scan assemblies for [Test] methods"]
-        D3["Create data sources & resolve property values"]
-        D3a["IAsyncDiscoveryInitializer.InitializeAsync()"]
-        D4["[After(TestDiscovery)]"]
-        D5["ITestRegisteredEventReceiver.OnTestRegistered()"]
-        D1 --> D2 --> D3 --> D3a --> D4 --> D5
-    end
+    D1["[Before(TestDiscovery)]"]
+    D2["Scan assemblies · create data sources · IAsyncDiscoveryInitializer"]
+    D3["[After(TestDiscovery)] · ITestRegisteredEventReceiver"]
+    S1["[Before(TestSession)] · IFirstTestInTestSessionEventReceiver"]
+    A1["[BeforeEvery(Assembly)] / [Before(Assembly)] · IFirstTestInAssemblyEventReceiver"]
+    C1["[BeforeEvery(Class)] / [Before(Class)] · IFirstTestInClassEventReceiver"]
+    T["Per-test flow — see Phase 2"]
+    C2["ILastTestInClassEventReceiver · [After(Class)] / [AfterEvery(Class)]"]
+    A2["ILastTestInAssemblyEventReceiver · [After(Assembly)] / [AfterEvery(Assembly)]"]
+    S2["ILastTestInTestSessionEventReceiver · [After(TestSession)]"]
 
-    subgraph Session["2. Test Session Execution"]
-        direction TB
-        S1["[Before(TestSession)]"]
-        S1a["IFirstTestInTestSessionEventReceiver"]
+    D1 --> D2 --> D3 --> S1 --> A1 --> C1 --> T --> C2 --> A2 --> S2
 
-        subgraph Assembly["Per Assembly"]
-            direction TB
-            A1["[BeforeEvery(Assembly)] / [Before(Assembly)]"]
-            A1a["IFirstTestInAssemblyEventReceiver"]
+    style T fill:#c8e6c9,stroke:#2e7d32,color:#1b5e20
+```
 
-            subgraph Class["Per Class"]
-                direction TB
-                C1["[BeforeEvery(Class)] / [Before(Class)]"]
-                C1a["IFirstTestInClassEventReceiver"]
+Everything inside a single test — construction, initialization, hooks, body and disposal:
 
-                subgraph Test["Per Test Execution"]
-                    direction TB
-                    T0["Create test class instance (constructor)"]
-                    T0a["Set injected property values on instance"]
-                    T0b["IAsyncInitializer.InitializeAsync()"]
-                    T1["[BeforeEvery(Test)]"]
-                    T1a["ITestStartEventReceiver (Early)"]
-                    T2["[Before(Test)]"]
-                    T2a["ITestStartEventReceiver (Late)"]
-                    T3["Test Body"]
-                    T3a["ITestEndEventReceiver (Early)"]
-                    T4["[After(Test)]"]
-                    T4a["ITestEndEventReceiver (Late)"]
-                    T5["[AfterEvery(Test)]"]
-                    T6["IDisposable / IAsyncDisposable"]
-                    T7["Cleanup tracked objects"]
+```mermaid
+flowchart TB
+    T0["Create test class instance (constructor)"]
+    T0a["Set injected property values on instance"]
+    T0b["IAsyncInitializer.InitializeAsync()"]
+    T1["[BeforeEvery(Test)] · ITestStartEventReceiver (Early)"]
+    T2["[Before(Test)] · ITestStartEventReceiver (Late)"]
+    T3["Test Body"]
+    T4["ITestEndEventReceiver (Early) · [After(Test)]"]
+    T5["ITestEndEventReceiver (Late) · [AfterEvery(Test)]"]
+    T6["IDisposable / IAsyncDisposable"]
+    T7["Cleanup tracked objects"]
 
-                    T0 --> T0a --> T0b --> T1
-                    T1 --> T1a --> T2 --> T2a --> T3
-                    T3 --> T3a --> T4 --> T4a --> T5 --> T6 --> T7
-                end
+    T0 --> T0a --> T0b --> T1 --> T2 --> T3 --> T4 --> T5 --> T6 --> T7
 
-                C2a["ILastTestInClassEventReceiver"]
-                C2["[After(Class)] / [AfterEvery(Class)]"]
-                C1 --> C1a --> Test --> C2a --> C2
-            end
-
-            A2a["ILastTestInAssemblyEventReceiver"]
-            A2["[After(Assembly)] / [AfterEvery(Assembly)]"]
-            A1 --> A1a --> Class --> A2a --> A2
-        end
-
-        S2a["ILastTestInTestSessionEventReceiver"]
-        S2["[After(TestSession)]"]
-        S1 --> S1a --> Assembly --> S2a --> S2
-    end
-
-    Discovery --> Session
-
-    style D2 fill:#e1f5fe
-    style D3a fill:#fff3e0
-    style T0b fill:#fff3e0
-    style T3 fill:#c8e6c9
-    style T6 fill:#ffcdd2
+    style T0b fill:#fff3e0,stroke:#ef6c00,color:#e65100
+    style T3 fill:#c8e6c9,stroke:#2e7d32,color:#1b5e20
+    style T6 fill:#ffcdd2,stroke:#c62828,color:#b71c1c
 ```
 
 ## Phase 1: Test Discovery
@@ -136,16 +112,14 @@ Use `IAsyncDiscoveryInitializer` when your data source needs async initializatio
 sequenceDiagram
     participant Engine as TUnit Engine
     participant Instance as Test Instance
-    participant Init as Initializers
     participant Hooks as Hook Attributes
     participant Events as Event Receivers
-    participant Dispose as Disposal
 
     Note over Engine: After BeforeClass hooks...
 
-    Engine->>Instance: Create test class instance (constructor)
-    Engine->>Instance: Set cached property values on instance
-    Engine->>Init: IAsyncInitializer.InitializeAsync() for all tracked objects
+    Engine->>Instance: Create instance (constructor)
+    Engine->>Instance: Set cached property values
+    Engine->>Instance: IAsyncInitializer.InitializeAsync()
 
     Engine->>Hooks: [BeforeEvery(Test)]
     Engine->>Events: ITestStartEventReceiver (Early)
@@ -159,8 +133,8 @@ sequenceDiagram
     Engine->>Events: ITestEndEventReceiver (Late)
     Engine->>Hooks: [AfterEvery(Test)]
 
-    Engine->>Dispose: IAsyncDisposable.DisposeAsync() / IDisposable.Dispose()
-    Engine->>Engine: Cleanup tracked objects (decrement ref counts, dispose if 0)
+    Engine->>Instance: DisposeAsync() / Dispose()
+    Engine->>Engine: Cleanup tracked objects (dispose at ref count 0)
 ```
 
 ### Complete Test Execution Order
@@ -244,19 +218,23 @@ flowchart TB
 ```mermaid
 flowchart LR
     subgraph AfterTest["After Each Test"]
+        direction TB
         A1["[After(Test)]"]
         A2["[AfterEvery(Test)]"]
-        A3["Test Instance: IAsyncDisposable / IDisposable"]
+        A3["Test Instance:<br/>IAsyncDisposable / IDisposable"]
+        A1 --> A2 --> A3
     end
 
     subgraph AfterScope["After Scope Ends"]
+        direction TB
         B1["Tracked objects with ref count = 0"]
-        B2["SharedType.PerClass objects after last test in class"]
-        B3["SharedType.PerAssembly objects after last test in assembly"]
-        B4["SharedType.PerTestSession objects after session"]
+        B2["SharedType.PerClass<br/>after last test in class"]
+        B3["SharedType.PerAssembly<br/>after last test in assembly"]
+        B4["SharedType.PerTestSession<br/>after session"]
+        B1 ~~~ B2 ~~~ B3 ~~~ B4
     end
 
-    A1 --> A2 --> A3 --> B1
+    AfterTest --> AfterScope
 ```
 
 ### Disposal by Sharing Type
@@ -322,17 +300,21 @@ For `ITestStartEventReceiver` and `ITestEndEventReceiver`:
 ```mermaid
 flowchart LR
     subgraph TestStart["Test Start"]
+        direction TB
         A1["[BeforeEvery(Test)]"]
         A2["ITestStartEventReceiver (Early)"]
         A3["[Before(Test)]"]
         A4["ITestStartEventReceiver (Late)"]
+        A1 --> A2 --> A3 --> A4
     end
 
     subgraph TestEnd["Test End"]
+        direction TB
         B1["ITestEndEventReceiver (Early)"]
         B2["[After(Test)]"]
         B3["ITestEndEventReceiver (Late)"]
         B4["[AfterEvery(Test)]"]
+        B1 --> B2 --> B3 --> B4
     end
 
     TestStart --> TestEnd

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -92,6 +92,15 @@ const config: Config = {
   themes: ['@docusaurus/theme-mermaid'],
 
   themeConfig: {
+    mermaid: {
+      options: {
+        // Default is 200px, which wraps most labels onto 4-5 lines and turns
+        // flowcharts into unreadably narrow, very tall diagrams.
+        flowchart: {
+          wrappingWidth: 400,
+        },
+      },
+    },
     // Replace with your project's social card
     algolia: {
       // The application ID provided by Algolia

--- a/docs/src/css/benchmark-charts.css
+++ b/docs/src/css/benchmark-charts.css
@@ -1,26 +1,28 @@
-/* Enhanced styling for Mermaid benchmark charts */
+/* Enhanced styling for Mermaid benchmark charts.
+   Scoped to xychart only - flowcharts and sequence diagrams must keep the
+   colours Mermaid picks for the active theme, otherwise labels lose contrast. */
 
 /* Enhance chart readability - light mode */
-.markdown .docusaurus-mermaid-container svg text {
+.markdown .docusaurus-mermaid-container svg[aria-roledescription='xychart'] text {
   fill: var(--ifm-font-color-base) !important;
   font-family: var(--ifm-font-family-base);
 }
 
 /* Grid lines for better readability */
-.markdown .docusaurus-mermaid-container svg line {
+.markdown .docusaurus-mermaid-container svg[aria-roledescription='xychart'] line {
   stroke: var(--ifm-color-emphasis-300);
   stroke-opacity: 0.5;
 }
 
 /* Dark mode adjustments */
-[data-theme='dark'] .markdown .docusaurus-mermaid-container svg text {
+[data-theme='dark'] .markdown .docusaurus-mermaid-container svg[aria-roledescription='xychart'] text {
   fill: var(--ifm-font-color-base) !important;
 }
 
-[data-theme='dark'] .markdown .docusaurus-mermaid-container svg .main > rect {
+[data-theme='dark'] .markdown .docusaurus-mermaid-container svg[aria-roledescription='xychart'] .main > rect {
   fill: var(--ifm-background-color) !important;
 }
 
-[data-theme='dark'] .markdown .docusaurus-mermaid-container svg line {
+[data-theme='dark'] .markdown .docusaurus-mermaid-container svg[aria-roledescription='xychart'] line {
   stroke: var(--ifm-color-emphasis-500);
 }


### PR DESCRIPTION
Fixes #6483

## Problem

The "Complete Lifecycle Diagram" on [Test Lifecycle Overview](https://tunit.dev/docs/writing-tests/lifecycle/) was a single flowchart with 32 nodes and 5 nested subgraphs. Mermaid laid it out as a **588 x 6156px** column, and in the reporter's browser it degenerated into a ~25px-wide thumbnail.

Root cause of the shape: Mermaid's default `flowchart.wrappingWidth` is 200px, so most labels wrapped onto 4-5 lines. Combined with 4 levels of nested subgraphs that produced an extremely narrow, extremely tall diagram.

## Changes

- **Split the monster diagram** into three: a scope overview, the hook-order chain, and the per-test flow. Tallest diagram is now 1174px (was 6156px).
- **`flowchart.wrappingWidth: 400`** in `themeConfig.mermaid.options` so labels stop wrapping onto 4-5 lines.
- **Explicit / invisible (`~~~`) links inside subgraphs** so `direction TB` is honoured — without them Mermaid lays unlinked nodes out in a wide row, which pushed one diagram to 1655px wide.
- **Trimmed the per-test sequence diagram** (folded `Initializers`/`Disposal` participants into `Test Instance`, shortened two messages) so it no longer shrinks to 57%.
- **Node `style` rules now set an explicit text colour**, so highlighted nodes keep contrast in dark mode.
- **Scoped benchmark chart CSS to `svg[aria-roledescription='xychart']`** — it was forcing `text { fill }` on every Mermaid diagram, including flowcharts and sequence diagrams.

## Verification

Built the site and measured every diagram's rendered scale (rendered width ÷ viewBox width) with Playwright:

| | before | after |
|---|---|---|
| tallest diagram | 6156px | 1174px |
| worst scale | 0.37 | 0.84 |

All 10 diagrams on the page now render at >= 0.84 scale; six render at 1.00. Benchmark xychart styling verified unchanged.
