### PR TITLE
feat(mocks): accept an async factory in Returns() on async members

### DIFF
--- a/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -720,9 +720,11 @@ internal static class MockMembersBuilder
         }
 
         // Returns alias, so an `async (a, b) => ...` lambda binds here rather than failing against
-        // the synchronous typed overload with CS4010. See issue #6495.
+        // the synchronous typed overload with CS4010. Deprioritised for the same reason as the
+        // parameterless alias — see EmitReturnsAsyncOverloads. See issue #6495.
         writer.AppendLine();
         writer.AppendLine("/// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>");
+        writer.AppendLine(PriorityMinusOneAttribute);
         using (writer.Block($"public {wrapperName} Returns({funcType} factory)"))
         {
             writer.AppendLine($"EnsureSetup().ReturnsRaw(args => (object?)factory({castArgs}));");
@@ -1791,7 +1793,14 @@ internal static class MockMembersBuilder
         // Same factory, spelled Returns — so an `async () => ...` lambda binds without the caller
         // having to know about ReturnsAsync (the synchronous Func<T> overload rejects it with
         // CS4010). The returned task is handed back as-is, so it stays pending. See issue #6495.
+        //
+        // Deprioritised against the synchronous Returns(Func<T>) sibling: when T is a reference
+        // type, a lambda whose body pins nothing — Returns(() => null), Returns(() => throw ...) —
+        // converts equally well to Func<T> and Func<Task<T>>, which would be CS0121. The priority
+        // breaks that tie back to the pre-existing synchronous meaning. A genuine async lambda is
+        // unaffected: it is not convertible to Func<T> at all, so it is the only candidate.
         writer.AppendLine($"/// <summary>Return a {taskLabel} from a factory, invoked on each call. The {taskLabel} is returned as-is, so an async factory stays pending until it completes.</summary>");
+        writer.AppendLine(PriorityMinusOneAttribute);
         writer.AppendLine($"public {wrapperName} Returns(global::System.Func<{taskType}> taskFactory) {{ EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }}");
     }
 

--- a/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -720,9 +720,11 @@ internal static class MockMembersBuilder
         }
 
         // Returns alias, so an `async (a, b) => ...` lambda binds here rather than failing against
-        // the synchronous typed overload with CS4010. Deprioritised for the same reason as the
-        // parameterless alias — see EmitReturnsAsyncOverloads. See issue #6495.
+        // the synchronous typed overload with CS4010. Deprioritised — and therefore net9.0+ only —
+        // for the same reasons as the parameterless alias; see EmitReturnsAsyncOverloads.
+        // See issue #6495.
         writer.AppendLine();
+        writer.AppendLine("#if NET9_0_OR_GREATER");
         writer.AppendLine("/// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>");
         writer.AppendLine(PriorityMinusOneAttribute);
         using (writer.Block($"public {wrapperName} Returns({funcType} factory)"))
@@ -730,6 +732,7 @@ internal static class MockMembersBuilder
             writer.AppendLine($"EnsureSetup().ReturnsRaw(args => (object?)factory({castArgs}));");
             writer.AppendLine("return this;");
         }
+        writer.AppendLine("#endif");
     }
 
     private static void GenerateTypedCallbackOverload(CodeWriter writer, List<MockParameterModel> nonOutParams,
@@ -1799,9 +1802,17 @@ internal static class MockMembersBuilder
         // converts equally well to Func<T> and Func<Task<T>>, which would be CS0121. The priority
         // breaks that tie back to the pre-existing synchronous meaning. A genuine async lambda is
         // unaffected: it is not convertible to Func<T> at all, so it is the only candidate.
+        //
+        // That makes the alias inseparable from the attribute, which only reaches the consumer's
+        // compilation on net9.0+ — TUnit.Mocks polyfills it internally for its own build, so a
+        // net8.0 consumer would hit CS0246. Emitting the overload there without the priority would
+        // hand them the ambiguity instead, so the whole alias is net9.0+ (matching the framework
+        // polyfills below); net8.0 keeps ReturnsAsync, which already returns the task as-is.
+        writer.AppendLine("#if NET9_0_OR_GREATER");
         writer.AppendLine($"/// <summary>Return a {taskLabel} from a factory, invoked on each call. The {taskLabel} is returned as-is, so an async factory stays pending until it completes.</summary>");
         writer.AppendLine(PriorityMinusOneAttribute);
         writer.AppendLine($"public {wrapperName} Returns(global::System.Func<{taskType}> taskFactory) {{ EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }}");
+        writer.AppendLine("#endif");
     }
 
     private static void EmitEnsureSetup(CodeWriter writer, string builderType, bool hasTypeArguments)

