### PR TITLE
Skip absent hook pipelines

### DIFF
--- a/src/TUnit.Core/Context.cs
+++ b/src/TUnit.Core/Context.cs
@@ -78,7 +78,13 @@ public abstract class Context : IContext, IDisposable
     }
 
 #if NET
-    internal System.Diagnostics.Activity? Activity { get; set; }
+    private System.Diagnostics.Activity? _activity;
+
+    internal System.Diagnostics.Activity? Activity
+    {
+        get => Volatile.Read(ref _activity);
+        set => Volatile.Write(ref _activity, value);
+    }
     internal ExecutionContext? ExecutionContext { get; private set; }
 #endif
 

--- a/src/TUnit.Core/Models/AssemblyHookContext.cs
+++ b/src/TUnit.Core/Models/AssemblyHookContext.cs
@@ -27,6 +27,7 @@ public class AssemblyHookContext : Context
     public required Assembly Assembly { get; init; }
 
     private readonly Lock _lock = new();
+    internal Lock SynchronizationLock => _lock;
     private readonly List<ClassHookContext> _testClasses = [];
     private TestContext[]? _cachedAllTests;
 

--- a/src/TUnit.Core/Models/ClassHookContext.cs
+++ b/src/TUnit.Core/Models/ClassHookContext.cs
@@ -29,6 +29,7 @@ public class ClassHookContext : Context
     public required Type ClassType { get; init; }
 
     private readonly Lock _lock = new();
+    internal Lock SynchronizationLock => _lock;
     private readonly HashSet<TestContext> _testSet = new(ReferenceEqualityComparer<TestContext>.Instance);
     private readonly List<TestContext> _tests = [];
 

--- a/src/TUnit.Engine/Services/AfterHookPairTracker.cs
+++ b/src/TUnit.Engine/Services/AfterHookPairTracker.cs
@@ -5,9 +5,46 @@ using TUnit.Core.Data;
 
 namespace TUnit.Engine.Services;
 
-internal delegate ValueTask<List<Exception>> AfterClassExecutor(
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
-    Type testClass);
+internal readonly struct AfterClassCleanup
+{
+    private readonly HookExecutor _hookExecutor;
+    private readonly CancellationToken _cancellationToken;
+    private readonly bool _finishActivity;
+
+    private AfterClassCleanup(
+        HookExecutor hookExecutor,
+        CancellationToken cancellationToken,
+        bool finishActivity)
+    {
+        _hookExecutor = hookExecutor;
+        _cancellationToken = cancellationToken;
+        _finishActivity = finishActivity;
+    }
+
+    internal static AfterClassCleanup ForHooks(
+        HookExecutor hookExecutor,
+        CancellationToken cancellationToken)
+        => new(hookExecutor, cancellationToken, finishActivity: false);
+
+#if NET
+    internal static AfterClassCleanup ForActivity(HookExecutor hookExecutor)
+        => new(hookExecutor, CancellationToken.None, finishActivity: true);
+#endif
+
+    internal ValueTask<List<Exception>> ExecuteAsync(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type testClass)
+    {
+#if NET
+        if (_finishActivity)
+        {
+            return _hookExecutor.FinishClassActivityAsync(testClass);
+        }
+#endif
+
+        return _hookExecutor.ExecuteAfterClassHooksAsync(testClass, _cancellationToken);
+    }
+}
 
 /// <summary>
 /// Responsible for ensuring After hooks run even when tests are cancelled.
@@ -114,7 +151,7 @@ internal sealed class AfterHookPairTracker
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass,
         CancellationToken sessionCancellationToken,
-        AfterClassExecutor afterHookExecutor)
+        AfterClassCleanup cleanup)
     {
         if (!_classHookRegistered.Add(testClass))
         {
@@ -123,9 +160,9 @@ internal sealed class AfterHookPairTracker
 
         var registration = sessionCancellationToken.Register(static state =>
         {
-            var (pairTracker, testClass, afterHookExecutor) = ((AfterHookPairTracker, Type, AfterClassExecutor))state!;
-            _ = pairTracker.GetOrCreateAfterClassTask(testClass, afterHookExecutor);
-        }, (this, testClass, afterHookExecutor));
+            var (pairTracker, testClass, cleanup) = ((AfterHookPairTracker, Type, AfterClassCleanup))state!;
+            _ = pairTracker.GetOrCreateAfterClassTask(testClass, cleanup);
+        }, (this, testClass, cleanup));
 
         _registrations.Add(registration);
     }
@@ -180,7 +217,7 @@ internal sealed class AfterHookPairTracker
     public ValueTask<List<Exception>> GetOrCreateAfterClassTask(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass,
-        AfterClassExecutor taskFactory)
+        AfterClassCleanup cleanup)
     {
         // Lock-free fast path avoids allocating a closure on the common cache-hit case.
         if (_afterClassTasks.TryGetValue(testClass, out var existingTask))
@@ -193,7 +230,7 @@ internal sealed class AfterHookPairTracker
         // behind a shared lock.
         var task = _afterClassTasks.GetOrAdd(
             testClass,
-            _ => taskFactory(testClass).AsTask());
+            _ => cleanup.ExecuteAsync(testClass).AsTask());
         return new ValueTask<List<Exception>>(task);
     }
 

--- a/src/TUnit.Engine/Services/AfterHookPairTracker.cs
+++ b/src/TUnit.Engine/Services/AfterHookPairTracker.cs
@@ -5,6 +5,10 @@ using TUnit.Core.Data;
 
 namespace TUnit.Engine.Services;
 
+internal delegate ValueTask<List<Exception>> AfterClassExecutor(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+    Type testClass);
+
 /// <summary>
 /// Responsible for ensuring After hooks run even when tests are cancelled.
 /// When a Before hook completes, this tracker registers the corresponding After hook
