### PR TITLE
Fix docs TypeScript 7 compatibility

### DIFF
--- a/docs/src/components/AssertionsLibrary/index.tsx
+++ b/docs/src/components/AssertionsLibrary/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { type JSX, useState, useMemo } from 'react';
 import styles from './styles.module.css';
 
 interface Assertion {

--- a/docs/src/components/BenchmarkChart/index.tsx
+++ b/docs/src/components/BenchmarkChart/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { type JSX, useEffect, useState } from 'react';
 import styles from './styles.module.css';
 
 interface BenchmarkData {

--- a/docs/src/components/BenchmarkHighlight/index.tsx
+++ b/docs/src/components/BenchmarkHighlight/index.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { type JSX, useEffect, useState } from 'react';
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 
-export default function BenchmarkHighlight(): JSX.Element {
+export default function BenchmarkHighlight(): JSX.Element | null {
   const [speedups, setSpeedups] = useState<any>(null);
 
   useEffect(() => {

--- a/docs/src/components/ChooseYourJourney/index.tsx
+++ b/docs/src/components/ChooseYourJourney/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import type {JSX} from 'react';
 import Heading from '@theme/Heading';
 import CodeBlock from '@theme/CodeBlock';
 import styles from './styles.module.css';

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import {Highlight, themes} from 'prism-react-renderer';
+import type {JSX} from 'react';
 
 import styles from './index.module.css';
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,19 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@docusaurus/tsconfig",
+  // Keep in sync with @docusaurus/tsconfig, which still uses the removed baseUrl option.
   "compilerOptions": {
-    "baseUrl": "."
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"],
+      "*": ["./*"]
+    },
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary

- replace the inherited Docusaurus TypeScript config because it still uses the removed `baseUrl` option
- preserve Docusaurus compiler settings with TypeScript 7-compatible `paths` mappings
- import React's exported `JSX` namespace instead of relying on the removed global namespace
- allow the benchmark highlight component's declared return type to include `null`

## Root cause

TypeScript 7 rejects `baseUrl`, including when inherited from `@docusaurus/tsconfig`. React 19 types also expose `JSX` through React instead of the global namespace.

## Validation

- `yarn install --frozen-lockfile`
- `yarn typecheck`
- `yarn build`