### PR TITLE
Fix outcome timeline overflow in HTML reports

### DIFF
--- a/src/TUnit.Engine/Reporters/Html/TestReport.template.html
+++ b/src/TUnit.Engine/Reporters/Html/TestReport.template.html
@@ -616,7 +616,7 @@
   /* ============================== run view ============================== */
   .run-wrap { max-width: 1280px; margin: 0 auto; padding: 28px 28px 80px; }
   .run-grid-1 { display: grid; grid-template-columns: 320px minmax(0, 1fr) minmax(0, 1fr); gap: 16px; margin-bottom: 16px; }
-  @media (max-width: 1100px) { .run-grid-1 { grid-template-columns: 1fr; } }
+  @media (max-width: 1100px) { .run-grid-1 { grid-template-columns: minmax(0, 1fr); } }
   .run-grid-2 { display: grid; grid-template-columns: 1.3fr 1fr; gap: 16px; margin-bottom: 16px; }
   @media (max-width: 1100px) { .run-grid-2 { grid-template-columns: 1fr; } }
 
@@ -656,7 +656,9 @@
   /* strip card */
   .strip-card { padding: 20px; }
   .strip-card .card-title { margin-bottom: 14px; }
-  .outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; overflow-x: auto; overflow-y: hidden; }
+  .outcome-strip-scroll { overflow-x: auto; overflow-y: hidden; padding: 2px 0; }
+  .outcome-strip-content { width: max-content; min-width: 100%; }
+  .outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; }
   .outcome-strip .tick { flex: 1; min-width: 2px; border-radius: 2px; opacity: 0.85; transition: opacity 100ms, transform 100ms; cursor: pointer; }
   .outcome-strip .tick:hover { opacity: 1; transform: scaleY(1.06); }
   .outcome-strip .tick.pass { background: var(--pass); }
@@ -994,7 +996,7 @@
 
     /* run view: stacked, tighter */
     .run-wrap { padding: 20px 18px 80px; }
-    .run-grid-1, .run-grid-2 { grid-template-columns: 1fr; gap: 12px; }
+    .run-grid-1, .run-grid-2 { grid-template-columns: minmax(0, 1fr); gap: 12px; }
     .donut-card { padding: 18px; }
     .panel-head { padding: 12px 16px; }
   }
@@ -1236,11 +1238,15 @@
 
       <div class="card strip-card">
         <div class="card-title">Outcome timeline</div>
-        <div class="outcome-strip" id="strip"></div>
-        <div class="strip-axis">
-          <span id="stripStart">start</span>
-          <span id="stripMid"></span>
-          <span id="stripEnd">end</span>
+        <div class="outcome-strip-scroll">
+          <div class="outcome-strip-content">
+            <div class="outcome-strip" id="strip"></div>
+            <div class="strip-axis">
+              <span id="stripStart">start</span>
+              <span id="stripMid"></span>
+              <span id="stripEnd">end</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/TUnit.Engine/Reporters/Html/TestReport.template.html
+++ b/src/TUnit.Engine/Reporters/Html/TestReport.template.html
@@ -615,7 +615,7 @@
 
   /* ============================== run view ============================== */
   .run-wrap { max-width: 1280px; margin: 0 auto; padding: 28px 28px 80px; }
-  .run-grid-1 { display: grid; grid-template-columns: 320px 1fr 1fr; gap: 16px; margin-bottom: 16px; }
+  .run-grid-1 { display: grid; grid-template-columns: 320px minmax(0, 1fr) minmax(0, 1fr); gap: 16px; margin-bottom: 16px; }
   @media (max-width: 1100px) { .run-grid-1 { grid-template-columns: 1fr; } }
   .run-grid-2 { display: grid; grid-template-columns: 1.3fr 1fr; gap: 16px; margin-bottom: 16px; }
   @media (max-width: 1100px) { .run-grid-2 { grid-template-columns: 1fr; } }
@@ -656,7 +656,7 @@
   /* strip card */
   .strip-card { padding: 20px; }
   .strip-card .card-title { margin-bottom: 14px; }
