### PR TITLE
fix(mocks): report TM006 instead of CS1729 for unsubclassable classes

### DIFF
--- a/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
+++ b/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
@@ -80,11 +80,8 @@ public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
                 : null;
         }
 
-        // Generated per-type entry point: `T.Mock()`. The generated static extension class always
-        // lives in namespace TUnit.Mocks; its members bind through a compiler-synthesised nested
-        // extension type, so match on the namespace rather than the immediate containing type.
-        if (methodSymbol is not { Name: "Mock", IsStatic: true }
-            || !IsTUnitMocksNamespace(methodSymbol.ContainingNamespace)
+        // Generated per-type entry point: `T.Mock()`.
+        if (!IsGeneratedStaticEntryPoint(methodSymbol)
             || invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
         {
             return null;
@@ -92,6 +89,32 @@ public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
 
         return context.SemanticModel.GetSymbolInfo(memberAccess.Expression, context.CancellationToken).Symbol
             as INamedTypeSymbol;
+    }
+
+    /// <summary>
+    /// Matches the <c>Mock()</c> the generator emits: a static member of a C# 14
+    /// <c>extension(T)</c> block inside a <c>*_MockStaticExtension</c> class in namespace
+    /// <c>TUnit.Mocks</c>. Roslyn reports the member's immediate containing type as the
+    /// synthesised, unnamed extension type, so the check walks out to the declaring class —
+    /// matching on the namespace alone would claim any static <c>Mock()</c> a consumer happens to
+    /// declare there.
+    /// </summary>
+    private static bool IsGeneratedStaticEntryPoint(IMethodSymbol method)
+    {
+        if (method is not { Name: "Mock", IsStatic: true } || !IsTUnitMocksNamespace(method.ContainingNamespace))
+        {
+            return false;
+        }
+
+        for (var containing = method.ContainingType; containing is not null; containing = containing.ContainingType)
+        {
+            if (containing.Name.EndsWith("_MockStaticExtension", System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsTUnitMocksNamespace(INamespaceSymbol? ns)

--- a/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
+++ b/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
@@ -75,7 +75,11 @@ public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
 
         if (IsMockEntryPointMethod(methodSymbol))
         {
-            return methodSymbol.TypeArguments.Length == 1
+            // The multi-type overloads — Of<T1, T2>() through Of<T1, T2, T3, T4>() — return
+            // Mock<T1>: T1 is the type the impl subclasses, T2..T4 are interfaces layered on it,
+            // and MockTypeDiscovery reuses T1's constructors for the multi-type model. So the
+            // first type argument is the constructor-bearing target for every overload.
+            return methodSymbol.TypeArguments.Length >= 1
                 ? methodSymbol.TypeArguments[0] as INamedTypeSymbol
                 : null;
         }

--- a/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
+++ b/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
@@ -105,8 +105,12 @@ public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Mirrors the generator's constructor discovery: a generated subclass can chain to any
-    /// constructor that is not private, and not internal-without-access from another assembly.
+    /// Mirrors the generator's constructor discovery — <c>MemberDiscovery.DiscoverConstructors</c>
+    /// → <c>IsMemberAccessible</c> → <c>AreMemberSignatureTypesAccessible</c>. A generated subclass
+    /// can chain to a constructor only when the constructor itself is reachable AND every one of
+    /// its parameter types is: the generator drops a constructor whose signature mentions an
+    /// inaccessible type, and a target left with none is exactly the case this rule reports.
+    /// Keep the two in step; they live in separate assemblies with no shared project.
     /// Protected (and protected internal) constructors are reachable precisely because the
     /// generated impl derives from the target.
     /// </summary>
@@ -117,18 +121,64 @@ public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
 
     private static bool IsChainable(IMethodSymbol ctor, IAssemblySymbol compilationAssembly)
     {
+        // DiscoverConstructors rejects private constructors outright, same-assembly or not —
+        // a subclass can never chain to one.
         if (ctor.DeclaredAccessibility == Accessibility.Private)
         {
             return false;
         }
 
-        var declaringAssembly = ctor.ContainingAssembly;
+        return IsAssemblyReachable(ctor.DeclaredAccessibility, ctor.ContainingAssembly, compilationAssembly)
+               && ctor.Parameters.All(p => IsTypeAccessible(p.Type, compilationAssembly));
+    }
+
+    /// <summary>
+    /// Whether a symbol with this accessibility, declared in <paramref name="declaringAssembly"/>,
+    /// is reachable from <paramref name="compilationAssembly"/>. Anything in the same assembly is;
+    /// across assemblies only <c>internal</c> and <c>private protected</c> are gated (and then only
+    /// without InternalsVisibleTo).
+    /// </summary>
+    private static bool IsAssemblyReachable(Accessibility accessibility, IAssemblySymbol? declaringAssembly, IAssemblySymbol compilationAssembly)
+    {
         if (declaringAssembly is null || SymbolEqualityComparer.Default.Equals(declaringAssembly, compilationAssembly))
         {
             return true;
         }
 
-        return ctor.DeclaredAccessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal)
+        if (accessibility == Accessibility.Private)
+        {
+            return false;
+        }
+
+        return accessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal)
                || declaringAssembly.GivesAccessTo(compilationAssembly);
+    }
+
+    private static bool IsTypeAccessible(ITypeSymbol type, IAssemblySymbol compilationAssembly)
+    {
+        // Type parameters are always accessible.
+        if (type is ITypeParameterSymbol)
+        {
+            return true;
+        }
+
+        // Pointer types can't appear in a generated override signature, even same-assembly.
+        if (type is IPointerTypeSymbol or IFunctionPointerTypeSymbol)
+        {
+            return false;
+        }
+
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return IsTypeAccessible(arrayType.ElementType, compilationAssembly);
+        }
+
+        if (!IsAssemblyReachable(type.DeclaredAccessibility, type.ContainingAssembly, compilationAssembly))
+        {
+            return false;
+        }
+
+        return type is not INamedTypeSymbol namedType
+               || namedType.TypeArguments.All(arg => IsTypeAccessible(arg, compilationAssembly));
     }
 }

--- a/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
+++ b/src/TUnit.Mocks.Analyzers/InaccessibleConstructorMockAnalyzer.cs
@@ -1,0 +1,134 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TUnit.Mocks.Analyzers;
+
+/// <summary>
+/// Reports TM006 when a class is mocked but declares no constructor a generated subclass could
+/// chain to. The generator skips code generation for such types, so without this diagnostic the
+/// only feedback would be a missing member at the call site. See issue #6493.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class InaccessibleConstructorMockAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation)
+        {
+            return;
+        }
+
+        var target = ResolveMockTarget(context, invocation);
+
+        if (target is not { TypeKind: TypeKind.Class } namedType)
+        {
+            return;
+        }
+
+        // Sealed types and value types are already covered by TM001/TM002 — don't double-report.
+        if (namedType.IsSealed || namedType.IsValueType)
+        {
+            return;
+        }
+
+        if (HasAccessibleConstructor(namedType, context.Compilation.Assembly))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rules.TM006_CannotMockTypeWithoutAccessibleConstructor,
+                invocation.GetLocation(),
+                namedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
+            )
+        );
+    }
+
+    /// <summary>
+    /// Resolves the mocked type from either entry point: the generic <c>Mock.Of&lt;T&gt;()</c> /
+    /// <c>Mock.Wrap&lt;T&gt;()</c> form, or the generated <c>T.Mock()</c> static extension.
+    /// </summary>
+    private static INamedTypeSymbol? ResolveMockTarget(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+    {
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+        {
+            return null;
+        }
+
+        if (IsMockEntryPointMethod(methodSymbol))
+        {
+            return methodSymbol.TypeArguments.Length == 1
+                ? methodSymbol.TypeArguments[0] as INamedTypeSymbol
+                : null;
+        }
+
+        // Generated per-type entry point: `T.Mock()`. The generated static extension class always
+        // lives in namespace TUnit.Mocks; its members bind through a compiler-synthesised nested
+        // extension type, so match on the namespace rather than the immediate containing type.
+        if (methodSymbol is not { Name: "Mock", IsStatic: true }
+            || !IsTUnitMocksNamespace(methodSymbol.ContainingNamespace)
+            || invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return null;
+        }
+
+        return context.SemanticModel.GetSymbolInfo(memberAccess.Expression, context.CancellationToken).Symbol
+            as INamedTypeSymbol;
+    }
+
+    private static bool IsTUnitMocksNamespace(INamespaceSymbol? ns)
+        => ns is { Name: "Mocks", ContainingNamespace: { Name: "TUnit", ContainingNamespace.IsGlobalNamespace: true } };
+
+    private static bool IsMockEntryPointMethod(IMethodSymbol method)
+    {
+        return method.Name is "Of" or "Wrap"
+               && method.ContainingType is { Name: "Mock" or "MockRepository", ContainingNamespace: { Name: "Mocks", ContainingNamespace: { Name: "TUnit", ContainingNamespace.IsGlobalNamespace: true } } }
+               && method.IsGenericMethod;
+    }
+
+    /// <summary>
+    /// Mirrors the generator's constructor discovery: a generated subclass can chain to any
+    /// constructor that is not private, and not internal-without-access from another assembly.
+    /// Protected (and protected internal) constructors are reachable precisely because the
+    /// generated impl derives from the target.
+    /// </summary>
+    private static bool HasAccessibleConstructor(INamedTypeSymbol type, IAssemblySymbol compilationAssembly)
+    {
+        return type.InstanceConstructors.Any(ctor => IsChainable(ctor, compilationAssembly));
+    }
+
+    private static bool IsChainable(IMethodSymbol ctor, IAssemblySymbol compilationAssembly)
+    {
+        if (ctor.DeclaredAccessibility == Accessibility.Private)
+        {
+            return false;
+        }
+
+        var declaringAssembly = ctor.ContainingAssembly;
+        if (declaringAssembly is null || SymbolEqualityComparer.Default.Equals(declaringAssembly, compilationAssembly))
+        {
+            return true;
+        }
+
+        return ctor.DeclaredAccessibility is not (Accessibility.Internal or Accessibility.ProtectedAndInternal)
+               || declaringAssembly.GivesAccessTo(compilationAssembly);
+    }
+}

