### PR TITLE
fix: run event receivers on injected properties

### DIFF
--- a/src/TUnit.Core/TestContext.cs
+++ b/src/TUnit.Core/TestContext.cs
@@ -409,6 +409,16 @@ public partial class TestContext : Context,
     internal bool EventReceiversBuilt { get; set; }
 
     /// <summary>
+    /// Set once this context's eligible event objects have been pushed into the
+    /// EventReceiverOrchestrator registry (normally by the eager PrepareForExecution pass).
+    /// Lets the per-test fallback registration skip re-scanning the eligible-object set.
+    /// Deliberately not cleared by <see cref="InvalidateEventReceiverCaches"/>: retry
+    /// invalidation rebuilds the same object instances (only ClassInstance changes, and
+    /// that is registered separately), so re-registration would be a pure dedup no-op.
+    /// </summary>
+    internal bool EventObjectsRegistered { get; set; }
+
+    /// <summary>
     /// Invalidates all cached event receiver data. Called when class instance changes (e.g., on retry).
     /// </summary>
     internal void InvalidateEventReceiverCaches()

--- a/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -79,6 +79,8 @@ internal sealed class EventReceiverOrchestrator
             _registry.RegisterReceivers(vlb.AsSpan());
         }
         vlb.Dispose();
+
+        context.EventObjectsRegistered = true;
     }
 
     // Precondition: ClassInstance has just been assigned; the initial RegisterReceivers call (with ClassInstance still null) already covered every other eligible object.

--- a/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -589,9 +589,21 @@ internal sealed class EventReceiverOrchestrator
     }
 
     /// <summary>
-    /// Initialize test counts for first/last event receivers
+    /// Prepares the orchestrator for execution: initializes test counts for first/last event
+    /// receivers and registers every test's eligible event receivers into the registry.
     /// </summary>
-    public void InitializeTestCounts(IReadOnlyList<AbstractExecutableTest> allTests)
+    /// <remarks>
+    /// Registration must be complete for ALL tests before ANY test executes: the first-in-
+    /// session/assembly/class events are one-shot (memoized per scope key) and enumerate the
+    /// registry at the moment the first gated test reaches them. Receivers registered lazily
+    /// per test (the pre-eager-pass design) missed those events whenever an earlier test with
+    /// a same-interface receiver had already triggered the memoized invocation (#6557).
+    /// Runs after the registration phase (argument/property resolution) and after deferred
+    /// placeholder expansion, so the eligible-object sets are complete — including injected
+    /// property values (#6554). Class instances don't exist yet; they are registered per test
+    /// via <see cref="RegisterClassInstanceReceiver"/>.
+    /// </remarks>
+    public void PrepareForExecution(IReadOnlyList<AbstractExecutableTest> allTests)
     {
         Interlocked.Exchange(ref _sessionTestCount, allTests.Count);
 
@@ -602,12 +614,15 @@ internal sealed class EventReceiverOrchestrator
 
         for (var i = 0; i < allTests.Count; i++)
         {
-            var classContext = allTests[i].Context.ClassContext;
+            var context = allTests[i].Context;
+            var classContext = context.ClassContext;
             var assemblyCounter = _assemblyTestCounts.GetOrAdd(classContext.AssemblyContext.Assembly, static _ => new Counter());
             assemblyCounter.Add(1);
 
             var classCounter = _classTestCounts.GetOrAdd(classContext.ClassType, static _ => new Counter());
             classCounter.Add(1);
+
+            RegisterReceivers(context);
         }
     }
 

--- a/src/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/src/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -78,6 +78,15 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
 
         // Track the cached objects so they get the correct reference count
         _objectTracker.TrackObjects(testContext);
+
+        // The per-context event receiver caches were already built and locked in before this
+        // point (GetTestRegisteredReceivers runs first so SkipAttribute can short-circuit
+        // expensive data sources). Injected property values can themselves be event receivers
+        // (e.g. ITestStartEventReceiver), so drop the stale caches to pick them up (#6554).
+        if (testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments.Count > 0)
+        {
+            testContext.InvalidateEventReceiverCaches();
+        }
     }
 
     /// <summary>

