### PR TITLE
Add xunit.v3.aot to speed comparison

### DIFF
--- a/.github/workflows/speed-comparison.yml
+++ b/.github/workflows/speed-comparison.yml
@@ -28,9 +28,10 @@ jobs:
           dotnet build -c Release -p:TestFramework=MSTEST
         working-directory: "tools/speed-comparison/UnifiedTests"
 
-      - name: Publish TUnit AOT
+      - name: Publish AOT
         run: |
           dotnet publish -c Release -p:TestFramework=TUNIT -p:Aot=true --use-current-runtime --output bin/Release-TUNIT-AOT/net10.0
+          dotnet publish -c Release -p:TestFramework=XUNIT3 -p:Aot=true --use-current-runtime --output bin/Release-XUNIT3-AOT/net10.0
         working-directory: "tools/speed-comparison/UnifiedTests"
 
       - name: Upload Build Artifacts

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -117,6 +117,7 @@
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.aot" Version="4.0.0" />
     <PackageVersion Include="xunit.v3.assert" Version="4.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>

--- a/tools/speed-comparison/Tests.Benchmark/FrameworkVersionColumn.cs
+++ b/tools/speed-comparison/Tests.Benchmark/FrameworkVersionColumn.cs
@@ -43,7 +43,7 @@ public class FrameworkVersionColumn : IColumn
         {
             "TUnit" or "TUnit_AOT" or "Build_TUnit" => GetTUnitVersion(),
             "xUnit" or "Build_xUnit" => GetXUnitVersion(),
-            "xUnit3" or "Build_xUnit3" => GetXUnit3Version(),
+            "xUnit3" or "xUnit3_AOT" or "Build_xUnit3" => GetXUnit3Version(),
             "NUnit" or "Build_NUnit" => GetNUnitVersion(),
             "MSTest" or "Build_MSTest" => GetMSTestVersion(),
             _ => "Unknown"

--- a/tools/speed-comparison/Tests.Benchmark/RuntimeBenchmarks.cs
+++ b/tools/speed-comparison/Tests.Benchmark/RuntimeBenchmarks.cs
@@ -70,6 +70,19 @@ public class RuntimeBenchmarks : BenchmarkBase
     }
 
     [Benchmark]
