### PR TITLE
Suppress HTML reports for nested test runs

### DIFF
--- a/tests/TUnit.Engine.Tests/EnvironmentVariables.cs
+++ b/tests/TUnit.Engine.Tests/EnvironmentVariables.cs
@@ -5,4 +5,11 @@ public class EnvironmentVariables
     public static readonly string? NetVersion = Environment.GetEnvironmentVariable("NET_VERSION");
 
     public static readonly bool IsNetFramework = NetVersion?.StartsWith("net4") == true;
+
+    // Keep the report for the outer TUnit.Engine.Tests suite, but do not generate or upload
+    // reports for the short-lived test applications that it launches as implementation details.
+    public static Dictionary<string, string?> DisableHtmlReporterForChildProcess() => new()
+    {
+        ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
+    };
 }

--- a/tests/TUnit.Engine.Tests/ExternalCancellationTests.cs
+++ b/tests/TUnit.Engine.Tests/ExternalCancellationTests.cs
@@ -62,6 +62,7 @@ public class ExternalCancellationTests(TestMode testMode) : InvokableTestBase(te
                     "--reflection"
                 ])
                 .WithWorkingDirectory(testProject.DirectoryName!)
+                .WithEnvironmentVariables(EnvironmentVariables.DisableHtmlReporterForChildProcess())
                 .WithValidation(CommandResultValidation.None),
 
             // Skip AOT mode for external cancellation (only test in CI)

--- a/tests/TUnit.Engine.Tests/FSharp.cs
+++ b/tests/TUnit.Engine.Tests/FSharp.cs
@@ -32,6 +32,7 @@ public class FSharp
                 ]
             )
             .WithWorkingDirectory(testProject.DirectoryName!)
+            .WithEnvironmentVariables(EnvironmentVariables.DisableHtmlReporterForChildProcess())
             .WithValidation(CommandResultValidation.None);
 
         var result = await command.ExecuteBufferedAsync();

--- a/tests/TUnit.Engine.Tests/InvokableTestBase.cs
+++ b/tests/TUnit.Engine.Tests/InvokableTestBase.cs
@@ -110,10 +110,7 @@ public abstract class InvokableTestBase(TestMode testMode)
 
     private static Dictionary<string, string?> BuildEnvironmentVariables(RunOptions runOptions)
     {
-        var environmentVariables = new Dictionary<string, string?>
-        {
-            ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
-        };
+        var environmentVariables = EnvironmentVariables.DisableHtmlReporterForChildProcess();
 
         foreach (var (key, value) in runOptions.EnvironmentVariables)
         {

--- a/tests/TUnit.Engine.Tests/ListTestsFilterTests.cs
+++ b/tests/TUnit.Engine.Tests/ListTestsFilterTests.cs
@@ -73,7 +73,7 @@ public class ListTestsFilterTests
         return await Cli.Wrap(executable.FullName)
             .WithArguments(arguments)
             .WithWorkingDirectory(testProject.DirectoryName!)
-            .WithEnvironmentVariables(new Dictionary<string, string?> { ["TUNIT_DISABLE_HTML_REPORTER"] = "true" })
+            .WithEnvironmentVariables(EnvironmentVariables.DisableHtmlReporterForChildProcess())
             .WithValidation(CommandResultValidation.None)
             .ExecuteBufferedAsync();
     }

--- a/tests/TUnit.Engine.Tests/VB.cs
+++ b/tests/TUnit.Engine.Tests/VB.cs
@@ -32,6 +32,7 @@ public class VB
                 ]
             )
             .WithWorkingDirectory(testProject.DirectoryName!)
+            .WithEnvironmentVariables(EnvironmentVariables.DisableHtmlReporterForChildProcess())
             .WithValidation(CommandResultValidation.None);
 
         var result = await command.ExecuteBufferedAsync();

--- a/tests/TUnit.RpcTests/TestHostSession.cs
+++ b/tests/TUnit.RpcTests/TestHostSession.cs
@@ -56,6 +56,12 @@ internal sealed class TestHostSession : IAsyncDisposable
                 "--server",
                 "--client-port", port.ToString()
             ])
+            // The RPC host is an implementation detail of this suite. Keep the outer
+            // TUnit.RpcTests report, but do not generate or upload one per RPC run.
+            .WithEnvironmentVariables(new Dictionary<string, string?>
+            {
+                ["TUNIT_DISABLE_HTML_REPORTER"] = "true"
+            })
             .WithStandardOutputPipe(PipeTarget.Null)
             .WithStandardErrorPipe(PipeTarget.Null)
             .WithValidation(CommandResultValidation.None)

--- a/tools/TUnit.Pipeline/Modules/RunPlaywrightTestsModule.cs
+++ b/tools/TUnit.Pipeline/Modules/RunPlaywrightTestsModule.cs
@@ -34,6 +34,7 @@ public class RunPlaywrightTestsModule : TestBaseModule
                 EnvironmentVariables = new Dictionary<string, string?>
                 {
                     ["DISABLE_GITHUB_REPORTER"] = "true",
+                    ["TUNIT_DISABLE_HTML_REPORTER"] = "true",
                 }
             }
         ));


### PR DESCRIPTION
## Summary

- disable HTML reporting for short-lived child test applications launched by `TUnit.Engine.Tests`
- disable HTML reporting for `TUnit.TestProject` RPC host sessions
- disable HTML reporting for the two-test Playwright template smoke run
- preserve reports for the outer, top-level test suites

## Why

A representative full .NET workflow produced 144 HTML artifacts. Of those, 54 came from RPC child hosts, 6 from nested F#/VB engine-test runs, and 3 from the Playwright template smoke project. These implementation-detail reports add artifact noise without improving suite-level diagnostics.

With the same matrix and workload, the expected HTML artifact count is reduced from 144 to 81.

## Validation

- `dotnet build tests/TUnit.Engine.Tests/TUnit.Engine.Tests.csproj -c Release -f net10.0 --no-restore`
- focused VB engine test passed; outer report remained and no child report was produced
- `dotnet build tests/TUnit.RpcTests/TUnit.RpcTests.csproj -c Release -f net10.0`
- focused RPC test passed for net8.0 and net10.0; outer report remained and no child reports were produced
- `dotnet build tools/TUnit.Pipeline/TUnit.Pipeline.csproj -c Release -f net10.0`
- `git diff --check`

The focused F# engine test was also attempted locally. Report suppression worked, but the test itself hit the existing local .NET 11 preview / FSharp.Core 11.0.0.0 resolution mismatch.