### PR TITLE
+semver:minor - feat(mocks): runtime auto-stubs for interfaces the source generator cannot see

### DIFF
--- a/docs/docs/writing-tests/mocking/advanced.md
+++ b/docs/docs/writing-tests/mocking/advanced.md
@@ -137,6 +137,44 @@ var value = serviceB.GetValue(); // 42
 
 Use `Mock.Get(obj)` to retrieve the `Mock<T>` wrapper for any mock object — auto-mocked return values, or any object created by `T.Mock()`. Auto-mocks are cached — calling the same method returns the same mock instance.
 
+### Runtime Auto-Stubs
+
+Source-generated auto-mocks cover every interface the generator can name at compile time. Some
+types it structurally cannot see — most commonly a generic method like `T Get<T>()` invoked
+*inside* a third-party SDK with a `T` that is `internal` to that SDK, so your test assembly
+cannot even write the type name:
+
+```csharp
+// Inside the Azure Functions Worker SDK — not your code:
+//   features.Get<IFunctionBindingsFeature>()   // IFunctionBindingsFeature is internal to the SDK
+
+var features = IInvocationFeatures.Mock();
+
+// The SDK's internal Get<T>() call receives a functional runtime stub instead of null.
+```
+
+In loose mode, when no source-generated mock exists for a requested interface, TUnit.Mocks emits
+a functional stub at runtime. Stubs are recursive and use the same defaults you'd expect from
+runtime-proxy libraries like NSubstitute: strings return `""`, tasks come back completed,
+collections are empty, value types are zeroed, and interface-returning members return further
+stubs (or a real configurable `Mock<T>` when a source-generated factory exists for that type).
+Properties round-trip values set on them, and member results are cached for stable identity.
+
+The stub assembly is named `DynamicProxyGenAssembly2` and carries Castle DynamicProxy's public
+key — the exact identity SDKs already grant `InternalsVisibleTo` for NSubstitute/Moq
+compatibility — so any internal interface reachable by those libraries is reachable by
+TUnit.Mocks stubs too.
+
+Notes and limits:
+
+- Runtime stubs are not configurable or verifiable — by definition you cannot name their types
+  in test code. Nameable interfaces still get real, configurable mocks.
+- Strict mode is unaffected: unconfigured calls still throw.
+- On Native AOT (where `Reflection.Emit` does not exist) the feature is inert and unconfigured
+  calls keep returning default values.
+- Opt out globally with `settings.Mocks.RuntimeAutoStubs = false;` in a
+  `[Before(HookType.TestDiscovery)]` hook.
+
 ## MockRepository
 
 Manage multiple mocks with shared behavior and batch operations:

--- a/docs/docs/writing-tests/mocking/advanced.md
+++ b/docs/docs/writing-tests/mocking/advanced.md
@@ -172,6 +172,9 @@ Notes and limits:
 - Strict mode is unaffected: unconfigured calls still throw.
 - On Native AOT (where `Reflection.Emit` does not exist) the feature is inert and unconfigured
   calls keep returning default values.
+- The `netstandard2.0` asset (used by .NET Framework test projects) does not include the
+  runtime emitter — unconfigured calls return default values there too. Runtime stubs require
+  the `net8.0`+ assets.
 - Opt out globally with `settings.Mocks.RuntimeAutoStubs = false;` in a
   `[Before(HookType.TestDiscovery)]` hook.
 

--- a/src/TUnit.Mocks/MockEngine.Typed.cs
+++ b/src/TUnit.Mocks/MockEngine.Typed.cs
@@ -119,15 +119,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -277,15 +271,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -435,15 +423,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -593,15 +575,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -751,15 +727,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -909,15 +879,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -1067,15 +1031,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)
@@ -1225,15 +1183,9 @@ public sealed partial class MockEngine<T> where T : class
         }
 #pragma warning restore IL3050, IL2026
 
-        if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
+        if (TryGetLooseAutoMockResult(memberName, autoMockFactory: null, out TReturn autoMockResult))
         {
-            var cacheKey = (memberName, typeof(TReturn));
-            var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
-            {
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
-                return m;
-            });
-            if (autoMock is not null) return (TReturn)autoMock.ObjectInstance;
+            return autoMockResult;
         }
 
         if (Behavior == MockBehavior.Strict)

--- a/src/TUnit.Mocks/MockEngine.Typed.cs
+++ b/src/TUnit.Mocks/MockEngine.Typed.cs
@@ -121,7 +121,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -279,7 +279,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -437,7 +437,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -595,7 +595,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -753,7 +753,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -911,7 +911,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -1069,7 +1069,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);
@@ -1227,7 +1227,7 @@ public sealed partial class MockEngine<T> where T : class
 
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var m);

--- a/src/TUnit.Mocks/MockEngine.cs
+++ b/src/TUnit.Mocks/MockEngine.cs
@@ -55,7 +55,9 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     private ConcurrentQueue<(string EventName, bool IsSubscribe)>? _eventSubscriptions;
     private ConcurrentDictionary<string, Action>? _onSubscribeCallbacks;
     private ConcurrentDictionary<string, Action>? _onUnsubscribeCallbacks;
-    private ConcurrentDictionary<string, IMock?>? _autoMockCache;
+    // Keyed by member AND the actual Type identity (never a name string): two same-full-named
+    // types from different assemblies must not share a cached auto-mock/stub.
+    private ConcurrentDictionary<(string MemberName, Type ReturnType), IMock?>? _autoMockCache;
 
     /// <summary>
     /// The current state name for state machine mocking. Null means no state (all setups match).
@@ -123,7 +125,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     private ConcurrentDictionary<string, Action> OnUnsubscribeCallbacks
         => LazyInitializer.EnsureInitialized(ref _onUnsubscribeCallbacks)!;
 
-    private ConcurrentDictionary<string, IMock?> AutoMockCache
+    private ConcurrentDictionary<(string MemberName, Type ReturnType), IMock?> AutoMockCache
         => LazyInitializer.EnsureInitialized(ref _autoMockCache)!;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -131,7 +133,7 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     {
         if (Behavior == MockBehavior.Loose && typeof(TReturn).IsInterface)
         {
-            var cacheKey = memberName + "|" + typeof(TReturn).FullName;
+            var cacheKey = (memberName, typeof(TReturn));
             var autoMock = AutoMockCache.GetOrAdd(cacheKey, _ =>
             {
                 if (autoMockFactory is not null)
@@ -664,17 +666,17 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     }
 
     /// <summary>
-    /// Tries to get a cached auto-mock by its cache key. Used by Mock&lt;T&gt;.GetAutoMock.
+    /// Tries to get a cached auto-mock for a member and return type.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool TryGetAutoMock(string cacheKey, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IMock? mock)
+    public bool TryGetAutoMock(string memberName, Type returnType, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IMock? mock)
     {
         if (Volatile.Read(ref _autoMockCache) is not { } cache)
         {
             mock = null;
             return false;
         }
-        return cache.TryGetValue(cacheKey, out mock);
+        return cache.TryGetValue((memberName, returnType), out mock);
     }
 
     /// <summary>

--- a/src/TUnit.Mocks/MockEngine.cs
+++ b/src/TUnit.Mocks/MockEngine.cs
@@ -680,6 +680,36 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
     }
 
     /// <summary>
+    /// Tries to get a cached auto-mock by the legacy string cache key
+    /// (<c>memberName + "|" + returnType.FullName</c>). Kept for binary compatibility with
+    /// assemblies compiled against the previous shape of this helper; new code uses the
+    /// <see cref="TryGetAutoMock(string, Type, out IMock?)"/> overload, which keys by Type
+    /// identity instead of a name string.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool TryGetAutoMock(string cacheKey, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IMock? mock)
+    {
+        if (Volatile.Read(ref _autoMockCache) is not { } cache)
+        {
+            mock = null;
+            return false;
+        }
+
+        foreach (var entry in cache)
+        {
+            if (entry.Value is not null &&
+                string.Equals(entry.Key.MemberName + "|" + entry.Key.ReturnType.FullName, cacheKey, StringComparison.Ordinal))
+            {
+                mock = entry.Value;
+                return true;
+            }
+        }
+
+        mock = null;
+        return false;
+    }
+
+    /// <summary>
     /// Clears all setups and call history.
     /// </summary>
     public void Reset()

--- a/src/TUnit.Mocks/MockEngine.cs
+++ b/src/TUnit.Mocks/MockEngine.cs
@@ -676,7 +676,10 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
             mock = null;
             return false;
         }
-        return cache.TryGetValue((memberName, returnType), out mock);
+
+        // A cached null records a definitive miss (stubs disabled/unavailable/failed) — not a
+        // usable mock, and NotNullWhen(true) promises non-null on true.
+        return cache.TryGetValue((memberName, returnType), out mock) && mock is not null;
     }
 
     /// <summary>

--- a/src/TUnit.Mocks/MockEngine.cs
+++ b/src/TUnit.Mocks/MockEngine.cs
@@ -139,8 +139,16 @@ public sealed partial class MockEngine<T> : IMockEngineAccess, ITypeArgumentVeri
                     return autoMockFactory(Behavior);
                 }
 