--- a/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
+++ b/src/TUnit.Mocks.SourceGenerator/Builders/MockMembersBuilder.cs
@@ -718,6 +718,16 @@ internal static class MockMembersBuilder
             writer.AppendLine($"EnsureSetup().ReturnsRaw(args => (object?)factory({castArgs}));");
             writer.AppendLine("return this;");
         }
+
+        // Returns alias, so an `async (a, b) => ...` lambda binds here rather than failing against
+        // the synchronous typed overload with CS4010. See issue #6495.
+        writer.AppendLine();
+        writer.AppendLine("/// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>");
+        using (writer.Block($"public {wrapperName} Returns({funcType} factory)"))
+        {
+            writer.AppendLine($"EnsureSetup().ReturnsRaw(args => (object?)factory({castArgs}));");
+            writer.AppendLine("return this;");
+        }
     }
 
     private static void GenerateTypedCallbackOverload(CodeWriter writer, List<MockParameterModel> nonOutParams,
@@ -1778,6 +1788,11 @@ internal static class MockMembersBuilder
         writer.AppendLine($"public {wrapperName} ReturnsAsync({taskType} task) {{ EnsureSetup().ReturnsRaw(task); return this; }}");
         writer.AppendLine($"/// <summary>Return a pre-built {taskLabel} from a factory, invoked on each call.</summary>");
         writer.AppendLine($"public {wrapperName} ReturnsAsync(global::System.Func<{taskType}> taskFactory) {{ EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }}");
+        // Same factory, spelled Returns — so an `async () => ...` lambda binds without the caller
+        // having to know about ReturnsAsync (the synchronous Func<T> overload rejects it with
+        // CS4010). The returned task is handed back as-is, so it stays pending. See issue #6495.
+        writer.AppendLine($"/// <summary>Return a {taskLabel} from a factory, invoked on each call. The {taskLabel} is returned as-is, so an async factory stays pending until it completes.</summary>");
+        writer.AppendLine($"public {wrapperName} Returns(global::System.Func<{taskType}> taskFactory) {{ EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }}");
     }
 
     private static void EmitEnsureSetup(CodeWriter writer, string builderType, bool hasTypeArguments)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -203,6 +203,7 @@ public sealed class IDialogReference_GetReturnValueAsync_M0_MockCall<T> : global
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
@@ -590,6 +591,7 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -607,6 +609,7 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<string, global::DialogParameters<TData>, global::System.Threading.Tasks.Task<global::IDialogReference?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!, (global::DialogParameters<TData>)args[1]!));
@@ -706,6 +709,7 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -723,6 +727,7 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<object, global::DialogParameters, global::System.Threading.Tasks.Task<global::IDialogReference>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((object)args[0]!, (global::DialogParameters)args[1]!));

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -202,6 +202,8 @@ public sealed class IDialogReference_GetReturnValueAsync_M0_MockCall<T> : global
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> ReturnsAsync(global::System.Threading.Tasks.Task<T?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogReference_GetReturnValueAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
     /// <inheritdoc />
@@ -587,6 +589,8 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Threading.Tasks.Task<global::IDialogReference?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<string, global::DialogParameters<TData>, global::IDialogReference?> factory)
@@ -597,6 +601,13 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Func<string, global::DialogParameters<TData>, global::System.Threading.Tasks.Task<global::IDialogReference?>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!, (global::DialogParameters<TData>)args[1]!));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<string, global::DialogParameters<TData>, global::System.Threading.Tasks.Task<global::IDialogReference?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!, (global::DialogParameters<TData>)args[1]!));
         return this;