@@ -109,8 +113,8 @@ internal sealed class AfterHookPairTracker
     public void RegisterAfterClassHook(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass,
-        HookExecutor hookExecutor,
-        CancellationToken sessionCancellationToken)
+        CancellationToken sessionCancellationToken,
+        AfterClassExecutor afterHookExecutor)
     {
         if (!_classHookRegistered.Add(testClass))
         {
@@ -119,9 +123,9 @@ internal sealed class AfterHookPairTracker
 
         var registration = sessionCancellationToken.Register(static state =>
         {
-            var (pairTracker, testClass, hookExecutor) = ((AfterHookPairTracker, Type, HookExecutor))state!;
-            _ = pairTracker.GetOrCreateAfterClassTask(testClass, hookExecutor, CancellationToken.None);
-        }, (this, testClass, hookExecutor));
+            var (pairTracker, testClass, afterHookExecutor) = ((AfterHookPairTracker, Type, AfterClassExecutor))state!;
+            _ = pairTracker.GetOrCreateAfterClassTask(testClass, afterHookExecutor);
+        }, (this, testClass, afterHookExecutor));
 
         _registrations.Add(registration);
     }
@@ -176,8 +180,7 @@ internal sealed class AfterHookPairTracker
     public ValueTask<List<Exception>> GetOrCreateAfterClassTask(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass,
-        HookExecutor hookExecutor,
-        CancellationToken cancellationToken)
+        AfterClassExecutor taskFactory)
     {
         // Lock-free fast path avoids allocating a closure on the common cache-hit case.
         if (_afterClassTasks.TryGetValue(testClass, out var existingTask))
@@ -190,7 +193,7 @@ internal sealed class AfterHookPairTracker
         // behind a shared lock.
         var task = _afterClassTasks.GetOrAdd(
             testClass,
-            _ => hookExecutor.ExecuteAfterClassHooksAsync(testClass, cancellationToken).AsTask());
+            _ => taskFactory(testClass).AsTask());
         return new ValueTask<List<Exception>>(task);
     }
 

--- a/src/TUnit.Engine/Services/HookExecutor.cs
+++ b/src/TUnit.Engine/Services/HookExecutor.cs
@@ -294,7 +294,7 @@ internal sealed class HookExecutor
             return;
         }
 
