### PR TITLE
Skip empty test registration work

### DIFF
--- a/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
+++ b/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
@@ -1,4 +1,5 @@
 using TUnit.Core;
+using TUnit.Core.PropertyInjection;
 
 namespace TUnit.Engine.Services;
 
@@ -21,12 +22,28 @@ internal sealed class TestArgumentRegistrationService
     /// for proper reference counting and disposal tracking.
     /// Property values are resolved lazily during test execution (not during discovery).
     /// </summary>
-    public async ValueTask RegisterTestArgumentsAsync(TestContext testContext, CancellationToken cancellationToken = default)
+    public ValueTask RegisterTestArgumentsAsync(TestContext testContext, CancellationToken cancellationToken = default)
     {
         TestContext.Current = testContext;
 
-        var classArguments = testContext.Metadata.TestDetails.TestClassArguments;
-        var methodArguments = testContext.Metadata.TestDetails.TestMethodArguments;
+        var testDetails = testContext.Metadata.TestDetails;
+        if (testDetails.TestClassArguments.Length == 0 &&
+            testDetails.TestMethodArguments.Length == 0 &&
+            !PropertyInjectionCache.GetOrCreatePlan(testDetails.ClassType).HasProperties)
+        {
+            return default;
+        }
+
+        return RegisterTestArgumentsCoreAsync(testContext, testDetails, cancellationToken);
+    }
+
+    private async ValueTask RegisterTestArgumentsCoreAsync(
+        TestContext testContext,
+        TestDetails testDetails,
+        CancellationToken cancellationToken)
+    {
+        var classArguments = testDetails.TestClassArguments;
+        var methodArguments = testDetails.TestMethodArguments;
 
         // Register class arguments (property injection during registration)
         await _objectLifecycleService.RegisterArgumentsAsync(

--- a/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
+++ b/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
@@ -51,7 +51,7 @@ internal sealed class TestArgumentRegistrationService
             testContext.StateBag.Items,
             testContext.Metadata.TestDetails.MethodMetadata,
             testContext.InternalEvents,
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
 
         // Register method arguments
         await _objectLifecycleService.RegisterArgumentsAsync(
@@ -59,9 +59,9 @@ internal sealed class TestArgumentRegistrationService
             testContext.StateBag.Items,
             testContext.Metadata.TestDetails.MethodMetadata,
             testContext.InternalEvents,
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
 
         // Register the test for tracking (inject properties and track objects for disposal)
-        await _objectLifecycleService.RegisterTestAsync(testContext, cancellationToken);
+        await _objectLifecycleService.RegisterTestAsync(testContext, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
+++ b/src/TUnit.Engine/Services/TestArgumentRegistrationService.cs
@@ -49,7 +49,7 @@ internal sealed class TestArgumentRegistrationService
         await _objectLifecycleService.RegisterArgumentsAsync(
             classArguments,
             testContext.StateBag.Items,
-            testContext.Metadata.TestDetails.MethodMetadata,
+            testDetails.MethodMetadata,
             testContext.InternalEvents,
             cancellationToken).ConfigureAwait(false);
 
@@ -57,7 +57,7 @@ internal sealed class TestArgumentRegistrationService
         await _objectLifecycleService.RegisterArgumentsAsync(
             methodArguments,
             testContext.StateBag.Items,
-            testContext.Metadata.TestDetails.MethodMetadata,
+            testDetails.MethodMetadata,
             testContext.InternalEvents,
             cancellationToken).ConfigureAwait(false);
 

--- a/src/TUnit.Engine/Services/TestFilterService.cs
+++ b/src/TUnit.Engine/Services/TestFilterService.cs
@@ -63,33 +63,38 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
 
     private async Task RegisterTest(AbstractExecutableTest test, bool isForExecution)
     {
-        var discoveredTest = new DiscoveredTest<object>
-        {
-            TestContext = test.Context
-        };
-
-        var registeredContext = new TestRegisteredContext(test.Context)
-        {
-            DiscoveredTest = discoveredTest
-        };
-
-        test.Context.InternalDiscoveredTest = discoveredTest;
+        var registeredReceivers = test.Context.GetTestRegisteredReceivers();
 
         // Invoke event receivers BEFORE argument registration so that SkipAttribute
         // and other ITestRegisteredEventReceiver implementations can set SkipReason
         // before any potentially expensive data source initialization occurs.
         // This is critical for derived SkipAttribute subclasses (e.g., skip-in-CI attributes)
         // that need to prevent ClassDataSource initialization when the test should be skipped.
-        foreach (var receiver in test.Context.GetTestRegisteredReceivers())
+        if (registeredReceivers.Length > 0)
         {
-            try
+            var discoveredTest = new DiscoveredTest<object>
             {
-                await receiver.OnTestRegistered(registeredContext);
-            }
-            catch (Exception ex)
+                TestContext = test.Context
+            };
+
+            var registeredContext = new TestRegisteredContext(test.Context)
             {
-                await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}");
-                throw;
+                DiscoveredTest = discoveredTest
+            };
+
+            test.Context.InternalDiscoveredTest = discoveredTest;
+
+            foreach (var receiver in registeredReceivers)
+            {
+                try
+                {
+                    await receiver.OnTestRegistered(registeredContext);
+                }
+                catch (Exception ex)
+                {
+                    await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}");
+                    throw;
+                }
             }
         }
 

--- a/src/TUnit.Engine/Services/TestFilterService.cs
+++ b/src/TUnit.Engine/Services/TestFilterService.cs
@@ -88,11 +88,11 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
             {
                 try
                 {
-                    await receiver.OnTestRegistered(registeredContext);
+                    await receiver.OnTestRegistered(registeredContext).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}");
+                    await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}").ConfigureAwait(false);
                     throw;
                 }
             }