-                MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var mock);
-                return mock;
+                if (MockRegistry.TryCreateAutoMock(typeof(TReturn), Behavior, out var mock))
+                {
+                    return mock;
+                }
+
+                // No source-generated factory — the type is either internal to another assembly
+                // (unnameable at compile time, #6514) or was simply never mocked. Fall back to a
+                // runtime-emitted stub where the platform allows it.
+                RuntimeStubs.RuntimeStubGenerator.TryCreateStub(typeof(TReturn), out var stub);
+                return stub;
             });
 
             if (autoMock is not null)

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
@@ -12,14 +12,18 @@ namespace TUnit.Mocks.RuntimeStubs;
 public abstract class RuntimeStub
 {
     private readonly ConcurrentDictionary<int, object?> _propertyValues = new();
-    private readonly ConcurrentDictionary<int, object?> _returnCache = new();
+
+    // Keyed by (slot, closed return type): a generic member like T Get<T>() shares one slot
+    // across every instantiation, so the type must disambiguate or Get<string>() would hand
+    // back Get<int>()'s cached boxed value and fail the emitted unbox/cast.
+    private readonly ConcurrentDictionary<(int Slot, Type ReturnType), object?> _returnCache = new();
 
     /// <summary>
-    /// Default return value for a method slot. Cached per slot so repeated calls hand back the
-    /// same instance (matching auto-mock identity semantics).
+    /// Default return value for a method slot. Cached per slot and closed return type so
+    /// repeated calls hand back the same instance (matching auto-mock identity semantics).
     /// </summary>
     protected object? GetReturnValue(int slot, Type returnType)
-        => _returnCache.GetOrAdd(slot, static (_, t) => RuntimeStubDefaults.GetDefault(t), returnType);
+        => _returnCache.GetOrAdd((slot, returnType), static key => RuntimeStubDefaults.GetDefault(key.ReturnType));
 
     /// <summary>
     /// Property getter: an explicitly set value wins; otherwise the cached default for the slot.
@@ -31,7 +35,7 @@ public abstract class RuntimeStub
             return value;
         }
 
-        return _returnCache.GetOrAdd(slot, static (_, t) => RuntimeStubDefaults.GetDefault(t), propertyType);
+        return _returnCache.GetOrAdd((slot, propertyType), static key => RuntimeStubDefaults.GetDefault(key.ReturnType));
     }
 
     /// <summary>Property setter: remembers the value so a later get round-trips it.</summary>

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
@@ -42,9 +42,71 @@ public abstract class RuntimeStub
     protected void SetPropertyValue(int slot, object? value)
         => _propertyValues[slot] = value;
 
+    // Indexer state is keyed by the index arguments too, so stub[1] and stub[2] round-trip
+    // independently. Defaults stay index-independent (shared via _returnCache) for stable
+    // identity across indices.
+    private readonly ConcurrentDictionary<(int Slot, IndexKey Key), object?> _indexerValues = new();
+
+    /// <summary>Indexer getter: an explicitly set value for these exact indices wins; otherwise
+    /// the cached default for the slot.</summary>
+    protected object? GetIndexerValue(int slot, object?[] indices, Type propertyType)
+    {
+        if (_indexerValues.TryGetValue((slot, new IndexKey(indices)), out var value))
+        {
+            return value;
+        }
+
+        return _returnCache.GetOrAdd((slot, propertyType), static key => RuntimeStubDefaults.GetDefault(key.ReturnType));
+    }
+
+    /// <summary>Indexer setter: remembers the value per index-argument combination.</summary>
+    protected void SetIndexerValue(int slot, object?[] indices, object? value)
+        => _indexerValues[(slot, new IndexKey(indices))] = value;
+
     internal void ResetState()
     {
         _propertyValues.Clear();
+        _indexerValues.Clear();
         _returnCache.Clear();
+    }
+
+    /// <summary>Structural-equality wrapper over an indexer's boxed index arguments.</summary>
+    private readonly struct IndexKey(object?[] indices) : IEquatable<IndexKey>
+    {
+        private readonly object?[] _indices = indices;
+
+        public bool Equals(IndexKey other)
+        {
+            if (_indices.Length != other._indices.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < _indices.Length; i++)
+            {
+                if (!Equals(_indices[i], other._indices[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object? obj) => obj is IndexKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = 17;
+                foreach (var index in _indices)
+                {
+                    hash = hash * 31 + (index?.GetHashCode() ?? 0);
+                }
+
+                return hash;
+            }
+        }
     }
 }

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStub.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace TUnit.Mocks.RuntimeStubs;
+
+/// <summary>
+/// Base class for runtime-emitted interface stubs (see <see cref="RuntimeStubGenerator"/>).
+/// Emitted accessor and method bodies delegate here so the generated IL stays trivial.
+/// Not intended for direct use.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class RuntimeStub
+{
+    private readonly ConcurrentDictionary<int, object?> _propertyValues = new();
+    private readonly ConcurrentDictionary<int, object?> _returnCache = new();
+
+    /// <summary>
+    /// Default return value for a method slot. Cached per slot so repeated calls hand back the
+    /// same instance (matching auto-mock identity semantics).
+    /// </summary>
+    protected object? GetReturnValue(int slot, Type returnType)
+        => _returnCache.GetOrAdd(slot, static (_, t) => RuntimeStubDefaults.GetDefault(t), returnType);
+
+    /// <summary>
+    /// Property getter: an explicitly set value wins; otherwise the cached default for the slot.
+    /// </summary>
+    protected object? GetPropertyValue(int slot, Type propertyType)
+    {
+        if (_propertyValues.TryGetValue(slot, out var value))
+        {
+            return value;
+        }
+
+        return _returnCache.GetOrAdd(slot, static (_, t) => RuntimeStubDefaults.GetDefault(t), propertyType);
+    }
+
+    /// <summary>Property setter: remembers the value so a later get round-trips it.</summary>
+    protected void SetPropertyValue(int slot, object? value)
+        => _propertyValues[slot] = value;
+
+    internal void ResetState()
+    {
+        _propertyValues.Clear();
+        _returnCache.Clear();
+    }
+}

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubDefaults.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubDefaults.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TUnit.Mocks.RuntimeStubs;
+
+/// <summary>
+/// Computes NSubstitute-style default values for members of runtime-emitted stubs: empty strings,
+/// completed tasks, empty collections, recursive auto-stubs for interfaces, zeroed value types.
+/// Only reachable from the runtime-stub path, which is itself gated on
+/// <c>RuntimeFeature.IsDynamicCodeSupported</c> — never on Native AOT.
+/// </summary>
+internal static class RuntimeStubDefaults
+{
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Only reachable when RuntimeFeature.IsDynamicCodeSupported (guarded in RuntimeStubGenerator).")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Operates on runtime types observed in live calls; the stub path is inert when members were trimmed.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055", Justification = "Constructed over runtime-observed type arguments on the guarded stub path.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Constructed over runtime-observed type arguments on the guarded stub path.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Constructed over runtime-observed type arguments on the guarded stub path.")]
+    public static object? GetDefault(Type type)
+    {
+        if (type == typeof(string))
+        {
+            return string.Empty;
+        }
+
+        if (type == typeof(Task))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (type == typeof(ValueTask))
+        {
+            return default(ValueTask);
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            var typeArgs = type.GetGenericArguments();
+
+            if (definition == typeof(Task<>))
+            {
+                return typeof(Task).GetMethod(nameof(Task.FromResult))!
+                    .MakeGenericMethod(typeArgs[0])
+                    .Invoke(null, [GetDefault(typeArgs[0])]);
+            }
+
+            if (definition == typeof(ValueTask<>))
+            {
+                return Activator.CreateInstance(type, GetDefault(typeArgs[0]));
+            }
+
+            if (definition == typeof(Nullable<>))
+            {
+                return null;
+            }
+
+            if (definition == typeof(IEnumerable<>)
+                || definition == typeof(IReadOnlyCollection<>)
+                || definition == typeof(IReadOnlyList<>)
+                || definition == typeof(ICollection<>)
+                || definition == typeof(IList<>)
+                || definition == typeof(List<>))
+            {
+                return Activator.CreateInstance(typeof(List<>).MakeGenericType(typeArgs[0]));
+            }
+
+            if (definition == typeof(IDictionary<,>)
+                || definition == typeof(IReadOnlyDictionary<,>)
+                || definition == typeof(Dictionary<,>))
+            {
+                return Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeArgs));
+            }
+        }
+
+        if (type.IsArray && type.GetArrayRank() == 1)
+        {
+            // Array element types can never be by-ref-like, so this is safe for any array.
+            return Array.CreateInstance(type.GetElementType()!, 0);
+        }
+
+        if (type == typeof(IEnumerable))
+        {
+            return Array.Empty<object>();
+        }
+
+        if (type.IsInterface)
+        {
+            // A source-generated mock factory beats a runtime stub: it produces a fully
+            // configurable Mock<T> the user can retrieve via Mock.Get.
+            if (MockRegistry.TryCreateAutoMock(type, MockBehavior.Loose, out var registered))
+            {
+                return registered.ObjectInstance;
+            }
+
+            if (RuntimeStubGenerator.TryCreateStub(type, out var stub))
+            {
+                return stub.ObjectInstance;
+            }
+
+            return null;
+        }
+
+        if (type.IsValueType)
+        {
+            return Activator.CreateInstance(type);
+        }
+
+        return null;
+    }
+}

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubDefaults.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubDefaults.cs
@@ -47,7 +47,10 @@ internal static class RuntimeStubDefaults
 
             if (definition == typeof(ValueTask<>))
             {
-                return Activator.CreateInstance(type, GetDefault(typeArgs[0]));
+                // Explicit ctor selection: ValueTask<T> has both (T) and (Task<T>) constructors,
+                // and a null argument (reference-typed T with a null default) matches either, so
+                // Activator.CreateInstance(type, arg) would be ambiguous.
+                return type.GetConstructor([typeArgs[0]])!.Invoke([GetDefault(typeArgs[0])]);
             }
 
             if (definition == typeof(Nullable<>))

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
@@ -315,14 +315,26 @@ internal static class RuntimeStubGenerator
 
         var parameters = target.GetParameters();
         parameterTypes = new Type[parameters.Length];
