### PR TITLE
Add per-test execution cancellation

### DIFF
--- a/docs/docs/execution/cancellation.md
+++ b/docs/docs/execution/cancellation.md
@@ -1,0 +1,32 @@
+# Cancelling a Test
+
+Call `TestContext.Execution.Cancel()` to request cooperative cancellation of the current test without affecting other tests or the test session:
+
+```csharp
+[Test]
+public async Task ProcessMessages(CancellationToken cancellationToken)
+{
+    var execution = TestContext.Current!.Execution;
+
+    messagePump.ShuttingDown += execution.Cancel;
+
+    try
+    {
+        await messagePump.RunAsync(cancellationToken);
+    }
+    finally
+    {
+        messagePump.ShuttingDown -= execution.Cancel;
+    }
+}
+```
+
+TUnit marks the test as `Cancelled` and cancels both the injected `CancellationToken` and `TestContext.Execution.CancellationToken`. Cancellation is cooperative: the test body must observe the token and stop.
+
+Capture `TestContext.Execution` for callbacks running on another thread. Do not depend on `TestContext.Current` being available in those callbacks.
+
+`Cancel()` is thread-safe and may be called more than once. Calls made after test execution has completed are ignored. Cleanup hooks still run with `CancellationToken.None`, allowing them to finish normally.
+
+Cancellation composes with `[Timeout]`, custom `ITestExecutor` implementations, and tokens added through `AddLinkedCancellationToken`.
+
+TUnit creates one lightweight `CancellationTokenSource` for each executed test attempt. `Cancel()` adds no background task, polling, or `Task.WhenAny` work.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -160,6 +160,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'execution/test-filters',
         'execution/parameters',
+        'execution/cancellation',
         'execution/timeouts',
         'execution/retrying',
         'execution/repeating',

--- a/src/TUnit.Core/Interfaces/ITestExecution.cs
+++ b/src/TUnit.Core/Interfaces/ITestExecution.cs
@@ -131,6 +131,16 @@ public interface ITestExecution
     bool IsNotDiscoverable { get; set; }
 
     /// <summary>
+    /// Requests cooperative cancellation of the current test execution.
+    /// </summary>
+    /// <remarks>
+    /// Cancellation is scoped to this test and does not cancel other tests or the test session.
+    /// The test body should observe <see cref="CancellationToken"/> and stop promptly. Calls made
+    /// after the test execution has completed are ignored.
+    /// </remarks>
+    void Cancel();
+
+    /// <summary>
     /// Links an external cancellation token to this test's execution token.
     /// Useful for coordinating cancellation across multiple operations or tests.
     /// </summary>

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -167,17 +167,27 @@ public partial class TestContext
     {
         lock (Lock)
         {
+            // Cancel() targets the whole execution, so retries inherit an accepted request.
+            var preserveCancellationRequest = CurrentRetryAttempt > 0 && _testCancellationRequested;
+
             if (_testCancellationTokenSource is { } previousTestCancellationTokenSource)
             {
                 (_retiredTestCancellationTokenSources ??= []).Add(previousTestCancellationTokenSource);
             }
 
-            _testCancellationTokenSource = cancellationToken.CanBeCanceled
+            var testCancellationTokenSource = cancellationToken.CanBeCanceled
                 ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
                 : new CancellationTokenSource();
+
+            if (preserveCancellationRequest)
+            {
+                testCancellationTokenSource.Cancel();
+            }
+
+            _testCancellationTokenSource = testCancellationTokenSource;
             _acceptingTestCancellation = true;
-            _testCancellationRequested = false;
-            _baseCancellationToken = _testCancellationTokenSource.Token;
+            _testCancellationRequested = preserveCancellationRequest;
+            _baseCancellationToken = testCancellationTokenSource.Token;
             RebuildLinkedCancellationTokenSource();
         }
     }

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -12,6 +12,10 @@ public partial class TestContext
 {
     // Internal backing fields and properties
     private CancellationToken _baseCancellationToken;
+    private CancellationTokenSource? _testCancellationTokenSource;
+    private List<CancellationTokenSource>? _retiredTestCancellationTokenSources;
+    private bool _acceptingTestCancellation;
+    private volatile bool _testCancellationRequested;
     private List<CancellationToken>? _externalCancellationTokens;
     private CancellationTokenSource? _linkedCancellationTokenSource;
     // Token copies can escape into user code and remain in use through teardown (#6339).
@@ -37,6 +41,8 @@ public partial class TestContext
     internal IHookExecutor? CustomHookExecutor { get; set; }
     internal bool ReportResult { get; set; } = true;
     internal bool IsNotDiscoverable { get; set; }
+    internal bool IsTestCancellationRequested => _testCancellationRequested;
+    internal CancellationToken TestCancellationToken => _testCancellationTokenSource?.Token ?? CancellationToken;
 
     // Explicit interface implementations for ITestExecution
     TestPhase ITestExecution.Phase => Phase;
@@ -88,6 +94,7 @@ public partial class TestContext
     }
 
     void ITestExecution.OverrideResult(TestState state, string reason) => OverrideResult(state, reason);
