### PR TITLE
fix(mocks): strip nullable annotation from constructor dispatch patterns

### DIFF
--- a/src/TUnit.Mocks.SourceGenerator/Builders/MockFactoryBuilder.cs
+++ b/src/TUnit.Mocks.SourceGenerator/Builders/MockFactoryBuilder.cs
@@ -273,16 +273,21 @@ internal static class MockFactoryBuilder
                         var innerKeyword = innerFirst ? "if" : "else if";
                         innerFirst = false;
 
-                        // Build type-check conditions for each parameter
-                        // Reference types accept null via (arg is null or Type); value types use (arg is Type)
+                        // Build type-check conditions for each parameter.
+                        // Anything that can hold null (reference types, and Nullable<T>) accepts
+                        // null via (arg is null or Type); non-nullable value types use (arg is Type).
                         var typeChecks = new List<string>();
                         var castArgs = new List<string>();
                         for (int i = 0; i < ctor.Parameters.Length; i++)
                         {
                             var p = ctor.Parameters[i];
-                            typeChecks.Add(p.IsValueType
-                                ? $"constructorArgs[{i}] is {p.FullyQualifiedType}"
-                                : $"(constructorArgs[{i}] is null or {p.FullyQualifiedType})");
+                            var patternType = StripNullableAnnotation(p.FullyQualifiedType);
+                            // A trailing '?' on a value type means Nullable<T>, which boxes to
+                            // either null or a boxed T — so match the underlying type and null.
+                            var acceptsNull = !p.IsValueType || patternType.Length != p.FullyQualifiedType.Length;
+                            typeChecks.Add(acceptsNull
+                                ? $"(constructorArgs[{i}] is null or {patternType})"
+                                : $"constructorArgs[{i}] is {patternType}");
                             castArgs.Add($"({p.FullyQualifiedType})constructorArgs[{i}]");
                         }
                         var condition = string.Join(" && ", typeChecks);
@@ -307,4 +312,15 @@ internal static class MockFactoryBuilder
             writer.AppendLine($"throw new global::System.ArgumentException($\"No matching constructor found for type '{model.FullyQualifiedName}' with {{constructorArgs.Length}} argument(s).\");");
         }
     }
+
+    /// <summary>
+    /// Removes a single trailing <c>?</c> from a fully qualified type name. A nullable type is
+    /// never legal as the type of an <c>is</c> pattern (CS8116) — neither the annotated reference
+    /// form (<c>Uri?</c>) nor <c>Nullable&lt;T&gt;</c> (<c>int?</c>) — so constructor dispatch must
+    /// test against the underlying type. See issue #6492.
+    /// </summary>
+    private static string StripNullableAnnotation(string fullyQualifiedType)
+        => fullyQualifiedType.EndsWith("?", StringComparison.Ordinal)
+            ? fullyQualifiedType.Substring(0, fullyQualifiedType.Length - 1)
+            : fullyQualifiedType;
 }