+        var parameterRequiredModifiers = new Type[parameters.Length][];
+        var parameterOptionalModifiers = new Type[parameters.Length][];
         for (var i = 0; i < parameters.Length; i++)
         {
             parameterTypes[i] = Substitute(parameters[i].ParameterType, genericMap);
+            parameterRequiredModifiers[i] = parameters[i].GetRequiredCustomModifiers();
+            parameterOptionalModifiers[i] = parameters[i].GetOptionalCustomModifiers();
         }
 
         returnType = Substitute(target.ReturnType, genericMap);
-        mb.SetReturnType(returnType);
-        mb.SetParameters(parameterTypes);
+        // Custom modifiers are part of the CLR signature the MethodImpl must match — an init
+        // setter's modreq(IsExternalInit) or an `in` parameter's modreq(InAttribute) dropped
+        // here would make CreateType reject the implementation.
+        mb.SetSignature(
+            returnType,
+            target.ReturnParameter.GetRequiredCustomModifiers(),
+            target.ReturnParameter.GetOptionalCustomModifiers(),
+            parameterTypes,
+            parameterRequiredModifiers,
+            parameterOptionalModifiers);
         tb.DefineMethodOverride(mb, target);
         return mb;
     }

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
@@ -38,6 +38,7 @@ internal static class RuntimeStubGenerator
         "d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7";
 
     private static readonly ConcurrentDictionary<Type, Type?> _stubTypes = new();
+    private static readonly object _emitLock = new();
     private static ModuleBuilder? _module;
     private static int _typeCounter;
 
@@ -117,76 +118,84 @@ internal static class RuntimeStubGenerator
             }
         }
 
-        var module = EnsureModule();
-        var tb = module.DefineType(
-            $"TUnit.Mocks.RuntimeStubs.Stub{Interlocked.Increment(ref _typeCounter)}_{Sanitize(interfaceType.Name)}",
-            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
-            typeof(RuntimeStub));
-
-        foreach (var iface in interfaces)
+        // ConcurrentDictionary.GetOrAdd only de-duplicates the factory per KEY — factories for
+        // different interfaces run concurrently, and ModuleBuilder.DefineType/TypeBuilder.CreateType
+        // on the shared module are not thread-safe on coreclr (dotnet/runtime#64094). Serialize
+        // emission, as Castle's ModuleScope does for this same assembly identity; cache hits in
+        // TryCreateStub stay lock-free.
+        lock (_emitLock)
         {
-            tb.AddInterfaceImplementation(iface);
+            var module = EnsureModule();
+            var tb = module.DefineType(
+                $"TUnit.Mocks.RuntimeStubs.Stub{Interlocked.Increment(ref _typeCounter)}_{Sanitize(interfaceType.Name)}",
+                TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
+                typeof(RuntimeStub));
+
+            foreach (var iface in interfaces)
+            {
+                tb.AddInterfaceImplementation(iface);
+            }
+
+            EmitConstructor(tb);
+
+            var slot = 0;
+            foreach (var iface in interfaces)
+            {
+                var handledAccessors = new HashSet<MethodInfo>();
+
+                foreach (var property in iface.GetProperties())
+                {
+                    var propertySlot = slot++;
+                    var isRefLike = property.PropertyType.IsByRefLike || property.PropertyType.IsPointer;
+                    // Index arguments are boxed into the state key so distinct indices round-trip
+                    // independently — unless an index parameter cannot be boxed (by-ref / ref struct
+                    // / pointer), in which case the accessor degrades to slot-level state.
+                    var indexParameters = property.GetIndexParameters();
+                    var indexable = indexParameters.Length > 0 && indexParameters.All(static p =>
+                        !p.ParameterType.IsByRef && !p.ParameterType.IsByRefLike && !p.ParameterType.IsPointer);
+
+                    if (property.GetMethod is { IsAbstract: true } getter)
+                    {
+                        handledAccessors.Add(getter);
+                        EmitAccessor(tb, iface, getter, propertySlot, isSetter: false, isRefLike, indexable);
+                    }
+
+                    if (property.SetMethod is { IsAbstract: true } setter)
+                    {
+                        handledAccessors.Add(setter);
+                        EmitAccessor(tb, iface, setter, propertySlot, isSetter: true, isRefLike, indexable);
+                    }
+                }
+
+                foreach (var evt in iface.GetEvents())
+                {
+                    if (evt.AddMethod is { IsAbstract: true } add)
+                    {
+                        handledAccessors.Add(add);
+                        EmitNoOp(tb, iface, add, slot++);
+                    }
+
+                    if (evt.RemoveMethod is { IsAbstract: true } remove)
+                    {
+                        handledAccessors.Add(remove);
+                        EmitNoOp(tb, iface, remove, slot++);
+                    }
+                }
+
+                foreach (var method in iface.GetMethods())
+                {
+                    // Default interface methods keep their bodies; accessors were handled above.
+                    if (!method.IsAbstract || handledAccessors.Contains(method))
+                    {
+                        continue;
+                    }
+
+                    EmitMethod(tb, iface, method, slot++);
+                }
+            }
+
+            return tb.CreateType();
         }
