### PR TITLE
Expose results directory through TestContext

### DIFF
--- a/docs/docs/writing-tests/artifacts.md
+++ b/docs/docs/writing-tests/artifacts.md
@@ -10,6 +10,23 @@ TUnit supports attaching artifacts at two levels:
 
 Attach files to individual tests using `TestContext.Current.Output.AttachArtifact()`.
 
+### Writing Artifacts to the Results Directory
+
+Use `TestContext.ResultsDirectory` to place generated files alongside reports and other
+artifacts. The property returns the absolute directory selected by Microsoft.Testing.Platform,
+including any `--results-directory` override.
+
+```csharp
+[Test]
+public async Task CaptureLog()
+{
+    var artifactPath = Path.Combine(TestContext.ResultsDirectory, "application.log");
+
+    await File.WriteAllTextAsync(artifactPath, "Diagnostic information");
+    TestContext.Current!.Output.AttachArtifact(artifactPath);
+}
+```
+
 ### Basic Usage
 
 The simplest way to attach an artifact is by providing just the file path:

--- a/docs/docs/writing-tests/test-context.md
+++ b/docs/docs/writing-tests/test-context.md
@@ -53,6 +53,10 @@ Both `Output.WriteLine()` and `OutputWriter.WriteLine()` are valid - the `Output
 
 Artifacts are particularly useful for debugging test failures, especially in integration tests. You can attach screenshots, logs, videos, configuration files, or any other files that help diagnose issues.
 
+Use `TestContext.ResultsDirectory` to get the absolute Microsoft.Testing.Platform results
+directory. It respects configuration such as `--results-directory` and is suitable for files
+that should live alongside test reports.
+
 For complete information about working with test artifacts, including session-level artifacts, best practices, and common use cases, see the [Test Artifacts](./artifacts.md) guide.
 
 ## Test Isolation

--- a/src/TUnit.Core/TestContext.cs
+++ b/src/TUnit.Core/TestContext.cs
@@ -231,6 +231,7 @@ public partial class TestContext : Context,
     public static IReadOnlyDictionary<string, List<string>> Parameters => InternalParametersDictionary;
 
     private static IConfiguration? _configuration;
+    private static string? _resultsDirectory;
 
     /// <summary>
     /// Gets the test configuration. Throws a descriptive exception if accessed before initialization.
@@ -244,6 +245,22 @@ public partial class TestContext : Context,
             "If you are accessing this from a static constructor or field initializer, " +
             "consider moving the code to a test setup method or test body instead.");
         internal set => _configuration = value;
+    }
+
+    /// <summary>
+    /// Gets the absolute path to the directory where test results are written.
+    /// This respects Microsoft.Testing.Platform configuration, including the
+    /// <c>--results-directory</c> command-line option.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if accessed before the test engine initializes it.</exception>
+    public static string ResultsDirectory
+    {
+        get => _resultsDirectory ?? throw new InvalidOperationException(
+            "TestContext.ResultsDirectory has not been initialized. " +
+            "This property is only available after the TUnit test engine has started. " +
+            "If you are accessing this from a static constructor or field initializer, " +
+            "consider moving the code to a test setup method or test body instead.");
+        internal set => _resultsDirectory = value;
     }
 
     /// <summary>

--- a/src/TUnit.Engine/Framework/TUnitServiceProvider.cs
+++ b/src/TUnit.Engine/Framework/TUnitServiceProvider.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Logging;
@@ -77,6 +78,7 @@ internal class TUnitServiceProvider : IServiceProvider, IAsyncDisposable
         var configuration = frameworkServiceProvider.GetConfiguration();
 
         TestContext.Configuration = new ConfigurationAdapter(configuration);
+        TestContext.ResultsDirectory = configuration.GetTestResultDirectory();
 
         // Register capabilities so they're available to test contexts
         Register<ITestFrameworkCapabilities>(capabilities);

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet10_0.verified.txt
@@ -1419,6 +1419,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string ResultsDirectory { get; }
         public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet8_0.verified.txt
@@ -1419,6 +1419,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string ResultsDirectory { get; }
         public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.DotNet9_0.verified.txt
@@ -1419,6 +1419,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string ResultsDirectory { get; }
         public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }

--- a/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
+++ b/tests/TUnit.PublicAPI/Tests.Core_Library_Has_No_API_Changes.Net4_7.verified.txt
@@ -1363,6 +1363,7 @@ namespace
         public new static .TestContext? Current { get; }
         public static string? OutputDirectory { get; }
         public static .<string, .<string>> Parameters { get; }
+        public static string ResultsDirectory { get; }
         public static string? TestDirectory { get; }
         public static string WorkingDirectory { get; set; }
         public override string GetErrorOutput() { }

--- a/tests/TUnit.TestProject/TestContextTests.cs
+++ b/tests/TUnit.TestProject/TestContextTests.cs
@@ -7,6 +7,17 @@ namespace TUnit.TestProject;
 public class TestContextTests
 {
     [Test]
+    public async Task ResultsDirectory_Is_Exposed()
+    {
+        var resultsDirectory = TestContext.ResultsDirectory;
+
+        await Assert.That(Path.IsPathFullyQualified(resultsDirectory)).IsTrue();
+        await Assert.That(Directory.Exists(resultsDirectory)).IsTrue();
+        await Assert.That(resultsDirectory)
+            .IsEqualTo(TestContext.Configuration.Get("platformOptions:resultDirectory"));
+    }
+
+    [Test]
     public async Task Test()
     {
         var id = TestContext.Current!.Id;


### PR DESCRIPTION
## Summary

- expose the resolved Microsoft.Testing.Platform results directory through `TestContext.ResultsDirectory`
- initialize it with `IConfiguration.GetTestResultDirectory()`, preserving `--results-directory` and configuration overrides
- document artifact creation and add runtime/public API coverage

## Testing

- `dotnet test tests/TUnit.TestProject/TUnit.TestProject.csproj --framework net10.0 --no-restore --treenode-filter "/*/*/TestContextTests/ResultsDirectory_Is_Exposed"`
- same focused test with `--results-directory TestResults/issue-6538-override`
- `dotnet test tests/TUnit.PublicAPI/TUnit.PublicAPI.csproj --no-restore` (18 passed)
- `dotnet test tests/TUnit.Engine.Tests/TUnit.Engine.Tests.csproj --no-restore` (244 passed, 124 skipped)

Fixes #6538