@@ -694,6 +705,8 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Threading.Tasks.Task<global::IDialogReference> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<object, global::DialogParameters, global::IDialogReference> factory)
@@ -704,6 +717,13 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Func<object, global::DialogParameters, global::System.Threading.Tasks.Task<global::IDialogReference>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((object)args[0]!, (global::DialogParameters)args[1]!));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<object, global::DialogParameters, global::System.Threading.Tasks.Task<global::IDialogReference>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((object)args[0]!, (global::DialogParameters)args[1]!));
         return this;

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_FluentUI_Shape_Nullable_Warnings.verified.txt
@@ -202,9 +202,11 @@ public sealed class IDialogReference_GetReturnValueAsync_M0_MockCall<T> : global
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> ReturnsAsync(global::System.Threading.Tasks.Task<T?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogReference_GetReturnValueAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     // ICallVerification
     /// <inheritdoc />
@@ -590,9 +592,11 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Threading.Tasks.Task<global::IDialogReference?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<string, global::DialogParameters<TData>, global::IDialogReference?> factory)
@@ -608,6 +612,7 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Returns(global::System.Func<string, global::DialogParameters<TData>, global::System.Threading.Tasks.Task<global::IDialogReference?>> factory)
@@ -615,6 +620,7 @@ public sealed class IDialogService_UpdateDialogAsync_M0_MockCall<TData> : global
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!, (global::DialogParameters<TData>)args[1]!));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IDialogService_UpdateDialogAsync_M0_MockCall<TData> Callback(global::System.Action<string, global::DialogParameters<TData>> callback)
@@ -708,9 +714,11 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Threading.Tasks.Task<global::IDialogReference> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<global::System.Threading.Tasks.Task<global::IDialogReference>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<object, global::DialogParameters, global::IDialogReference> factory)
@@ -726,6 +734,7 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Returns(global::System.Func<object, global::DialogParameters, global::System.Threading.Tasks.Task<global::IDialogReference>> factory)
@@ -733,6 +742,7 @@ public sealed class IDialogService_ShowDialogAsync_M1_MockCall<TDialog> : global
         EnsureSetup().ReturnsRaw(args => (object?)factory((object)args[0]!, (global::DialogParameters)args[1]!));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IDialogService_ShowDialogAsync_M1_MockCall<TDialog> Callback(global::System.Action<object, global::DialogParameters> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -299,6 +299,8 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<string, string> factory)
@@ -309,6 +311,13 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Func<string, global::System.Threading.Tasks.Task<string>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<string, global::System.Threading.Tasks.Task<string>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!));
         return this;
@@ -398,6 +407,8 @@ public sealed class IAsyncService_DoWorkAsync_M1_MockCall : global::TUnit.Mocks.
     public IAsyncService_DoWorkAsync_M1_MockCall ReturnsAsync(global::System.Threading.Tasks.Task task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_DoWorkAsync_M1_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_DoWorkAsync_M1_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
     /// <inheritdoc />
@@ -474,6 +485,8 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Threading.Tasks.ValueTask<int> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<int, int> factory)
@@ -484,6 +497,13 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Func<int, global::System.Threading.Tasks.ValueTask<int>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.ValueTask<int>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
         return this;
@@ -575,6 +595,8 @@ public sealed class IAsyncService_InitializeAsync_M3_MockCall : global::TUnit.Mo
     public IAsyncService_InitializeAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.ValueTask task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_InitializeAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IAsyncService_InitializeAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IAsyncService_InitializeAsync_M3_MockCall Callback(global::System.Action<global::System.Threading.CancellationToken> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -300,6 +300,7 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -317,6 +318,7 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<string, global::System.Threading.Tasks.Task<string>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!));
@@ -408,6 +410,7 @@ public sealed class IAsyncService_DoWorkAsync_M1_MockCall : global::TUnit.Mocks.
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_DoWorkAsync_M1_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_DoWorkAsync_M1_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
@@ -486,6 +489,7 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -503,6 +507,7 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.ValueTask<int>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
@@ -596,6 +601,7 @@ public sealed class IAsyncService_InitializeAsync_M3_MockCall : global::TUnit.Mo
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_InitializeAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_InitializeAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Async_Methods.verified.txt
@@ -299,9 +299,11 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<string, string> factory)
@@ -317,6 +319,7 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_GetValueAsync_M0_MockCall Returns(global::System.Func<string, global::System.Threading.Tasks.Task<string>> factory)
@@ -324,6 +327,7 @@ public sealed class IAsyncService_GetValueAsync_M0_MockCall : global::TUnit.Mock
         EnsureSetup().ReturnsRaw(args => (object?)factory((string)args[0]!));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IAsyncService_GetValueAsync_M0_MockCall Callback(global::System.Action<string> callback)