+    void ITestExecution.Cancel() => Cancel();
     void ITestExecution.AddLinkedCancellationToken(CancellationToken cancellationToken) => AddLinkedCancellationToken(cancellationToken);
 
     // Internal implementation methods
@@ -152,6 +159,63 @@ public partial class TestContext
             (_externalCancellationTokens ??= []).Add(cancellationToken);
             RebuildLinkedCancellationTokenSource();
         }
+    }
+
+    internal void InitializeTestCancellation(CancellationToken cancellationToken)
+    {
+        lock (Lock)
+        {
+            if (_testCancellationTokenSource is { } previousTestCancellationTokenSource)
+            {
+                (_retiredTestCancellationTokenSources ??= []).Add(previousTestCancellationTokenSource);
+            }
+
+            _testCancellationTokenSource = cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : new CancellationTokenSource();
+            _acceptingTestCancellation = true;
+            _testCancellationRequested = false;
+            _baseCancellationToken = _testCancellationTokenSource.Token;
+            RebuildLinkedCancellationTokenSource();
+        }
+    }
+
+    internal void CompleteTestCancellation()
+    {
+        lock (Lock)
+        {
+            _acceptingTestCancellation = false;
+        }
+    }
+
+    internal void RestoreTestCancellationToken()
+    {
+        lock (Lock)
+        {
+            if (_testCancellationTokenSource is not null)
+            {
+                _baseCancellationToken = _testCancellationTokenSource.Token;
+                RebuildLinkedCancellationTokenSource();
+            }
+        }
+    }
+
+    internal void Cancel()
+    {
+        CancellationTokenSource cancellationTokenSource;
+
+        lock (Lock)
+        {
+            if (!_acceptingTestCancellation || _testCancellationTokenSource is null)
+            {
+                return;
+            }
+
+            _testCancellationRequested = true;
+            cancellationTokenSource = _testCancellationTokenSource;
+        }
+
+        cancellationTokenSource.Cancel();
     }
 
     internal void SetCancellationToken(CancellationToken cancellationToken)
@@ -219,6 +283,21 @@ public partial class TestContext
 
             _externalCancellationTokens = null;
             CancellationToken = _baseCancellationToken;
+
+            _testCancellationTokenSource?.Dispose();
+            _testCancellationTokenSource = null;
+
+            if (_retiredTestCancellationTokenSources is { } retiredTestCancellationTokenSources)
+            {
+                for (var i = retiredTestCancellationTokenSources.Count - 1; i >= 0; i--)
+                {
+                    retiredTestCancellationTokenSources[i].Dispose();
+                }
+
+                _retiredTestCancellationTokenSources = null;
+            }
+
+            _acceptingTestCancellation = false;
         }
     }
 }

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -215,7 +215,15 @@ public partial class TestContext
             cancellationTokenSource = _testCancellationTokenSource;
         }
 
-        cancellationTokenSource.Cancel();
+        try
+        {
+            cancellationTokenSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Final cleanup can dispose the source after we release Lock but before Cancel runs.
+            // Treat that race as a late cancellation request, which is intentionally a no-op.
+        }
     }
 
     internal void SetCancellationToken(CancellationToken cancellationToken)

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -180,11 +180,12 @@ public partial class TestContext
         }
     }
 
-    internal void CompleteTestCancellation()
+    internal bool CompleteTestCancellation()
     {
         lock (Lock)
         {
             _acceptingTestCancellation = false;
+            return _testCancellationRequested;
         }
     }
 

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -201,6 +201,17 @@ public partial class TestContext
         }
     }
 
+    internal void OpenTestCancellationForRetry()
+    {
+        lock (Lock)
+        {
+            if (_testCancellationTokenSource is not null)
+            {
+                _acceptingTestCancellation = true;
+            }
+        }
+    }
+
     internal void RestoreTestCancellationToken()
     {
         lock (Lock)

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -14,6 +14,8 @@ public partial class TestContext
     private CancellationToken _baseCancellationToken;
     private CancellationTokenSource? _testCancellationTokenSource;
     private List<CancellationTokenSource>? _retiredTestCancellationTokenSources;
+    private int _activeTestCancellationOperations;
+    private bool _disposeCancellationTokenSourcesPending;
     private bool _acceptingTestCancellation;
     private volatile bool _testCancellationRequested;
     private List<CancellationToken>? _externalCancellationTokens;
@@ -213,6 +215,7 @@ public partial class TestContext
             }
 
             _testCancellationRequested = true;
+            _activeTestCancellationOperations++;
             cancellationTokenSource = _testCancellationTokenSource;
         }
 
@@ -220,10 +223,17 @@ public partial class TestContext
         {
             cancellationTokenSource.Cancel();
         }
-        catch (ObjectDisposedException)
+        finally
         {
-            // Final cleanup can dispose the source after we release Lock but before Cancel runs.
-            // Treat that race as a late cancellation request, which is intentionally a no-op.
+            lock (Lock)
+            {
+                _activeTestCancellationOperations--;
+
+                if (_activeTestCancellationOperations == 0 && _disposeCancellationTokenSourcesPending)
+                {
+                    DisposeCancellationTokenSourcesUnderLock();
+                }
+            }
         }
     }
 