--- a/src/TUnit.Engine/Services/ObjectLifecycleService.cs
+++ b/src/TUnit.Engine/Services/ObjectLifecycleService.cs
@@ -72,20 +72,28 @@ internal sealed class ObjectLifecycleService : IObjectRegistry, IInitializationC
         var events = testContext.InternalEvents;
         var testClassType = testContext.Metadata.TestDetails.ClassType;
 
-        // Resolve property values (creating shared objects) and cache them WITHOUT setting on placeholder instance
-        // This ensures shared objects are created once and tracked with the correct reference count
-        await PropertyInjector.ResolveAndCachePropertiesAsync(testClassType, objectBag, methodMetadata, events, testContext, cancellationToken);
-
-        // Track the cached objects so they get the correct reference count
-        _objectTracker.TrackObjects(testContext);
-
-        // The per-context event receiver caches were already built and locked in before this
-        // point (GetTestRegisteredReceivers runs first so SkipAttribute can short-circuit
-        // expensive data sources). Injected property values can themselves be event receivers
-        // (e.g. ITestStartEventReceiver), so drop the stale caches to pick them up (#6554).
-        if (testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments.Count > 0)
+        try
         {
-            testContext.InvalidateEventReceiverCaches();
+            // Resolve property values (creating shared objects) and cache them WITHOUT setting on placeholder instance
+            // This ensures shared objects are created once and tracked with the correct reference count
+            await PropertyInjector.ResolveAndCachePropertiesAsync(testClassType, objectBag, methodMetadata, events, testContext, cancellationToken);
+
+            // Track the cached objects so they get the correct reference count
+            _objectTracker.TrackObjects(testContext);
+        }
+        finally
+        {
+            // The per-context event receiver caches were already built and locked in before this
+            // point (GetTestRegisteredReceivers runs first so SkipAttribute can short-circuit
+            // expensive data sources). Injected property values can themselves be event receivers
+            // (e.g. ITestStartEventReceiver), so drop the stale caches to pick them up (#6554).
+            // Runs in finally because resolution is parallel (Task.WhenAll): when one property
+            // throws, sibling properties may still have resolved and cached receivers, and the
+            // failed test's ITestEndEventReceiver invocation must see them.
+            if (testContext.Metadata.TestDetails.TestClassInjectedPropertyArguments.Count > 0)
+            {
+                testContext.InvalidateEventReceiverCaches();
+            }
         }
     }
 

--- a/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -63,8 +63,11 @@ internal sealed class TestCoordinator : ITestCoordinator
 
             _contextRestorer.RestoreContext(test);
 
-            // Register event receivers early so that skip event receivers work
-            // even when the test is skipped before full initialization.
+            // Fallback registration for tests that bypass the eager PrepareForExecution pass
+            // (e.g. dynamically queued tests added mid-session). For scheduled tests this is a
+            // cheap no-op: the eligible-object cache is valid and every object dedups against
+            // the orchestrator's already-registered set. Also keeps skip event receivers
+            // working when the test is skipped before full initialization.
             _eventReceiverOrchestrator.RegisterReceivers(test.Context);
 
             // Check if test was already marked as skipped during registration

--- a/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -64,11 +64,12 @@ internal sealed class TestCoordinator : ITestCoordinator
             _contextRestorer.RestoreContext(test);
 
             // Fallback registration for tests that bypass the eager PrepareForExecution pass
-            // (e.g. dynamically queued tests added mid-session). For scheduled tests this is a
-            // cheap no-op: the eligible-object cache is valid and every object dedups against
-            // the orchestrator's already-registered set. Also keeps skip event receivers
-            // working when the test is skipped before full initialization.
-            _eventReceiverOrchestrator.RegisterReceivers(test.Context);
+            // (e.g. dynamically queued tests added mid-session). Gated so normally scheduled
+            // tests don't pay a second eligible-object scan per test.
+            if (!test.Context.EventObjectsRegistered)
+            {
+                _eventReceiverOrchestrator.RegisterReceivers(test.Context);
+            }
 
             // Check if test was already marked as skipped during registration
             // (e.g., by a derived SkipAttribute evaluated in OnTestRegistered).

