### PR TITLE
Address xUnit speed comparison review feedback

### DIFF
--- a/tools/speed-comparison/Tests.Benchmark/TestVersionColumn.cs
+++ b/tools/speed-comparison/Tests.Benchmark/TestVersionColumn.cs
@@ -11,7 +11,7 @@ public class TestVersionColumn
         Console.WriteLine("Testing Framework Version Column:");
         Console.WriteLine("---------------------------------");
 
-        var methods = new[] { "TUnit", "TUnit_AOT", "Build_TUnit", "xUnit", "Build_xUnit", "xUnit3", "xUnit3_AOT", "Build_xUnit3", "NUnit", "Build_NUnit", "MSTest", "Build_MSTest" };
+        string[] methods = ["TUnit", "TUnit_AOT", "Build_TUnit", "xUnit", "Build_xUnit", "xUnit3", "xUnit3_AOT", "Build_xUnit3", "NUnit", "Build_NUnit", "MSTest", "Build_MSTest"];
 
         foreach (var method in methods)
         {

--- a/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
+++ b/tools/speed-comparison/UnifiedTests/SetupTeardownTests.cs
@@ -11,10 +11,10 @@ public class SetupTeardownTests
 #endif
 {
     // Simulated expensive state
-    private byte[] _databaseConnection;
-    private List<string> _tempFiles;
-    private HttpClient _httpClient;
-    private StringBuilder _logBuilder;
+    private byte[] _databaseConnection = null!;
+    private List<string> _tempFiles = null!;
+    private HttpClient _httpClient = null!;
+    private StringBuilder _logBuilder = null!;
 
 #if TUNIT
     [Before(Test)]


### PR DESCRIPTION
## Summary

- use a typed collection expression for the framework-version method list
- explicitly initialize lifecycle-owned fields with `null!`

## Why

Follow-up to #6621. Its unresolved review feedback identified inconsistent modern C# syntax and CS8618 nullable warnings because xUnit lifecycle initialization is not visible to constructor analysis.

## Impact

No runtime behavior changes. The benchmark helper follows repository style, and the xUnit 3 speed-comparison project no longer reports CS8618 for lifecycle-owned state.

## Validation

- `git diff --check`
- `dotnet build tools/speed-comparison/Tests.Benchmark/Tests.Benchmark.csproj -c Release`
- `dotnet build tools/speed-comparison/UnifiedTests/UnifiedTests.csproj -c Release -p:TestFramework=XUNIT3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal test and benchmark initialization syntax.
  * Suppressed initialization warnings without changing runtime behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->