@@ -277,36 +287,49 @@ public partial class TestContext
     {
         lock (Lock)
         {
-            _linkedCancellationTokenSource?.Dispose();
-            _linkedCancellationTokenSource = null;
-
-            if (_retiredLinkedCancellationTokenSources is { } retiredLinkedCancellationTokenSources)
-            {
-                for (var i = retiredLinkedCancellationTokenSources.Count - 1; i >= 0; i--)
-                {
-                    retiredLinkedCancellationTokenSources[i].Dispose();
-                }
-
-                _retiredLinkedCancellationTokenSources = null;
-            }
-
-            _externalCancellationTokens = null;
-            CancellationToken = _baseCancellationToken;
-
-            _testCancellationTokenSource?.Dispose();
-            _testCancellationTokenSource = null;
-
-            if (_retiredTestCancellationTokenSources is { } retiredTestCancellationTokenSources)
-            {
-                for (var i = retiredTestCancellationTokenSources.Count - 1; i >= 0; i--)
-                {
-                    retiredTestCancellationTokenSources[i].Dispose();
-                }
-
-                _retiredTestCancellationTokenSources = null;
-            }
-
             _acceptingTestCancellation = false;
+
+            if (_activeTestCancellationOperations > 0)
+            {
+                _disposeCancellationTokenSourcesPending = true;
+                return;
+            }
+
+            DisposeCancellationTokenSourcesUnderLock();
         }
+    }
+
+    private void DisposeCancellationTokenSourcesUnderLock()
+    {
+        _linkedCancellationTokenSource?.Dispose();
+        _linkedCancellationTokenSource = null;
+
+        if (_retiredLinkedCancellationTokenSources is { } retiredLinkedCancellationTokenSources)
+        {
+            for (var i = retiredLinkedCancellationTokenSources.Count - 1; i >= 0; i--)
+            {
+                retiredLinkedCancellationTokenSources[i].Dispose();
+            }
+
+            _retiredLinkedCancellationTokenSources = null;
+        }
+
+        _externalCancellationTokens = null;
+        CancellationToken = _baseCancellationToken;
+
+        _testCancellationTokenSource?.Dispose();
+        _testCancellationTokenSource = null;
+
+        if (_retiredTestCancellationTokenSources is { } retiredTestCancellationTokenSources)
+        {
+            for (var i = retiredTestCancellationTokenSources.Count - 1; i >= 0; i--)
+            {
+                retiredTestCancellationTokenSources[i].Dispose();
+            }
+
+            _retiredTestCancellationTokenSources = null;
+        }
+
+        _disposeCancellationTokenSourcesPending = false;
     }
 }

--- a/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
+++ b/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
@@ -36,7 +36,12 @@ internal static class RetryHelper
                 }
                 catch
                 {
-                    testContext.CompleteTestCancellation();
+                    if (testContext.CompleteTestCancellation())
+                    {
+                        SetCancelledResult(testContext);
+                        return;
+                    }
+
                     throw;
                 }
 

--- a/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
+++ b/src/TUnit.Engine/Services/TestExecution/RetryHelper.cs
@@ -27,7 +27,20 @@ internal static class RetryHelper
                     throw;
                 }
 
-                if (await ShouldRetry(testContext, ex, attempt))
+                testContext.OpenTestCancellationForRetry();
+
+                bool shouldRetry;
+                try
+                {
+                    shouldRetry = await ShouldRetry(testContext, ex, attempt);
+                }
+                catch
+                {
+                    testContext.CompleteTestCancellation();
+                    throw;
+                }
+
+                if (shouldRetry)
                 {
 #if NET
                     // Stop the failed attempt's activity before retrying
@@ -41,9 +54,6 @@ internal static class RetryHelper
                         testContext.Activity = null;
                     }
 #endif
-
-                    // Apply backoff delay before retrying
-                    await ApplyBackoffDelay(testContext, attempt).ConfigureAwait(false);
 
                     // Record this failed attempt before it's cleared, so reporters (e.g. the HTML
                     // report's retry/flaky UI) can show the full attempt history. The engine only
@@ -77,7 +87,30 @@ internal static class RetryHelper
                     testContext.TestStart = null;
                     testContext.Execution.TestEnd = null;
                     testContext.Timings.Clear();
+
+                    try
+                    {
+                        await ApplyBackoffDelay(testContext, attempt).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (testContext.IsTestCancellationRequested)
+                    {
+                        SetCancelledResult(testContext);
+                        return;
+                    }
+
+                    if (testContext.IsTestCancellationRequested)
+                    {
+                        SetCancelledResult(testContext);
+                        return;
+                    }
+
                     continue;
+                }
+
+                if (testContext.CompleteTestCancellation())
+                {
+                    SetCancelledResult(testContext);
+                    return;
                 }
 
                 throw;
@@ -119,5 +152,11 @@ internal static class RetryHelper
         }
 
         return Task.CompletedTask;
