### PR TITLE
Fast-path unconstrained single-test runs

### DIFF
--- a/src/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/src/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -92,41 +92,55 @@ internal sealed class TestScheduler : ITestScheduler
         if (_logger.IsDebugEnabled)
             await _logger.LogDebugAsync($"Scheduling execution of {testList.Count} tests").ConfigureAwait(false);
 
-        var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(testList);
+        var singleTest = testList.Count == 1 &&
+                         testList[0].Dependencies.Length == 0 &&
+                         testList[0].Context.ParallelConstraints.Count == 0
+            ? testList[0]
+            : null;
 
-        var testsInCircularDependencies = new HashSet<AbstractExecutableTest>();
-
-        foreach (var (test, dependencyChain) in circularDependencies)
+        List<AbstractExecutableTest> executableTests;
+        if (singleTest is null)
         {
-            // Format the error message to match the expected format
-            var simpleNames = new List<string>(dependencyChain.Count);
-            foreach (var t in dependencyChain)
+            var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(testList);
+
+            var testsInCircularDependencies = new HashSet<AbstractExecutableTest>();
+
+            foreach (var (test, dependencyChain) in circularDependencies)
             {
-                simpleNames.Add($"{t.Metadata.TestClassType.Name}.{t.Metadata.TestMethodName}");
+                // Format the error message to match the expected format
+                var simpleNames = new List<string>(dependencyChain.Count);
+                foreach (var t in dependencyChain)
+                {
+                    simpleNames.Add($"{t.Metadata.TestClassType.Name}.{t.Metadata.TestMethodName}");
+                }
+
+                var errorMessage = $"DependsOn Conflict: {string.Join(" > ", simpleNames)}";
+                var exception = new CircularDependencyException(errorMessage);
+
+                // Mark all tests in the dependency chain as failed
+                foreach (var chainTest in dependencyChain)
+                {
+                    if (testsInCircularDependencies.Add(chainTest))
+                    {
+                        _testStateManager.MarkCircularDependencyFailed(chainTest, exception);
+                        TestSessionContext.Current?.MarkFailure();
+                        await _messageBus.Failed(chainTest.Context, exception, DateTimeOffset.UtcNow).ConfigureAwait(false);
+                    }
+                }
             }
 
-            var errorMessage = $"DependsOn Conflict: {string.Join(" > ", simpleNames)}";
-            var exception = new CircularDependencyException(errorMessage);
-
-            // Mark all tests in the dependency chain as failed
-            foreach (var chainTest in dependencyChain)
+            executableTests = new List<AbstractExecutableTest>(testList.Count);
+            foreach (var test in testList)
             {
-                if (testsInCircularDependencies.Add(chainTest))
+                if (!testsInCircularDependencies.Contains(test))
                 {
-                    _testStateManager.MarkCircularDependencyFailed(chainTest, exception);
-                    TestSessionContext.Current?.MarkFailure();
-                    await _messageBus.Failed(chainTest.Context, exception, DateTimeOffset.UtcNow).ConfigureAwait(false);
+                    executableTests.Add(test);
                 }
             }
         }
-
-        var executableTests = new List<AbstractExecutableTest>(testList.Count);
-        foreach (var test in testList)
+        else
         {
-            if (!testsInCircularDependencies.Contains(test))
-            {
-                executableTests.Add(test);
-            }
+            executableTests = testList;
         }
 
         if (executableTests.Count == 0)
@@ -141,18 +155,25 @@ internal sealed class TestScheduler : ITestScheduler
         // Track static properties for disposal at session end
         _staticPropertyHandler.TrackStaticProperties();
 
-        // Group tests by their parallel constraints
-        var groupedTests = await _groupingService.GroupTestsByConstraintsAsync(executableTests).ConfigureAwait(false);
+        if (singleTest is not null)
+        {
+            await ExecuteSingleTestAsync(singleTest, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // Group tests by their parallel constraints
+            var groupedTests = await _groupingService.GroupTestsByConstraintsAsync(executableTests).ConfigureAwait(false);
 
-        MarkDependencyRelatedTestsForExecutionDedup(executableTests);
+            MarkDependencyRelatedTestsForExecutionDedup(executableTests);
 
-        // Suites with no global [NotInParallel] tests skip the runtime exclusion
-        // lock entirely. Once enabled, the flag is monotonic — dynamic batches
-        // that introduce NIP later (see ExecuteDynamicBatchAsync) keep it on.
-        MarkGlobalNotInParallelTests(groupedTests);
+            // Suites with no global [NotInParallel] tests skip the runtime exclusion
+            // lock entirely. Once enabled, the flag is monotonic — dynamic batches
+            // that introduce NIP later (see ExecuteDynamicBatchAsync) keep it on.
+            MarkGlobalNotInParallelTests(groupedTests);
 
-        // Execute tests according to their grouping
-        await ExecuteGroupedTestsAsync(groupedTests, cancellationToken).ConfigureAwait(false);
+            // Execute tests according to their grouping
+            await ExecuteGroupedTestsAsync(groupedTests, cancellationToken).ConfigureAwait(false);
+        }
 
         var sessionHookExceptions = await _afterHookPairTracker.GetOrCreateAfterTestSessionTask(
             () => _hookExecutor.ExecuteAfterTestSessionHooksAsync(cancellationToken)).ConfigureAwait(false) ?? [];
@@ -184,6 +205,21 @@ internal sealed class TestScheduler : ITestScheduler
         await ExecuteAllPhasesAsync(groupedTests, cancellationToken).ConfigureAwait(false);
 
         // Mark the queue as complete and wait for remaining dynamic tests to finish
+        _dynamicTestQueue.Complete();
+        await dynamicTestProcessingTask.ConfigureAwait(false);
+    }
+
+    #if NET
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Test execution involves reflection for hooks and initialization")]
+    #endif
+    private async Task ExecuteSingleTestAsync(
+        AbstractExecutableTest test,
+        CancellationToken cancellationToken)
+    {
+        var dynamicTestProcessingTask = ProcessDynamicTestQueueAsync(cancellationToken);
+
+        await ExecuteScheduledTestAsync(test, cancellationToken).ConfigureAwait(false);
+
         _dynamicTestQueue.Complete();
         await dynamicTestProcessingTask.ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary

- fast-path one test with no dependencies or parallel constraints
- bypass cycle detection, executable copying, constraint grouping, and `Parallel.ForEachAsync`
- preserve static-property lifecycle, session hooks, and concurrent dynamic-test queue processing
- retain the normal scheduler for constrained, dependent, and multi-test runs

## Performance

31 paired alternating one-empty-test runs after 5 warmups, with Microsoft Testing Platform and .NET CLI telemetry disabled:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| TUnit session median | 115.310 ms | 107.949 ms | **-7.361 ms (-6.38%)** |
| Paired session delta median | | | **-7.535 ms** |
| TUnit session mean | 119.711 ms | 107.866 ms | **-11.845 ms** |

CPU-sampling traces captured before/after with `dotnet-trace`.

## Validation

- dynamic test variant: 2 passed
- constrained fallback: 1 passed
- dependency path: 2 passed
- session/class/test hooks: 1 passed