### PR TITLE
Stabilize immediate WaitsFor assertion test

### DIFF
--- a/tests/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
+++ b/tests/TUnit.Assertions.Tests/WaitsForAssertionTests.cs
@@ -8,17 +8,18 @@ public class WaitsForAssertionTests
     [Test]
     public async Task WaitsFor_Passes_Immediately_When_Assertion_Succeeds()
     {
-        var stopwatch = Stopwatch.StartNew();
-
         var value = 42;
+        var attemptCount = 0;
+
         await Assert.That(value).WaitsFor(
-            assert => assert.IsEqualTo(42),
+            assert =>
+            {
+                attemptCount++;
+                return assert.IsEqualTo(42);
+            },
             timeout: TimeSpan.FromSeconds(5));
 
-        stopwatch.Stop();
-
-        // Should complete very quickly since assertion passes immediately
-        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(100));
+        await Assert.That(attemptCount).IsEqualTo(1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- replace the wall-clock threshold in the immediate `WaitsFor` test with an exact attempt-count assertion
- verify successful assertions complete on the first polling attempt without relying on runner speed

## Root cause

Ubuntu CI exceeded the test's 100 ms threshold by 0.6408 ms under load even though the assertion passed immediately. Elapsed time was an indirect and environment-sensitive proxy for retry behavior.

## Impact

The test now checks the intended behavior deterministically and no longer flakes on slow CI runners.

## Validation

- `dotnet test tests/TUnit.Assertions.Tests/TUnit.Assertions.Tests.csproj --configuration Release --framework net10.0 --no-build --treenode-filter "/*/*/WaitsForAssertionTests/*"` — 27 passed
- focused immediate-success test — passed once with build plus 10 repeated no-build runs

Originating failure: https://github.com/thomhurst/TUnit/actions/runs/31318658536/job/93257973205