### PR TITLE
Enhance matrix tests documentation

### DIFF
--- a/docs/docs/writing-tests/matrix-tests.md
+++ b/docs/docs/writing-tests/matrix-tests.md
@@ -45,6 +45,10 @@ public class MyTestClass
 
 That will generate 100 test cases. 10 different values for value1, and 10 different values for value2. 10\*10 is 100.
 
+:::info
+Using `[Matrix]` without arguments on a `bool` or `enum` parameter will automatically expand all known values.
+:::
+
 ## Matrix Range
 
 You can also use the `[MatrixRange<T>]` for numerical types. It will generated a range between the minimum and maximum, with an optional step parameter to define how far to step between each value. By default, this is 1.


### PR DESCRIPTION
Explain matrix behaviour for bool/enum as requested in https://github.com/thomhurst/TUnit/discussions/5187#discussioncomment-16200293.

## Description

`[Matrix]` has a special behaviour when used with `bool` / `enum` which was undocumented. This PR documents it in an info box.

## Related Issue

https://github.com/thomhurst/TUnit/discussions/5187

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [X] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [X] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [ ] I have written tests that prove my fix is effective or my feature works