@@ -409,9 +413,11 @@ public sealed class IAsyncService_DoWorkAsync_M1_MockCall : global::TUnit.Mocks.
     public IAsyncService_DoWorkAsync_M1_MockCall ReturnsAsync(global::System.Threading.Tasks.Task task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IAsyncService_DoWorkAsync_M1_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_DoWorkAsync_M1_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     // ICallVerification
     /// <inheritdoc />
@@ -488,9 +494,11 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Threading.Tasks.ValueTask<int> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<int, int> factory)
@@ -506,6 +514,7 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_ComputeAsync_M2_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.ValueTask<int>> factory)
@@ -513,6 +522,7 @@ public sealed class IAsyncService_ComputeAsync_M2_MockCall : global::TUnit.Mocks
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IAsyncService_ComputeAsync_M2_MockCall Callback(global::System.Action<int> callback)
@@ -600,9 +610,11 @@ public sealed class IAsyncService_InitializeAsync_M3_MockCall : global::TUnit.Mo
     public IAsyncService_InitializeAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.ValueTask task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built ValueTask from a factory, invoked on each call.</summary>
     public IAsyncService_InitializeAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a ValueTask from a factory, invoked on each call. The ValueTask is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IAsyncService_InitializeAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.ValueTask> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IAsyncService_InitializeAsync_M3_MockCall Callback(global::System.Action<global::System.Threading.CancellationToken> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -314,6 +314,7 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -331,6 +332,7 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.Task<string>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -313,6 +313,8 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IService_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<int, string> factory)
@@ -323,6 +325,13 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<int, global::System.Threading.Tasks.Task<string>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IService_GetAsync_M3_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.Task<string>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
         return this;

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Mixed_Members.verified.txt
@@ -313,9 +313,11 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IService_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<int, string> factory)
@@ -331,6 +333,7 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IService_GetAsync_M3_MockCall Returns(global::System.Func<int, global::System.Threading.Tasks.Task<string>> factory)
@@ -338,6 +341,7 @@ public sealed class IService_GetAsync_M3_MockCall : global::TUnit.Mocks.Verifica
         EnsureSetup().ReturnsRaw(args => (object?)factory((int)args[0]!));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IService_GetAsync_M3_MockCall Callback(global::System.Action<int> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -613,6 +613,8 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<string?, string?> factory)
@@ -623,6 +625,13 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<string?, global::System.Threading.Tasks.Task<string?>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((string?)args[0]));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<string?, global::System.Threading.Tasks.Task<string?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string?)args[0]));
         return this;

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -613,9 +613,11 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<string?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<string?, string?> factory)
@@ -631,6 +633,7 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<string?, global::System.Threading.Tasks.Task<string?>> factory)
@@ -638,6 +641,7 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
         EnsureSetup().ReturnsRaw(args => (object?)factory((string?)args[0]));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IFoo_GetAsync_M3_MockCall Callback(global::System.Action<string?> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Nullable_Reference_Type_Parameters.verified.txt
@@ -614,6 +614,7 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_GetAsync_M3_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -631,6 +632,7 @@ public sealed class IFoo_GetAsync_M3_MockCall : global::TUnit.Mocks.Verification
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_GetAsync_M3_MockCall Returns(global::System.Func<string?, global::System.Threading.Tasks.Task<string?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((string?)args[0]));

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -701,6 +701,8 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Threading.Tasks.Task<string?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<TData?, string?> factory)
@@ -711,6 +713,13 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
 
     /// <summary>Configure a typed computed async return value using the actual method parameters.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Func<TData?, global::System.Threading.Tasks.Task<string?>> factory)
+    {
+        EnsureSetup().ReturnsRaw(args => (object?)factory((TData?)args[0]));
+        return this;
+    }
+
+    /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<TData?, global::System.Threading.Tasks.Task<string?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((TData?)args[0]));
         return this;

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -701,9 +701,11 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Threading.Tasks.Task<string?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<TData?, string?> factory)
@@ -719,6 +721,7 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
         return this;
     }
 
+    #if NET9_0_OR_GREATER
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<TData?, global::System.Threading.Tasks.Task<string?>> factory)
@@ -726,6 +729,7 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
         EnsureSetup().ReturnsRaw(args => (object?)factory((TData?)args[0]));
         return this;
     }
