### PR TITLE
Fix Mermaid label contrast in dark mode

### DIFF
--- a/docs/docs/writing-tests/lifecycle.md
+++ b/docs/docs/writing-tests/lifecycle.md
@@ -54,7 +54,7 @@ flowchart TB
 
     T0 --> T0a --> T0b --> T1 --> T2 --> T3 --> T4 --> T5 --> T6 --> T7
 
-    style T0b fill:#fff3e0,stroke:#ef6c00,color:#e65100
+    style T0b fill:#fff3e0,stroke:#ef6c00,color:#9a3412
     style T3 fill:#c8e6c9,stroke:#2e7d32,color:#1b5e20
     style T6 fill:#ffcdd2,stroke:#c62828,color:#b71c1c
 ```

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -93,6 +93,12 @@ body {
   color: var(--text-body);
 }
 
+/* Mermaid assigns node text colours on a parent element. Keep labels inheriting
+   those colours instead of applying the global dark-mode paragraph colour. */
+[data-theme='dark'] .docusaurus-mermaid-container .nodeLabel p {
+  color: inherit;
+}
+
 /* Better code block contrast */
 [data-theme='dark'] code {
   background: rgba(20, 184, 166, 0.15) !important;


### PR DESCRIPTION
## Summary

- restore Mermaid node-specific text colours in dark mode
- darken the highlighted initializer label to meet WCAG AA contrast

## Root cause

The global dark-mode paragraph rule overrode colours inherited by Mermaid labels. This changed highlighted node text to `#cbd5e1`, producing contrast as low as 1.05:1 on pastel backgrounds.

The Mermaid-specific rule now preserves inherited node colours. The orange initializer label increases from 3.46:1 to 6.66:1 contrast.

## Validation

- `yarn build` (docs)
- `git diff --check`
- contrast ratios checked for all three highlighted lifecycle nodes

Addresses [discussion #6530](https://github.com/thomhurst/TUnit/discussions/6530).