### PR TITLE
Add opt-in test failure signals

### DIFF
--- a/docs/docs/extending/extension-points.md
+++ b/docs/docs/extending/extension-points.md
@@ -75,6 +75,8 @@ public async Task MyTest()
 }
 ```
 
+Custom executors also compose with [failure signals](../writing-tests/failure-signals.md). Await the supplied `action` and use `context.Execution.AddLinkedCancellationToken(...)` when the executor needs to contribute cancellation; TUnit passes the latest linked token to the test body.
+
 ### STA Thread Example
 
 A common use case for `ITestExecutor` is running tests on an STA thread (required by some COM / UI components on Windows):

--- a/docs/docs/writing-tests/failure-signals.md
+++ b/docs/docs/writing-tests/failure-signals.md
@@ -1,0 +1,108 @@
+# Failure Signals
+
+Use a failure signal when a callback, event handler, or detached operation discovers a failure outside the test's awaited call stack. It safely transfers that failure to TUnit instead of throwing on the callback thread.
+
+For failures raised directly by the test's awaited code, continue to use `Fail.Test(...)`.
+
+## Basic Usage
+
+Create the signal before the test body starts, subscribe to the external callback, and unsubscribe during cleanup:
+
+```csharp
+public class ConnectionTests : ITestStartEventReceiver, ITestEndEventReceiver
+{
+    private ITestFailureSignal _failureSignal = null!;
+    private Action<Exception>? _failureHandler;
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        _failureSignal = context.Execution.CreateFailureSignal();
+        _failureHandler = exception => _failureSignal.Report(exception);
+        Connection.FatalError += _failureHandler;
+
+        return default;
+    }
+
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        Connection.FatalError -= _failureHandler;
+        return default;
+    }
+
+    [Test]
+    public async Task ConnectionRemainsHealthy(CancellationToken cancellationToken)
+    {
+        await Connection.RunAsync(cancellationToken);
+    }
+}
+```
+
+`CreateFailureSignal()` must be called from a `[Before(Test)]` hook or `ITestStartEventReceiver.OnTestStart`. Calling it after the test body has started throws an `InvalidOperationException`. Repeated calls during the same attempt return the same signal.
+
+Capture the signal in the callback as shown above. A callback running on another thread should not depend on `TestContext.Current` being available.
+
+## Reporting Failures
+
+Report either the original exception or a reason:
+
+```csharp
+failureSignal.Report(exception);
+failureSignal.Report("The background service stopped unexpectedly");
+```
+
+`Report` does not throw the supplied failure on the callback thread. The first report wins; later or post-test reports are ignored.
+
+Use `TryReport` when the callback needs to know whether TUnit accepted its report:
+
+```csharp
+if (!failureSignal.TryReport(exception))
+{
+    // Another callback already reported a failure, or the test has ended.
+}
+```
+
+## Cancellation and Cleanup
+
+When a failure is reported, TUnit cancels the test's execution token and waits for a bounded grace period before continuing to teardown. Accept and observe the injected `CancellationToken` so the test body can stop promptly:
+
+```csharp
+[Test]
+public async Task ProcessMessages(CancellationToken cancellationToken)
+{
+    await processor.RunAsync(cancellationToken);
+}
+```
+
+Always unsubscribe callbacks in an `[After(Test)]` hook or `ITestEndEventReceiver.OnTestEnd`. A failure signal is scoped to one test attempt, so retries receive a fresh signal and reports from an earlier attempt are ignored.
+
+## Custom Test Executors
+
+Failure signals compose with `ITestExecutor`, test timeouts, and tokens added through `AddLinkedCancellationToken`. The `action` receives the latest linked execution token. A custom executor should await the action and place cleanup in `finally` so it completes during signal cancellation:
+
+```csharp
+public sealed class CustomExecutor : ITestExecutor
+{
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        context.Execution.AddLinkedCancellationToken(cancellationSource.Token);
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            await ReleaseExecutorResourcesAsync();
+        }
+    }
+}
+```
+
+Create the failure signal in a test-start receiver or before-test hook, not inside `ITestExecutor.ExecuteTest`, because the test body execution phase has already begun when the executor is invoked.
+
+If both the signal and the custom executor report exceptions while stopping, TUnit preserves both failures.
+
+## Performance
+
+Failure signals are opt-in. When `CreateFailureSignal()` is not called, TUnit does not allocate the signal's cancellation source or completion task and does not race the test body against a signal task. The normal execution path only performs a nullable check.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -51,6 +51,7 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: [
             'writing-tests/test-context',
+            'writing-tests/failure-signals',
             'writing-tests/artifacts',
           ],
         },

--- a/src/TUnit.Core/Exceptions/FailTestException.cs
+++ b/src/TUnit.Core/Exceptions/FailTestException.cs
@@ -1,6 +1,6 @@
 ﻿namespace TUnit.Core.Exceptions;
 
-public class FailTestException(string reason) : TUnitException
+public class FailTestException(string reason) : TUnitException(reason)
 {
     public string Reason { get; } = reason;
 }

--- a/src/TUnit.Core/Interfaces/ITestExecution.cs
+++ b/src/TUnit.Core/Interfaces/ITestExecution.cs
@@ -131,6 +131,19 @@ public interface ITestExecution
     bool IsNotDiscoverable { get; set; }
 
     /// <summary>
+    /// Creates a signal that can safely report failures from callbacks or other detached work
+    /// to this test execution.
+    /// </summary>
+    /// <remarks>
+    /// The signal must be created before the test body starts, such as from a Before(Test) hook
+    /// or <see cref="ITestStartEventReceiver.OnTestStart"/>. The first report wins. Reports made
+    /// after the test body completes are ignored. Calling this method more than once returns the
+    /// same signal for the current test attempt.
+    /// </remarks>
+    /// <returns>A failure signal scoped to the current test attempt.</returns>
+    ITestFailureSignal CreateFailureSignal();
+
+    /// <summary>
     /// Links an external cancellation token to this test's execution token.
     /// Useful for coordinating cancellation across multiple operations or tests.
     /// </summary>

--- a/src/TUnit.Core/Interfaces/ITestFailureSignal.cs
+++ b/src/TUnit.Core/Interfaces/ITestFailureSignal.cs
@@ -1,0 +1,39 @@
+namespace TUnit.Core.Interfaces;
+
+/// <summary>
+/// Reports failures raised by callbacks or other detached work to the currently executing test.
+/// </summary>
+/// <remarks>
+/// Reporting a failure cancels the test execution token. Test code should observe that token so
+/// it can stop during the framework's bounded cancellation grace period.
+/// </remarks>
+public interface ITestFailureSignal
+{
+    /// <summary>
+    /// Reports an exception as the test failure.
+    /// This method does not throw the supplied exception on the calling thread.
+    /// </summary>
+    /// <param name="exception">The exception that caused the failure.</param>
+    void Report(Exception exception);
+
+    /// <summary>
+    /// Reports a reason as the test failure.
+    /// This method does not throw on the calling thread.
+    /// </summary>
+    /// <param name="reason">The reason the test failed.</param>
+    void Report(string reason);
+
+    /// <summary>
+    /// Attempts to report an exception as the test failure.
+    /// </summary>
+    /// <param name="exception">The exception that caused the failure.</param>
+    /// <returns><see langword="true"/> when this report was accepted; otherwise, <see langword="false"/>.</returns>
+    bool TryReport(Exception exception);
+
+    /// <summary>
+    /// Attempts to report a reason as the test failure.
+    /// </summary>
+    /// <param name="reason">The reason the test failed.</param>
+    /// <returns><see langword="true"/> when this report was accepted; otherwise, <see langword="false"/>.</returns>
+    bool TryReport(string reason);
+}

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -32,6 +32,7 @@ public partial class TestContext
     internal IHookExecutor? CustomHookExecutor { get; set; }
     internal bool ReportResult { get; set; } = true;
     internal bool IsNotDiscoverable { get; set; }
+    internal TestFailureSignal? FailureSignal { get; private set; }
 
     // Explicit interface implementations for ITestExecution
     TestPhase ITestExecution.Phase => Phase;
@@ -84,6 +85,7 @@ public partial class TestContext
 
     void ITestExecution.OverrideResult(TestState state, string reason) => OverrideResult(state, reason);
     void ITestExecution.AddLinkedCancellationToken(CancellationToken cancellationToken) => AddLinkedCancellationToken(cancellationToken);
+    ITestFailureSignal ITestExecution.CreateFailureSignal() => CreateFailureSignal();
 
     // Internal implementation methods
     internal void OverrideResult(TestState state, string reason)
@@ -138,6 +140,27 @@ public partial class TestContext
 
             InternalExecutableTest.State = state;
         }
+    }
+
+    internal ITestFailureSignal CreateFailureSignal()
+    {
+        lock (Lock)
+        {
+            if (TestStart is not null)
+            {
+                throw new InvalidOperationException(
+                    "A failure signal must be created before the test body starts. " +
+                    "Create it in a Before(Test) hook or ITestStartEventReceiver.OnTestStart.");
+            }
+
+            return FailureSignal ??= new TestFailureSignal(CancellationToken);
+        }
+    }
+
+    internal void ResetFailureSignal()
+    {
+        FailureSignal?.Dispose();
+        FailureSignal = null;
     }
 
     internal void AddLinkedCancellationToken(CancellationToken cancellationToken)

--- a/src/TUnit.Core/TestFailureSignal.cs
+++ b/src/TUnit.Core/TestFailureSignal.cs
@@ -1,0 +1,87 @@
+using TUnit.Core.Exceptions;
+using TUnit.Core.Interfaces;
+
+namespace TUnit.Core;
+
+internal sealed class TestFailureSignal(CancellationToken cancellationToken) : ITestFailureSignal, IDisposable
+{
+    private readonly object _lock = new();
+    private readonly CancellationTokenSource _cancellationTokenSource =
+        CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    private readonly TaskCompletionSource<Exception> _failureSource =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Exception? _exception;
+    private bool _closed;
+
+    internal CancellationToken CancellationToken => _cancellationTokenSource.Token;
+    internal Task<Exception> FailureTask => _failureSource.Task;
+
+    public void Report(Exception exception)
+    {
+        TryReport(exception);
+    }
+
+    public void Report(string reason)
+    {
+        TryReport(reason);
+    }
+
+    public bool TryReport(Exception exception)
+    {
+        if (exception is null)
+        {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        lock (_lock)
+        {
+            if (_closed || _exception is not null)
+            {
+                return false;
+            }
+
+            _exception = exception;
+            _failureSource.TrySetResult(exception);
+        }
+
+        try
+        {
+            _cancellationTokenSource.Cancel();
+        }
+        catch (Exception ex) when (ex is AggregateException or ObjectDisposedException)
+        {
+            // Cancellation callback exceptions must not escape on the reporting thread.
+        }
+
+        return true;
+    }
+
+    public bool TryReport(string reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Failure reason cannot be empty or whitespace.", nameof(reason));
+        }
+
+        return TryReport(new FailTestException(reason));
+    }
+
+    internal Exception? Complete()
+    {
+        lock (_lock)
+        {
+            _closed = true;
+            return _exception;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            _closed = true;
+        }
+
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
+++ b/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
@@ -72,6 +72,11 @@ internal static class RetryHelper
                         };
                     (testContext.RetryAttempts ??= []).Add(attemptResult);
 
+                    if (testContext.FailureSignal is not null)
+                    {
+                        testContext.ResetFailureSignal();
+                    }
+
                     // Clear the previous result before retrying
                     testContext.Execution.Result = null;
                     testContext.TestStart = null;

--- a/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -343,6 +343,11 @@ internal sealed class TestCoordinator : ITestCoordinator
             test.Context.TimeoutCancellationSource?.Dispose();
             test.Context.TimeoutCancellationSource = null;
 
+            if (test.Context.FailureSignal is not null)
+            {
+                test.Context.ResetFailureSignal();
+            }
+
             test.Context.RemoveFromRegistry();
         }
     }

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -499,7 +499,7 @@ internal class TestExecutor
             var timeoutMessage = $"Test '{context.Metadata.TestDetails.TestName}' timed out after {testTimeout.Value}";
 
             testBodyTask = TimeoutHelper.ExecuteWithTimeoutAsync(
-                ct => ExecuteTestAsync(executableTest, ct).AsTask(),
+                ct => ExecuteTestWithFailureSignalCoreAsync(executableTest, ct, failureSignal).AsTask(),
                 testTimeout.Value,
                 testBodyTimeoutCts,
                 failureSignal.CancellationToken,
@@ -507,7 +507,10 @@ internal class TestExecutor
         }
         else
         {
-            testBodyTask = ExecuteTestAsync(executableTest, failureSignal.CancellationToken).AsTask();
+            testBodyTask = ExecuteTestWithFailureSignalCoreAsync(
+                executableTest,
+                failureSignal.CancellationToken,
+                failureSignal).AsTask();
         }
 
         var completedTask = await Task.WhenAny(testBodyTask, failureSignal.FailureTask).ConfigureAwait(false);
@@ -572,6 +575,59 @@ internal class TestExecutor
         }
 
         ExceptionDispatchInfo.Capture(reportedException).Throw();
+    }
+
+    // Keep this separate from ExecuteTestAsync so tests that do not opt in retain the direct hot path.
+    private static async ValueTask ExecuteTestWithFailureSignalCoreAsync(
+        AbstractExecutableTest executableTest,
+        CancellationToken cancellationToken,
+        TestFailureSignal failureSignal)
+    {
+        if (executableTest.Context.Metadata.TestDetails.ClassInstance is SkippedTestInstance ||
+            !string.IsNullOrEmpty(executableTest.Context.SkipReason))
+        {
+            failureSignal.Complete();
+            return;
+        }
+
+        executableTest.Context.TestStart = DateTimeOffset.UtcNow;
+        executableTest.Context.CancellationToken = cancellationToken;
+
+        if (executableTest.Context.InternalDiscoveredTest?.TestExecutor is { } testExecutor)
+        {
+            try
+            {
+                await testExecutor.ExecuteTest(
+                    executableTest.Context,
+                    () => InvokeTestAndCompleteFailureSignalAsync(executableTest, failureSignal)).ConfigureAwait(false);
+            }
+            finally
+            {
+                // Also close the signal when an executor does not invoke the supplied action.
+                failureSignal.Complete();
+            }
+
+            return;
+        }
+
+        await InvokeTestAndCompleteFailureSignalAsync(executableTest, failureSignal).ConfigureAwait(false);
+    }
+
+    private static async ValueTask InvokeTestAndCompleteFailureSignalAsync(
+        AbstractExecutableTest executableTest,
+        TestFailureSignal failureSignal)
+    {
+        try
+        {
+            await executableTest.InvokeTestAsync(
+                executableTest.Context.Metadata.TestDetails.ClassInstance,
+                executableTest.Context.Execution.CancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Close before the invocation task completes, leaving no window for a post-body report.
+            failureSignal.Complete();
+        }
     }
 
     internal async Task<List<Exception>?> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -6,6 +6,7 @@ using TUnit.Core.Enums;
 using TUnit.Core.Exceptions;
 using TUnit.Core.Interfaces;
 using TUnit.Core.Services;
+using TUnit.Engine.Constants;
 using TUnit.Engine.Helpers;
 using TUnit.Engine.Services;
 #if NET
@@ -249,9 +250,18 @@ internal class TestExecutor
                     TUnitActivitySource.SpanTestBody);
             }
 #endif
+            var failureSignal = executableTest.Context.FailureSignal;
+
             try
             {
-                if (testTimeout.HasValue)
+                if (failureSignal is not null)
+                {
+                    await ExecuteTestWithFailureSignalAsync(
+                        executableTest,
+                        testTimeout,
+                        failureSignal).ConfigureAwait(false);
+                }
+                else if (testTimeout.HasValue)
                 {
                     // Own the linked timeout source across the whole test lifecycle rather than letting
                     // TimeoutHelper dispose it on return. The body can hand Context.CancellationToken to
@@ -304,7 +314,7 @@ internal class TestExecutor
                 // receivers, After(Test)/AfterEvery(Test) hooks, and any retry back-off observe a live
                 // token via the context property. (The source itself is kept alive on the context and
                 // disposed later by TestCoordinator, so token copies captured mid-body stay valid — #6339.)
-                if (testTimeout.HasValue)
+                if (testTimeout.HasValue || failureSignal is not null)
                 {
                     executableTest.Context.CancellationToken = cancellationToken;
                 }
@@ -327,6 +337,10 @@ internal class TestExecutor
         }
         finally
         {
+            // Stop accepting reports before teardown begins. The signal's cancellation source stays
+            // alive until all teardown has completed so token copies captured by the body remain valid.
+            executableTest.Context.FailureSignal?.Complete();
+
             // After hooks must use CancellationToken.None to ensure cleanup runs even when cancelled
             // This matches the pattern used for After Class/Assembly hooks in TestCoordinator
 
@@ -466,6 +480,98 @@ internal class TestExecutor
         {
             await executableTest.InvokeTestAsync(executableTest.Context.Metadata.TestDetails.ClassInstance, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static async ValueTask ExecuteTestWithFailureSignalAsync(
+        AbstractExecutableTest executableTest,
+        TimeSpan? testTimeout,
+        TestFailureSignal failureSignal)
+    {
+        Task testBodyTask;
+
+        if (testTimeout.HasValue)
+        {
+            var context = executableTest.Context;
+            context.TimeoutCancellationSource?.Dispose();
+            var testBodyTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(failureSignal.CancellationToken);
+            context.TimeoutCancellationSource = testBodyTimeoutCts;
+
+            var timeoutMessage = $"Test '{context.Metadata.TestDetails.TestName}' timed out after {testTimeout.Value}";
+
+            testBodyTask = TimeoutHelper.ExecuteWithTimeoutAsync(
+                ct => ExecuteTestAsync(executableTest, ct).AsTask(),
+                testTimeout.Value,
+                testBodyTimeoutCts,
+                failureSignal.CancellationToken,
+                timeoutMessage);
+        }
+        else
+        {
+            testBodyTask = ExecuteTestAsync(executableTest, failureSignal.CancellationToken).AsTask();
+        }
+
+        var completedTask = await Task.WhenAny(testBodyTask, failureSignal.FailureTask).ConfigureAwait(false);
+
+        if (completedTask == failureSignal.FailureTask)
+        {
+            Exception? gracePeriodException = null;
+
+            try
+            {
+                await testBodyTask.WaitAsync(EngineDefaults.TimeoutGracePeriod, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (System.TimeoutException)
+            {
+                // The body ignored cancellation. Continue with the reported failure after the grace period.
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the body cooperatively observes the signal's cancellation token.
+            }
+            catch (Exception ex)
+            {
+                gracePeriodException = ex;
+            }
+
+            var signalException = failureSignal.Complete()!;
+
+            if (gracePeriodException is not null)
+            {
+                throw new AggregateException(gracePeriodException, signalException);
+            }
+
+            ExceptionDispatchInfo.Capture(signalException).Throw();
+        }
+
+        Exception? testBodyException = null;
+
+        try
+        {
+            await testBodyTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            testBodyException = ex;
+        }
+
+        var reportedException = failureSignal.Complete();
+
+        if (reportedException is null)
+        {
+            if (testBodyException is not null)
+            {
+                ExceptionDispatchInfo.Capture(testBodyException).Throw();
+            }
+
+            return;
+        }
+
+        if (testBodyException is not null and not OperationCanceledException)
+        {
+            throw new AggregateException(testBodyException, reportedException);
+        }
+
+        ExceptionDispatchInfo.Capture(reportedException).Throw();
     }
 
     internal async Task<List<Exception>?> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,

--- a/tests/TUnit.Engine.Tests/FailureSignalTests.cs
+++ b/tests/TUnit.Engine.Tests/FailureSignalTests.cs
@@ -1,0 +1,43 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class FailureSignalTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task CallbackFailuresAreReportedByTheTestRunner()
+    {
+        await RunTestsWithFilter(
+            "/*/*/FailureSignalTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(3),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(3),
+                result =>
+                {
+                    var messages = string.Join(
+                        Environment.NewLine,
+                        result.Results.Select(x => x.Output?.ErrorInfo?.Message));
+
+                    messages.ShouldContain("Failure reported from callback");
+                    messages.ShouldContain("Failure reason reported from callback");
+                    messages.ShouldContain("Non-cooperative body failed");
+                }
+            ]);
+    }
+
+    [Test]
+    public async Task FailureSignalsAreScopedToRetryAttempts()
+    {
+        await RunTestsWithFilter(
+            "/*/*/FailureSignalRetryTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+}

--- a/tests/TUnit.Engine.Tests/FailureSignalTests.cs
+++ b/tests/TUnit.Engine.Tests/FailureSignalTests.cs
@@ -64,4 +64,17 @@ public class FailureSignalTests(TestMode testMode) : InvokableTestBase(testMode)
                 }
             ]);
     }
+
+    [Test]
+    public async Task ReportsAfterTheTestBodyCompletesAreIgnoredWithCustomTestExecutors()
+    {
+        await RunTestsWithFilter(
+            "/*/*/FailureSignalCustomExecutorLateReportTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
 }

--- a/tests/TUnit.Engine.Tests/FailureSignalTests.cs
+++ b/tests/TUnit.Engine.Tests/FailureSignalTests.cs
@@ -40,4 +40,28 @@ public class FailureSignalTests(TestMode testMode) : InvokableTestBase(testMode)
                 result => result.ResultSummary.Counters.Failed.ShouldBe(0)
             ]);
     }
+
+    [Test]
+    public async Task FailureSignalsComposeWithCustomTestExecutors()
+    {
+        await RunTestsWithFilter(
+            "/*/*/FailureSignalCustomExecutorTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(2),
+                result =>
+                {
+                    var messages = string.Join(
+                        Environment.NewLine,
+                        result.Results.Select(x => x.Output?.ErrorInfo?.Message));
+
+                    messages.ShouldContain("Failure reported through custom executor");
+                    messages.ShouldContain("Failure reported before executor cleanup");
+                    messages.ShouldContain("Custom executor cleanup failed");
+                    messages.ShouldNotContain("The custom test executor did not complete after signal cancellation");
+                }
+            ]);
+    }
 }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2698,11 +2698,19 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        . CreateFailureSignal();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor
     {
         . ExecuteTest(.TestContext context, <.> action);
+    }
+    public interface ITestFailureSignal
+    {
+        void Report( exception);
+        void Report(string reason);
+        bool TryReport( exception);
+        bool TryReport(string reason);
     }
     public interface ITestFinder
     {

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2698,11 +2698,19 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        . CreateFailureSignal();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor
     {
         . ExecuteTest(.TestContext context, <.> action);
+    }
+    public interface ITestFailureSignal
+    {
+        void Report( exception);
+        void Report(string reason);
+        bool TryReport( exception);
+        bool TryReport(string reason);
     }
     public interface ITestFinder
     {

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2698,11 +2698,19 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        . CreateFailureSignal();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor
     {
         . ExecuteTest(.TestContext context, <.> action);
+    }
+    public interface ITestFailureSignal
+    {
+        void Report( exception);
+        void Report(string reason);
+        bool TryReport( exception);
+        bool TryReport(string reason);
     }
     public interface ITestFinder
     {

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2629,11 +2629,19 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        . CreateFailureSignal();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor
     {
         . ExecuteTest(.TestContext context, <.> action);
+    }
+    public interface ITestFailureSignal
+    {
+        void Report( exception);
+        void Report(string reason);
+        bool TryReport( exception);
+        bool TryReport(string reason);
     }
     public interface ITestFinder
     {

--- a/tests/TUnit.TestProject/FailureSignalTests.cs
+++ b/tests/TUnit.TestProject/FailureSignalTests.cs
@@ -1,3 +1,4 @@
+using TUnit.Core.Executors;
 using TUnit.Core.Interfaces;
 using TUnit.TestProject.Attributes;
 
@@ -77,5 +78,82 @@ public class FailureSignalRetryTests : ITestStartEventReceiver
 
         await Assert.That(_previousSignal).IsNotNull();
         await Assert.That(_previousSignal!.TryReport("Late failure from previous attempt")).IsFalse();
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+[TestExecutor<FailureSignalTestExecutor>]
+public class FailureSignalCustomExecutorTests : ITestStartEventReceiver, ITestEndEventReceiver
+{
+    internal const string ExecutorCompletedKey = nameof(ExecutorCompletedKey);
+    internal const string ThrowFromExecutorKey = nameof(ThrowFromExecutorKey);
+    private ITestFailureSignal _failureSignal = null!;
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        _failureSignal = context.Execution.CreateFailureSignal();
+        return default;
+    }
+
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        if (!context.StateBag.TryGetValue<bool>(ExecutorCompletedKey, out var completed) || !completed)
+        {
+            throw new InvalidOperationException("The custom test executor did not complete after signal cancellation");
+        }
+
+        return default;
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task SignalCancelsTheTokenUsedByACustomExecutor(CancellationToken cancellationToken)
+    {
+        ThreadPool.QueueUserWorkItem(
+            static state => ((ITestFailureSignal)state!).Report("Failure reported through custom executor"),
+            _failureSignal);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public async Task SignalAndCustomExecutorFailureAreBothReported(CancellationToken cancellationToken)
+    {
+        TestContext.Current!.StateBag[ThrowFromExecutorKey] = true;
+
+        ThreadPool.QueueUserWorkItem(
+            static state => ((ITestFailureSignal)state!).Report("Failure reported before executor cleanup"),
+            _failureSignal);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+}
+
+public sealed class FailureSignalTestExecutor : ITestExecutor
+{
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        using var executorCancellationSource = new CancellationTokenSource();
+        context.Execution.AddLinkedCancellationToken(executorCancellationSource.Token);
+
+        try
+        {
+            await action();
+        }
+        catch (OperationCanceledException) when (context.Execution.CancellationToken.IsCancellationRequested)
+        {
+            // Custom executors may translate or consume cooperative cancellation. The reported
+            // failure must still fail the test even when the executor returns successfully.
+        }
+        finally
+        {
+            context.StateBag[FailureSignalCustomExecutorTests.ExecutorCompletedKey] = true;
+        }
+
+        if (context.StateBag.TryGetValue<bool>(FailureSignalCustomExecutorTests.ThrowFromExecutorKey, out var shouldThrow)
+            && shouldThrow)
+        {
+            throw new InvalidOperationException("Custom executor cleanup failed");
+        }
     }
 }

--- a/tests/TUnit.TestProject/FailureSignalTests.cs
+++ b/tests/TUnit.TestProject/FailureSignalTests.cs
@@ -1,0 +1,81 @@
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Failure)]
+public class FailureSignalTests : ITestStartEventReceiver
+{
+    private ITestFailureSignal _failureSignal = null!;
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        _failureSignal = context.Execution.CreateFailureSignal();
+        return default;
+    }
+
+    [Test]
+    public async Task ExceptionReportedFromCallbackFailsTest(CancellationToken cancellationToken)
+    {
+        ThreadPool.QueueUserWorkItem(
+            static state => ((ITestFailureSignal)state!).Report(
+                new InvalidOperationException("Failure reported from callback")),
+            _failureSignal);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public async Task ReasonReportedFromCallbackFailsTest(CancellationToken cancellationToken)
+    {
+        ThreadPool.QueueUserWorkItem(
+            static state => ((ITestFailureSignal)state!).Report("Failure reason reported from callback"),
+            _failureSignal);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public async Task ReportedFailureDoesNotWaitForeverForNonCooperativeBody()
+    {
+        ThreadPool.QueueUserWorkItem(
+            static state => ((ITestFailureSignal)state!).Report("Non-cooperative body failed"),
+            _failureSignal);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan);
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[Retry(1)]
+public class FailureSignalRetryTests : ITestStartEventReceiver
+{
+    private const string PreviousSignalKey = nameof(FailureSignalRetryTests);
+    private ITestFailureSignal _failureSignal = null!;
+    private ITestFailureSignal? _previousSignal;
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        context.StateBag.TryGetValue(PreviousSignalKey, out _previousSignal);
+        _failureSignal = context.Execution.CreateFailureSignal();
+        context.StateBag[PreviousSignalKey] = _failureSignal;
+        return default;
+    }
+
+    [Test]
+    public async Task SignalIsScopedToCurrentRetryAttempt(CancellationToken cancellationToken)
+    {
+        if (TestContext.Current!.Execution.CurrentRetryAttempt == 0)
+        {
+            ThreadPool.QueueUserWorkItem(
+                static state => ((ITestFailureSignal)state!).Report("First attempt failed"),
+                _failureSignal);
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return;
+        }
+
+        await Assert.That(_previousSignal).IsNotNull();
+        await Assert.That(_previousSignal!.TryReport("Late failure from previous attempt")).IsFalse();
+    }
+}

--- a/tests/TUnit.TestProject/FailureSignalTests.cs
+++ b/tests/TUnit.TestProject/FailureSignalTests.cs
@@ -157,3 +157,36 @@ public sealed class FailureSignalTestExecutor : ITestExecutor
         }
     }
 }
+
+[EngineTest(ExpectedResult.Pass)]
+[TestExecutor<LateReportingFailureSignalTestExecutor>]
+public class FailureSignalCustomExecutorLateReportTests : ITestStartEventReceiver
+{
+    internal const string FailureSignalKey = nameof(FailureSignalKey);
+
+    public ValueTask OnTestStart(TestContext context)
+    {
+        context.StateBag[FailureSignalKey] = context.Execution.CreateFailureSignal();
+        return default;
+    }
+
+    [Test]
+    public void ReportAfterTestBodyCompletesIsIgnored()
+    {
+    }
+}
+
+public sealed class LateReportingFailureSignalTestExecutor : ITestExecutor
+{
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        await action();
+
+        var signal = (ITestFailureSignal)context.StateBag[FailureSignalCustomExecutorLateReportTests.FailureSignalKey]!;
+
+        if (signal.TryReport("Late report from custom executor"))
+        {
+            throw new InvalidOperationException("A failure signal accepted a report after the test body completed");
+        }
+    }
+}

--- a/tests/TUnit.UnitTests/TestFailureSignalTests.cs
+++ b/tests/TUnit.UnitTests/TestFailureSignalTests.cs
@@ -1,0 +1,57 @@
+using TUnit.Core.Exceptions;
+
+namespace TUnit.UnitTests;
+
+public class TestFailureSignalTests
+{
+    [Test]
+    public async Task FirstReportWinsAndCancelsToken()
+    {
+        using var signal = new TestFailureSignal(CancellationToken.None);
+        var firstException = new InvalidOperationException("first");
+
+        var firstAccepted = signal.TryReport(firstException);
+        var secondAccepted = signal.TryReport(new InvalidOperationException("second"));
+        var reportedException = signal.Complete();
+
+        await Assert.That(firstAccepted).IsTrue();
+        await Assert.That(secondAccepted).IsFalse();
+        await Assert.That(signal.CancellationToken.IsCancellationRequested).IsTrue();
+        await Assert.That(reportedException).IsSameReferenceAs(firstException);
+    }
+
+    [Test]
+    public async Task ReportAfterCompletionIsRejected()
+    {
+        using var signal = new TestFailureSignal(CancellationToken.None);
+        signal.Complete();
+
+        var accepted = signal.TryReport(new InvalidOperationException("too late"));
+
+        await Assert.That(accepted).IsFalse();
+    }
+
+    [Test]
+    public async Task ReasonCreatesFailTestException()
+    {
+        using var signal = new TestFailureSignal(CancellationToken.None);
+
+        signal.Report("callback failed");
+
+        var exception = signal.Complete();
+        await Assert.That(exception).IsTypeOf<FailTestException>();
+        await Assert.That(exception!.Message).IsEqualTo("callback failed");
+    }
+
+    [Test]
+    public async Task CancellationCallbackExceptionsDoNotEscapeReportingThread()
+    {
+        using var signal = new TestFailureSignal(CancellationToken.None);
+        using var registration = signal.CancellationToken.Register(
+            static () => throw new InvalidOperationException("cancellation callback failed"));
+
+        signal.Report(new InvalidOperationException("test failed"));
+
+        await Assert.That(signal.Complete()).IsNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

- add opt-in `ITestExecution.CreateFailureSignal()` and `ITestFailureSignal`
- let callbacks and detached work report exceptions or failure reasons without throwing on their own threads
- cancel the injected test token, allow a one-second cooperative shutdown grace period, then report the signaled failure
- isolate signals per retry attempt and reject duplicate or late reports
- preserve the existing execution fast path when no signal is created
- document lifecycle, cleanup, retry, performance, and custom-executor usage

## Why

Detached callbacks cannot use `Fail.Test(...)` reliably because that exception faults the callback's own task or thread instead of flowing through the test runner. This adds an execution-scoped bridge for that common integration-test scenario.

Normal tests allocate no cancellation source, completion source, delegate, or `Task.WhenAny` state for this feature. They only encounter nullable state checks.

Discussion: https://github.com/thomhurst/TUnit/discussions/3099#discussioncomment-17944167

## Example

```csharp
public ValueTask OnTestStart(TestContext context)
{
    var failure = context.Execution.CreateFailureSignal();
    application.FatalError += failure.Report;
    return default;
}
```

## Compatibility

This adds a member to `ITestExecution`. Custom implementations must implement `CreateFailureSignal()`.

Failure signals compose with `ITestExecutor`, `[Timeout]`, and tokens added through `AddLinkedCancellationToken`. Integration coverage verifies cooperative cancellation and executor cleanup, executors that consume `OperationCanceledException`, and aggregation when executor cleanup also fails.

## Validation

- `dotnet build TUnit.Dev.slnx --no-restore -graphBuild:True`
- public API tests on .NET 8, .NET 9, .NET 10, and .NET Framework
- focused unit tests on .NET 8, .NET 9, and .NET 10
- source-generated callback failure and retry scenarios
- reflection callback failure, retry, and custom-executor scenarios
- Docusaurus production build
- broad solution run: 15,439 passed and 129 skipped; its two fixture-dependent VB/F# tests initially lacked prebuilt Release projects, then passed individually after those fixtures were built
- AOT cases are included in the existing engine harness and run in CI