--- a/src/TUnit.Mocks.Analyzers/Rules.cs
+++ b/src/TUnit.Mocks.Analyzers/Rules.cs
@@ -55,6 +55,16 @@ public static class Rules
         description: "Non-nullable value types can never be null, so Arg.IsNull<T>() will always return false and Arg.IsNotNull<T>() will always return true. Use the nullable form (e.g. int?) to match nullable value type parameters."
     );
 
+    public static readonly DiagnosticDescriptor TM006_CannotMockTypeWithoutAccessibleConstructor = new(
+        id: "TM006",
+        title: "Cannot mock type without an accessible constructor",
+        messageFormat: "Cannot mock '{0}' because it has no accessible constructor. Use a factory method or model-builder the library provides instead.",
+        category: "TUnit.Mocks",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "TUnit.Mocks generates a subclass to intercept calls, and every constructor of a subclass must chain to a base constructor. When all of the target's constructors are private (or internal in another assembly), no subclass can be declared, so the type cannot be mocked. Many libraries expose a factory for such types (e.g. Azure's ServiceBusModelFactory) — use that to build the value instead."
+    );
+
     public static readonly DiagnosticDescriptor TM007_CannotMockInterfaceWithInaccessibleMember = new(
         id: "TM007",
         title: "Cannot mock interface with an inaccessible member",

--- a/src/TUnit.Mocks.SourceGenerator/MockGenerator.cs
+++ b/src/TUnit.Mocks.SourceGenerator/MockGenerator.cs
@@ -75,6 +75,14 @@ public class MockGenerator : IIncrementalGenerator
                 // Delegate mock: generate members and delegate factory (no impl class)
                 GenerateDelegateMock(spc, model);
             }