+    }
+
+    private static void SetCancelledResult(TestContext testContext)
+    {
+        testContext.Execution.Result = null;
+        testContext.InternalExecutableTest.SetResult(TestState.Cancelled);
     }
 }

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -279,10 +279,10 @@ internal class TestExecutor
                 }
                 else
                 {
-                    // Fast path: no timeout — invoke directly, no CTS/TCS/WhenAny overhead
+                    // Fast path: no timeout — invoke directly, with no timeout-specific CTS/TCS/WhenAny overhead
                     await ExecuteTestAsync(
                         executableTest,
-                        executableTest.Context.Execution.CancellationToken).ConfigureAwait(false);
+                        executableTest.Context.TestCancellationToken).ConfigureAwait(false);
                 }
             }
             catch
@@ -314,7 +314,7 @@ internal class TestExecutor
                 }
             }
 
-            executableTest.SetResult(executableTest.Context.IsTestCancellationRequested
+            executableTest.SetResult(executableTest.Context.CompleteTestCancellation()
                 ? TestState.Cancelled
                 : TestState.Passed);
         }

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -314,7 +314,7 @@ internal class TestExecutor
                 }
             }
 
-            executableTest.SetResult(executableTest.Context.CompleteTestCancellation()
+            executableTest.SetResult(executableTest.Context.IsTestCancellationRequested
                 ? TestState.Cancelled
                 : TestState.Passed);
         }
@@ -337,8 +337,6 @@ internal class TestExecutor
         }
         finally
         {
-            executableTest.Context.CompleteTestCancellation();
-
             // After hooks must use CancellationToken.None to ensure cleanup runs even when cancelled
             // This matches the pattern used for After Class/Assembly hooks in TestCoordinator
 
@@ -367,6 +365,18 @@ internal class TestExecutor
             if (hookExceptions.Count > 0 || eventReceiverExceptions.Count > 0)
             {
                 hookException = new TestExecutionException(null, hookExceptions, eventReceiverExceptions);
+            }
+
+            // Keep cancellation open while a failed attempt hands control back to RetryHelper.
+            // Closing it here would create a gap where Cancel() could be lost before retry handling begins.
+            var canRetry = executableTest.Context.CurrentRetryAttempt
+                < executableTest.Context.Metadata.TestDetails.RetryLimit
+                && capturedException is not SkipTestException
+                && (capturedException is not null || hookException is not null);
+
+            if (!canRetry && executableTest.Context.CompleteTestCancellation())
+            {
+                executableTest.SetResult(TestState.Cancelled);
             }
         }
 

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -113,7 +113,7 @@ internal class TestExecutor
     /// </summary>
     public async ValueTask ExecuteAsync(AbstractExecutableTest executableTest, TestInitializer testInitializer, CancellationToken cancellationToken, TimeSpan? testTimeout = null)
     {
-        executableTest.Context.SetCancellationToken(cancellationToken);
+        executableTest.Context.InitializeTestCancellation(cancellationToken);
 
         var testClass = executableTest.Metadata.TestClassType;
         var testAssembly = testClass.Assembly;
@@ -264,7 +264,8 @@ internal class TestExecutor
                     // retry attempt's source (if any) is released here before the new one replaces it.
                     var context = executableTest.Context;
                     context.TimeoutCancellationSource?.Dispose();
-                    var testBodyTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    var testCancellationToken = context.TestCancellationToken;
+                    var testBodyTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(testCancellationToken);
                     context.TimeoutCancellationSource = testBodyTimeoutCts;
 
                     var timeoutMessage = $"Test '{context.Metadata.TestDetails.TestName}' timed out after {testTimeout.Value}";
@@ -273,13 +274,15 @@ internal class TestExecutor
                         ct => ExecuteTestAsync(executableTest, ct).AsTask(),
                         testTimeout.Value,
                         testBodyTimeoutCts,
-                        cancellationToken,
+                        testCancellationToken,
                         timeoutMessage).ConfigureAwait(false);
                 }
                 else
                 {
                     // Fast path: no timeout — invoke directly, no CTS/TCS/WhenAny overhead
-                    await ExecuteTestAsync(executableTest, cancellationToken).ConfigureAwait(false);
+                    await ExecuteTestAsync(
+                        executableTest,
+                        executableTest.Context.Execution.CancellationToken).ConfigureAwait(false);
                 }
             }
             catch
@@ -307,11 +310,13 @@ internal class TestExecutor
                 // disposed later by TestCoordinator, so token copies captured mid-body stay valid — #6339.)
                 if (testTimeout.HasValue)
                 {
-                    executableTest.Context.SetCancellationToken(cancellationToken);
+                    executableTest.Context.RestoreTestCancellationToken();
                 }
             }
 
-            executableTest.SetResult(TestState.Passed);
+            executableTest.SetResult(executableTest.Context.IsTestCancellationRequested
+                ? TestState.Cancelled
+                : TestState.Passed);
         }
         catch (SkipTestException ex)
         {
@@ -321,6 +326,10 @@ internal class TestExecutor
             executableTest.Context.SkipReason ??= ex.Reason;
             capturedException = ex;
         }