--- a/src/TUnit.Engine/TestSessionCoordinator.cs
+++ b/src/TUnit.Engine/TestSessionCoordinator.cs
@@ -100,7 +100,7 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
 
     private void InitializeEventReceivers(List<AbstractExecutableTest> testList, CancellationToken cancellationToken)
     {
-        _eventReceiverOrchestrator.InitializeTestCounts(testList);
+        _eventReceiverOrchestrator.PrepareForExecution(testList);
     }
 
     /// <summary>

--- a/tests/TUnit.Engine.Tests/PartialInjectionFailure6554Tests.cs
+++ b/tests/TUnit.Engine.Tests/PartialInjectionFailure6554Tests.cs
@@ -1,0 +1,27 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+/// <summary>
+/// Verifies the partial-injection-failure edge of issue #6554: when one injected property's
+/// data source throws during registration, event receivers on sibling properties that DID
+/// resolve must still fire. Runs both classes in Bugs/_6554/PartialInjectionFailureTests.cs:
+/// the registration failure itself plus the observer test that asserts OnTestEnd ran.
+/// </summary>
+public class PartialInjectionFailure6554Tests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/PartialInjectionFailure*/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result => result.ResultSummary.Counters.NotExecuted.ShouldBe(0)
+            ]);
+    }
+}

--- a/tests/TUnit.TestProject/Bugs/_6554/PartialInjectionFailureTests.cs
+++ b/tests/TUnit.TestProject/Bugs/_6554/PartialInjectionFailureTests.cs
@@ -1,0 +1,62 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6554;
+
+/// <summary>
+/// Partial-injection-failure edge of issue #6554 (surfaced by review on PR #6556).
+///
+/// Property resolution runs all of a test's injected properties in parallel (Task.WhenAll), so
+/// when one property's data source throws, sibling properties may still have resolved and
+/// cached their values — including values that implement event receiver interfaces. The test
+/// is then marked failed at registration, and TestCoordinator invokes ITestEndEventReceiver
+/// for it. The receiver-cache invalidation in ObjectLifecycleService.RegisterTestAsync must
+/// therefore run even when resolution exits exceptionally (finally), otherwise the
+/// successfully-created receiver stays invisible to the stale pre-injection cache and misses
+/// the OnTestEnd callback.
+/// </summary>
+public sealed class EndRecordingResource : ITestEndEventReceiver
+{
+    public static bool OnTestEndRan { get; private set; }
+
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        OnTestEndRan = true;
+        return default;
+    }
+
+    public int Order => 0;
+}
+
+public sealed class ThrowingResource
+{
+    public ThrowingResource() => throw new InvalidOperationException("Deliberate resolution failure (#6554 partial-injection edge)");
+}
+
+[EngineTest(ExpectedResult.Failure)]
+public sealed class PartialInjectionFailureTests
+{
+    [ClassDataSource<EndRecordingResource>(Shared = SharedType.PerTestSession)]
+    public required EndRecordingResource Good { get; init; }
+
+    [ClassDataSource<ThrowingResource>(Shared = SharedType.PerTestSession)]
+    public required ThrowingResource Bad { get; init; }
+
+    [Test]
+    public void Fails_During_Registration()
+    {
+        // Never runs: ThrowingResource's constructor throws while property values are being
+        // resolved during registration, so the test is marked failed before execution.
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public sealed class PartialInjectionFailureObserverTests
+{
+    [Test]
+    [DependsOn(typeof(PartialInjectionFailureTests), nameof(PartialInjectionFailureTests.Fails_During_Registration), ProceedOnFailure = true)]
+    public async Task End_Receiver_On_Successfully_Resolved_Property_Fired()
+    {
+        await Assert.That(EndRecordingResource.OnTestEndRan).IsTrue();
+    }
+}

--- a/tests/TUnit.TestProject/Bugs/_6554/PartialInjectionFailureTests.cs
+++ b/tests/TUnit.TestProject/Bugs/_6554/PartialInjectionFailureTests.cs
@@ -50,7 +50,11 @@ public sealed class PartialInjectionFailureTests
     }
 }
 