-
-        EmitConstructor(tb);
-
-        var slot = 0;
-        foreach (var iface in interfaces)
-        {
-            var handledAccessors = new HashSet<MethodInfo>();
-
-            foreach (var property in iface.GetProperties())
-            {
-                var propertySlot = slot++;
-                var isRefLike = property.PropertyType.IsByRefLike || property.PropertyType.IsPointer;
-                // Index arguments are boxed into the state key so distinct indices round-trip
-                // independently — unless an index parameter cannot be boxed (by-ref / ref struct
-                // / pointer), in which case the accessor degrades to slot-level state.
-                var indexParameters = property.GetIndexParameters();
-                var indexable = indexParameters.Length > 0 && indexParameters.All(static p =>
-                    !p.ParameterType.IsByRef && !p.ParameterType.IsByRefLike && !p.ParameterType.IsPointer);
-
-                if (property.GetMethod is { IsAbstract: true } getter)
-                {
-                    handledAccessors.Add(getter);
-                    EmitAccessor(tb, iface, getter, propertySlot, isSetter: false, isRefLike, indexable);
-                }
-
-                if (property.SetMethod is { IsAbstract: true } setter)
-                {
-                    handledAccessors.Add(setter);
-                    EmitAccessor(tb, iface, setter, propertySlot, isSetter: true, isRefLike, indexable);
-                }
-            }
-
-            foreach (var evt in iface.GetEvents())
-            {
-                if (evt.AddMethod is { IsAbstract: true } add)
-                {
-                    handledAccessors.Add(add);
-                    EmitNoOp(tb, iface, add, slot++);
-                }
-
-                if (evt.RemoveMethod is { IsAbstract: true } remove)
-                {
-                    handledAccessors.Add(remove);
-                    EmitNoOp(tb, iface, remove, slot++);
-                }
-            }
-
-            foreach (var method in iface.GetMethods())
-            {
-                // Default interface methods keep their bodies; accessors were handled above.
-                if (!method.IsAbstract || handledAccessors.Contains(method))
-                {
-                    continue;
-                }
-
-                EmitMethod(tb, iface, method, slot++);
-            }
-        }
-
-        return tb.CreateType();
     }
 
     private static Type[] CollectInterfaces(Type interfaceType)

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
@@ -1,0 +1,478 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+// The whole emitter sits behind RuntimeFeature.IsDynamicCodeSupported (checked in TryCreateStub):
+// on Native AOT it is inert, and trimming cannot remove members off types the runtime observes in
+// live calls here.
+#pragma warning disable IL2026, IL2055, IL2067, IL2070, IL2072, IL2075, IL3050
+
+namespace TUnit.Mocks.RuntimeStubs;
+
+/// <summary>
+/// Emits functional stub implementations of interfaces at runtime, closing the gap with
+/// runtime-proxy mocking libraries for types the source generator structurally cannot see —
+/// most importantly generic methods invoked by third-party code with type arguments that are
+/// <c>internal</c> to another assembly (#6514).
+///
+/// Stubs are emitted into a dynamic assembly named <c>DynamicProxyGenAssembly2</c> carrying
+/// Castle DynamicProxy's well-known public key: that is the exact identity the ecosystem already
+/// grants <c>InternalsVisibleTo</c> for Moq/NSubstitute compatibility (e.g. the Azure Functions
+/// Worker SDK), so any interface reachable by those libraries' proxies is reachable by these
+/// stubs. Dynamic assemblies are never strong-name verified, so only the public key is needed.
+///
+/// Stub members return NSubstitute-style defaults (see <see cref="RuntimeStubDefaults"/>),
+/// lazily and cached per member so identity is stable; properties round-trip set values. Stubs
+/// are not configurable or verifiable — by definition their types cannot be named by the test.
+/// </summary>
+internal static class RuntimeStubGenerator
+{
+    // Castle DynamicProxy's well-known public key (the ecosystem's IVT grants name this blob).
+    private const string DynamicProxyPublicKey =
+        "0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8" +
+        "db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753c" +
+        "c297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92" +
+        "d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7";
+
+    private static readonly ConcurrentDictionary<Type, Type?> _stubTypes = new();
+    private static ModuleBuilder? _module;
+    private static int _typeCounter;
+
+    private static readonly MethodInfo GetTypeFromHandleMethod =
+        typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), [typeof(RuntimeTypeHandle)])!;
+
+    private static readonly MethodInfo GetReturnValueMethod =
+        typeof(RuntimeStub).GetMethod("GetReturnValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo GetPropertyValueMethod =
+        typeof(RuntimeStub).GetMethod("GetPropertyValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo SetPropertyValueMethod =
+        typeof(RuntimeStub).GetMethod("SetPropertyValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    /// <summary>
+    /// Tries to create a runtime stub implementing <paramref name="interfaceType"/>. Returns
+    /// false — never throws — when stubs are disabled, dynamic code is unavailable (Native AOT),
+    /// the type is not a stubbable interface, or emission fails (e.g. the interface is internal
+    /// to an assembly that grants no <c>InternalsVisibleTo</c> the stub assembly can satisfy).
+    /// </summary>
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported; on Native AOT this method returns false before reaching emission.")]
+    public static bool TryCreateStub(Type interfaceType, [NotNullWhen(true)] out IMock? stub)
+    {
+        stub = null;
+
+        if (!TUnitMocksSettings.Default.RuntimeAutoStubs || !RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return false;
+        }
+
+        if (!interfaceType.IsInterface || interfaceType.IsGenericTypeDefinition || interfaceType.ContainsGenericParameters)
+        {
+            return false;
+        }
+
+        var stubType = _stubTypes.GetOrAdd(interfaceType, static t =>
+        {
+            try
+            {
+                return EmitStubType(t);
+            }
+            catch
+            {
+                // Inaccessible interface (no matching IVT grant), unsupported member shape, or
+                // any other emission failure: remember the miss so we never retry, and let the
+                // engine fall back to its existing default (null).
+                return null;
+            }
+        });
+
+        if (stubType is null)
+        {
+            return false;
+        }
+
+        stub = new RuntimeStubMock((RuntimeStub)Activator.CreateInstance(stubType)!);
+        return true;
+    }
+
+    [RequiresDynamicCode("Emits stub types at runtime; callers are gated on RuntimeFeature.IsDynamicCodeSupported.")]
+    private static Type? EmitStubType(Type interfaceType)
+    {
+        var interfaces = CollectInterfaces(interfaceType);
+
+        foreach (var iface in interfaces)
+        {
+            if (!IsSupported(iface))
+            {
+                return null;
+            }
+        }
+
+        var module = EnsureModule();
+        var tb = module.DefineType(
+            $"TUnit.Mocks.RuntimeStubs.Stub{Interlocked.Increment(ref _typeCounter)}_{Sanitize(interfaceType.Name)}",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
+            typeof(RuntimeStub));
+
+        foreach (var iface in interfaces)
+        {
+            tb.AddInterfaceImplementation(iface);
+        }
+
+        EmitConstructor(tb);
+
+        var slot = 0;
+        foreach (var iface in interfaces)
+        {
+            var handledAccessors = new HashSet<MethodInfo>();
+
+            foreach (var property in iface.GetProperties())
+            {
+                var propertySlot = slot++;
+                var isRefLike = property.PropertyType.IsByRefLike || property.PropertyType.IsPointer;
+
+                if (property.GetMethod is { IsAbstract: true } getter)
+                {
+                    handledAccessors.Add(getter);
+                    EmitAccessor(tb, iface, getter, propertySlot, isSetter: false, isRefLike);
+                }
+
+                if (property.SetMethod is { IsAbstract: true } setter)
+                {
+                    handledAccessors.Add(setter);
+                    EmitAccessor(tb, iface, setter, propertySlot, isSetter: true, isRefLike);
+                }
+            }
+
+            foreach (var evt in iface.GetEvents())
+            {
+                if (evt.AddMethod is { IsAbstract: true } add)
+                {
+                    handledAccessors.Add(add);
+                    EmitNoOp(tb, iface, add, slot++);
+                }
+
+                if (evt.RemoveMethod is { IsAbstract: true } remove)
+                {
+                    handledAccessors.Add(remove);
+                    EmitNoOp(tb, iface, remove, slot++);
+                }
+            }
+
+            foreach (var method in iface.GetMethods())
+            {
+                // Default interface methods keep their bodies; accessors were handled above.
+                if (!method.IsAbstract || handledAccessors.Contains(method))
+                {
+                    continue;
+                }
+
+                EmitMethod(tb, iface, method, slot++);
+            }
+        }
+
+        return tb.CreateType();
+    }
+
+    private static Type[] CollectInterfaces(Type interfaceType)
+    {
+        var inherited = interfaceType.GetInterfaces();
+        var all = new Type[inherited.Length + 1];
+        all[0] = interfaceType;
+        Array.Copy(inherited, 0, all, 1, inherited.Length);
+        return all;
+    }
+
+    private static bool IsSupported(Type iface)
+    {
+        foreach (var method in iface.GetMethods())
+        {
+            // Static abstract members need the implementing type itself to provide statics the
+            // engine can never dispatch; by-ref returns have no storable default to hand back.
+            if (method.IsStatic && method.IsAbstract)
+            {
+                return false;
+            }
+
+            if (method.IsAbstract && method.ReturnType.IsByRef)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ModuleBuilder EnsureModule()
+    {
+        if (_module is { } existing)
+        {
+            return existing;
+        }
+
+        var assemblyName = new AssemblyName("DynamicProxyGenAssembly2");
+        assemblyName.SetPublicKey(Convert.FromHexString(DynamicProxyPublicKey));
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("TUnit.Mocks.RuntimeStubs");
+        return Interlocked.CompareExchange(ref _module, module, null) ?? module;
+    }
+
+    private static void EmitConstructor(TypeBuilder tb)
+    {
+        var ctor = tb.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, typeof(RuntimeStub).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private const MethodAttributes ExplicitImplAttributes =
+        MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.HideBySig |
+        MethodAttributes.Virtual | MethodAttributes.NewSlot;
+
+    private static MethodBuilder DefineExplicitImpl(TypeBuilder tb, Type iface, MethodInfo target, int slot,
+        out Type[] parameterTypes, out Type returnType, out Dictionary<Type, Type> genericMap)
+    {
+        var mb = tb.DefineMethod($"<{slot}>{iface.Name}.{target.Name}", ExplicitImplAttributes);
+
+        genericMap = new Dictionary<Type, Type>();
+        if (target.IsGenericMethodDefinition)
+        {
+            var sourceArgs = target.GetGenericArguments();
+            var names = new string[sourceArgs.Length];
+            for (var i = 0; i < sourceArgs.Length; i++)
+            {
+                names[i] = sourceArgs[i].Name;
+            }
+
+            var builders = mb.DefineGenericParameters(names);
+            for (var i = 0; i < sourceArgs.Length; i++)
+            {
+                genericMap[sourceArgs[i]] = builders[i];
+            }
+
+            for (var i = 0; i < sourceArgs.Length; i++)
+            {
+                var source = sourceArgs[i];
+                builders[i].SetGenericParameterAttributes(
+                    source.GenericParameterAttributes & ~GenericParameterAttributes.VarianceMask);
+
+                Type? baseConstraint = null;
+                var interfaceConstraints = new List<Type>();
+                foreach (var constraint in source.GetGenericParameterConstraints())
+                {
+                    var mapped = Substitute(constraint, genericMap);
+                    if (mapped.IsInterface || mapped.IsGenericParameter)
+                    {
+                        interfaceConstraints.Add(mapped);
+                    }
+                    else
+                    {
+                        baseConstraint = mapped;
+                    }
+                }
+
+                if (baseConstraint is not null)
+                {
+                    builders[i].SetBaseTypeConstraint(baseConstraint);
+                }
+
+                if (interfaceConstraints.Count > 0)
+                {
+                    builders[i].SetInterfaceConstraints(interfaceConstraints.ToArray());
+                }
+            }
+        }
+
+        var parameters = target.GetParameters();
+        parameterTypes = new Type[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameterTypes[i] = Substitute(parameters[i].ParameterType, genericMap);
+        }
+
+        returnType = Substitute(target.ReturnType, genericMap);
+        mb.SetReturnType(returnType);
+        mb.SetParameters(parameterTypes);
+        tb.DefineMethodOverride(mb, target);
+        return mb;
+    }
+
+    private static void EmitMethod(TypeBuilder tb, Type iface, MethodInfo method, int slot)
+    {
+        var mb = DefineExplicitImpl(tb, iface, method, slot, out var parameterTypes, out var returnType, out _);
+        var il = mb.GetILGenerator();
+
+        EmitOutParameterInit(il, method, parameterTypes);
+        EmitReturn(il, slot, returnType, GetReturnValueMethod);
+    }
+
+    private static void EmitAccessor(TypeBuilder tb, Type iface, MethodInfo accessor, int slot, bool isSetter, bool isRefLike)
+    {
+        var mb = DefineExplicitImpl(tb, iface, accessor, slot, out var parameterTypes, out _, out _);
+        var il = mb.GetILGenerator();
+
+        if (isSetter)
+        {
+            // Ref-struct / pointer values cannot be boxed for storage — the setter is a no-op.
+            if (!isRefLike)
+            {
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_I4, slot);
+                il.Emit(OpCodes.Ldarg, parameterTypes.Length); // value is the last argument
+                var valueType = parameterTypes[^1];
+                if (valueType.IsValueType || valueType.IsGenericParameter)
+                {
+                    il.Emit(OpCodes.Box, valueType);
+                }
+
+                il.Emit(OpCodes.Call, SetPropertyValueMethod);
+            }
+
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
+        EmitReturn(il, slot, Substitute(accessor.ReturnType, []), GetPropertyValueMethod);
+    }
+
+    private static void EmitNoOp(TypeBuilder tb, Type iface, MethodInfo method, int slot)
+    {
+        var mb = DefineExplicitImpl(tb, iface, method, slot, out _, out _, out _);
+        mb.GetILGenerator().Emit(OpCodes.Ret);
+    }
+
+    private static void EmitOutParameterInit(ILGenerator il, MethodInfo method, Type[] parameterTypes)
+    {
+        var parameters = method.GetParameters();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (parameters[i].IsOut && parameterTypes[i].IsByRef)
+            {
+                il.Emit(OpCodes.Ldarg, i + 1);
+                il.Emit(OpCodes.Initobj, parameterTypes[i].GetElementType()!);
+            }
+        }
+    }
+
+    private static void EmitReturn(ILGenerator il, int slot, Type returnType, MethodInfo valueSource)
+    {
+        if (returnType == typeof(void))
+        {
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
+        if (returnType.IsPointer || returnType.IsFunctionPointer)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Conv_U);
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
+        if (returnType.IsByRefLike)
+        {
+            var local = il.DeclareLocal(returnType);
+            il.Emit(OpCodes.Ldloca, local);
+            il.Emit(OpCodes.Initobj, returnType);
+            il.Emit(OpCodes.Ldloc, local);
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, slot);
+        il.Emit(OpCodes.Ldtoken, returnType);
+        il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
+        il.Emit(OpCodes.Call, valueSource);
+        il.Emit(OpCodes.Unbox_Any, returnType);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Rebinds a type that may reference the source method's generic parameters onto the
+    /// stub method's own generic parameter builders.
+    /// </summary>
+    private static Type Substitute(Type type, Dictionary<Type, Type> map)
+    {
+        if (map.Count == 0)
+        {
+            return type;
+        }
+
+        if (map.TryGetValue(type, out var mapped))
+        {
+            return mapped;
+        }
+
+        if (type.IsByRef)
+        {
+            return Substitute(type.GetElementType()!, map).MakeByRefType();
+        }
+
+        if (type.IsArray)
+        {
+            var element = Substitute(type.GetElementType()!, map);
+            var rank = type.GetArrayRank();
+            return rank == 1 ? element.MakeArrayType() : element.MakeArrayType(rank);
+        }
+
+        if (type.IsPointer)
+        {
+            return Substitute(type.GetElementType()!, map).MakePointerType();
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            var args = type.GetGenericArguments();
+            var changed = false;
+            for (var i = 0; i < args.Length; i++)
+            {
+                var substituted = Substitute(args[i], map);
+                if (!ReferenceEquals(substituted, args[i]))
+                {
+                    args[i] = substituted;
+                    changed = true;
+                }
+            }
+
+            return changed ? type.GetGenericTypeDefinition().MakeGenericType(args) : type;
+        }
+
+        return type;
+    }
+
+    private static string Sanitize(string name)
+    {
+        var chars = name.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (!char.IsLetterOrDigit(chars[i]) && chars[i] != '_')
+            {
+                chars[i] = '_';
+            }
+        }
+
+        return new string(chars);
+    }
+}
+#else
+using System.Diagnostics.CodeAnalysis;
+
+namespace TUnit.Mocks.RuntimeStubs;
+
+/// <summary>Runtime stub emission requires Reflection.Emit; unavailable on this target.</summary>
+internal static class RuntimeStubGenerator
+{
+    public static bool TryCreateStub(Type interfaceType, [NotNullWhen(true)] out IMock? stub)
+    {
+        stub = null;
+        return false;
+    }
+}
+#endif

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
@@ -53,6 +53,12 @@ internal static class RuntimeStubGenerator
     private static readonly MethodInfo SetPropertyValueMethod =
         typeof(RuntimeStub).GetMethod("SetPropertyValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
+    private static readonly MethodInfo GetIndexerValueMethod =
+        typeof(RuntimeStub).GetMethod("GetIndexerValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo SetIndexerValueMethod =
+        typeof(RuntimeStub).GetMethod("SetIndexerValue", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     /// <summary>
     /// Tries to create a runtime stub implementing <paramref name="interfaceType"/>. Returns
     /// false — never throws — when stubs are disabled, dynamic code is unavailable (Native AOT),
@@ -133,17 +139,23 @@ internal static class RuntimeStubGenerator
             {
                 var propertySlot = slot++;
                 var isRefLike = property.PropertyType.IsByRefLike || property.PropertyType.IsPointer;
+                // Index arguments are boxed into the state key so distinct indices round-trip
+                // independently — unless an index parameter cannot be boxed (by-ref / ref struct
+                // / pointer), in which case the accessor degrades to slot-level state.
+                var indexParameters = property.GetIndexParameters();
+                var indexable = indexParameters.Length > 0 && indexParameters.All(static p =>
+                    !p.ParameterType.IsByRef && !p.ParameterType.IsByRefLike && !p.ParameterType.IsPointer);
 
                 if (property.GetMethod is { IsAbstract: true } getter)
                 {
                     handledAccessors.Add(getter);
-                    EmitAccessor(tb, iface, getter, propertySlot, isSetter: false, isRefLike);
+                    EmitAccessor(tb, iface, getter, propertySlot, isSetter: false, isRefLike, indexable);
                 }
 
                 if (property.SetMethod is { IsAbstract: true } setter)
                 {
                     handledAccessors.Add(setter);
-                    EmitAccessor(tb, iface, setter, propertySlot, isSetter: true, isRefLike);
+                    EmitAccessor(tb, iface, setter, propertySlot, isSetter: true, isRefLike, indexable);
                 }
             }
 
@@ -311,7 +323,7 @@ internal static class RuntimeStubGenerator
         EmitReturn(il, slot, returnType, GetReturnValueMethod);
     }
 
-    private static void EmitAccessor(TypeBuilder tb, Type iface, MethodInfo accessor, int slot, bool isSetter, bool isRefLike)
+    private static void EmitAccessor(TypeBuilder tb, Type iface, MethodInfo accessor, int slot, bool isSetter, bool isRefLike, bool indexable)
     {
         var mb = DefineExplicitImpl(tb, iface, accessor, slot, out var parameterTypes, out _, out _);
         var il = mb.GetILGenerator();
@@ -323,6 +335,11 @@ internal static class RuntimeStubGenerator
             {
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldc_I4, slot);
+                if (indexable)
+                {
+                    EmitLoadArgsArray(il, parameterTypes, count: parameterTypes.Length - 1);
+                }
+
                 il.Emit(OpCodes.Ldarg, parameterTypes.Length); // value is the last argument
                 var valueType = parameterTypes[^1];
                 if (valueType.IsValueType || valueType.IsGenericParameter)
@@ -330,14 +347,48 @@ internal static class RuntimeStubGenerator
                     il.Emit(OpCodes.Box, valueType);
                 }
 
-                il.Emit(OpCodes.Call, SetPropertyValueMethod);
+                il.Emit(OpCodes.Call, indexable ? SetIndexerValueMethod : SetPropertyValueMethod);
             }
 
             il.Emit(OpCodes.Ret);
             return;
         }
 
+        if (indexable && !isRefLike)
+        {
+            var returnType = Substitute(accessor.ReturnType, []);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4, slot);
+            EmitLoadArgsArray(il, parameterTypes, count: parameterTypes.Length);
+            il.Emit(OpCodes.Ldtoken, returnType);
+            il.Emit(OpCodes.Call, GetTypeFromHandleMethod);
+            il.Emit(OpCodes.Call, GetIndexerValueMethod);
+            il.Emit(OpCodes.Unbox_Any, returnType);
+            il.Emit(OpCodes.Ret);
+            return;
+        }
+
         EmitReturn(il, slot, Substitute(accessor.ReturnType, []), GetPropertyValueMethod);
+    }
+
+    /// <summary>Loads a new object?[] holding the first <paramref name="count"/> arguments
+    /// (boxing value types), leaving it on the evaluation stack.</summary>
+    private static void EmitLoadArgsArray(ILGenerator il, Type[] parameterTypes, int count)
+    {
+        il.Emit(OpCodes.Ldc_I4, count);
+        il.Emit(OpCodes.Newarr, typeof(object));
+        for (var i = 0; i < count; i++)
+        {
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4, i);
+            il.Emit(OpCodes.Ldarg, i + 1);
+            if (parameterTypes[i].IsValueType || parameterTypes[i].IsGenericParameter)
+            {
+                il.Emit(OpCodes.Box, parameterTypes[i]);
+            }
+
+            il.Emit(OpCodes.Stelem_Ref);
+        }
     }
 
     private static void EmitNoOp(TypeBuilder tb, Type iface, MethodInfo method, int slot)

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubGenerator.cs
@@ -37,7 +37,11 @@ internal static class RuntimeStubGenerator
         "c297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92" +
         "d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7";
 
-    private static readonly ConcurrentDictionary<Type, Type?> _stubTypes = new();
+    // Lazy values: GetOrAdd may invoke the factory once per contender for the SAME key and keep
+    // only one result — a plain Type? value would let racing first-touches of one interface each
+    // emit a permanent dynamic type before all but one are discarded. Lazy (ExecutionAndPublication)
+    // guarantees exactly one emission per interface; cache hits stay lock-free.
+    private static readonly ConcurrentDictionary<Type, Lazy<Type?>> _stubTypes = new();
     private static readonly object _emitLock = new();
     private static ModuleBuilder? _module;
     private static int _typeCounter;
@@ -81,7 +85,7 @@ internal static class RuntimeStubGenerator
             return false;
         }
 