+        catch (OperationCanceledException) when (executableTest.Context.IsTestCancellationRequested)
+        {
+            executableTest.SetResult(TestState.Cancelled);
+        }
         catch (Exception ex)
         {
             executableTest.SetResult(TestState.Failed, ex);
@@ -328,6 +337,8 @@ internal class TestExecutor
         }
         finally
         {
+            executableTest.Context.CompleteTestCancellation();
+
             // After hooks must use CancellationToken.None to ensure cleanup runs even when cancelled
             // This matches the pattern used for After Class/Assembly hooks in TestCoordinator
 

--- a/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
@@ -1,0 +1,33 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task CancelMarksCurrentTestExecutionAsCancelled()
+    {
+        await RunTestsWithFilter(
+            "/*/*/TestExecutionCancellationTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(2)
+            ]);
+    }
+
+    [Test]
+    public async Task CancelAfterTheTestExecutionCompletesIsIgnored()
+    {
+        await RunTestsWithFilter(
+            "/*/*/LateTestExecutionCancellationTests/*",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Completed"),
+                result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(0)
+            ]);
+    }
+}

--- a/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
@@ -25,8 +25,8 @@ public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBa
             "/*/*/LateTestExecutionCancellationTests/*",
             [
                 result => result.ResultSummary.Outcome.ShouldBe("Completed"),
-                result => result.ResultSummary.Counters.Total.ShouldBe(1),
-                result => result.ResultSummary.Counters.Passed.ShouldBe(1),
+                result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                result => result.ResultSummary.Counters.Passed.ShouldBe(2),
                 result => result.ResultSummary.Counters.Failed.ShouldBe(0)
             ]);
     }

--- a/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
@@ -7,6 +7,7 @@ namespace TUnit.Engine.Tests;
 public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBase(testMode)
 {
     private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+    private const string RetryBackoffCancellationClassName = "RetryBackoffCancellationTests";
 
     [Test]
     public async Task CancelMarksCurrentTestExecutionAsCancelled()
@@ -50,5 +51,34 @@ public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBa
                 result => result.ResultSummary.Counters.Passed.ShouldBe(2),
                 result => result.ResultSummary.Counters.Failed.ShouldBe(0)
             ]);