-[EngineTest(ExpectedResult.Pass)]
+// Marked Failure (not Pass) despite passing itself: DependsOn pulls Fails_During_Registration
+// into any filtered run containing this test, which would poison the EngineTest=Pass bucket's
+// TRX outcome. Both classes are verified together by PartialInjectionFailure6554Tests in
+// TUnit.Engine.Tests.
+[EngineTest(ExpectedResult.Failure)]
 public sealed class PartialInjectionFailureObserverTests
 {
     [Test]

--- a/tests/TUnit.TestProject/Bugs/_6554/Tests.cs
+++ b/tests/TUnit.TestProject/Bugs/_6554/Tests.cs
@@ -1,0 +1,68 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6554;
+
+/// <summary>
+/// Reproduction for issue #6554: "Injected properties don't get their event receivers executed."
+/// https://github.com/thomhurst/TUnit/issues/6554
+///
+/// The per-context event receiver caches are built (and marked as built) when
+/// ITestRegisteredEventReceiver instances are gathered during registration — which deliberately
+/// happens BEFORE injected property values are resolved, so SkipAttribute can short-circuit
+/// expensive data sources. The caches were never invalidated after property resolution, so the
+/// eligible-event-object set fed to the EventReceiverRegistry at execution time was stale and
+/// missing the injected property values. If the only ITestStartEventReceiver /
+/// ITestEndEventReceiver in the run was an injected property (like below), the registry-level
+/// fast-path gates reported "no receivers" and the events never fired.
+/// </summary>
+public sealed class EventRecordingResource : IAsyncInitializer, ITestStartEventReceiver, ITestEndEventReceiver
+{
+    public bool InitializeAsyncRan { get; private set; }
+    public int OnTestStartCount { get; private set; }
+    public int OnTestEndCount { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        InitializeAsyncRan = true;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        OnTestStartCount++;
+        return default;
+    }
+
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        OnTestEndCount++;
+        return default;
+    }
+
+    public int Order => 0;
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public sealed class InjectedPropertyEventReceiverTests
+{
+    [ClassDataSource<EventRecordingResource>(Shared = SharedType.PerTestSession)]
+    public required EventRecordingResource Resource { get; init; }
+
+    [Test]
+    public async Task Injected_Property_Receives_OnTestStart()
+    {
+        await Assert.That(Resource.InitializeAsyncRan).IsTrue();
+        await Assert.That(Resource.OnTestStartCount).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    [DependsOn(nameof(Injected_Property_Receives_OnTestStart))]
+    public async Task Injected_Property_Receives_OnTestEnd()
+    {
+        // The first test has fully completed (DependsOn), so its OnTestEnd must have fired
+        // on the shared instance. Our own OnTestStart must have fired too.
+        await Assert.That(Resource.OnTestEndCount).IsGreaterThanOrEqualTo(1);
+        await Assert.That(Resource.OnTestStartCount).IsGreaterThanOrEqualTo(2);
+    }
+}

--- a/tests/TUnit.TestProject/Bugs/_6557/Tests.cs
+++ b/tests/TUnit.TestProject/Bugs/_6557/Tests.cs
@@ -1,0 +1,59 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6557;
+
+/// <summary>
+/// Reproduction for issue #6557: first-in-session/assembly event receivers registered mid-run
+/// could miss the one-shot event.
+/// https://github.com/thomhurst/TUnit/issues/6557
+///
+/// The first-in-X invocations are memoized per scope key and enumerate the EventReceiverRegistry
+/// at the moment the first gated test reaches them. Receivers used to be registered lazily when
+/// their own test entered TestCoordinator, so a receiver belonging to a later-scheduled test
+/// missed the one-shot whenever an earlier test with a same-interface receiver had already
+/// triggered the memoized invocation. The test project contains other
+/// IFirstTestInAssemblyEventReceiver implementations, so in a full-suite run this test was
+/// non-deterministic by exactly that mechanism.
+///
+/// EventReceiverOrchestrator.PrepareForExecution now registers every test's eligible receivers
+/// (including injected property values, #6554) before any test executes, making this
+/// deterministic: every test awaits the memoized first-in-session/assembly invocations before
+/// its body runs, and those invocations see the complete registry.
+/// </summary>
+public sealed class FirstEventRecordingResource : IFirstTestInTestSessionEventReceiver, IFirstTestInAssemblyEventReceiver
+{
+    public static bool OnFirstTestInSessionRan { get; private set; }
+    public static bool OnFirstTestInAssemblyRan { get; private set; }
+
+    public ValueTask OnFirstTestInTestSession(TestSessionContext current, TestContext testContext)
+    {
+        OnFirstTestInSessionRan = true;
+        return default;
+    }
+
+    public ValueTask OnFirstTestInAssembly(AssemblyHookContext context, TestContext testContext)
+    {
+        OnFirstTestInAssemblyRan = true;
+        return default;
+    }
+
+    public int Order => 0;
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public sealed class InjectedPropertyFirstEventReceiverTests
+{
+    [ClassDataSource<FirstEventRecordingResource>(Shared = SharedType.PerTestSession)]
+    public required FirstEventRecordingResource Resource { get; init; }
+
+    [Test]
+    public async Task Injected_Property_Receives_First_In_Session_And_Assembly_Events()
+    {
+        // The one-shot events fired on the chronologically first test of the session/assembly
+        // (possibly this one). This test awaited those memoized invocations before its body,
+        // so the flags must be set by now regardless of scheduling order.
+        await Assert.That(FirstEventRecordingResource.OnFirstTestInSessionRan).IsTrue();
+        await Assert.That(FirstEventRecordingResource.OnFirstTestInAssemblyRan).IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6554 and #6557 — two related gaps in event receiver registration:

1. **#6554:** receivers implemented by property-injected objects (e.g. `[ClassDataSource<T>]` properties) were never invoked.
2. **#6557 (found in review):** one-shot first-in-session/assembly events could miss receivers registered mid-run.

## Root causes

**#6554 — stale per-context caches.** `TestFilterService.RegisterTest` calls `GetTestRegisteredReceivers()`, building **all** per-context receiver caches (`EventReceiversBuilt = true`) — deliberately **before** property resolution so `SkipAttribute` can short-circuit expensive data sources. `ObjectLifecycleService.RegisterTestAsync` then resolves injected property values, but the caches were never invalidated, so the eligible-event-object set consumed later was stale and missing the injected values. The registry-level fast-path gates (`HasTestStartReceivers()` etc.) then reported no receivers and the events were skipped entirely.

**#6557 — one-shot events vs lazy registration.** First-in-session/assembly/class invocations memoize per scope key and enumerate the `EventReceiverRegistry` when the first gated test reaches them. Receivers were registered lazily when their own test entered `TestCoordinator`, so an object-scoped receiver on a later-scheduled test missed the one-shot whenever an earlier same-interface receiver had already triggered the memoized invocation. Pre-existing and source-agnostic (ctor/method args had the same exposure); surfaced by Codex review on this PR.

## Fixes

- `ObjectLifecycleService.RegisterTestAsync`: invalidate the per-context receiver caches after property resolution (only when injected properties exist) — cache coherence at the single mutation point. O(1), off the hot path, both source-gen and reflection modes.
- `EventReceiverOrchestrator.InitializeTestCounts` → renamed `PrepareForExecution`: registers every test's eligible receivers in its existing pre-execution loop over all executable tests. Runs after argument/property resolution **and** deferred placeholder expansion (`TestSessionCoordinator` ordering), so eligible-object sets are complete and the registry is fully populated before any one-shot event can fire.
- `TestCoordinator`'s per-test `RegisterReceivers` stays as a fallback for dynamically queued tests that bypass the eager pass; for scheduled tests it's a cheap dedup no-op.
- Class instances still don't exist at the eager pass; they keep registering per test via `RegisterClassInstanceReceiver` (unchanged).

Note: `ITestRegisteredEventReceiver` on injected properties remains unsupported by design — `OnTestRegistered` intentionally fires before data sources are materialized so skip attributes can prevent their creation.

## Testing

- `Bugs/_6554`: injected `PerTestSession` property implementing start/end receivers. Fails without the invalidation fix, passes with it — **both source-gen and reflection modes**.
- `Bugs/_6557`: injected property implementing first-in-session/assembly receivers, deterministic under the eager pass (every test awaits the memoized one-shot invocations before its body; the pre-fix behavior was scheduling-dependent, which is exactly the bug).
- `*EventReceiver*` and `*PropertyInjection*` suites: failure sets identical with and without these changes in both parallel and sequential (`--maximum-parallel-tests 1`) runs — the handful of filtered-run failures pre-exist on main.