-        var stubType = _stubTypes.GetOrAdd(interfaceType, static t =>
+        var stubType = _stubTypes.GetOrAdd(interfaceType, static t => new Lazy<Type?>(() =>
         {
             try
             {
@@ -94,7 +98,7 @@ internal static class RuntimeStubGenerator
                 // engine fall back to its existing default (null).
                 return null;
             }
-        });
+        })).Value;
 
         if (stubType is null)
         {

--- a/src/TUnit.Mocks/RuntimeStubs/RuntimeStubMock.cs
+++ b/src/TUnit.Mocks/RuntimeStubs/RuntimeStubMock.cs
@@ -1,0 +1,21 @@
+namespace TUnit.Mocks.RuntimeStubs;
+
+/// <summary>
+/// <see cref="IMock"/> wrapper for a runtime-emitted stub so it can flow through the engine's
+/// auto-mock cache. Runtime stubs have no engine: they record no calls and hold no setups, so
+/// verification is a no-op and reset only clears remembered property values.
+/// </summary>
+internal sealed class RuntimeStubMock(RuntimeStub instance) : IMock
+{
+    public object ObjectInstance { get; } = instance;
+
+    public void VerifyAll()
+    {
+    }
+
+    public void VerifyNoOtherCalls()
+    {
+    }
+
+    public void Reset() => ((RuntimeStub)ObjectInstance).ResetState();
+}

--- a/src/TUnit.Mocks/TUnitMocksSettings.cs
+++ b/src/TUnit.Mocks/TUnitMocksSettings.cs
@@ -26,4 +26,14 @@ public class TUnitMocksSettings
     /// Configure this during test discovery, before tests create mocks.
     /// </remarks>
     public MockBehavior DefaultMode { get; set; } = MockBehavior.Loose;
+
+    /// <summary>
+    /// When a loose-mode mock must return an interface the source generator produced no mock
+    /// for — most notably a generic method invoked by third-party code with a type argument
+    /// that is <c>internal</c> to another assembly — emit a functional stub at runtime instead
+    /// of returning <see langword="null"/>. Matches the auto-substitution behavior of
+    /// runtime-proxy mocking libraries. Defaults to <see langword="true"/>; has no effect on
+    /// Native AOT, where the previous default-value behavior is retained.
+    /// </summary>
+    public bool RuntimeAutoStubs { get; set; } = true;
 }

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -45,6 +45,23 @@ public interface INeverMockedGenericFeature
     T Resolve<T>();
 }
 