+    }
+
+    [Test]
+    public async Task CancelDuringRetryBackoffStopsTheRetry()
+    {
+        var runId = Guid.NewGuid().ToString("N");
+        var stateDirectory = Path.Combine(Path.GetTempPath(), RetryBackoffCancellationClassName, runId);
+
+        try
+        {
+            await RunTestsWithFilter(
+                "/*/*/RetryBackoffCancellationTests/*",
+                [
+                    result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                    result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                    result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                    result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                    _ => File.ReadAllText(Path.Combine(stateDirectory, "FinalState.txt"))
+                        .ShouldBe(TestState.Cancelled.ToString())
+                ],
+                new RunOptions().WithEnvironmentVariable(StateRecordingRunId, runId));
+        }
+        finally
+        {
+            if (Directory.Exists(stateDirectory))
+            {
+                Directory.Delete(stateDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
@@ -1,21 +1,42 @@
 using Shouldly;
+using TUnit.Core.Enums;
 using TUnit.Engine.Tests.Enums;
 
 namespace TUnit.Engine.Tests;
 
 public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBase(testMode)
 {
+    private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+
     [Test]
     public async Task CancelMarksCurrentTestExecutionAsCancelled()
     {
-        await RunTestsWithFilter(
-            "/*/*/TestExecutionCancellationTests/*",
-            [
-                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
-                result => result.ResultSummary.Counters.Total.ShouldBe(2),
-                result => result.ResultSummary.Counters.Passed.ShouldBe(0),
-                result => result.ResultSummary.Counters.Failed.ShouldBe(2)
-            ]);
+        var runId = Guid.NewGuid().ToString("N");
+        var stateDirectory = Path.Combine(Path.GetTempPath(), nameof(TestExecutionCancellationTests), runId);
+
+        try
+        {
+            await RunTestsWithFilter(
+                "/*/*/TestExecutionCancellationTests/*",
+                [
+                    result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                    result => result.ResultSummary.Counters.Total.ShouldBe(2),
+                    result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                    result => result.ResultSummary.Counters.Failed.ShouldBe(2),
+                    _ => ReadState("CancelStopsCooperativeTestBody").ShouldBe(TestState.Cancelled.ToString()),
+                    _ => ReadState("CancelMarksTestAsCancelledWhenBodyReturnsNormally").ShouldBe(TestState.Cancelled.ToString())
+                ],
+                new RunOptions().WithEnvironmentVariable(StateRecordingRunId, runId));
+        }
+        finally
+        {
+            if (Directory.Exists(stateDirectory))
+            {
+                Directory.Delete(stateDirectory, recursive: true);
+            }
+        }
+
+        string ReadState(string testName) => File.ReadAllText(Path.Combine(stateDirectory, $"{testName}.txt"));
     }
 
     [Test]

--- a/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestExecutionCancellationTests.cs
@@ -8,6 +8,8 @@ public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBa
 {
     private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
     private const string RetryBackoffCancellationClassName = "RetryBackoffCancellationTests";
+    private const string CancelDuringRetryTransitionClassName = "CancelDuringRetryTransitionTests";
+    private const string CancelAndThrowDuringRetryClassName = "CancelAndThrowDuringRetryTests";
 
     [Test]
     public async Task CancelMarksCurrentTestExecutionAsCancelled()
@@ -63,6 +65,37 @@ public class TestExecutionCancellationTests(TestMode testMode) : InvokableTestBa
         {
             await RunTestsWithFilter(
                 "/*/*/RetryBackoffCancellationTests/*",
+                [
+                    result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                    result => result.ResultSummary.Counters.Total.ShouldBe(1),
+                    result => result.ResultSummary.Counters.Passed.ShouldBe(0),
+                    result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                    _ => File.ReadAllText(Path.Combine(stateDirectory, "FinalState.txt"))
+                        .ShouldBe(TestState.Cancelled.ToString())
+                ],
+                new RunOptions().WithEnvironmentVariable(StateRecordingRunId, runId));
+        }
+        finally
+        {
+            if (Directory.Exists(stateDirectory))
+            {
+                Directory.Delete(stateDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Test]
+    [Arguments(CancelDuringRetryTransitionClassName)]
+    [Arguments(CancelAndThrowDuringRetryClassName)]
+    public async Task CancelDuringRetryTransitionStopsTheRetry(string className)
+    {
+        var runId = Guid.NewGuid().ToString("N");
+        var stateDirectory = Path.Combine(Path.GetTempPath(), className, runId);
+
+        try
+        {
+            await RunTestsWithFilter(
+                $"/*/*/{className}/*",
                 [
                     result => result.ResultSummary.Outcome.ShouldBe("Failed"),
                     result => result.ResultSummary.Counters.Total.ShouldBe(1),

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -2698,6 +2698,7 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        void Cancel();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -2698,6 +2698,7 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        void Cancel();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -2698,6 +2698,7 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        void Cancel();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -2629,6 +2629,7 @@ namespace .Interfaces
         ? TestEnd { get; }
         ? TestStart { get; }
         void AddLinkedCancellationToken(.CancellationToken cancellationToken);
+        void Cancel();
         void OverrideResult(.TestState state, string reason);
     }
     public interface ITestExecutor

--- a/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
@@ -80,3 +80,47 @@ public class LateTestExecutionCancellationTests
         _completedExecution!.Cancel();
     }
 }
+
+[EngineTest(ExpectedResult.Failure)]
+[CancelDuringRetry]
+public class RetryBackoffCancellationTests
+{
+    private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+    private static ITestExecution? _execution;
+
+    [Test]
+    public void CancelBetweenRetryAttempts()
+    {
+        _execution = TestContext.Current!.Execution;
+        throw new InvalidOperationException("Trigger retry.");
+    }
+
+    [After(Class)]
+    public static void RecordFinalState()
+    {
+        if (Environment.GetEnvironmentVariable(StateRecordingRunId) is not { Length: > 0 } runId)
+        {
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), nameof(RetryBackoffCancellationTests), runId);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, "FinalState.txt"),
+            _execution?.Result?.State.ToString() ?? "No result");
+    }
+}
+
+public sealed class CancelDuringRetryAttribute : RetryAttribute
+{
+    public CancelDuringRetryAttribute() : base(1)
+    {
+        BackoffMs = 5_000;
+    }
+
+    public override Task<bool> ShouldRetry(TestContext context, Exception exception, int currentRetryCount)
+    {
+        context.Execution.Cancel();
+        return Task.FromResult(true);
+    }
+}

--- a/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
@@ -8,6 +8,8 @@ namespace TUnit.TestProject;
 [TestExecutor<CancellationObservingTestExecutor>]
 public class TestExecutionCancellationTests
 {
+    private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+
     [Test]
     [Timeout(5_000)]
     public async Task CancelStopsCooperativeTestBody(CancellationToken cancellationToken)
@@ -23,6 +25,21 @@ public class TestExecutionCancellationTests
     public void CancelMarksTestAsCancelledWhenBodyReturnsNormally()
     {
         TestContext.Current!.Execution.Cancel();
+    }
+
+    [After(Test)]
+    public void RecordFinalState(TestContext context)
+    {
+        if (Environment.GetEnvironmentVariable(StateRecordingRunId) is not { Length: > 0 } runId)
+        {
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), nameof(TestExecutionCancellationTests), runId);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, $"{context.Metadata.TestDetails.MethodName}.txt"),
+            context.Execution.Result?.State.ToString() ?? "No result");
     }
 }
 

--- a/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
@@ -124,3 +124,77 @@ public sealed class CancelDuringRetryAttribute : RetryAttribute
         return Task.FromResult(true);
     }
 }
+
+[EngineTest(ExpectedResult.Failure)]
+[Retry(1)]
+public class CancelDuringRetryTransitionTests
+{
+    private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+    private static ITestExecution? _execution;
+
+    [Test]
+    public void FailBeforeCancellation()
+    {
+        _execution = TestContext.Current!.Execution;
+        throw new InvalidOperationException("Trigger retry.");
+    }
+
+    [After(Test)]
+    public void CancelAfterFailedAttempt() => TestContext.Current!.Execution.Cancel();
+
+    [After(Class)]
+    public static void RecordFinalState() => RecordState(nameof(CancelDuringRetryTransitionTests), _execution);
+
+    private static void RecordState(string className, ITestExecution? execution)
+    {
+        if (Environment.GetEnvironmentVariable(StateRecordingRunId) is not { Length: > 0 } runId)
+        {
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), className, runId);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "FinalState.txt"), execution?.Result?.State.ToString() ?? "No result");
+    }
+}
+
+[EngineTest(ExpectedResult.Failure)]
+[CancelAndThrowDuringRetry]
+public class CancelAndThrowDuringRetryTests
+{
+    private const string StateRecordingRunId = "TUNIT_CANCELLATION_STATE_RUN_ID";
+    private static ITestExecution? _execution;
+
+    [Test]
+    public void FailBeforeRetryDecision()
+    {
+        _execution = TestContext.Current!.Execution;
+        throw new InvalidOperationException("Trigger retry.");
+    }
+
+    [After(Class)]
+    public static void RecordFinalState()
+    {
+        if (Environment.GetEnvironmentVariable(StateRecordingRunId) is not { Length: > 0 } runId)
+        {
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), nameof(CancelAndThrowDuringRetryTests), runId);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "FinalState.txt"), _execution?.Result?.State.ToString() ?? "No result");
+    }
+}
+
+public sealed class CancelAndThrowDuringRetryAttribute : RetryAttribute
+{
+    public CancelAndThrowDuringRetryAttribute() : base(1)
+    {
+    }
+
+    public override Task<bool> ShouldRetry(TestContext context, Exception exception, int currentRetryCount)
+    {
+        context.Execution.Cancel();
+        throw new InvalidOperationException("Retry decision failed after cancellation.");
+    }
+}