--- a/tests/TUnit.Mocks.Tests/Issue6492Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6492Tests.cs
@@ -1,0 +1,98 @@
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6492
+// The generated factory dispatches between same-arity constructor overloads with `is` patterns
+// built from each parameter's fully qualified type. Nullable types are never legal as the type of
+// an `is` pattern (CS8116), so a constructor taking `Uri?`, a nullable delegate, or `int?` emitted
+// uncompilable code. The pattern must test the underlying type; anything nullable also accepts null.
+
+#region Test types
+
+public delegate string NullableSerializerFactory(int seed);
+
+public interface INullableCtorDependency
+{
+    string Name { get; }
+}
+
+public class NullableCtorClient
+{
+    // Two same-arity overloads force the type-check dispatch path (a single overload per arity
+    // would be dispatched positionally without any `is` pattern).
+    public NullableCtorClient(Uri? uri) => Origin = uri?.ToString() ?? "<none>";
+
+    public NullableCtorClient(string? host) => Origin = host ?? "<none>";
+
+    public NullableCtorClient(NullableSerializerFactory? factory, INullableCtorDependency? dependency)
+        => Origin = $"{factory?.Invoke(1) ?? "<none>"}/{dependency?.Name ?? "<none>"}";
+
+    public NullableCtorClient(int? port, INullableCtorDependency? dependency)
+        => Origin = $"{port?.ToString() ?? "<none>"}/{dependency?.Name ?? "<none>"}";
+
+    public virtual string Origin { get; }
+
+    public virtual string Describe() => Origin;
+}
+
+#endregion
+
+public class Issue6492Tests
+{
+    [Test]
+    public async Task Ctor_With_Nullable_Reference_Type_Compiles_And_Dispatches()
+    {
+        var mock = NullableCtorClient.Mock(new Uri("http://localhost:9200"));
+
+        await Assert.That(mock.Object.Origin).IsEqualTo("http://localhost:9200/");
+    }
+
+    [Test]
+    public async Task Ctor_Overload_Dispatch_Picks_The_Matching_Nullable_Parameter_Type()
+    {
+        var mock = NullableCtorClient.Mock("elastic-host");
+
+        await Assert.That(mock.Object.Origin).IsEqualTo("elastic-host");
+    }
+
+    [Test]
+    public async Task Ctor_With_Nullable_Delegate_And_Interface_Parameters_Compiles()
+    {
+        NullableSerializerFactory factory = seed => $"serializer-{seed}";
+        var dependency = INullableCtorDependency.Mock();
+        dependency.Name.Returns("dep");
+
+        var mock = NullableCtorClient.Mock(factory, dependency.Object);
+
+        await Assert.That(mock.Object.Origin).IsEqualTo("serializer-1/dep");
+    }
+
+    [Test]
+    public async Task Ctor_With_Nullable_Value_Type_Parameter_Dispatches_On_Boxed_Value()
+    {
+        var dependency = INullableCtorDependency.Mock();
+        dependency.Name.Returns("dep");
+
+        var mock = NullableCtorClient.Mock((int?)9200, dependency.Object);
+
+        await Assert.That(mock.Object.Origin).IsEqualTo("9200/dep");
+    }
+
+    [Test]
+    public async Task Null_Argument_Still_Selects_A_Nullable_Overload()
+    {
+        var mock = NullableCtorClient.Mock((Uri?)null);
+
+        await Assert.That(mock.Object.Origin).IsEqualTo("<none>");
+    }
+
+    [Test]
+    public async Task Mocked_Members_Work_On_A_Nullable_Ctor_Type()
+    {
+        var mock = NullableCtorClient.Mock(new Uri("http://localhost:9200"));
+        mock.Describe().Returns("stubbed");
+
+        await Assert.That(mock.Object.Describe()).IsEqualTo("stubbed");
+    }
+}


### PR DESCRIPTION
Fixes #6492

## Problem

`T.Mock()` failed to compile for any class with a constructor parameter of a nullable type, e.g. `Elastic.Clients.Elasticsearch.ElasticsearchClientSettings`:

```
MockImplFactory.g.cs(121,52): error CS8116: It is not legal to use nullable type 'Uri?' in a
pattern; use the underlying type 'Uri' instead.
```

`MockFactoryBuilder.GenerateConstructorDispatch` builds an `is` pattern per parameter from `MockParameterModel.FullyQualifiedType`, which carries the nullable annotation. `x is Uri?` / `x is int?` are never legal C#.

## Fix

Strip a single trailing `?` before emitting the pattern type. A trailing `?` on a value type means `Nullable<T>` — which boxes to either `null` or a boxed `T` — so those parameters now take the null-accepting `(arg is null or T)` branch alongside reference types, instead of the value-type-only `arg is T` branch that would have rejected a legitimate `null`.

The cast used to invoke the constructor keeps the annotated type, so nullability of the actual argument is unchanged.

## Tests

`tests/TUnit.Mocks.Tests/Issue6492Tests.cs` — a class with same-arity constructor overloads (forcing the type-check dispatch path) taking `Uri?`, `string?`, a nullable delegate + nullable interface, and `int?` + nullable interface. Covers compilation, correct overload dispatch, boxed `Nullable<T>` dispatch, and null arguments.

Full `TUnit.Mocks.Tests` suite: 1166 passed. `TUnit.Mocks.SourceGenerator.Tests` snapshots: 80 passed, unchanged.