### PR TITLE
Fix linked cancellation from before-test hooks

### DIFF
--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -11,8 +11,13 @@ namespace TUnit.Core;
 public partial class TestContext
 {
     // Internal backing fields and properties
-    internal CancellationToken CancellationToken { get; set; }
-    internal CancellationTokenSource? LinkedCancellationTokens { get; set; }
+    private CancellationToken _baseCancellationToken;
+    private List<CancellationToken>? _externalCancellationTokens;
+    private CancellationTokenSource? _linkedCancellationTokenSource;
+    // Token copies can escape into user code and remain in use through teardown (#6339).
+    // Keep replaced sources alive until the complete test lifecycle has finished.
+    private List<CancellationTokenSource>? _retiredLinkedCancellationTokenSources;
+    internal CancellationToken CancellationToken { get; private set; }
 
     // Linked source backing the per-test timeout token. Owned for the whole test lifecycle — the body
     // plus every teardown phase (After(Test) hooks, instance/OnDispose, object cleanup, After(Class)/
@@ -144,19 +149,76 @@ public partial class TestContext
     {
         lock (Lock)
         {
-            if (LinkedCancellationTokens == null)
+            (_externalCancellationTokens ??= []).Add(cancellationToken);
+            RebuildLinkedCancellationTokenSource();
+        }
+    }
+
+    internal void SetCancellationToken(CancellationToken cancellationToken)
+    {
+        lock (Lock)
+        {
+            if (_baseCancellationToken == cancellationToken)
             {
-                LinkedCancellationTokens = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
-            }
-            else
-            {
-                var existingToken = LinkedCancellationTokens.Token;
-                var oldCts = LinkedCancellationTokens;
-                LinkedCancellationTokens = CancellationTokenSource.CreateLinkedTokenSource(existingToken, cancellationToken);
-                oldCts.Dispose();
+                return;
             }
 
-            CancellationToken = LinkedCancellationTokens.Token;
+            _baseCancellationToken = cancellationToken;
+            RebuildLinkedCancellationTokenSource();
+        }
+    }
+
+    private void RebuildLinkedCancellationTokenSource()
+    {
+        if (_externalCancellationTokens is not { Count: > 0 } externalCancellationTokens)
+        {
+            CancellationToken = _baseCancellationToken;
+            return;
+        }
+
+        CancellationTokenSource linkedCancellationTokenSource;
+        if (externalCancellationTokens.Count == 1)
+        {
+            linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                _baseCancellationToken,
+                externalCancellationTokens[0]);
+        }
+        else
+        {
+            var cancellationTokens = new CancellationToken[externalCancellationTokens.Count + 1];
+            cancellationTokens[0] = _baseCancellationToken;
+            externalCancellationTokens.CopyTo(cancellationTokens, 1);
+            linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokens);
+        }
+
+        if (_linkedCancellationTokenSource is { } previousLinkedCancellationTokenSource)
+        {
+            (_retiredLinkedCancellationTokenSources ??= []).Add(previousLinkedCancellationTokenSource);
+        }
+
+        _linkedCancellationTokenSource = linkedCancellationTokenSource;
+        CancellationToken = linkedCancellationTokenSource.Token;
+    }
+
+    internal void DisposeLinkedCancellationTokenSources()
+    {
+        lock (Lock)
+        {
+            _linkedCancellationTokenSource?.Dispose();
+            _linkedCancellationTokenSource = null;
+
+            if (_retiredLinkedCancellationTokenSources is { } retiredLinkedCancellationTokenSources)
+            {
+                for (var i = retiredLinkedCancellationTokenSources.Count - 1; i >= 0; i--)
+                {
+                    retiredLinkedCancellationTokenSources[i].Dispose();
+                }
+
+                _retiredLinkedCancellationTokenSources = null;
+            }
+
+            _externalCancellationTokens = null;
+            CancellationToken = _baseCancellationToken;
         }
     }
 }