-        lock (assemblyContext)
+        lock (assemblyContext.SynchronizationLock)
         {
             if (assemblyContext.Activity is not null)
             {
@@ -324,7 +324,7 @@ internal sealed class HookExecutor
     private void FinishAssemblyActivity(Assembly assembly, bool hasErrors)
     {
         var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
-        lock (assemblyContext)
+        lock (assemblyContext.SynchronizationLock)
         {
             var activity = assemblyContext.Activity;
             if (activity is null)
@@ -488,7 +488,7 @@ internal sealed class HookExecutor
             return;
         }
 
-        lock (classContext)
+        lock (classContext.SynchronizationLock)
         {
             if (classContext.Activity is not null)
             {
@@ -525,7 +525,7 @@ internal sealed class HookExecutor
         Type testClass, bool hasErrors)
     {
         var classContext = _contextProvider.GetOrCreateClassContext(testClass);
-        lock (classContext)
+        lock (classContext.SynchronizationLock)
         {
             var activity = classContext.Activity;
             if (activity is null)

--- a/src/TUnit.Engine/Services/HookExecutor.cs
+++ b/src/TUnit.Engine/Services/HookExecutor.cs
@@ -162,17 +162,7 @@ internal sealed class HookExecutor
         var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
 
 #if NET
-        if (TUnitActivitySource.LifecycleSource.HasListeners())
-        {
-            var sessionActivity = _contextProvider.TestSessionContext.Activity;
-            assemblyContext.Activity = TUnitActivitySource.StartLifecycleActivity(
-                TUnitActivitySource.SpanTestAssembly,
-                System.Diagnostics.ActivityKind.Internal,
-                sessionActivity?.Context ?? default,
-                [
-                    new(TUnitActivitySource.TagAssemblyName, assembly.GetName().Name)
-                ]);
-        }
+        TryStartAssemblyActivity(assembly);
 #endif
 
         // Execute BeforeEvery(Assembly) hooks first (global hooks run before specific hooks)
@@ -291,25 +281,67 @@ internal sealed class HookExecutor
     }
 
 #if NET
-    private void FinishAssemblyActivity(Assembly assembly, bool hasErrors)
+    internal void TryStartAssemblyActivity(Assembly assembly)
     {
-        var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
-        var activity = assemblyContext.Activity;
-
-        if (activity is null)
+        if (!TUnitActivitySource.LifecycleSource.HasListeners())
         {
             return;
         }
 
-        activity.SetTag(TUnitActivitySource.TagTestCount, assemblyContext.TestCount);
-
-        if (hasErrors)
+        var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
+        if (assemblyContext.Activity is not null)
         {
-            activity.SetStatus(System.Diagnostics.ActivityStatusCode.Error);
+            return;
         }
 
-        TUnitActivitySource.StopActivity(activity);
-        assemblyContext.Activity = null;
+        lock (assemblyContext)
+        {
+            if (assemblyContext.Activity is not null)
+            {
+                return;
+            }
+
+            var sessionActivity = _contextProvider.TestSessionContext.Activity;
+            assemblyContext.Activity = TUnitActivitySource.StartLifecycleActivity(
+                TUnitActivitySource.SpanTestAssembly,
+                System.Diagnostics.ActivityKind.Internal,
+                sessionActivity?.Context ?? default,
+                [
+                    new(TUnitActivitySource.TagAssemblyName, assembly.GetName().Name)
+                ]);
+        }
+    }
+
+    internal bool HasAssemblyActivity(Assembly assembly)
+        => _contextProvider.GetOrCreateAssemblyContext(assembly).Activity is not null;
+
+    internal ValueTask<List<Exception>> FinishAssemblyActivityAsync(Assembly assembly)
+    {
+        FinishAssemblyActivity(assembly, hasErrors: false);
+        return new ValueTask<List<Exception>>([]);
+    }
+
+    private void FinishAssemblyActivity(Assembly assembly, bool hasErrors)
+    {
+        var assemblyContext = _contextProvider.GetOrCreateAssemblyContext(assembly);
+        lock (assemblyContext)
+        {
+            var activity = assemblyContext.Activity;
+            if (activity is null)
+            {
+                return;
+            }
+
+            activity.SetTag(TUnitActivitySource.TagTestCount, assemblyContext.TestCount);
+
+            if (hasErrors)
+            {
+                activity.SetStatus(System.Diagnostics.ActivityStatusCode.Error);
+            }
+
+            TUnitActivitySource.StopActivity(activity);
+            assemblyContext.Activity = null;
+        }
     }
 #endif
 
@@ -320,18 +352,7 @@ internal sealed class HookExecutor
         var classContext = _contextProvider.GetOrCreateClassContext(testClass);
 
 #if NET
-        if (TUnitActivitySource.LifecycleSource.HasListeners())
-        {
-            var assemblyActivity = classContext.AssemblyContext.Activity;
-            classContext.Activity = TUnitActivitySource.StartLifecycleActivity(
-                TUnitActivitySource.SpanTestSuite,
-                System.Diagnostics.ActivityKind.Internal,
-                assemblyActivity?.Context ?? default,
-                [
-                    new(TUnitActivitySource.TagTestSuiteName, testClass.Name),
-                    new(TUnitActivitySource.TagClassNamespace, testClass.Namespace)
-                ]);
-        }
+        TryStartClassActivity(testClass);
 #endif
 
         // Execute BeforeEvery(Class) hooks first (global hooks run before specific hooks)
@@ -452,27 +473,76 @@ internal sealed class HookExecutor
     }
 
 #if NET
+    internal void TryStartClassActivity(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type testClass)
+    {
+        if (!TUnitActivitySource.LifecycleSource.HasListeners())
+        {
+            return;
+        }
+
+        var classContext = _contextProvider.GetOrCreateClassContext(testClass);
+        if (classContext.Activity is not null)
+        {
+            return;
+        }
+
+        lock (classContext)
+        {
+            if (classContext.Activity is not null)
+            {
+                return;
+            }
+
+            var assemblyActivity = classContext.AssemblyContext.Activity;
+            classContext.Activity = TUnitActivitySource.StartLifecycleActivity(
+                TUnitActivitySource.SpanTestSuite,
+                System.Diagnostics.ActivityKind.Internal,
+                assemblyActivity?.Context ?? default,
+                [
+                    new(TUnitActivitySource.TagTestSuiteName, testClass.Name),
+                    new(TUnitActivitySource.TagClassNamespace, testClass.Namespace)
+                ]);
+        }
+    }
+
+    internal bool HasClassActivity(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type testClass)
+        => _contextProvider.GetOrCreateClassContext(testClass).Activity is not null;
+
+    internal ValueTask<List<Exception>> FinishClassActivityAsync(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type testClass)
+    {
+        FinishClassActivity(testClass, hasErrors: false);
+        return new ValueTask<List<Exception>>([]);
+    }
+
     private void FinishClassActivity(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass, bool hasErrors)
     {
         var classContext = _contextProvider.GetOrCreateClassContext(testClass);
-        var activity = classContext.Activity;
-
-        if (activity is null)
+        lock (classContext)
         {
-            return;
+            var activity = classContext.Activity;
+            if (activity is null)
+            {
+                return;
+            }
+
+            activity.SetTag(TUnitActivitySource.TagTestCount, classContext.TestCount);
+
+            if (hasErrors)
+            {
+                activity.SetStatus(System.Diagnostics.ActivityStatusCode.Error);
+            }
+
+            TUnitActivitySource.StopActivity(activity);
+            classContext.Activity = null;
         }
-
-        activity.SetTag(TUnitActivitySource.TagTestCount, classContext.TestCount);
-
-        if (hasErrors)
-        {
-            activity.SetStatus(System.Diagnostics.ActivityStatusCode.Error);
-        }
-
-        TUnitActivitySource.StopActivity(activity);
-        classContext.Activity = null;
     }
 #endif
 

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -202,17 +202,10 @@ internal class TestExecutor
             }
 #endif
 
-            Func<Assembly, ValueTask<List<Exception>>>? cancelledAfterAssemblyFactory = null;
-            if (hasAssemblyHooks)
-            {
-                cancelledAfterAssemblyFactory = _cancelledAfterAssemblyHookFactory;
-            }
-#if NET
-            else if (_hookExecutor.HasAssemblyActivity(testAssembly))
-            {
-                cancelledAfterAssemblyFactory = _finishAssemblyActivityFactory;
-            }
-#endif
+            var cancelledAfterAssemblyFactory = ResolveAssemblyCleanup(
+                testAssembly,
+                hasAssemblyHooks,
+                _cancelledAfterAssemblyHookFactory);
 
             if (cancelledAfterAssemblyFactory is not null)
             {
@@ -241,17 +234,10 @@ internal class TestExecutor
             }
 #endif
 
-            AfterClassExecutor? cancelledAfterClassFactory = null;
-            if (hasClassHooks)
-            {
-                cancelledAfterClassFactory = _cancelledAfterClassHookFactory;
-            }
-#if NET
-            else if (_hookExecutor.HasClassActivity(testClass))
-            {
-                cancelledAfterClassFactory = _finishClassActivityFactory;
-            }
-#endif
+            var cancelledAfterClassFactory = ResolveClassCleanup(
+                testClass,
+                hasClassHooks,
+                _cancelledAfterClassHookFactory);
 
             if (cancelledAfterClassFactory is not null)
             {
@@ -652,6 +638,47 @@ internal class TestExecutor
         }
     }
 
+    private Func<Assembly, ValueTask<List<Exception>>>? ResolveAssemblyCleanup(
+        Assembly assembly,
+        bool hasHooks,
+        Func<Assembly, ValueTask<List<Exception>>> hookFactory)
+    {
+        if (hasHooks)
+        {
+            return hookFactory;
+        }
+
+#if NET
+        if (_hookExecutor.HasAssemblyActivity(assembly))
+        {
+            return _finishAssemblyActivityFactory;
+        }
+#endif
+
+        return null;
+    }
+
+    private AfterClassExecutor? ResolveClassCleanup(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type testClass,
+        bool hasHooks,
+        AfterClassExecutor hookFactory)
+    {
+        if (hasHooks)
+        {
+            return hookFactory;
+        }
+
+#if NET
+        if (_hookExecutor.HasClassActivity(testClass))
+        {
+            return _finishClassActivityFactory;
+        }
+#endif
+
+        return null;
+    }
+
     [UnconditionalSuppressMessage("Trimming", "IL2067",
         Justification = "The class cleanup delegate is invoked with the annotated testClass parameter.")]
     internal async Task<List<Exception>?> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,
@@ -670,17 +697,10 @@ internal class TestExecutor
 
         if (flags.ShouldExecuteAfterClass)
         {
-            AfterClassExecutor? afterClassFactory = null;
-            if (HasClassHooks(testClass))
-            {
-                afterClassFactory = type => _hookExecutor.ExecuteAfterClassHooksAsync(type, cancellationToken);
-            }
-#if NET
-            else if (_hookExecutor.HasClassActivity(testClass))
-            {
-                afterClassFactory = _finishClassActivityFactory;
-            }
-#endif
+            var afterClassFactory = ResolveClassCleanup(
+                testClass,
+                HasClassHooks(testClass),
+                type => _hookExecutor.ExecuteAfterClassHooksAsync(type, cancellationToken));
 
             if (afterClassFactory is not null)
             {
@@ -695,17 +715,10 @@ internal class TestExecutor
 
         if (flags.ShouldExecuteAfterAssembly)
         {
-            Func<Assembly, ValueTask<List<Exception>>>? afterAssemblyFactory = null;
-            if (HasAssemblyHooks(testAssembly))
-            {
-                afterAssemblyFactory = assembly => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, cancellationToken);
-            }
-#if NET
-            else if (_hookExecutor.HasAssemblyActivity(testAssembly))
-            {
-                afterAssemblyFactory = _finishAssemblyActivityFactory;
-            }
-#endif
+            var afterAssemblyFactory = ResolveAssemblyCleanup(
+                testAssembly,
+                HasAssemblyHooks(testAssembly),
+                assembly => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, cancellationToken));
 
             if (afterAssemblyFactory is not null)
             {

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -36,7 +36,17 @@ internal class TestExecutor
     // each time (these run on the hot path and the factory is only invoked on the first cache miss).
     private readonly Func<CancellationToken, ValueTask> _beforeTestSessionHookFactory;
     private readonly Func<Assembly, CancellationToken, ValueTask> _beforeAssemblyHookFactory;
+    private readonly Func<Assembly, ValueTask<List<Exception>>> _cancelledAfterAssemblyHookFactory;
+    private readonly AfterClassExecutor _cancelledAfterClassHookFactory;
+#if NET
+    private readonly Func<Assembly, ValueTask<List<Exception>>> _finishAssemblyActivityFactory;
+    private readonly AfterClassExecutor _finishClassActivityFactory;
+#endif
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Class cleanup delegates receive only test-class types annotated at the execution boundary.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2111",
+        Justification = "The annotated class cleanup method is captured as a delegate, not accessed through reflection.")]
     public TestExecutor(
         HookExecutor hookExecutor,
         TestLifecycleCoordinator lifecycleCoordinator,
@@ -54,6 +64,12 @@ internal class TestExecutor
 
         _beforeTestSessionHookFactory = ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct);
         _beforeAssemblyHookFactory = (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct);
+        _cancelledAfterAssemblyHookFactory = assembly => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, CancellationToken.None);
+        _cancelledAfterClassHookFactory = testClass => _hookExecutor.ExecuteAfterClassHooksAsync(testClass, CancellationToken.None);
+#if NET
+        _finishAssemblyActivityFactory = _hookExecutor.FinishAssemblyActivityAsync;
+        _finishClassActivityFactory = _hookExecutor.FinishClassActivityAsync;
+#endif
     }
 
 