-  .outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; }
+  .outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; overflow-x: auto; overflow-y: hidden; }
   .outcome-strip .tick { flex: 1; min-width: 2px; border-radius: 2px; opacity: 0.85; transition: opacity 100ms, transform 100ms; cursor: pointer; }
   .outcome-strip .tick:hover { opacity: 1; transform: scaleY(1.06); }
   .outcome-strip .tick.pass { background: var(--pass); }

--- a/tests/TUnit.Engine.Tests/HtmlReporterTests.cs
+++ b/tests/TUnit.Engine.Tests/HtmlReporterTests.cs
@@ -376,6 +376,26 @@ public class HtmlReporterTests
     }
 
     [Test]
+    public void GenerateHtml_Constrains_Outcome_Timeline_To_Its_Grid_Column()
+    {
+        var html = HtmlReportGenerator.GenerateHtml(new ReportData
+        {
+            AssemblyName = "Tests",
+            MachineName = "machine",
+            Timestamp = "2026-08-09T00:00:00.0000000Z",
+            TUnitVersion = "1.0.0",
+            OperatingSystem = "Windows",
+            RuntimeVersion = ".NET 10.0",
+            TotalDurationMs = 0,
+            Summary = new ReportSummary(),
+            Groups = [],
+        });
+
+        html.ShouldContain("grid-template-columns: 320px minmax(0, 1fr) minmax(0, 1fr)");
+        html.ShouldContain(".outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; overflow-x: auto; overflow-y: hidden; }");
+    }
+
+    [Test]
     public void GenerateHtml_EmitsAttemptsArray_WhenTestWasRetried()
     {
         // Per-attempt status/duration drives the renderer's flaky panel + per-test

--- a/tests/TUnit.Engine.Tests/HtmlReporterTests.cs
+++ b/tests/TUnit.Engine.Tests/HtmlReporterTests.cs
@@ -376,7 +376,7 @@ public class HtmlReporterTests
     }
 
     [Test]
-    public void GenerateHtml_Constrains_Outcome_Timeline_To_Its_Grid_Column()
+    public void GenerateHtml_EmitsOutcomeTimelineOverflowCss()
     {
         var html = HtmlReportGenerator.GenerateHtml(new ReportData
         {
@@ -392,7 +392,11 @@ public class HtmlReporterTests
         });
 
         html.ShouldContain("grid-template-columns: 320px minmax(0, 1fr) minmax(0, 1fr)");
-        html.ShouldContain(".outcome-strip { display: flex; gap: 1px; height: 60px; align-items: stretch; overflow-x: auto; overflow-y: hidden; }");
+        html.ShouldContain("@media (max-width: 1100px) { .run-grid-1 { grid-template-columns: minmax(0, 1fr); } }");
+        html.ShouldContain(".run-grid-1, .run-grid-2 { grid-template-columns: minmax(0, 1fr); gap: 12px; }");
+        html.ShouldContain(".outcome-strip-scroll { overflow-x: auto; overflow-y: hidden; padding: 2px 0; }");
+        html.ShouldContain(".outcome-strip-content { width: max-content; min-width: 100%; }");
+        html.ShouldContain("<div class=\"outcome-strip-scroll\">");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- constrain the overview grid's flexible columns so large timelines cannot widen the report
- add horizontal scrolling when outcome ticks exceed the card width
- add regression coverage for the generated report CSS

## Root cause

Each outcome tick has a 2px minimum width plus a 1px gap. With hundreds of tests, that minimum content width expanded the grid's `1fr` track beyond the report container.

## Impact

Large test suites keep the HTML report within its normal max width while preserving individually clickable timeline ticks through horizontal scrolling.

## Validation

- `dotnet test tests/TUnit.Engine.Tests/TUnit.Engine.Tests.csproj --no-restore --treenode-filter "/*/*/HtmlReporterTests/*"` — 37 passed
- Full `TUnit.Engine.Tests` run — 238 passed, 124 skipped, 7 unrelated reflection-harness failures where child runs discovered zero tests

Closes #6551