--- a/src/TUnit.Core/TestContext.cs
+++ b/src/TUnit.Core/TestContext.cs
@@ -40,6 +40,7 @@ public partial class TestContext : Context,
     public TestContext(string testName, IServiceProvider serviceProvider, ClassHookContext classContext, TestBuilderContext testBuilderContext, CancellationToken cancellationToken) : base(classContext)
     {
         _testBuilderContext = testBuilderContext;
+        _baseCancellationToken = cancellationToken;
         CancellationToken = cancellationToken;
         ServiceProvider = serviceProvider;
         ClassContext = classContext;

--- a/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -305,46 +305,51 @@ internal sealed class TestCoordinator : ITestCoordinator
             TestExecutor.FinishTestActivity(test);
 #endif
 
-            switch (test.State)
+            try
             {
-                case TestState.NotStarted:
-                case TestState.WaitingForDependencies:
-                case TestState.Queued:
-                case TestState.Running:
-                    // This shouldn't happen
-                    await _messageBus.Cancelled(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
-                    break;
-                case TestState.Passed:
-                    await _messageBus.Passed(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
-                    break;
-                case TestState.Timeout:
-                case TestState.Failed:
-                    TestSessionContext.Current?.MarkFailure();
-                    await _messageBus.Failed(test.Context, test.Context.Execution.Result?.Exception!, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
-                    break;
-                case TestState.Skipped:
-                    var skipReason = test.Context.SkipReason
-                                     ?? (test.Context.Execution.Result?.IsOverridden == true ? test.Context.Execution.Result.OverrideReason : null)
-                                     ?? "Skipped";
-                    await _messageBus.Skipped(test.Context, skipReason).ConfigureAwait(false);
-                    break;
-                case TestState.Cancelled:
-                    TestSessionContext.Current?.MarkFailure();
-                    await _messageBus.Cancelled(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
+                switch (test.State)
+                {
+                    case TestState.NotStarted:
+                    case TestState.WaitingForDependencies:
+                    case TestState.Queued:
+                    case TestState.Running:
+                        // This shouldn't happen
+                        await _messageBus.Cancelled(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
+                        break;
+                    case TestState.Passed:
+                        await _messageBus.Passed(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
+                        break;
+                    case TestState.Timeout:
+                    case TestState.Failed:
+                        TestSessionContext.Current?.MarkFailure();
+                        await _messageBus.Failed(test.Context, test.Context.Execution.Result?.Exception!, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
+                        break;
+                    case TestState.Skipped:
+                        var skipReason = test.Context.SkipReason
+                                         ?? (test.Context.Execution.Result?.IsOverridden == true ? test.Context.Execution.Result.OverrideReason : null)
+                                         ?? "Skipped";
+                        await _messageBus.Skipped(test.Context, skipReason).ConfigureAwait(false);
+                        break;
+                    case TestState.Cancelled:
+                        TestSessionContext.Current?.MarkFailure();
+                        await _messageBus.Cancelled(test.Context, test.StartTime.GetValueOrDefault()).ConfigureAwait(false);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
             }
+            finally
+            {
+                // Dispose the per-test cancellation sources now that the body and every teardown phase — After(Test)
+                // hooks, instance/OnDispose, object cleanup, After(Class)/After(Assembly) and Last receivers —
+                // have all run. Keeping them alive this long means a token copy captured mid-body stayed backed
+                // by a live source throughout teardown instead of throwing ObjectDisposedException (#6339).
+                test.Context.DisposeLinkedCancellationTokenSources();
+                test.Context.TimeoutCancellationSource?.Dispose();
+                test.Context.TimeoutCancellationSource = null;
 
-            // Dispose the per-test cancellation sources now that the body and every teardown phase — After(Test)
-            // hooks, instance/OnDispose, object cleanup, After(Class)/After(Assembly) and Last receivers —
-            // have all run. Keeping them alive this long means a token copy captured mid-body stayed backed
-            // by a live source throughout teardown instead of throwing ObjectDisposedException (#6339).
-            test.Context.DisposeLinkedCancellationTokenSources();
-            test.Context.TimeoutCancellationSource?.Dispose();
-            test.Context.TimeoutCancellationSource = null;
-
-            test.Context.RemoveFromRegistry();
+                test.Context.RemoveFromRegistry();
+            }
         }
     }
 

--- a/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
+++ b/src/TUnit.Engine/Services/TestExecution/TestCoordinator.cs
@@ -336,10 +336,11 @@ internal sealed class TestCoordinator : ITestCoordinator
                     throw new ArgumentOutOfRangeException();
             }
 
-            // Dispose the per-test timeout source now that the body and every teardown phase — After(Test)
+            // Dispose the per-test cancellation sources now that the body and every teardown phase — After(Test)
             // hooks, instance/OnDispose, object cleanup, After(Class)/After(Assembly) and Last receivers —
-            // have all run. Keeping it alive this long means a token copy captured mid-body stayed backed
+            // have all run. Keeping them alive this long means a token copy captured mid-body stayed backed
             // by a live source throughout teardown instead of throwing ObjectDisposedException (#6339).
+            test.Context.DisposeLinkedCancellationTokenSources();
             test.Context.TimeoutCancellationSource?.Dispose();
             test.Context.TimeoutCancellationSource = null;
 

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -113,6 +113,7 @@ internal class TestExecutor
     /// </summary>
     public async ValueTask ExecuteAsync(AbstractExecutableTest executableTest, TestInitializer testInitializer, CancellationToken cancellationToken, TimeSpan? testTimeout = null)
     {
+        executableTest.Context.SetCancellationToken(cancellationToken);
 
         var testClass = executableTest.Metadata.TestClassType;
         var testAssembly = testClass.Assembly;
@@ -306,7 +307,7 @@ internal class TestExecutor
                 // disposed later by TestCoordinator, so token copies captured mid-body stay valid — #6339.)
                 if (testTimeout.HasValue)
                 {
-                    executableTest.Context.CancellationToken = cancellationToken;
+                    executableTest.Context.SetCancellationToken(cancellationToken);
                 }
             }
 
@@ -453,7 +454,7 @@ internal class TestExecutor
         executableTest.Context.TestStart = DateTimeOffset.UtcNow;
 
         // Set the cancellation token on the context so source-generated tests can access it
-        executableTest.Context.CancellationToken = cancellationToken;
+        executableTest.Context.SetCancellationToken(cancellationToken);
 
         if (executableTest.Context.InternalDiscoveredTest?.TestExecutor is { } testExecutor)
         {
@@ -464,7 +465,9 @@ internal class TestExecutor
         }
         else
         {
-            await executableTest.InvokeTestAsync(executableTest.Context.Metadata.TestDetails.ClassInstance, cancellationToken).ConfigureAwait(false);
+            await executableTest.InvokeTestAsync(
+                executableTest.Context.Metadata.TestDetails.ClassInstance,
+                executableTest.Context.Execution.CancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/tests/TUnit.Engine.Tests/LinkedCancellationTokenFromBeforeHookTests.cs
+++ b/tests/TUnit.Engine.Tests/LinkedCancellationTokenFromBeforeHookTests.cs
@@ -1,0 +1,20 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class LinkedCancellationTokenFromBeforeHookTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Test()
+    {
+        await RunTestsWithFilter(
+            "/*/*/LinkedCancellationTokenFromBeforeHookTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(2),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+}

--- a/tests/TUnit.TestProject/Bugs/6567/LinkedCancellationTokenFromBeforeHookTests.cs
+++ b/tests/TUnit.TestProject/Bugs/6567/LinkedCancellationTokenFromBeforeHookTests.cs
@@ -1,0 +1,53 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6567;
+
+[EngineTest(ExpectedResult.Pass)]
+public sealed class LinkedCancellationTokenFromBeforeHookTests
+{
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    [Before(Test)]
+    public void BeforeTest(TestContext context)
+    {
+        _cancellationTokenSource = new CancellationTokenSource(100);
+        context.Execution.AddLinkedCancellationToken(_cancellationTokenSource.Token);
+    }
+
+    [Test]
+    public Task LinkedCancellationReachesInjectedToken(CancellationToken cancellationToken)
+    {
+        return ObserveCancellation(cancellationToken);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task AdditionalLinkPreservesInjectedAndCurrentTokens(CancellationToken cancellationToken)
+    {
+        TestContext.Current!.Execution.AddLinkedCancellationToken(CancellationToken.None);
+
+        await Task.WhenAll(
+            ObserveCancellation(cancellationToken),
+            ObserveCancellation(TestContext.Current.Execution.CancellationToken));
+    }
+
+    [After(Test)]
+    public void AfterTest()
+    {
+        _cancellationTokenSource?.Dispose();
+    }
+
+    private static async Task ObserveCancellation(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(1_000, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException("Token did not observe linked cancellation.");
+    }
+}

--- a/tests/TUnit.TestProject/Bugs/6567/LinkedCancellationTokenFromBeforeHookTests.cs
+++ b/tests/TUnit.TestProject/Bugs/6567/LinkedCancellationTokenFromBeforeHookTests.cs
@@ -10,25 +10,27 @@ public sealed class LinkedCancellationTokenFromBeforeHookTests
     [Before(Test)]
     public void BeforeTest(TestContext context)
     {
-        _cancellationTokenSource = new CancellationTokenSource(100);
+        _cancellationTokenSource = new CancellationTokenSource();
         context.Execution.AddLinkedCancellationToken(_cancellationTokenSource.Token);
     }
 
     [Test]
-    public Task LinkedCancellationReachesInjectedToken(CancellationToken cancellationToken)
+    public void LinkedCancellationReachesInjectedToken(CancellationToken cancellationToken)
     {
-        return ObserveCancellation(cancellationToken);
+        _cancellationTokenSource!.Cancel();
+
+        AssertCancellationObserved(cancellationToken);
     }
 
     [Test]
     [Timeout(5_000)]
-    public async Task AdditionalLinkPreservesInjectedAndCurrentTokens(CancellationToken cancellationToken)
+    public void AdditionalLinkPreservesInjectedAndCurrentTokens(CancellationToken cancellationToken)
     {
         TestContext.Current!.Execution.AddLinkedCancellationToken(CancellationToken.None);
+        _cancellationTokenSource!.Cancel();
 
-        await Task.WhenAll(
-            ObserveCancellation(cancellationToken),
-            ObserveCancellation(TestContext.Current.Execution.CancellationToken));
+        AssertCancellationObserved(cancellationToken);
+        AssertCancellationObserved(TestContext.Current.Execution.CancellationToken);
     }
 
     [After(Test)]
@@ -37,17 +39,11 @@ public sealed class LinkedCancellationTokenFromBeforeHookTests
         _cancellationTokenSource?.Dispose();
     }
 
-    private static async Task ObserveCancellation(CancellationToken cancellationToken)
+    private static void AssertCancellationObserved(CancellationToken cancellationToken)
     {
-        try
+        if (!cancellationToken.IsCancellationRequested)
         {
-            await Task.Delay(1_000, cancellationToken);
+            throw new InvalidOperationException("Token did not observe linked cancellation.");
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException("Token did not observe linked cancellation.");
     }
 }


### PR DESCRIPTION
## Summary

- preserve externally linked cancellation tokens when execution swaps scheduler and timeout tokens
- pass the composed execution token to injected `CancellationToken` parameters
- keep superseded linked sources alive through teardown, then dispose them
- cover source-generated, reflection, timeout, and repeated-link paths

## Root cause

`[Before(Test)]` correctly updated `TestContext.Execution.CancellationToken`, but `TestExecutor` replaced it with the raw scheduler or timeout token immediately before invoking the test body.

## Validation

- `dotnet build tests/TUnit.TestProject/TUnit.TestProject.csproj -c Release -f net10.0 --no-restore`
- regression test passed in source-generated and reflection modes
- engine wrapper passed locally (reflection passed; AOT skipped outside CI)
- existing custom-executor and timeout cancellation regressions passed in both modes

Closes #6567