@@ -105,20 +121,34 @@ internal class TestExecutor
         // it re-applies the same captured contexts).
         test.Context.ClassContext.AssemblyContext.TestSessionContext.RestoreExecutionContext();
 
-        if (HasAssemblyHooks(testClass.Assembly))
+        var hasAssemblyHooks = HasAssemblyHooks(testClass.Assembly);
+        if (hasAssemblyHooks)
         {
             await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
                 testClass.Assembly,
                 _beforeAssemblyHookFactory,
                 cancellationToken).ConfigureAwait(false);
         }
+#if NET
+        else
+        {
+            _hookExecutor.TryStartAssemblyActivity(testClass.Assembly);
+        }
+#endif
 
         test.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
 
-        if (HasClassHooks(testClass))
+        var hasClassHooks = HasClassHooks(testClass);
+        if (hasClassHooks)
         {
             await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
         }
+#if NET
+        else
+        {
+            _hookExecutor.TryStartClassActivity(testClass);
+        }
+#endif
 
         // Note: the caller (TestCoordinator) restores ClassContext.RestoreExecutionContext() right
         // before constructing the instance so AsyncLocals captured by BeforeAssembly/BeforeClass flow
@@ -164,12 +194,33 @@ internal class TestExecutor
                     testAssembly,
                     _beforeAssemblyHookFactory,
                     cancellationToken).ConfigureAwait(false);
+            }
+#if NET
+            else
+            {
+                _hookExecutor.TryStartAssemblyActivity(testAssembly);
+            }
+#endif
 