+    #endif
 
     /// <summary>Execute a typed callback using the actual method parameters.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> Callback(global::System.Action<TData?> callback)

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Obsolete_Members.verified.txt
@@ -702,6 +702,7 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IDialogService_ShowPanel_M1_MockCall<TData> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<global::System.Threading.Tasks.Task<string?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     /// <summary>Configure a typed computed return value using the actual method parameters.</summary>
@@ -719,6 +720,7 @@ public sealed class IDialogService_ShowPanel_M1_MockCall<TData> : global::TUnit.
     }
 
     /// <summary>Configure a typed computed async return value using the actual method parameters. The returned task is handed back as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IDialogService_ShowPanel_M1_MockCall<TData> Returns(global::System.Func<TData?, global::System.Threading.Tasks.Task<string?>> factory)
     {
         EnsureSetup().ReturnsRaw(args => (object?)factory((TData?)args[0]));

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -228,9 +228,11 @@ public sealed class IFoo_DoSomethingAsync_M0_MockCall<T> : global::TUnit.Mocks.V
     public IFoo_DoSomethingAsync_M0_MockCall<T> ReturnsAsync(global::System.Threading.Tasks.Task<T?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_DoSomethingAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_DoSomethingAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -228,6 +228,8 @@ public sealed class IFoo_DoSomethingAsync_M0_MockCall<T> : global::TUnit.Mocks.V
     public IFoo_DoSomethingAsync_M0_MockCall<T> ReturnsAsync(global::System.Threading.Tasks.Task<T?> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_DoSomethingAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public IFoo_DoSomethingAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Interface_With_Unconstrained_Nullable_Generic.verified.txt
@@ -229,6 +229,7 @@ public sealed class IFoo_DoSomethingAsync_M0_MockCall<T> : global::TUnit.Mocks.V
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public IFoo_DoSomethingAsync_M0_MockCall<T> ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public IFoo_DoSomethingAsync_M0_MockCall<T> Returns(global::System.Func<global::System.Threading.Tasks.Task<T?>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -205,6 +205,7 @@ public sealed class ILongMethodSignatures_SomeMethod_M0_MockCall : global::TUnit
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongMethodSignatures_SomeMethod_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public ILongMethodSignatures_SomeMethod_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -204,6 +204,8 @@ public sealed class ILongMethodSignatures_SomeMethod_M0_MockCall : global::TUnit
     public ILongMethodSignatures_SomeMethod_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongMethodSignatures_SomeMethod_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public ILongMethodSignatures_SomeMethod_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -204,9 +204,11 @@ public sealed class ILongMethodSignatures_SomeMethod_M0_MockCall : global::TUnit
     public ILongMethodSignatures_SomeMethod_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongMethodSignatures_SomeMethod_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public ILongMethodSignatures_SomeMethod_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -207,6 +207,8 @@ public sealed class ILongReturningSignature_Sum_M0_MockCall : global::TUnit.Mock
     public ILongReturningSignature_Sum_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<int> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongReturningSignature_Sum_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    public ILongReturningSignature_Sum_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -208,6 +208,7 @@ public sealed class ILongReturningSignature_Sum_M0_MockCall : global::TUnit.Mock
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongReturningSignature_Sum_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
+    [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public ILongReturningSignature_Sum_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
 
     // ICallVerification

--- a/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
+++ b/tests/TUnit.Mocks.SourceGenerator.Tests/Snapshots/Returning_Async_Method_With_More_Params_Than_Func_Action_Arity.verified.txt
@@ -207,9 +207,11 @@ public sealed class ILongReturningSignature_Sum_M0_MockCall : global::TUnit.Mock
     public ILongReturningSignature_Sum_M0_MockCall ReturnsAsync(global::System.Threading.Tasks.Task<int> task) { EnsureSetup().ReturnsRaw(task); return this; }
     /// <summary>Return a pre-built Task from a factory, invoked on each call.</summary>
     public ILongReturningSignature_Sum_M0_MockCall ReturnsAsync(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #if NET9_0_OR_GREATER
     /// <summary>Return a Task from a factory, invoked on each call. The Task is returned as-is, so an async factory stays pending until it completes.</summary>
     [global::System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
     public ILongReturningSignature_Sum_M0_MockCall Returns(global::System.Func<global::System.Threading.Tasks.Task<int>> taskFactory) { EnsureSetup().ReturnsRaw(() => (object?)taskFactory()); return this; }
+    #endif
 
     // ICallVerification
     /// <inheritdoc />

--- a/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6495
+// `.Returns()` on an async member only accepted a synchronous Func<T>, so an `async () => ...`
+// lambda failed with CS4010 and the only workaround (Thread.Sleep) blocked the caller before the
+// task was ever handed back — making it impossible to race a mocked call against a timeout.
+
+public interface ISlowService
+{
+    Task<int> GetValueAsync();
+
+    Task<int> GetValueAsync(int seed);
+
+    ValueTask<int> GetValueValueTaskAsync();
+
+    Task DoWorkAsync();
+}
+
+public class Issue6495Tests
+{
+    private const int NeverInTestTimeMs = 30_000;
+
+    [Test]
+    public async Task Returns_Async_Lambda_Stays_Pending_So_A_Timeout_Can_Win()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync().Returns(async () =>
+        {
+            await Task.Delay(NeverInTestTimeMs);
+            return 42;
+        });
+
+        var call = mock.Object.GetValueAsync();
+        var timeout = Task.Delay(50);
+
+        // The mocked call must come back incomplete, or the timeout branch could never win.
+        await Assert.That(call.IsCompleted).IsFalse();
+        await Assert.That(await Task.WhenAny(call, timeout)).IsSameReferenceAs(timeout);
+    }
+
+    [Test]
+    public async Task Returns_Async_Lambda_Still_Produces_The_Value()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync().Returns(async () =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Returns_Async_Lambda_Is_Invoked_Per_Call()
+    {
+        var calls = 0;
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync().Returns(async () =>
+        {
+            await Task.Yield();
+            return ++calls;
+        });
+
+        await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(1);
+        await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Returns_Async_Lambda_With_Parameters()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync(Arg.Any<int>()).Returns(async seed =>
+        {
+            await Task.Yield();
+            return seed * 2;
+        });
+
+        await Assert.That(await mock.Object.GetValueAsync(21)).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Returns_Async_Lambda_On_ValueTask_Member()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueValueTaskAsync().Returns(async () =>
+        {
+            await Task.Yield();
+            return 7;
+        });
+
+        await Assert.That(await mock.Object.GetValueValueTaskAsync()).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Returns_Async_Lambda_On_Task_Returning_Member_Stays_Pending()
+    {
+        var mock = ISlowService.Mock();
+        mock.DoWorkAsync().Returns(async () => await Task.Delay(NeverInTestTimeMs));
+
+        var call = mock.Object.DoWorkAsync();
+
+        await Assert.That(call.IsCompleted).IsFalse();
+    }
+
+    [Test]
+    public async Task Synchronous_Returns_Factory_Still_Works()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync().Returns(() => 42);
+
+        await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task ReturnsAsync_Factory_Is_Unchanged()
+    {
+        var mock = ISlowService.Mock();
+        mock.GetValueAsync().ReturnsAsync(async () =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(42);
+    }
+}

--- a/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
@@ -19,6 +19,15 @@ public interface ISlowService
     Task DoWorkAsync();
 }
 
+// A reference-typed async result: null and throw-expression lambda bodies convert to both T and
+// Task<T>, so the two Returns factory overloads must not become an ambiguity (CS0121).
+public interface IReferenceResultService
+{
+    Task<string?> GetNameAsync();
+
+    Task<string?> GetNameAsync(int id);
+}
+
 public class Issue6495Tests
 {
     private const int NeverInTestTimeMs = 30_000;
@@ -113,6 +122,55 @@ public class Issue6495Tests
         mock.GetValueAsync().Returns(() => 42);
 
         await Assert.That(await mock.Object.GetValueAsync()).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Null_Returning_Lambda_Still_Binds_To_The_Synchronous_Factory()
+    {
+        // `() => null` converts to both Func<string?> and Func<Task<string?>>. The async overload
+        // is deprioritised, so this keeps its pre-existing meaning: null is the *value*, and the
+        // member still returns a completed task.
+        var mock = IReferenceResultService.Mock();
+        mock.GetNameAsync().Returns(() => null);
+
+        var call = mock.Object.GetNameAsync();
+
+        await Assert.That(call.IsCompleted).IsTrue();
+        await Assert.That(await call).IsNull();
+    }
+
+    [Test]
+    public async Task Throwing_Lambda_Still_Binds_To_The_Synchronous_Factory()
+    {
+        var mock = IReferenceResultService.Mock();
+        mock.GetNameAsync().Returns(() => throw new InvalidOperationException("boom"));
+
+        await Assert.That(async () => await mock.Object.GetNameAsync())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Null_Returning_Typed_Lambda_Still_Binds_To_The_Synchronous_Factory()
+    {
+        var mock = IReferenceResultService.Mock();
+        mock.GetNameAsync(Arg.Any<int>()).Returns(id => null);
+
+        await Assert.That(await mock.Object.GetNameAsync(1)).IsNull();
+    }
+
+    [Test]
+    public async Task Async_Lambda_Still_Binds_On_A_Reference_Typed_Result()
+    {
+        var mock = IReferenceResultService.Mock();
+        mock.GetNameAsync().Returns(async () =>
+        {
+            await Task.Delay(NeverInTestTimeMs);
+            return "late";
+        });
+
+        var call = mock.Object.GetNameAsync();
+
+        await Assert.That(call.IsCompleted).IsFalse();
     }
 
     [Test]

--- a/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6495Tests.cs
@@ -32,6 +32,11 @@ public class Issue6495Tests
 {
     private const int NeverInTestTimeMs = 30_000;
 
+#if NET9_0_OR_GREATER
+    // The async-factory Returns overload carries [OverloadResolutionPriority], which only reaches
+    // a consumer's compilation on net9.0+ — so the overload, and these tests, are net9.0+ only.
+    // net8.0 consumers keep ReturnsAsync, covered by ReturnsAsync_Factory_Is_Unchanged below.
+
     [Test]
     public async Task Returns_Async_Lambda_Stays_Pending_So_A_Timeout_Can_Win()
     {
@@ -115,6 +120,8 @@ public class Issue6495Tests
         await Assert.That(call.IsCompleted).IsFalse();
     }
 
+#endif
+
     [Test]
     public async Task Synchronous_Returns_Factory_Still_Works()
     {
@@ -158,6 +165,7 @@ public class Issue6495Tests
         await Assert.That(await mock.Object.GetNameAsync(1)).IsNull();
     }
 
+#if NET9_0_OR_GREATER
     [Test]
     public async Task Async_Lambda_Still_Binds_On_A_Reference_Typed_Result()
     {
@@ -172,6 +180,8 @@ public class Issue6495Tests
 
         await Assert.That(call.IsCompleted).IsFalse();
     }
+
+#endif
 
     [Test]
     public async Task ReturnsAsync_Factory_Is_Unchanged()


### PR DESCRIPTION
Fixes #6495

## Problem

```csharp
mock.SomeMethodAsync().Returns(async () => { await Task.Delay(1000); return 42; });
// error CS4010: Cannot convert async lambda expression to delegate type 'Func<int>'
```

`Returns` on an async member is generated over the *unwrapped* return type, so its factory overload is `Func<int>` — an async lambda has nowhere to bind. The shape that does compile, `Returns(() => { Thread.Sleep(1000); return 42; })`, blocks the caller and hands back an already-completed task, so `await Task.WhenAny(mock.SomeMethodAsync(), Task.Delay(timeout))` can never let the timeout branch win. That makes timeout-handling tests unwritable — the reporter kept NSubstitute for one test because of it.

`ReturnsAsync(Func<Task<T>>)` already did the right thing, but nothing at the `Returns` call site pointed there.

## Fix

Emit a `Returns` overload alongside every existing `ReturnsAsync` factory overload — the parameterless form in `EmitReturnsAsyncOverloads` and the typed-parameter form in `GenerateTypedReturnsAsyncOverload` — routing through the same `ReturnsRaw` path. The factory's task is handed back as-is, so it stays pending until it completes.

Covers `Task<T>`, `ValueTask<T>`, `Task` and `ValueTask` members. The synchronous `Func<T>` overload is untouched; `ReturnsAsync` is unchanged.

## Tests

`tests/TUnit.Mocks.Tests/Issue6495Tests.cs` — 8 cases: the timeout race (asserting the returned task is incomplete and that a 50ms timeout beats it), value propagation, per-call invocation, the typed-parameter form, `ValueTask<T>` and `Task` members, plus guards that the synchronous `Returns` factory and `ReturnsAsync` still behave as before.

`TUnit.Mocks.Tests` 1168 passed. Generator snapshots regenerated (8 files, additive only) and passing on net8.0/net9.0/net10.0. Analyzers 30, Http 54, Logging 31.