### PR TITLE
fix: Allow Item.Member after HasSingleItem

### DIFF
--- a/src/TUnit.Assertions/Conditions/MemberAssertion.cs
+++ b/src/TUnit.Assertions/Conditions/MemberAssertion.cs
@@ -132,10 +132,10 @@ internal class TypeErasedAssertion<T> : Assertion<object?>
         _innerAssertion = innerAssertion ?? throw new ArgumentNullException(nameof(innerAssertion));
     }
 
-    public override async Task<object?> AssertAsync()
+    protected override async Task<AssertionResult> CheckAsync(EvaluationMetadata<object?> metadata)
     {
         await _innerAssertion.AssertAsync();
-        return null;
+        return AssertionResult.Passed;
     }
 
     protected override string GetExpectation() => _innerAssertion.InternalGetExpectation();

--- a/tests/TUnit.Assertions.Tests/Bugs/Issue6581Tests.cs
+++ b/tests/TUnit.Assertions.Tests/Bugs/Issue6581Tests.cs
@@ -1,0 +1,36 @@
+namespace TUnit.Assertions.Tests.Bugs;
+
+public class Issue6581Tests
+{
+    [Test]
+    public async Task Member_After_HasSingleItem_Item_Succeeds()
+    {
+        var items = new List<TestObject>
+        {
+            new() { Value = 4 }
+        };
+
+        await Assert
+            .That(items).HasSingleItem()
+            .Item.Member(item => item.Value, value => value.IsEqualTo(4));
+    }
+
+    [Test]
+    public async Task Member_After_HasSingleItem_With_Predicate_Item_Succeeds()
+    {
+        var items = new List<TestObject>
+        {
+            new() { Value = 3 },
+            new() { Value = 4 }
+        };
+
+        await Assert
+            .That(items).HasSingleItem(item => item.Value == 4)
+            .Item.Member(item => item.Value, value => value.IsEqualTo(4));
+    }
+
+    private sealed class TestObject
+    {
+        public int Value { get; init; }
+    }
+}


### PR DESCRIPTION
## Description

Ensure TypeErasedAssertion uses the standard assertion execution pipeline, preserving deferred pre-work from `HasSingleItem().Item`.

Added a regression coverage test for the issue.

## Related Issue

Fixes #6581

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [x] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works

### Testing

- [x] All existing tests pass (`dotnet test`)
- [x] I have added tests that cover my changes
- [x] I have tested both source-generated and reflection modes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed member assertions used after single-item assertions so they now complete successfully instead of returning an invalid result.
  * Corrected behavior for both predicate-based and non-predicate member assertions.

* **Tests**
  * Added coverage for asynchronous member assertion scenarios following single-item checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->