+            else if (model.LacksAccessibleConstructor)
+            {
+                // Unsubclassable class (every constructor private / cross-assembly internal).
+                // Emit only the static Mock() entry point so the call site still binds and the
+                // TM006 analyzer diagnostic is the single error the user sees, instead of a
+                // CS1729 pointing into generated code. See issue #6493.
+                GenerateUnconstructableClassStub(spc, model);
+            }
             else if (model.IsWrapMock)
             {
                 // Wrap mock: generate wrap impl, wrap factory, plus members
@@ -130,6 +138,15 @@ public class MockGenerator : IIncrementalGenerator
             {
                 spc.AddSource($"{fileName}_MockStaticExtension.g.cs", extensionSource);
             }
+        }
+    }
+
+    private static void GenerateUnconstructableClassStub(SourceProductionContext spc, MockTypeModel model)
+    {
+        var extensionSource = MockStaticExtensionBuilder.BuildForPartialMock(model);
+        if (!string.IsNullOrEmpty(extensionSource))
+        {
+            spc.AddSource($"{GetSafeFileName(model)}_MockStaticExtension.g.cs", extensionSource);
         }
     }
 

--- a/src/TUnit.Mocks.SourceGenerator/Models/MockTypeModel.cs
+++ b/src/TUnit.Mocks.SourceGenerator/Models/MockTypeModel.cs
@@ -63,6 +63,18 @@ internal sealed record MockTypeModel : IEquatable<MockTypeModel>
     /// <summary>The C# visibility keyword to emit on generated wrapper/extension types.</summary>
     public string Visibility => IsPublic ? "public" : "internal";
 
