### PR TITLE
Honor cancellation tokens linked by custom test executors

### DIFF
--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -458,7 +458,9 @@ internal class TestExecutor
         if (executableTest.Context.InternalDiscoveredTest?.TestExecutor is { } testExecutor)
         {
             await testExecutor.ExecuteTest(executableTest.Context,
-                () => new ValueTask(executableTest.InvokeTestAsync(executableTest.Context.Metadata.TestDetails.ClassInstance, cancellationToken))).ConfigureAwait(false);
+                () => new ValueTask(executableTest.InvokeTestAsync(
+                    executableTest.Context.Metadata.TestDetails.ClassInstance,
+                    executableTest.Context.Execution.CancellationToken))).ConfigureAwait(false);
         }
         else
         {

--- a/tests/TUnit.Engine.Tests/TestExecutorCancellationTokenTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutorCancellationTokenTests.cs
@@ -1,0 +1,20 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class TestExecutorCancellationTokenTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/TestExecutorCancellationTokenTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+}

--- a/tests/TUnit.TestProject/TestExecutorCancellationTokenTests.cs
+++ b/tests/TUnit.TestProject/TestExecutorCancellationTokenTests.cs
@@ -1,0 +1,28 @@
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Pass)]
+public class TestExecutorCancellationTokenTests
+{
+    [Test]
+    [TestExecutor<CancellingTestExecutor>]
+    public async Task LinkedCancellationToken_IsPassedToTest(CancellationToken cancellationToken)
+    {
+        await Assert.That(cancellationToken.IsCancellationRequested).IsTrue();
+    }
+}
+
+public class CancellingTestExecutor : ITestExecutor
+{
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        context.Execution.AddLinkedCancellationToken(cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        await action();
+    }
+}


### PR DESCRIPTION
## Summary

- resolve the test-body cancellation token when a custom `ITestExecutor` invokes its action
- add regression coverage for source-generated and reflection execution

## Root cause

The executor action captured the engine cancellation token before the custom executor ran. Calling `context.Execution.AddLinkedCancellationToken(...)` updated the context, but the test method still received the stale captured token.

## User impact

Custom test executors can now link and cancel a token before invoking the test body, and an injected `CancellationToken` observes that cancellation. This enables the background-failure executor pattern discussed in [discussion #3099](https://github.com/thomhurst/TUnit/discussions/3099).

## Validation

- `dotnet build tests/TUnit.TestProject/TUnit.TestProject.csproj -c Release --no-restore --nologo`
- source-generated filtered test on `net8.0`, `net9.0`, and `net10.0`
- reflection filtered engine test on `net10.0`

AOT runtime coverage remains enabled for CI; it is skipped locally by the existing test harness.