-                // Register After Assembly hook to run on cancellation (guarantees cleanup)
+            Func<Assembly, ValueTask<List<Exception>>>? cancelledAfterAssemblyFactory = null;
+            if (hasAssemblyHooks)
+            {
+                cancelledAfterAssemblyFactory = _cancelledAfterAssemblyHookFactory;
+            }
+#if NET
+            else if (_hookExecutor.HasAssemblyActivity(testAssembly))
+            {
+                cancelledAfterAssemblyFactory = _finishAssemblyActivityFactory;
+            }
+#endif
+
+            if (cancelledAfterAssemblyFactory is not null)
+            {
+                // Register lifecycle cleanup on cancellation.
                 _afterHookPairTracker.RegisterAfterAssemblyHook(
                     testAssembly,
                     cancellationToken,
-                    (assembly) => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, CancellationToken.None));
+                    cancelledAfterAssemblyFactory);
             }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInAssemblyEventReceiversAsync(
@@ -182,9 +233,33 @@ internal class TestExecutor
             if (hasClassHooks)
             {
                 await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+            }
+#if NET
+            else
+            {
+                _hookExecutor.TryStartClassActivity(testClass);
+            }
+#endif
 
-                // Register After Class hook to run on cancellation (guarantees cleanup)
-                _afterHookPairTracker.RegisterAfterClassHook(testClass, _hookExecutor, cancellationToken);
+            AfterClassExecutor? cancelledAfterClassFactory = null;
+            if (hasClassHooks)
+            {
+                cancelledAfterClassFactory = _cancelledAfterClassHookFactory;
+            }
+#if NET
+            else if (_hookExecutor.HasClassActivity(testClass))
+            {
+                cancelledAfterClassFactory = _finishClassActivityFactory;
+            }
+#endif
+
+            if (cancelledAfterClassFactory is not null)
+            {
+                // Register lifecycle cleanup on cancellation.
+                _afterHookPairTracker.RegisterAfterClassHook(
+                    testClass,
+                    cancellationToken,
+                    cancelledAfterClassFactory);
             }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInClassEventReceiversAsync(
@@ -577,6 +652,8 @@ internal class TestExecutor
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "The class cleanup delegate is invoked with the annotated testClass parameter.")]
     internal async Task<List<Exception>?> ExecuteAfterClassAssemblyHooks(AbstractExecutableTest executableTest,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties
             | DynamicallyAccessedMemberTypes.PublicMethods)]
@@ -593,23 +670,53 @@ internal class TestExecutor
 
         if (flags.ShouldExecuteAfterClass)
         {
-            // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
-            var classExceptions = await _afterHookPairTracker.GetOrCreateAfterClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
-            if (classExceptions.Count > 0)
+            AfterClassExecutor? afterClassFactory = null;
+            if (HasClassHooks(testClass))
             {
-                (exceptions ??= []).AddRange(classExceptions);
+                afterClassFactory = type => _hookExecutor.ExecuteAfterClassHooksAsync(type, cancellationToken);
+            }
+#if NET
+            else if (_hookExecutor.HasClassActivity(testClass))
+            {
+                afterClassFactory = _finishClassActivityFactory;
+            }
+#endif
+
+            if (afterClassFactory is not null)
+            {
+                // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
+                var classExceptions = await _afterHookPairTracker.GetOrCreateAfterClassTask(testClass, afterClassFactory).ConfigureAwait(false);
+                if (classExceptions.Count > 0)
+                {
+                    (exceptions ??= []).AddRange(classExceptions);
+                }
             }
         }
 
         if (flags.ShouldExecuteAfterAssembly)
         {
-            // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
-            var assemblyExceptions = await _afterHookPairTracker.GetOrCreateAfterAssemblyTask(
-                testAssembly,
-                (assembly) => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, cancellationToken)).ConfigureAwait(false);
-            if (assemblyExceptions.Count > 0)
+            Func<Assembly, ValueTask<List<Exception>>>? afterAssemblyFactory = null;
+            if (HasAssemblyHooks(testAssembly))
             {
-                (exceptions ??= []).AddRange(assemblyExceptions);
+                afterAssemblyFactory = assembly => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, cancellationToken);
+            }
+#if NET
+            else if (_hookExecutor.HasAssemblyActivity(testAssembly))
+            {
+                afterAssemblyFactory = _finishAssemblyActivityFactory;
+            }
+#endif
+
+            if (afterAssemblyFactory is not null)
+            {
+                // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
+                var assemblyExceptions = await _afterHookPairTracker.GetOrCreateAfterAssemblyTask(
+                    testAssembly,
+                    afterAssemblyFactory).ConfigureAwait(false);
+                if (assemblyExceptions.Count > 0)
+                {
+                    (exceptions ??= []).AddRange(assemblyExceptions);
+                }
             }
         }
 

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -37,16 +37,12 @@ internal class TestExecutor
     private readonly Func<CancellationToken, ValueTask> _beforeTestSessionHookFactory;
     private readonly Func<Assembly, CancellationToken, ValueTask> _beforeAssemblyHookFactory;
     private readonly Func<Assembly, ValueTask<List<Exception>>> _cancelledAfterAssemblyHookFactory;
-    private readonly AfterClassExecutor _cancelledAfterClassHookFactory;
+    private readonly AfterClassCleanup _cancelledAfterClassHookCleanup;
 #if NET
     private readonly Func<Assembly, ValueTask<List<Exception>>> _finishAssemblyActivityFactory;
-    private readonly AfterClassExecutor _finishClassActivityFactory;
+    private readonly AfterClassCleanup _finishClassActivityCleanup;
 #endif
 
-    [UnconditionalSuppressMessage("Trimming", "IL2067",
-        Justification = "Class cleanup delegates receive only test-class types annotated at the execution boundary.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2111",
-        Justification = "The annotated class cleanup method is captured as a delegate, not accessed through reflection.")]
     public TestExecutor(
         HookExecutor hookExecutor,
         TestLifecycleCoordinator lifecycleCoordinator,
@@ -65,10 +61,10 @@ internal class TestExecutor
         _beforeTestSessionHookFactory = ct => _hookExecutor.ExecuteBeforeTestSessionHooksAsync(ct);
         _beforeAssemblyHookFactory = (assembly, ct) => _hookExecutor.ExecuteBeforeAssemblyHooksAsync(assembly, ct);
         _cancelledAfterAssemblyHookFactory = assembly => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, CancellationToken.None);
-        _cancelledAfterClassHookFactory = testClass => _hookExecutor.ExecuteAfterClassHooksAsync(testClass, CancellationToken.None);
+        _cancelledAfterClassHookCleanup = AfterClassCleanup.ForHooks(_hookExecutor, CancellationToken.None);
 #if NET
         _finishAssemblyActivityFactory = _hookExecutor.FinishAssemblyActivityAsync;
-        _finishClassActivityFactory = _hookExecutor.FinishClassActivityAsync;
+        _finishClassActivityCleanup = AfterClassCleanup.ForActivity(_hookExecutor);
 #endif
     }
 