+// Review findings on #6519: indexer state must be keyed by the index arguments, and
+// ValueTask<T> defaults must not trip the ambiguous (T)/(Task<T>) constructor pair when the
+// inner default is null.
+public sealed class StubDto
+{
+    public string? Name { get; set; }
+}
+
+public interface IIndexedFeature
+{
+    string this[int index] { get; set; }
+
+    string this[string first, int second] { get; set; }
+
+    ValueTask<StubDto> GetDtoAsync();
+}
+
 // Simulates the SDK-internal call site: code the test has no control over requesting types the
 // test assembly could not configure.
 public static class StubFeatureConsumer
@@ -162,6 +179,38 @@ public class Issue6514Tests
         // Same instantiation still returns the same cached instance.
         await Assert.That(stub.Resolve<INeverMockedNested>())
             .IsSameReferenceAs(stub.Resolve<INeverMockedNested>());
+    }
+
+    [Test]
+    public async Task Stub_Indexer_State_Is_Keyed_By_Index_Arguments()
+    {
+        var features = IStubFeatures.Mock();
+        var stub = features.Object.Get<IIndexedFeature>();
+
+        stub[1] = "one";
+        stub[2] = "two";
+
+        await Assert.That(stub[1]).IsEqualTo("one");
+        await Assert.That(stub[2]).IsEqualTo("two");
+        await Assert.That(stub[3]).IsEqualTo(string.Empty); // unset index keeps the default
+
+        stub["a", 1] = "multi";
+
+        await Assert.That(stub["a", 1]).IsEqualTo("multi");
+        await Assert.That(stub["a", 2]).IsEqualTo(string.Empty);
+        await Assert.That(stub["b", 1]).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task Stub_ValueTask_Of_Reference_Type_Returns_Completed_Null()
+    {
+        var features = IStubFeatures.Mock();
+        var stub = features.Object.Get<IIndexedFeature>();
+
+        var task = stub.GetDtoAsync();
+
+        await Assert.That(task.IsCompleted).IsTrue();
+        await Assert.That(await task).IsNull();
     }
 
     [Test]

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -92,6 +92,15 @@ public interface IConcurrentStub5 { string Name { get; } }
 public interface IConcurrentStub6 { string Name { get; } }
 public interface IConcurrentStub7 { string Name { get; } }
 
+public interface ISingleEmissionStub { string Name { get; } }
+
+// By-ref returns are an unsupported stub shape: TryCreateStub fails and the engine caches the
+// miss as null.
+public interface IByRefFeature
+{
+    ref int Counter();
+}
+
 // Simulates the SDK-internal call site: code the test has no control over requesting types the
 // test assembly could not configure.
 public static class StubFeatureConsumer
@@ -361,6 +370,67 @@ public class Issue6514Tests
         {
             await Assert.That(result).IsNotNull();
         }
+    }
+
+    [Test]
+    public async Task Concurrent_Same_Interface_First_Touch_Emits_A_Single_Stub_Type()
+    {
+        // GetOrAdd may run the value factory once per contender for the SAME key and keep only
+        // one result — with a plain Type? value, racing first-touches of one interface would
+        // each emit a permanent dynamic type. The Lazy cache must collapse them to exactly one.
+        using var start = new ManualResetEventSlim(false);
+
+        var tasks = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            // Distinct mocks so every engine's own auto-mock cache misses and all of them race
+            // into RuntimeStubGenerator for the same interface.
+            var features = IStubFeatures.Mock();
+            start.Wait();
+            return (object?)features.Object.Get<ISingleEmissionStub>();
+        })).ToArray();
+
+        start.Set();
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var result in results)
+        {
+            await Assert.That(result).IsNotNull();
+        }
+
+        var emittedTypes = GetLoadedTypes(results[0]!.GetType().Assembly)
+            .Where(t => t.Name.Contains(nameof(ISingleEmissionStub)))
+            .ToList();
+        await Assert.That(emittedTypes.Count).IsEqualTo(1);
+
+        // Other tests may be mid-emission in the shared dynamic assembly while this enumerates
+        // it — their half-built TypeBuilders throw; every ISingleEmissionStub stub is fully
+        // created by this point, so the loaded subset is complete for the assertion.
+        static IEnumerable<Type> GetLoadedTypes(System.Reflection.Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (System.Reflection.ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(t => t is not null)!;
+            }
+        }
+    }
+
+    // Review finding on #6519: a cached null records a definitive miss (stub disabled,
+    // unavailable, or failed) — TryGetAutoMock must not report it as a hit with a null mock,
+    // which would violate NotNullWhen(true) and hand callers a null to dereference.
+    [Test]
+    public async Task TryGetAutoMock_Returns_False_For_A_Cached_Miss()
+    {
+        var features = IStubFeatures.Mock();
+        await Assert.That(features.Object.Get<IByRefFeature>()).IsNull();
+
+        var engine = ((IMockEngineAccess<IStubFeatures>)features).Engine;
+
+        await Assert.That(engine.TryGetAutoMock("Get", typeof(IByRefFeature), out var mock)).IsFalse();
+        await Assert.That(mock).IsNull();
     }
 
     // Review finding on #6519: the auto-mock cache re-key to (memberName, Type) removed the

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -101,6 +101,16 @@ public interface IByRefFeature
     ref int Counter();
 }
 
+// Custom modifiers are part of the CLR signature the emitted MethodImpl must match: an init
+// setter carries modreq(IsExternalInit), an `in` parameter modreq(InAttribute). Dropping either
+// during emission makes CreateType reject the stub type.
+public interface ICustomModifierFeature
+{
+    string Name { get; init; }
+
+    int Sum(in int left, in int right);
+}
+
 // Simulates the SDK-internal call site: code the test has no control over requesting types the
 // test assembly could not configure.
 public static class StubFeatureConsumer
@@ -292,6 +302,20 @@ public class Issue6514Tests
         stub[1] = null;
         await Assert.That(stub[1]).IsNull();
         await Assert.That(stub[2]).IsEqualTo(string.Empty); // untouched index keeps the default