+    [BenchmarkCategory("Runtime", "AOT")]
+    public async Task xUnit3_AOT()
+    {
+        var aotPath = Path.Combine(UnifiedPath, "bin", "Release-XUNIT3-AOT", Framework);
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "UnifiedTests.exe" : "UnifiedTests";
+
+        await Cli.Wrap(Path.Combine(aotPath, exeName))
+            .WithArguments(["--filter-query", $"/*/*/{ClassName}/*"])
+            .WithStandardOutputPipe(PipeTarget.ToStream(OutputStream))
+            .ExecuteBufferedAsync();
+    }
+
+    [Benchmark]
     public async Task xUnit3()
     {
         var binPath = Path.Combine(UnifiedPath, "bin", "Release-XUNIT3", Framework);

--- a/tools/speed-comparison/Tests.Benchmark/TestVersionColumn.cs
+++ b/tools/speed-comparison/Tests.Benchmark/TestVersionColumn.cs
@@ -11,7 +11,7 @@ public class TestVersionColumn
         Console.WriteLine("Testing Framework Version Column:");
         Console.WriteLine("---------------------------------");
 
-        var methods = new[] { "TUnit", "TUnit_AOT", "Build_TUnit", "xUnit", "Build_xUnit", "xUnit3", "Build_xUnit3", "NUnit", "Build_NUnit", "MSTest", "Build_MSTest" };
+        var methods = new[] { "TUnit", "TUnit_AOT", "Build_TUnit", "xUnit", "Build_xUnit", "xUnit3", "xUnit3_AOT", "Build_xUnit3", "NUnit", "Build_NUnit", "MSTest", "Build_MSTest" };
 
         foreach (var method in methods)
         {

--- a/tools/speed-comparison/UnifiedTests/GlobalUsings.cs
+++ b/tools/speed-comparison/UnifiedTests/GlobalUsings.cs
@@ -24,6 +24,7 @@ global using TestAttribute = Xunit.FactAttribute;
 global using DataDrivenTestAttribute = Xunit.TheoryAttribute;
 global using TestDataAttribute = Xunit.InlineDataAttribute;
 global using TestDataSourceAttribute = Xunit.MemberDataAttribute;
+[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]
 #elif NUNIT
 global using TestAttribute = NUnit.Framework.TestAttribute;
 global using DataDrivenTestAttribute = NUnit.Framework.TestAttribute;

--- a/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
+++ b/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
@@ -5,7 +5,7 @@ namespace UnifiedTests;
 
 [TestClass]
 #if XUNIT3
-public class SetupTeardownTests : IDisposable
+public class SetupTeardownTests : IAsyncLifetime
 #else
 public class SetupTeardownTests
 #endif
@@ -20,7 +20,7 @@ public class SetupTeardownTests
     [Before(Test)]
     public async Task Setup()
 #elif XUNIT3
-    public SetupTeardownTests()
+    public async ValueTask InitializeAsync()
 #elif NUNIT
     [SetUp]
     public async Task Setup()
@@ -31,13 +31,6 @@ public class SetupTeardownTests
     public async Task Setup()
 #endif
     {
-#if XUNIT3
-        SetupCore().GetAwaiter().GetResult();
-    }
-
-    private async Task SetupCore()
-    {
-#endif
         // Simulate expensive database connection initialization
         _databaseConnection = new byte[1024 * 100]; // 100KB allocation
         for (int i = 0; i < _databaseConnection.Length; i++)
@@ -67,7 +60,7 @@ public class SetupTeardownTests
     [After(Test)]
     public async Task Cleanup()
 #elif XUNIT3
-    public void Dispose()
+    public async ValueTask DisposeAsync()
 #elif NUNIT
     [TearDown]
     public async Task Cleanup()
@@ -78,13 +71,6 @@ public class SetupTeardownTests
     public async Task Cleanup()
 #endif
     {
-#if XUNIT3
-        CleanupCore().GetAwaiter().GetResult();
-    }
-
-    private async Task CleanupCore()
-    {
-#endif
         // Simulate database connection cleanup
         if (_databaseConnection != null)
         {

--- a/tools/speed-comparison/UnifiedTests/UnifiedTests.csproj
+++ b/tools/speed-comparison/UnifiedTests/UnifiedTests.csproj
@@ -45,7 +45,8 @@
 
     <!-- xUnit v3 packages -->
     <ItemGroup Condition="'$(TestFramework)' == 'XUNIT3'">
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3" Condition="'$(Aot)' != 'true'" />
+        <PackageReference Include="xunit.v3.aot" Condition="'$(Aot)' == 'true'" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -63,13 +64,13 @@
         <PackageReference Include="MSTest" />
     </ItemGroup>
 
-    <!-- AOT and SingleFile configurations for TUnit -->
-    <PropertyGroup Condition="'$(TestFramework)' == 'TUNIT' AND '$(Aot)' == 'true'">
+    <!-- AOT and SingleFile configurations -->
+    <PropertyGroup Condition="'$(Aot)' == 'true'">
         <PublishAot>true</PublishAot>
         <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(TestFramework)' == 'TUNIT' AND '$(SingleFile)' == 'true'">
+    <PropertyGroup Condition="'$(SingleFile)' == 'true'">
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
     </PropertyGroup>


### PR DESCRIPTION
## Description

With version 4.0.0 of xunit.v3 support for AOT was added. https://xunit.net/releases/v3/4.0.0
This adds it to the speed comparison tests.

In addition it support full parallelization which I have enabled in the tests as well. https://xunit.net/docs/running-tests-in-parallel
```c#
[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.All)]
```

I have also modernized the `SetupTeardownTests` to use `IAsyncLifetime`.

## Related Issue

None

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [X] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [X] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [X] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [X] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [X] All existing tests pass (`dotnet test`)
- [X] I have added tests that cover my changes
- [X] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AOT benchmark coverage for xUnit 3 alongside existing test frameworks.
  - Added support for publishing both TUnit and xUnit 3 AOT artifacts.
  - Enabled xUnit 3 AOT builds with appropriate package and publishing settings.

- **Bug Fixes**
  - Improved xUnit 3 test lifecycle handling with asynchronous setup and cleanup.
  - Enabled parallel execution across xUnit 3 tests for more representative benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->