--- a/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
@@ -1,0 +1,65 @@
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Failure)]
+[TestExecutor<CancellationObservingTestExecutor>]
+public class TestExecutionCancellationTests
+{
+    [Test]
+    [Timeout(5_000)]
+    public async Task CancelStopsCooperativeTestBody(CancellationToken cancellationToken)
+    {
+        var execution = TestContext.Current!.Execution;
+
+        ThreadPool.QueueUserWorkItem(static state => ((ITestExecution)state!).Cancel(), execution);
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public void CancelMarksTestAsCancelledWhenBodyReturnsNormally()
+    {
+        TestContext.Current!.Execution.Cancel();
+    }
+}
+
+public sealed class CancellationObservingTestExecutor : ITestExecutor
+{
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        using var executorCancellationSource = new CancellationTokenSource();
+        context.Execution.AddLinkedCancellationToken(executorCancellationSource.Token);
+
+        try
+        {
+            await action();
+        }
+        catch (OperationCanceledException) when (context.Execution.CancellationToken.IsCancellationRequested)
+        {
+            // Custom executors may consume cooperative cancellation. The execution result
+            // must still remain cancelled when the executor returns successfully.
+        }
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[CancelAtTestEnd]
+public class LateTestExecutionCancellationTests
+{
+    [Test]
+    public void LateCancellationDoesNotChangeCompletedTest()
+    {
+    }
+}
+
+public sealed class CancelAtTestEndAttribute : Attribute, ITestEndEventReceiver
+{
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        context.Execution.Cancel();
+        return default;
+    }
+}

--- a/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
+++ b/tests/TUnit.TestProject/TestExecutionCancellationTests.cs
@@ -46,20 +46,20 @@ public sealed class CancellationObservingTestExecutor : ITestExecutor
 }
 
 [EngineTest(ExpectedResult.Pass)]
-[CancelAtTestEnd]
 public class LateTestExecutionCancellationTests
 {
-    [Test]
-    public void LateCancellationDoesNotChangeCompletedTest()
-    {
-    }
-}
+    private static ITestExecution? _completedExecution;
 
-public sealed class CancelAtTestEndAttribute : Attribute, ITestEndEventReceiver
-{
-    public ValueTask OnTestEnd(TestContext context)
+    [Test]
+    public void CaptureExecution()
     {
-        context.Execution.Cancel();
-        return default;
+        _completedExecution = TestContext.Current!.Execution;
+    }
+
+    [Test]
+    [DependsOn(nameof(CaptureExecution))]
+    public void CancelAfterPreviousTestIsDisposed()
+    {
+        _completedExecution!.Cancel();
     }
 }