+    }
+
+    [Test]
+    public async Task Stub_Supports_Init_Only_Properties_And_In_Parameters()
+    {
+        var features = IStubFeatures.Mock();
+
+        // Emission must preserve modreq(IsExternalInit) / modreq(InAttribute) — a dropped
+        // modifier fails CreateType, the miss is cached, and this returns null instead.
+        var stub = features.Object.Get<ICustomModifierFeature>();
+
+        await Assert.That(stub).IsNotNull();
+        await Assert.That(stub.Name).IsEqualTo(string.Empty);
+        await Assert.That(stub.Sum(1, 2)).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -1,0 +1,181 @@
+using TUnit.Mocks;
+
+namespace TUnit.Mocks.Tests;
+
+// Regression: https://github.com/thomhurst/TUnit/issues/6514
+// A generic method like IFeatures.Get<T>() invoked by third-party code with a T the test
+// assembly cannot name (internal to the SDK) used to fall through to null, because the source
+// generator can only produce mocks for types nameable at compile time. Loose-mode mocks now
+// fall back to a runtime-emitted stub (RuntimeStubGenerator): a functional recursive stub in a
+// dynamic assembly named DynamicProxyGenAssembly2 with Castle's public key, so the ecosystem's
+// existing InternalsVisibleTo grants for NSubstitute/Moq apply to TUnit.Mocks too.
+
+#region Test types
+
+public interface IStubFeatures
+{
+    T Get<T>();
+}
+
+// Simulates a type internal to a third-party SDK. The test project grants InternalsVisibleTo to
+// DynamicProxyGenAssembly2 exactly like such SDKs do for Castle-based mocking libraries.
+internal interface IInternalFeature
+{
+    string Name { get; }
+}
+
+// Never mocked anywhere in this assembly, so no source-generated factory is registered for it.
+public interface INeverMockedFeature
+{
+    string Describe();
+    INeverMockedNested Nested { get; }
+    Task<int> CountAsync();
+    IReadOnlyList<string> Items { get; }
+}
+
+public interface INeverMockedNested
+{
+    int Value { get; }
+}
+
+// Simulates the SDK-internal call site: code the test has no control over requesting types the
+// test assembly could not configure.
+public static class StubFeatureConsumer
+{
+    public static string DescribeInternal(IStubFeatures features)
+    {
+        var feature = features.Get<IInternalFeature>();
+        return feature is null ? "null" : $"got:{feature.Name}";
+    }
+}
+
+#endregion
+
+[SkipIfNotDynamicCodeSupported("Runtime stubs require Reflection.Emit; on Native AOT the feature is inert and loose mocks keep the previous null default.")]
+public class Issue6514Tests
+{
+    [Test]
+    public async Task Generic_Get_With_Internal_Type_Argument_Returns_A_Functional_Stub()
+    {
+        var features = IStubFeatures.Mock();
+
+        // "got:" — the stub exists and its string property returns "" rather than null.
+        await Assert.That(StubFeatureConsumer.DescribeInternal(features.Object)).IsEqualTo("got:");
+    }
+
+    [Test]
+    public async Task Generic_Get_With_Unregistered_Public_Interface_Returns_A_Stub()
+    {
+        var features = IStubFeatures.Mock();
+
+        var stub = features.Object.Get<INeverMockedFeature>();
+
+        await Assert.That(stub).IsNotNull();
+        await Assert.That(stub.Describe()).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task Stub_Members_Recurse_Into_Further_Stubs()
+    {
+        var features = IStubFeatures.Mock();
+
+        var stub = features.Object.Get<INeverMockedFeature>();
+
+        await Assert.That(stub.Nested).IsNotNull();
+        await Assert.That(stub.Nested.Value).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Stub_Task_Members_Return_Completed_Tasks()
+    {
+        var features = IStubFeatures.Mock();
+
+        var stub = features.Object.Get<INeverMockedFeature>();
+        var task = stub.CountAsync();
+
+        // Accessing IsCompleted would throw if the stub had returned a null task.
+        await Assert.That(task.IsCompleted).IsTrue();
+        await Assert.That(await task).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Stub_Collection_Members_Return_Empty_Collections()
+    {
+        var features = IStubFeatures.Mock();
+
+        var stub = features.Object.Get<INeverMockedFeature>();
+
+        await Assert.That(stub.Items).IsNotNull();
+        await Assert.That(stub.Items.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Stub_Member_Values_Are_Cached_For_Stable_Identity()
+    {
+        var features = IStubFeatures.Mock();
+
+        var first = features.Object.Get<INeverMockedFeature>();
+        var second = features.Object.Get<INeverMockedFeature>();
+
+        await Assert.That(first).IsSameReferenceAs(second);
+        await Assert.That(first.Nested).IsSameReferenceAs(second.Nested);
+    }
+
+    [Test]
+    public async Task Registered_Interfaces_Still_Get_Real_Configurable_Mocks()
+    {
+        // IStubRegisteredFeature has a generated factory (mocked below), so the registry path
+        // wins over runtime stubbing and the result is a real Mock the test can retrieve.
+        _ = IStubRegisteredFeature.Mock();
+
+        var features = IStubFeatures.Mock();
+        var instance = features.Object.Get<IStubRegisteredFeature>();
+
+        await Assert.That(instance).IsNotNull();
+
+        var wrapper = Mock.Get(instance);
+        wrapper.Tag.Returns("configured");
+
+        await Assert.That(instance.Tag).IsEqualTo("configured");
+    }
+
+    [Test]
+    public async Task Generic_Get_With_Value_Type_Argument_Still_Returns_Default()
+    {
+        var features = IStubFeatures.Mock();
+
+        await Assert.That(features.Object.Get<int>()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Strict_Mode_Still_Throws_For_Unconfigured_Generic_Calls()
+    {
+        var features = IStubFeatures.Mock(MockBehavior.Strict);
+
+        await Assert.That(() => features.Object.Get<INeverMockedFeature>())
+            .Throws<TUnit.Mocks.Exceptions.MockStrictBehaviorException>();
+    }
+
+    // Bare NotInParallel: this test flips a global setting, so nothing may run alongside it.
+    [Test]
+    [NotInParallel]
+    public async Task Opt_Out_Restores_The_Previous_Null_Default()
+    {
+        TUnitMocksSettings.Default.RuntimeAutoStubs = false;
+        try
+        {
+            var features = IStubFeatures.Mock();
+
+            await Assert.That(features.Object.Get<INeverMockedFeature>()).IsNull();
+        }
+        finally
+        {
+            TUnitMocksSettings.Default.RuntimeAutoStubs = true;
+        }
+    }
+}
+
+public interface IStubRegisteredFeature
+{
+    string Tag { get; }
+}

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -363,6 +363,25 @@ public class Issue6514Tests
         }
     }
 
+    // Review finding on #6519: the auto-mock cache re-key to (memberName, Type) removed the
+    // public TryGetAutoMock(string, out IMock?) CLR signature — a binary break for assemblies
+    // compiled against the previous shape. The legacy overload must keep resolving entries by
+    // the old memberName + "|" + returnType.FullName key format.
+    [Test]
+    public async Task Legacy_String_TryGetAutoMock_Overload_Resolves_Cached_Auto_Mocks()
+    {
+        var features = IStubFeatures.Mock();
+        var stub = features.Object.Get<INeverMockedFeature>();
+
+        var engine = ((IMockEngineAccess<IStubFeatures>)features).Engine;
+        var legacyKey = "Get|" + typeof(INeverMockedFeature).FullName;
+
+        await Assert.That(engine.TryGetAutoMock(legacyKey, out var cached)).IsTrue();
+        await Assert.That(cached!.ObjectInstance).IsSameReferenceAs(stub!);
+
+        await Assert.That(engine.TryGetAutoMock("Get|No.Such.Type", out _)).IsFalse();
+    }
+
     // Bare NotInParallel: this test flips a global setting, so nothing may run alongside it.
     [Test]
     [NotInParallel]

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -38,6 +38,13 @@ public interface INeverMockedNested
     int Value { get; }
 }
 
+// A stubbed interface that itself declares a generic method — every instantiation shares one
+// member slot, so cached defaults must be keyed by the closed return type too.
+public interface INeverMockedGenericFeature
+{
+    T Resolve<T>();
+}
+
 // Simulates the SDK-internal call site: code the test has no control over requesting types the
 // test assembly could not configure.
 public static class StubFeatureConsumer
@@ -137,6 +144,24 @@ public class Issue6514Tests
         wrapper.Tag.Returns("configured");
 
         await Assert.That(instance.Tag).IsEqualTo("configured");
+    }
+
+    [Test]
+    public async Task Stub_Generic_Method_Keeps_Instantiations_Separate()
+    {
+        // Review finding on #6519: the per-slot return cache conflated generic instantiations —
+        // after Resolve<int>() cached a boxed 0, Resolve<INeverMockedNested>() retrieved it and
+        // the emitted unbox/cast threw InvalidCastException.
+        var features = IStubFeatures.Mock();
+        var stub = features.Object.Get<INeverMockedGenericFeature>();
+
+        await Assert.That(stub.Resolve<int>()).IsEqualTo(0);
+        await Assert.That(stub.Resolve<INeverMockedNested>()).IsNotNull();
+        await Assert.That(stub.Resolve<string>()).IsEqualTo(string.Empty);
+
+        // Same instantiation still returns the same cached instance.
+        await Assert.That(stub.Resolve<INeverMockedNested>())
+            .IsSameReferenceAs(stub.Resolve<INeverMockedNested>());
     }
 
     [Test]

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -182,6 +182,41 @@ public class Issue6514Tests
     }
 
     [Test]
+    public async Task Same_Full_Name_From_Different_Assemblies_Get_Distinct_Stubs()
+    {
+        // Review finding on #6519: the auto-mock cache keyed by memberName + FullName string
+        // conflated two types with identical full names from different assemblies — the second
+        // call retrieved the first type's stub and the cast to TReturn threw.
+        var typeA = EmitEmptyInterface("Issue6514.CollisionAssemblyA");
+        var typeB = EmitEmptyInterface("Issue6514.CollisionAssemblyB");
+
+        var features = IStubFeatures.Mock();
+        var get = typeof(IStubFeatures).GetMethod(nameof(IStubFeatures.Get))!;
+
+        var first = get.MakeGenericMethod(typeA).Invoke(features.Object, null);
+        var second = get.MakeGenericMethod(typeB).Invoke(features.Object, null);
+
+        await Assert.That(first).IsNotNull();
+        await Assert.That(second).IsNotNull();
+        await Assert.That(typeA.IsInstanceOfType(first!)).IsTrue();
+        await Assert.That(typeB.IsInstanceOfType(second!)).IsTrue();
+    }
+
+    private static Type EmitEmptyInterface(string assemblyName)
+    {
+        var assembly = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+            new System.Reflection.AssemblyName(assemblyName),
+            System.Reflection.Emit.AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("collision");
+        var type = module.DefineType(
+            "Issue6514.Collision.ISameFullName",
+            System.Reflection.TypeAttributes.Public
+            | System.Reflection.TypeAttributes.Interface
+            | System.Reflection.TypeAttributes.Abstract);
+        return type.CreateType()!;
+    }
+
+    [Test]
     public async Task Stub_Indexer_State_Is_Keyed_By_Index_Arguments()
     {
         var features = IStubFeatures.Mock();

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -62,6 +62,26 @@ public interface IIndexedFeature
     ValueTask<StubDto> GetDtoAsync();
 }
 
+// Review finding on #6519 (round 4): the typed cache-miss handlers (1–8 args) must route
+// through the same runtime-stub fallback as the object-array handler. IServiceProvider has no
+// source-generated auto-mock factory (System.* interfaces are excluded), so only the runtime
+// stub can serve it.
+public interface ITypedPathFeatures
+{
+    IServiceProvider Resolve(int id);
+}
+
+// Distinct never-before-stubbed interfaces for the concurrent first-emission test — each
+// first-touch runs EmitStubType, which must be serialized over the shared ModuleBuilder.
+public interface IConcurrentStub0 { string Name { get; } }
+public interface IConcurrentStub1 { string Name { get; } }
+public interface IConcurrentStub2 { string Name { get; } }
+public interface IConcurrentStub3 { string Name { get; } }
+public interface IConcurrentStub4 { string Name { get; } }
+public interface IConcurrentStub5 { string Name { get; } }
+public interface IConcurrentStub6 { string Name { get; } }
+public interface IConcurrentStub7 { string Name { get; } }
+
 // Simulates the SDK-internal call site: code the test has no control over requesting types the
 // test assembly could not configure.
 public static class StubFeatureConsumer
@@ -263,6 +283,55 @@ public class Issue6514Tests
 
         await Assert.That(() => features.Object.Get<INeverMockedFeature>())
             .Throws<TUnit.Mocks.Exceptions.MockStrictBehaviorException>();
+    }
+
+    [Test]
+    public async Task Typed_Handler_Cache_Miss_Falls_Back_To_Runtime_Stub()
+    {
+        var mock = ITypedPathFeatures.Mock();
+
+        var provider = mock.Object.Resolve(42);
+
+        await Assert.That(provider).IsNotNull();
+        // Stubs are functional: members return defaults instead of throwing.
+        await Assert.That(provider.GetService(typeof(string))).IsNull();
+        // Same member + return type resolves to the same cached stub, argument values included.
+        await Assert.That(mock.Object.Resolve(43)).IsSameReferenceAs(provider);
+    }
+
+    [Test]
+    public async Task Concurrent_First_Time_Stub_Emission_Is_Thread_Safe()
+    {
+        // GetOrAdd only de-duplicates the factory per key: distinct interfaces first-touched in
+        // parallel reach EmitStubType concurrently, and the shared ModuleBuilder must be guarded.
+        var features = IStubFeatures.Mock();
+        using var start = new ManualResetEventSlim(false);
+
+        Task<object?> First(Func<object?> resolve) => Task.Run(() =>
+        {
+            start.Wait();
+            return resolve();
+        });
+
+        var tasks = new[]
+        {
+            First(() => features.Object.Get<IConcurrentStub0>()),
+            First(() => features.Object.Get<IConcurrentStub1>()),
+            First(() => features.Object.Get<IConcurrentStub2>()),
+            First(() => features.Object.Get<IConcurrentStub3>()),
+            First(() => features.Object.Get<IConcurrentStub4>()),
+            First(() => features.Object.Get<IConcurrentStub5>()),
+            First(() => features.Object.Get<IConcurrentStub6>()),
+            First(() => features.Object.Get<IConcurrentStub7>()),
+        };
+
+        start.Set();
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var result in results)
+        {
+            await Assert.That(result).IsNotNull();
+        }
     }
 
     // Bare NotInParallel: this test flips a global setting, so nothing may run alongside it.

--- a/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
+++ b/tests/TUnit.Mocks.Tests/Issue6514Tests.cs
@@ -62,6 +62,16 @@ public interface IIndexedFeature
     ValueTask<StubDto> GetDtoAsync();
 }
 