@@ -115,7 +115,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         {
             try
             {
-                await testArgumentRegistrationService.RegisterTestArgumentsAsync(test.Context);
+                await testArgumentRegistrationService.RegisterTestArgumentsAsync(test.Context).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -145,7 +145,7 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         {
             foreach (var test in testList)
             {
-                await RegisterTest(test, isForExecution);
+                await RegisterTest(test, isForExecution).ConfigureAwait(false);
             }
             return;
         }


### PR DESCRIPTION
## Summary

- return synchronously when a test has no constructor arguments, method arguments, or injectable properties
- allocate `DiscoveredTest` and `TestRegisteredContext` only when registered event receivers exist
- retain property-injection, lifecycle tracking, custom executor, and receiver behavior on the slow path

## Performance

Source-generated .NET 10 executable with exactly 1,000 empty argument-free tests. Baseline and branch executables were built separately; 5 warmups and 31 alternating paired runs. Metric is the TUnit report totalDurationMs.

| Metric | Baseline | Current | Change |
|---|---:|---:|---:|
| TUnit session median | 163.371 ms | 161.028 ms | **-2.343 ms (-1.43%)** |
| Paired session delta median | | | **-2.564 ms** |

A separate 600-test suite with method arguments did not exercise this fast path and was discarded from the evidence.

## Validation

- `dotnet build tests/TUnit.TestProject/TUnit.TestProject.csproj -c Release -f net10.0 --no-restore`
- `DependenciesAvailableInEventReceiverTests`: 2 passed
- `InjectedPropertyEventReceiverTests`: 2 passed
- `PropertyInitializationTests`: 2 passed

The injected-property test initially exposed an unsafe dictionary-count predicate; the final implementation gates on cached `PropertyInjectionPlan.HasProperties` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved test setup by skipping unnecessary argument registration when no arguments or injectable properties are present.
  * Reduced overhead during test registration when no event receivers are configured.
  * Improved asynchronous test registration efficiency.

* **Reliability**
  * Preserved existing receiver invocation and exception handling behavior while optimizing registration processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->