--- a/tests/TUnit.UnitTests/TestContextCancellationTests.cs
+++ b/tests/TUnit.UnitTests/TestContextCancellationTests.cs
@@ -1,0 +1,50 @@
+using TUnit.Core;
+
+namespace TUnit.UnitTests;
+
+public class TestContextCancellationTests
+{
+    [Test]
+    public async Task CleanupDefersSourceDisposalWhileAcceptedCancellationIsInProgress()
+    {
+        var currentContext = TestContext.Current!;
+        var context = new TestContext(
+            nameof(CleanupDefersSourceDisposalWhileAcceptedCancellationIsInProgress),
+            currentContext.ServiceProvider,
+            currentContext.ClassContext,
+            new TestBuilderContext
+            {
+                TestMetadata = currentContext.TestDetails.MethodMetadata
+            },
+            CancellationToken.None);
+
+        context.InitializeTestCancellation(CancellationToken.None);
+
+        var cancellationToken = context.TestCancellationToken;
+        var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCallback = new ManualResetEventSlim();
+        using var registration = cancellationToken.Register(() =>
+        {
+            callbackStarted.TrySetResult();
+            releaseCallback.Wait(TimeSpan.FromSeconds(10));
+        });
+
+        var cancellationTask = Task.Run(context.Cancel);
+
+        try
+        {
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            context.DisposeLinkedCancellationTokenSources();
+
+            await Assert.That(() => cancellationToken.WaitHandle).ThrowsNothing();
+        }
+        finally
+        {
+            releaseCallback.Set();
+            await cancellationTask;
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+}

--- a/tests/TUnit.UnitTests/TestContextCancellationTests.cs
+++ b/tests/TUnit.UnitTests/TestContextCancellationTests.cs
@@ -7,17 +7,7 @@ public class TestContextCancellationTests
     [Test]
     public async Task CleanupDefersSourceDisposalWhileAcceptedCancellationIsInProgress()
     {
-        var currentContext = TestContext.Current!;
-        var context = new TestContext(
-            nameof(CleanupDefersSourceDisposalWhileAcceptedCancellationIsInProgress),
-            currentContext.ServiceProvider,
-            currentContext.ClassContext,
-            new TestBuilderContext
-            {
-                TestMetadata = currentContext.TestDetails.MethodMetadata
-            },
-            CancellationToken.None);
-
+        var context = CreateContext();
         context.InitializeTestCancellation(CancellationToken.None);
 
         var cancellationToken = context.TestCancellationToken;
@@ -46,5 +36,55 @@ public class TestContextCancellationTests
             context.DisposeLinkedCancellationTokenSources();
             context.RemoveFromRegistry();
         }
+    }
+
+    [Test]
+    public async Task RetrySourcePreservesAcceptedCancellation()
+    {
+        var context = CreateContext();
+        context.InitializeTestCancellation(CancellationToken.None);
+
+        var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseCallback = new ManualResetEventSlim();
+        using var registration = context.TestCancellationToken.Register(() =>
+        {
+            callbackStarted.TrySetResult();
+            releaseCallback.Wait(TimeSpan.FromSeconds(10));
+        });
+
+        var cancellationTask = Task.Run(context.Cancel);
+
+        try
+        {
+            await callbackStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            context.CurrentRetryAttempt = 1;
+            context.InitializeTestCancellation(CancellationToken.None);
+
+            await Assert.That(context.IsTestCancellationRequested).IsTrue();
+            await Assert.That(context.TestCancellationToken.IsCancellationRequested).IsTrue();
+        }
+        finally
+        {
+            releaseCallback.Set();
+            await cancellationTask;
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+
+    private static TestContext CreateContext()
+    {
+        var currentContext = TestContext.Current!;
+
+        return new TestContext(
+            nameof(TestContextCancellationTests),
+            currentContext.ServiceProvider,
+            currentContext.ClassContext,
+            new TestBuilderContext
+            {
+                TestMetadata = currentContext.TestDetails.MethodMetadata
+            },
+            CancellationToken.None);
     }
 }

--- a/tests/TUnit.UnitTests/TestContextCancellationTests.cs
+++ b/tests/TUnit.UnitTests/TestContextCancellationTests.cs
@@ -73,6 +73,28 @@ public class TestContextCancellationTests
         }
     }
 
+    [Test]
+    public async Task RetryWindowAcceptsCancellationBetweenAttempts()
+    {
+        var context = CreateContext();
+        context.InitializeTestCancellation(CancellationToken.None);
+        context.CompleteTestCancellation();
+
+        try
+        {
+            context.OpenTestCancellationForRetry();
+            context.Cancel();
+
+            await Assert.That(context.IsTestCancellationRequested).IsTrue();
+            await Assert.That(context.TestCancellationToken.IsCancellationRequested).IsTrue();
+        }
+        finally
+        {
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+
     private static TestContext CreateContext()
     {
         var currentContext = TestContext.Current!;


### PR DESCRIPTION
## Summary

- add `TestContext.Execution.Cancel()` for cooperative, test-scoped cancellation
- create one lightweight cancellation source per executed attempt and propagate it through injected tokens, timeouts, and custom test executors
- mark the execution `Cancelled` even when the body or a custom executor consumes the cancellation exception
- ignore late cancellation requests after execution completes
- document usage and update public API snapshots

## Performance

A .NET 10 microprobe measured source creation and disposal at approximately:

- 48 B and 11 ns with a non-cancellable parent token
- 64 B and 47 ns with a cancellable parent token

There is no background task, polling, `TaskCompletionSource`, or `Task.WhenAny` overhead.

## Validation

- `dotnet build TUnit.Dev.slnx --no-restore -graphBuild:True`
- focused cancellation/custom executor/timeout integration tests
- existing linked cancellation regression tests
- public API verification on `net472`, `net8.0`, `net9.0`, and `net10.0`
- documentation production build

`yarn typecheck` remains blocked by the existing TypeScript 7 `baseUrl` incompatibility in `docs/tsconfig.json`; the Docusaurus production build succeeds.

## Stack

Based on #6568 because its linked cancellation ownership changes are the prerequisite for composing this API with `AddLinkedCancellationToken` and `[Timeout]`. Retarget to `main` after #6568 merges.