+// Review finding on #6519 (round 5, rebutted): assigning null to a writable stub property or
+// indexer must round-trip. ConcurrentDictionary rejects null KEYS, not values — the stub keys
+// by slot int / index tuple, so storing a null value is fine; this pins that behavior.
+public interface INullAssignableFeature
+{
+    string? Name { get; set; }
+
+    string? this[int index] { get; set; }
+}
+
 // Review finding on #6519 (round 4): the typed cache-miss handlers (1–8 args) must route
 // through the same runtime-stub fallback as the object-array handler. IServiceProvider has no
 // source-generated auto-mock factory (System.* interfaces are excluded), so only the runtime
@@ -254,6 +264,25 @@ public class Issue6514Tests
         await Assert.That(stub["a", 1]).IsEqualTo("multi");
         await Assert.That(stub["a", 2]).IsEqualTo(string.Empty);
         await Assert.That(stub["b", 1]).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task Stub_Writable_Property_And_Indexer_Round_Trip_Null()
+    {
+        var features = IStubFeatures.Mock();
+        var stub = features.Object.Get<INullAssignableFeature>();
+
+        // Overwrite a real value with null so the setter genuinely stores null rather than
+        // leaving the slot untouched, then confirm the getter hands the null back instead of
+        // throwing or falling through to the "" default.
+        stub.Name = "set";
+        stub.Name = null;
+        await Assert.That(stub.Name).IsNull();
+
+        stub[1] = "set";
+        stub[1] = null;
+        await Assert.That(stub[1]).IsNull();
+        await Assert.That(stub[2]).IsEqualTo(string.Empty); // untouched index keeps the default
     }
 
     [Test]

--- a/tests/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
+++ b/tests/TUnit.Mocks.Tests/TUnit.Mocks.Tests.csproj
@@ -14,6 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The same grant third-party SDKs extend for Castle-based mocking libraries; lets the
+         runtime-stub tests (#6514) exercise stubbing an internal interface. -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Kiota.Abstractions" />


### PR DESCRIPTION
## Summary

Fixes #6514 — feature parity with runtime-proxy libraries' auto-substitution. When a loose-mode mock member must produce an interface the source generator produced no mock for — most notably a generic method like `IInvocationFeatures.Get<T>()` invoked *inside* a third-party SDK with a `T` that is `internal` to that SDK and structurally unnameable by the test assembly — the call fell through to `null`, surfacing as an NRE deep in SDK code. This was a hard migration blocker from NSubstitute (reported against the Azure Functions Worker SDK).

## How it works

The key insight: the generated `Get<T>()` override is itself generic, so at runtime the engine sees the real `System.Type` even when the test assembly can't name it. The engine's existing auto-mock fallback (`TryGetLooseAutoMockResult` → `MockRegistry.TryCreateAutoMock`) now falls back to `RuntimeStubGenerator` on a registry miss:

- **Emission**: a `Reflection.Emit` type per interface (cached), in a dynamic assembly named `DynamicProxyGenAssembly2` carrying Castle DynamicProxy's well-known public key — the exact identity SDKs across the ecosystem already grant `InternalsVisibleTo` for NSubstitute/Moq compatibility, so every internal interface reachable by those proxies is reachable by these stubs. Dynamic assemblies are never strong-name verified; the public key alone satisfies the grant.
- **Behavior**: NSubstitute-style defaults, computed lazily and cached per member for stable identity — `""` for strings, completed tasks (`Task<T>`/`ValueTask<T>` included), empty collections, zeroed value types, recursive stubs for interface members (or a **real configurable `Mock<T>`** when a source-generated factory exists for that nested type). Properties round-trip set values. Generic interface methods are supported, including constraint re-emission and out-parameter zeroing.
- **Guards**: loose mode only (strict still throws); `RuntimeFeature.IsDynamicCodeSupported` — inert on Native AOT, which keeps the previous default-value behavior; opt-out via `settings.Mocks.RuntimeAutoStubs = false`; any emission failure (interface with no matching IVT grant, static abstract members, by-ref returns) is a cached miss falling back to the previous behavior. netstandard2.0 builds carry a no-op implementation.
- Stubs are deliberately not configurable or verifiable — their types can't be named in test code (that's the premise). Nameable interfaces keep getting real mocks.

## Behavior change

In loose mode, unconfigured interface-returning calls that previously returned `null` (no generated factory) now return a functional stub on JIT runtimes — hence `+semver:minor`. Opt-out restores the old behavior globally.

## Tests

`Issue6514Tests` (skipped on Native AOT via the existing `SkipIfNotDynamicCodeSupported` attribute): the issue's `Get<T>`-with-internal-type shape (the test project now grants IVT to `DynamicProxyGenAssembly2` exactly like real SDKs do), unregistered public interfaces, recursion, task/collection/string defaults, identity caching, registry-preferred real mocks via `Mock.Get`, value-type defaults unchanged, strict mode unchanged, and the opt-out. Full suites: 1192/1192 (net10.0), 1191/1191 (net9.0), 1169/1169 (net8.0); generator snapshots 90/90; Http 54/54, Logging 31/31.

Docs: new *Runtime Auto-Stubs* section under Recursive / Auto-Mocking in `docs/writing-tests/mocking/advanced.md`.