@@ -234,18 +230,18 @@ internal class TestExecutor
             }
 #endif
 
-            var cancelledAfterClassFactory = ResolveClassCleanup(
+            var cancelledAfterClassCleanup = ResolveClassCleanup(
                 testClass,
                 hasClassHooks,
-                _cancelledAfterClassHookFactory);
+                _cancelledAfterClassHookCleanup);
 
-            if (cancelledAfterClassFactory is not null)
+            if (cancelledAfterClassCleanup is { } cleanup)
             {
                 // Register lifecycle cleanup on cancellation.
                 _afterHookPairTracker.RegisterAfterClassHook(
                     testClass,
                     cancellationToken,
-                    cancelledAfterClassFactory);
+                    cleanup);
             }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInClassEventReceiversAsync(
@@ -658,21 +654,21 @@ internal class TestExecutor
         return null;
     }
 
-    private AfterClassExecutor? ResolveClassCleanup(
+    private AfterClassCleanup? ResolveClassCleanup(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
         Type testClass,
         bool hasHooks,
-        AfterClassExecutor hookFactory)
+        AfterClassCleanup hookCleanup)
     {
         if (hasHooks)
         {
-            return hookFactory;
+            return hookCleanup;
         }
 
 #if NET
         if (_hookExecutor.HasClassActivity(testClass))
         {
-            return _finishClassActivityFactory;
+            return _finishClassActivityCleanup;
         }
 #endif
 
@@ -697,15 +693,15 @@ internal class TestExecutor
 
         if (flags.ShouldExecuteAfterClass)
         {
-            var afterClassFactory = ResolveClassCleanup(
+            var afterClassCleanup = ResolveClassCleanup(
                 testClass,
                 HasClassHooks(testClass),
-                type => _hookExecutor.ExecuteAfterClassHooksAsync(type, cancellationToken));
+                AfterClassCleanup.ForHooks(_hookExecutor, cancellationToken));
 
-            if (afterClassFactory is not null)
+            if (afterClassCleanup is { } cleanup)
             {
                 // Use AfterHookPairTracker to prevent double execution if already triggered by cancellation
-                var classExceptions = await _afterHookPairTracker.GetOrCreateAfterClassTask(testClass, afterClassFactory).ConfigureAwait(false);
+                var classExceptions = await _afterHookPairTracker.GetOrCreateAfterClassTask(testClass, cleanup).ConfigureAwait(false);
                 if (classExceptions.Count > 0)
                 {
                     (exceptions ??= []).AddRange(classExceptions);

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -1,9 +1,11 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using TUnit.Core;
 using TUnit.Core.Enums;
 using TUnit.Core.Exceptions;
+using TUnit.Core.Hooks;
 using TUnit.Core.Interfaces;
 using TUnit.Core.Services;
 using TUnit.Engine.Helpers;
@@ -20,6 +22,9 @@ namespace TUnit.Engine;
 /// </summary>
 internal class TestExecutor
 {
+    private static readonly ConcurrentDictionary<Type, bool> ClassHookPresenceCache = new();
+    private static readonly ConcurrentDictionary<Type, bool> TestHookPresenceCache = new();
+
     private readonly HookExecutor _hookExecutor;
     private readonly TestLifecycleCoordinator _lifecycleCoordinator;
     private readonly BeforeHookTaskCache _beforeHookTaskCache;
@@ -59,6 +64,11 @@ internal class TestExecutor
     /// </summary>
     public async ValueTask EnsureTestSessionHooksExecutedAsync(CancellationToken cancellationToken)
     {
+        if (!HasTestSessionHooks())
+        {
+            return;
+        }
+
         // Get or create and cache Before hooks - these run only once
         await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
             _beforeTestSessionHookFactory,
@@ -82,9 +92,12 @@ internal class TestExecutor
     {
         var testClass = test.Metadata.TestClassType;
 
-        await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
-            _beforeTestSessionHookFactory,
-            cancellationToken).ConfigureAwait(false);
+        if (HasTestSessionHooks())
+        {
+            await _beforeHookTaskCache.GetOrCreateBeforeTestSessionTask(
+                _beforeTestSessionHookFactory,
+                cancellationToken).ConfigureAwait(false);
+        }
 
         // Flow AsyncLocals captured by BeforeTestSession into the BeforeAssembly hook, and likewise
         // BeforeAssembly into BeforeClass. This mirrors the RestoreExecutionContext chain in
@@ -92,14 +105,20 @@ internal class TestExecutor
         // it re-applies the same captured contexts).
         test.Context.ClassContext.AssemblyContext.TestSessionContext.RestoreExecutionContext();
 
-        await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
-            testClass.Assembly,
-            _beforeAssemblyHookFactory,
-            cancellationToken).ConfigureAwait(false);
+        if (HasAssemblyHooks(testClass.Assembly))
+        {
+            await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
+                testClass.Assembly,
+                _beforeAssemblyHookFactory,
+                cancellationToken).ConfigureAwait(false);
+        }
 
         test.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
 
-        await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+        if (HasClassHooks(testClass))
+        {
+            await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+        }
 
         // Note: the caller (TestCoordinator) restores ClassContext.RestoreExecutionContext() right
         // before constructing the instance so AsyncLocals captured by BeforeAssembly/BeforeClass flow
@@ -117,13 +136,20 @@ internal class TestExecutor
 
         var testClass = executableTest.Metadata.TestClassType;
         var testAssembly = testClass.Assembly;
+        var hasSessionHooks = HasTestSessionHooks();
+        var hasAssemblyHooks = HasAssemblyHooks(testAssembly);
+        var hasClassHooks = HasClassHooks(testClass);
+        var hasTestHooks = HasTestHooks(testClass);
 
         Exception? capturedException = null;
         Exception? hookException = null;
 
         try
         {
-            await EnsureTestSessionHooksExecutedAsync(cancellationToken).ConfigureAwait(false);
+            if (hasSessionHooks)
+            {
+                await EnsureTestSessionHooksExecutedAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInSessionEventReceiversAsync(
                 executableTest.Context,
@@ -132,16 +158,19 @@ internal class TestExecutor
 
             executableTest.Context.ClassContext.AssemblyContext.TestSessionContext.RestoreExecutionContext();
 
-            await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
-                testAssembly,
-                _beforeAssemblyHookFactory,
-                cancellationToken).ConfigureAwait(false);
+            if (hasAssemblyHooks)
+            {
+                await _beforeHookTaskCache.GetOrCreateBeforeAssemblyTask(
+                    testAssembly,
+                    _beforeAssemblyHookFactory,
+                    cancellationToken).ConfigureAwait(false);
 
-            // Register After Assembly hook to run on cancellation (guarantees cleanup)
-            _afterHookPairTracker.RegisterAfterAssemblyHook(
-                testAssembly,
-                cancellationToken,
-                (assembly) => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, CancellationToken.None));
+                // Register After Assembly hook to run on cancellation (guarantees cleanup)
+                _afterHookPairTracker.RegisterAfterAssemblyHook(
+                    testAssembly,
+                    cancellationToken,
+                    (assembly) => _hookExecutor.ExecuteAfterAssemblyHooksAsync(assembly, CancellationToken.None));
+            }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInAssemblyEventReceiversAsync(
                 executableTest.Context,
@@ -150,10 +179,13 @@ internal class TestExecutor
 
             executableTest.Context.ClassContext.AssemblyContext.RestoreExecutionContext();
 
-            await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
+            if (hasClassHooks)
+            {
+                await _beforeHookTaskCache.GetOrCreateBeforeClassTask(testClass, _hookExecutor, cancellationToken).ConfigureAwait(false);
 
-            // Register After Class hook to run on cancellation (guarantees cleanup)
-            _afterHookPairTracker.RegisterAfterClassHook(testClass, _hookExecutor, cancellationToken);
+                // Register After Class hook to run on cancellation (guarantees cleanup)
+                _afterHookPairTracker.RegisterAfterClassHook(testClass, _hookExecutor, cancellationToken);
+            }
 
             await _eventReceiverOrchestrator.InvokeFirstTestInClassEventReceiversAsync(
                 executableTest.Context,
@@ -224,7 +256,10 @@ internal class TestExecutor
 
             executableTest.Context.RestoreExecutionContext();
 
-            await _hookExecutor.ExecuteBeforeTestHooksAsync(executableTest, cancellationToken).ConfigureAwait(false);
+            if (hasTestHooks)
+            {
+                await _hookExecutor.ExecuteBeforeTestHooksAsync(executableTest, cancellationToken).ConfigureAwait(false);
+            }
 
             // Late stage test start receivers run after instance-level hooks (default behavior)
             await _eventReceiverOrchestrator.InvokeTestStartEventReceiversAsync(executableTest.Context, cancellationToken, EventReceiverStage.Late).ConfigureAwait(false);
@@ -343,7 +378,9 @@ internal class TestExecutor
             // Early stage test end receivers run before instance-level hooks
             var earlyStageExceptions = await _eventReceiverOrchestrator.InvokeTestEndEventReceiversAsync(executableTest.Context, CancellationToken.None, EventReceiverStage.Early).ConfigureAwait(false);
 
-            var hookExceptions = await _hookExecutor.ExecuteAfterTestHooksAsync(executableTest, CancellationToken.None).ConfigureAwait(false);
+            var hookExceptions = hasTestHooks
+                ? await _hookExecutor.ExecuteAfterTestHooksAsync(executableTest, CancellationToken.None).ConfigureAwait(false)
+                : [];
 
             // Late stage test end receivers run after instance-level hooks (default behavior)
             var lateStageExceptions = await _eventReceiverOrchestrator.InvokeTestEndEventReceiversAsync(executableTest.Context, CancellationToken.None, EventReceiverStage.Late).ConfigureAwait(false);
@@ -403,6 +440,54 @@ internal class TestExecutor
         {
             ExceptionDispatchInfo.Capture(hookException).Throw();
         }
+    }
+
+    private static bool HasTestSessionHooks()
+        => !Sources.BeforeTestSessionHooks.IsEmpty || !Sources.AfterTestSessionHooks.IsEmpty;
+
+    private static bool HasAssemblyHooks(Assembly assembly)
+        => !Sources.BeforeEveryAssemblyHooks.IsEmpty ||
+           !Sources.AfterEveryAssemblyHooks.IsEmpty ||
+           Sources.BeforeAssemblyHooks.ContainsKey(assembly) ||
+           Sources.AfterAssemblyHooks.ContainsKey(assembly);
+
+    private static bool HasClassHooks(Type testClass)
+        => !Sources.BeforeEveryClassHooks.IsEmpty ||
+           !Sources.AfterEveryClassHooks.IsEmpty ||
+           ClassHookPresenceCache.GetOrAdd(testClass, static type =>
+               HasHooksInHierarchy(type, Sources.BeforeClassHooks, Sources.AfterClassHooks));
+
+    private static bool HasTestHooks(Type testClass)
+        => !Sources.BeforeEveryTestHooks.IsEmpty ||
+           !Sources.AfterEveryTestHooks.IsEmpty ||
+           TestHookPresenceCache.GetOrAdd(testClass, static type =>
+               HasHooksInHierarchy(type, Sources.BeforeTestHooks, Sources.AfterTestHooks));
+
+    private static bool HasHooksInHierarchy<TBeforeHook, TAfterHook>(
+        Type type,
+        ConcurrentDictionary<Type, ConcurrentBag<LazyHookEntry<TBeforeHook>>> beforeHooks,
+        ConcurrentDictionary<Type, ConcurrentBag<LazyHookEntry<TAfterHook>>> afterHooks)
+        where TBeforeHook : HookMethod
+        where TAfterHook : HookMethod
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (beforeHooks.ContainsKey(current) || afterHooks.ContainsKey(current))
+            {
+                return true;
+            }
+
+            if (current is { IsGenericType: true, IsGenericTypeDefinition: false })
+            {
+                var genericDefinition = current.GetGenericTypeDefinition();
+                if (beforeHooks.ContainsKey(genericDefinition) || afterHooks.ContainsKey(genericDefinition))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
 #if NET

--- a/tests/TUnit.UnitTests/SessionActivityLifecycleTests.cs
+++ b/tests/TUnit.UnitTests/SessionActivityLifecycleTests.cs
@@ -30,6 +30,13 @@ public class SessionActivityLifecycleTests
     private static (HookExecutor Executor, TestSessionContext SessionContext) CreateHookExecutor(
         string? testFilter = null)
     {
+        var (executor, sessionContext, _) = CreateLifecycleHookExecutor(testFilter);
+        return (executor, sessionContext);
+    }
+
+    private static (HookExecutor Executor, TestSessionContext SessionContext, StubContextProvider ContextProvider)
+        CreateLifecycleHookExecutor(string? testFilter = null)
+    {
         var beforeDiscovery = new BeforeTestDiscoveryContext { TestFilter = testFilter };
         var discoveryContext = new TestDiscoveryContext(beforeDiscovery) { TestFilter = testFilter };
         var sessionContext = new TestSessionContext(discoveryContext)
@@ -45,7 +52,7 @@ public class SessionActivityLifecycleTests
         // so we pass null — the executor will never call it in these tests.
         var executor = new HookExecutor(hookDelegateBuilder, contextProvider, null!);
 
-        return (executor, sessionContext);
+        return (executor, sessionContext, contextProvider);
     }
 
     [Test]
@@ -220,6 +227,38 @@ public class SessionActivityLifecycleTests
     }
 
     [Test]
+    public async Task HooklessAssemblyAndClassActivities_PreserveLifecycleHierarchy()
+    {
+        var (executor, sessionContext, contextProvider) = CreateLifecycleHookExecutor();
+        var testClass = typeof(SessionActivityLifecycleTests);
+        var assembly = testClass.Assembly;
+
+        using var scope = new ActivityListenerScope();
+
+        executor.TryStartSessionActivity();
+        executor.TryStartAssemblyActivity(assembly);
+        executor.TryStartClassActivity(testClass);
+
+        var assemblyContext = contextProvider.GetOrCreateAssemblyContext(assembly);
+        var classContext = contextProvider.GetOrCreateClassContext(testClass);
+        var assemblyActivity = assemblyContext.Activity;
+        var classActivity = classContext.Activity;
+
+        await Assert.That(assemblyActivity).IsNotNull();
+        await Assert.That(assemblyActivity!.ParentId).IsEqualTo(sessionContext.Activity!.Id);
+        await Assert.That(classActivity).IsNotNull();
+        await Assert.That(classActivity!.ParentId).IsEqualTo(assemblyActivity.Id);
+
+        await executor.FinishClassActivityAsync(testClass);
+        await executor.FinishAssemblyActivityAsync(assembly);
+
+        await Assert.That(classActivity.IsStopped).IsTrue();
+        await Assert.That(assemblyActivity.IsStopped).IsTrue();
+        await Assert.That(classContext.Activity).IsNull();
+        await Assert.That(assemblyContext.Activity).IsNull();
+    }
+
+    [Test]
     public async Task DiscoverySpan_InSameTrace_WhenParentedUnderSession()
     {
         var (executor, sessionContext) = CreateHookExecutor();
@@ -290,6 +329,9 @@ public class SessionActivityLifecycleTests
     /// </summary>
     private sealed class StubContextProvider(TestSessionContext sessionContext) : IContextProvider
     {
+        private readonly ConcurrentDictionary<Assembly, AssemblyHookContext> _assemblyContexts = new();
+        private readonly ConcurrentDictionary<Type, ClassHookContext> _classContexts = new();
+
         public BeforeTestDiscoveryContext BeforeTestDiscoveryContext =>
             throw new NotSupportedException();
 
@@ -299,14 +341,21 @@ public class SessionActivityLifecycleTests
         public TestSessionContext TestSessionContext => sessionContext;
 
         public AssemblyHookContext GetOrCreateAssemblyContext(Assembly assembly) =>
-            throw new NotSupportedException();
+            _assemblyContexts.GetOrAdd(assembly, static (key, context) => new AssemblyHookContext(context)
+            {
+                Assembly = key
+            }, sessionContext);
 
         public ClassHookContext GetOrCreateClassContext(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors |
                                         DynamicallyAccessedMemberTypes.PublicProperties |
                                         DynamicallyAccessedMemberTypes.PublicMethods)]
             Type classType) =>
-            throw new NotSupportedException();
+            _classContexts.GetOrAdd(classType, static (key, provider) =>
+                new ClassHookContext(provider.GetOrCreateAssemblyContext(key.Assembly))
+                {
+                    ClassType = key
+                }, this);
 
         public TestContext CreateTestContext(
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors |


### PR DESCRIPTION
## Summary

- inspect append-only hook metadata before session, assembly, class, and test hook pipelines
- skip empty hook collection while preserving assembly/class lifecycle spans
- retain cancellation cleanup, receiver execution, and normal hook behavior

## Performance

Source-generated .NET 9 suite of 600 empty independent tests with HTML lifecycle tracing active. Baseline and branch executables were built separately; final review-fixed commit used 5 warmups and 31 alternating paired runs:

| Metric | Baseline | Current | Change |
|---|---:|---:|---:|
| TUnit session median | 145.331 ms | 136.871 ms | **-8.460 ms (-5.82%)** |
| Paired session delta median | | | **-7.528 ms** |
| Process wall median | 417.966 ms | 402.541 ms | **-15.425 ms (-3.69%)** |

The full mixed 1,452-test benchmark was effectively neutral (-0.11% session), as reporting and test work dominate there.

## Validation

- TUnit.Engine Release build for netstandard2.0, net8.0, net9.0, and net10.0
- 33 SessionActivityLifecycleTests passed across net8.0, net9.0, and net10.0
- source-generated class-hook and assembly-hook/receiver paths passed
- reflection class-hook and assembly-hook/receiver paths passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle tracking for assembly and class activities, including scenarios without lifecycle hooks.
  * Activities now remain correctly linked to the session and are reliably finalized and cleared.
  * Prevented duplicate cleanup and unnecessary hook execution during test runs.
  * Improved handling of cancellation and activity completion to preserve accurate status and test counts.
* **Tests**
  * Added coverage for hookless assembly and class activity lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->