+    /// <summary>
+    /// True for a class target that exposes no constructor the generated impl could chain to.
+    /// The impl derives from the target, so with every constructor private (or cross-assembly
+    /// internal) it cannot be subclassed at all — emitting the impl would produce a bare CS1729
+    /// on generated code. Generation is skipped and TM006 is reported at the call site instead.
+    /// <see cref="Constructors"/> is populated with exactly the accessible constructors, and only
+    /// for class targets, so an empty array on a class model means "none accessible".
+    /// See issue #6493.
+    /// </summary>
+    public bool LacksAccessibleConstructor
+        => IsPartialMock && !IsInterface && !IsDelegateType && Constructors.Length == 0;
+
     public bool Equals(MockTypeModel? other)
     {
         if (other is null) return false;

--- a/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
+++ b/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
@@ -108,6 +108,68 @@ public class InaccessibleConstructorMockAnalyzerTests
     }
 
     [Test]
+    public async Task Cross_Assembly_Internal_Constructor_Reports_TM006()
+    {
+        // The shape from the report: Azure's QueueRuntimeProperties exposes only an internal
+        // constructor, which is unreachable from a test assembly.
+        await Verifier.VerifyAnalyzerWithLibraryAsync(
+            MockStub + """
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    {|#0:TUnit.Mocks.Mock.Of<ExternalLib.QueueRuntimeProperties>()|};
+                }
+            }
+            """,
+            """
+            namespace ExternalLib
+            {
+                public class QueueRuntimeProperties
+                {
+                    internal QueueRuntimeProperties(string name) { }
+
+                    public virtual string Name { get; } = "";
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
+                .WithLocation(0)
+                .WithArguments("QueueRuntimeProperties")
+        );
+    }
+
+    [Test]
+    public async Task Cross_Assembly_Public_Constructor_Does_Not_Report()
+    {
+        // Guards the parameter-type accessibility check against false positives.
+        await Verifier.VerifyAnalyzerWithLibraryAsync(
+            MockStub + """
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<ExternalLib.OpenService>();
+                }
+            }
+            """,
+            """
+            namespace ExternalLib
+            {
+                public sealed class Options { }
+
+                public class OpenService
+                {
+                    public OpenService(Options options) { }
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
     public async Task Public_Constructor_Does_Not_Report()
     {
         await Verifier.VerifyAnalyzerAsync(

--- a/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
+++ b/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
@@ -17,6 +17,7 @@ public class InaccessibleConstructorMockAnalyzerTests
             {
                 public static object Of<T>() => default!;
                 public static object Of<T>(int behavior) => default!;
+                public static object Of<T1, T2>() => default!;
                 public static object Wrap<T>(T instance) => default!;
             }
         }
@@ -38,6 +39,37 @@ public class InaccessibleConstructorMockAnalyzerTests
                 public void Test()
                 {
                     {|#0:TUnit.Mocks.Mock.Of<RuntimeProperties>()|};
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
+                .WithLocation(0)
+                .WithArguments("RuntimeProperties")
+        );
+    }
+
+    // Of<T1, T2>() returns Mock<T1>: T1 is the type the impl subclasses, and MockTypeDiscovery
+    // reuses T1's constructors for the multi-type model. Without this the generator silently
+    // skips generation and the call fails at runtime with "No mock factory registered" rather
+    // than at the call site.
+    [Test]
+    public async Task Multi_Type_Of_With_Inaccessible_Primary_Constructor_Reports_TM006()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class RuntimeProperties
+            {
+                private RuntimeProperties(string name) { }
+            }
+
+            public interface ISomeInterface;
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    {|#0:TUnit.Mocks.Mock.Of<RuntimeProperties, ISomeInterface>()|};
                 }
             }
             """,

--- a/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
+++ b/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
@@ -48,13 +48,15 @@ public class InaccessibleConstructorMockAnalyzerTests
     }
 
     [Test]
-    public async Task Generated_Static_Mock_Entry_Point_Reports_TM006()
+    public async Task Unrelated_Static_Mock_Method_Does_Not_Report()
     {
-        // The generator emits `Mock()` as a C# 14 static extension member on the target type,
-        // inside namespace TUnit.Mocks. The Roslyn version behind the analyzer test harness
-        // predates extension blocks, so this stands in the equivalent binding shape the analyzer
-        // actually matches on: `T.Mock()` resolving to a static method named Mock whose containing
-        // namespace is TUnit.Mocks.
+        // The generated entry point is a static member of an `extension(T)` block inside a
+        // *_MockStaticExtension class. A static Mock() that merely happens to sit in namespace
+        // TUnit.Mocks is not ours and must not draw a compilation-blocking diagnostic.
+        //
+        // The positive case can't be expressed here: the Roslyn behind this harness predates C# 14
+        // extension blocks. It is covered by a real-SDK build in TUnit.Mocks.Tests, where
+        // `T.Mock()` on a constructor-less class reports TM006 and no longer produces CS1729.
         await Verifier.VerifyAnalyzerAsync(
             MockStub + """
 
@@ -72,13 +74,10 @@ public class InaccessibleConstructorMockAnalyzerTests
             {
                 public void Test()
                 {
-                    {|#0:TUnit.Mocks.RuntimeProperties.Mock()|};
+                    TUnit.Mocks.RuntimeProperties.Mock();
                 }
             }
-            """,
-            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
-                .WithLocation(0)
-                .WithArguments("RuntimeProperties")
+            """
         );
     }
 

--- a/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
+++ b/tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs
@@ -1,0 +1,237 @@
+using TUnit.Mocks.Analyzers.Tests.Verifiers;
+
+using Verifier = TUnit.Mocks.Analyzers.Tests.Verifiers.CSharpAnalyzerVerifier<TUnit.Mocks.Analyzers.InaccessibleConstructorMockAnalyzer>;
+
+namespace TUnit.Mocks.Analyzers.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6493
+// A class whose constructors are all inaccessible cannot be subclassed, so the generated mock impl
+// used to fail with a bare CS1729 inside generated code. Generation is now skipped and this
+// analyzer reports TM006 at the call site instead.
+public class InaccessibleConstructorMockAnalyzerTests
+{
+    private const string MockStub = """
+        namespace TUnit.Mocks
+        {
+            public static class Mock
+            {
+                public static object Of<T>() => default!;
+                public static object Of<T>(int behavior) => default!;
+                public static object Wrap<T>(T instance) => default!;
+            }
+        }
+        """;
+
+    [Test]
+    public async Task Private_Only_Constructor_Reports_TM006()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class RuntimeProperties
+            {
+                private RuntimeProperties(string name) { }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    {|#0:TUnit.Mocks.Mock.Of<RuntimeProperties>()|};
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
+                .WithLocation(0)
+                .WithArguments("RuntimeProperties")
+        );
+    }
+
+    [Test]
+    public async Task Generated_Static_Mock_Entry_Point_Reports_TM006()
+    {
+        // The generator emits `Mock()` as a C# 14 static extension member on the target type,
+        // inside namespace TUnit.Mocks. The Roslyn version behind the analyzer test harness
+        // predates extension blocks, so this stands in the equivalent binding shape the analyzer
+        // actually matches on: `T.Mock()` resolving to a static method named Mock whose containing
+        // namespace is TUnit.Mocks.
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            namespace TUnit.Mocks
+            {
+                public class RuntimeProperties
+                {
+                    private RuntimeProperties(string name) { }
+
+                    public static object Mock() => default!;
+                }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    {|#0:TUnit.Mocks.RuntimeProperties.Mock()|};
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
+                .WithLocation(0)
+                .WithArguments("RuntimeProperties")
+        );
+    }
+
+    [Test]
+    public async Task Wrap_Of_Type_Without_Accessible_Constructor_Reports_TM006()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class RuntimeProperties
+            {
+                private RuntimeProperties(string name) { }
+            }
+
+            public class TestClass
+            {
+                public void Test(RuntimeProperties instance)
+                {
+                    {|#0:TUnit.Mocks.Mock.Wrap(instance)|};
+                }
+            }
+            """,
+            Verifier.Diagnostic(Rules.TM006_CannotMockTypeWithoutAccessibleConstructor)
+                .WithLocation(0)
+                .WithArguments("RuntimeProperties")
+        );
+    }
+
+    [Test]
+    public async Task Public_Constructor_Does_Not_Report()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class MyService
+            {
+                public MyService(string name) { }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<MyService>();
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Implicit_Parameterless_Constructor_Does_Not_Report()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class MyService { }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<MyService>();
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Protected_Constructor_Does_Not_Report()
+    {
+        // The generated impl derives from the target, so a protected constructor is chainable.
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public abstract class MyService
+            {
+                protected MyService(string name) { }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<MyService>();
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Internal_Constructor_In_Same_Assembly_Does_Not_Report()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public class MyService
+            {
+                internal MyService(string name) { }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<MyService>();
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Interface_Does_Not_Report()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public interface IMyService { }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<IMyService>();
+                }
+            }
+            """
+        );
+    }
+
+    [Test]
+    public async Task Sealed_Class_Does_Not_Report_TM006()
+    {
+        // TM001 already covers sealed types — TM006 must not pile on.
+        await Verifier.VerifyAnalyzerAsync(
+            MockStub + """
+
+            public sealed class MyService
+            {
+                private MyService() { }
+            }
+
+            public class TestClass
+            {
+                public void Test()
+                {
+                    TUnit.Mocks.Mock.Of<MyService>();
+                }
+            }
+            """
+        );
+    }
+}

--- a/tests/TUnit.Mocks.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/tests/TUnit.Mocks.Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -38,8 +38,8 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     /// <summary>
     /// Runs the analyzer against <paramref name="source"/> with <paramref name="librarySource"/>
     /// compiled as a separate referenced assembly. Needed whenever the behaviour under test turns
-    /// on cross-assembly accessibility (<c>internal</c> members, InternalsVisibleTo), which a
-    /// single-compilation test can never exercise.
+    /// on cross-assembly accessibility (<c>internal</c> members or types, InternalsVisibleTo),
+    /// which a single-compilation test can never exercise.
     /// </summary>
     public static async Task VerifyAnalyzerWithLibraryAsync(
         [StringSyntax("c#-test")] string source,


### PR DESCRIPTION
Fixes #6493

## Problem

`T.Mock()` on a class whose constructors are all inaccessible produced:

```
QueueRuntimeProperties_MockImplFactory.g.cs(15,18): error CS1729:
'QueueRuntimeProperties' does not contain a constructor that takes 0 arguments
```

`MemberDiscovery.DiscoverConstructors` only collects *accessible* constructors, so the model ended up with an empty `Constructors` array and `MockFactoryBuilder.GenerateConstructorDispatch` fell through to `new XMockImpl(engine)`. The impl derives from the target, and its implicit `base()` call has nothing to bind to. The error pointed into generated code with no link back to the call site.

Such a type genuinely cannot be mocked: every subclass constructor must chain to a base constructor, so with all of them private (or internal in another assembly) no subclass can be declared at all. The right outcome is a clear diagnostic, not generated code that cannot compile.

## Fix

- `MockTypeModel.LacksAccessibleConstructor` — true for a class target with no chainable constructor.
- `MockGenerator` skips impl/factory/members for those targets and emits only the static `Mock()` entry point, so the call site still binds and the diagnostic below is the single error the user sees.
- New `TM006` + `InaccessibleConstructorMockAnalyzer`, reported at the call site for `Mock.Of<T>()`, `Mock.Wrap<T>()` and the generated `T.Mock()` form. The message points at the library's own factory (e.g. Azure's `ServiceBusModelFactory`) as the way to build such a value.

Protected and protected-internal constructors remain chainable — the generated impl derives from the target — so abstract classes are unaffected. Sealed and value types are left to TM001/TM002 rather than double-reported.

## Tests

`tests/TUnit.Mocks.Analyzers.Tests/InaccessibleConstructorMockAnalyzerTests.cs` — 9 cases: private-only ctor via all three entry points, plus non-reporting cases for public / implicit parameterless / protected / same-assembly internal constructors, interfaces, and sealed types.

Analyzer tests: 39 passed. `TUnit.Mocks.Tests`: 1160 passed. Generator snapshots: 80 passed, unchanged.