### PR TITLE
Remove single-test discovery copies

### DIFF
--- a/src/TUnit.Engine/Building/TestBuilder.cs
+++ b/src/TUnit.Engine/Building/TestBuilder.cs
@@ -999,6 +999,11 @@ internal sealed class TestBuilder : ITestBuilder
 
     private static void PopulateDependencies(AbstractExecutableTest test, List<TestDetails> dependencies)
     {
+        if (test.Dependencies.Length == 0)
+        {
+            return;
+        }
+
         var collected = new HashSet<TestDetails>();
         var visited = new HashSet<AbstractExecutableTest>();
         CollectAllDependencies(test, collected, visited);

--- a/src/TUnit.Engine/Building/TestBuilderPipeline.cs
+++ b/src/TUnit.Engine/Building/TestBuilderPipeline.cs
@@ -107,6 +107,19 @@ internal sealed class TestBuilderPipeline
     {
         var metadataList = testMetadata as IReadOnlyList<TestMetadata> ?? testMetadata.ToList();
 
+        if (metadataList.Count == 0)
+        {
+            return [];
+        }
+
+        if (metadataList.Count == 1)
+        {
+            return await BuildTestsForMetadataAsync(
+                metadataList[0],
+                buildingContext,
+                cancellationToken).ConfigureAwait(false);
+        }
+
         var testGroups = await ParallelMap.SelectParallelAsync(
             metadataList,
             metadata => BuildTestsForMetadataAsync(metadata, buildingContext, cancellationToken),

--- a/src/TUnit.Engine/Framework/TestRequestHandler.cs
+++ b/src/TUnit.Engine/Framework/TestRequestHandler.cs
@@ -63,13 +63,11 @@ internal sealed class TestRequestHandler : IRequestHandler
         }
 #endif
 
-        var allTests = discoveryResult.Tests.ToArray();
-
         // Skip sending Discovered messages during execution - they're only needed for discovery requests
         // This saves significant time and allocations when running tests
 
         await serviceProvider.TestSessionCoordinator.ExecuteTests(
-            allTests,
+            discoveryResult.Tests,
             request.Filter,
             context.MessageBus,
             context.CancellationToken);

--- a/src/TUnit.Engine/Interfaces/ITestExecutor.cs
+++ b/src/TUnit.Engine/Interfaces/ITestExecutor.cs
@@ -10,7 +10,7 @@ namespace TUnit.Engine.Interfaces;
 internal interface ITestExecutor
 {
     Task ExecuteTests(
-        IEnumerable<AbstractExecutableTest> tests,
+        List<AbstractExecutableTest> tests,
         ITestExecutionFilter? filter,
         IMessageBus messageBus,
         CancellationToken cancellationToken);

--- a/src/TUnit.Engine/TestDiscoveryService.cs
+++ b/src/TUnit.Engine/TestDiscoveryService.cs
@@ -13,10 +13,10 @@ namespace TUnit.Engine;
 
 internal sealed class TestDiscoveryResult
 {
-    public IEnumerable<AbstractExecutableTest> Tests { get; }
+    public List<AbstractExecutableTest> Tests { get; }
     public ExecutionContext? ExecutionContext { get; }
 
-    public TestDiscoveryResult(IEnumerable<AbstractExecutableTest> tests, ExecutionContext? executionContext)
+    public TestDiscoveryResult(List<AbstractExecutableTest> tests, ExecutionContext? executionContext)
     {
         Tests = tests;
         ExecutionContext = executionContext;
@@ -114,10 +114,12 @@ internal sealed class TestDiscoveryService : IDataProducer
             filteredTests = [.. testsToInclude];
         }
 
-        await _testFilterService.RegisterTestsAsync(filteredTests, isForExecution).ConfigureAwait(false);
+        var finalTests = filteredTests as List<AbstractExecutableTest> ?? [.. filteredTests];
+
+        await _testFilterService.RegisterTestsAsync(finalTests, isForExecution).ConfigureAwait(false);
 
         var finalContext = ExecutionContext.Capture();
-        return new TestDiscoveryResult(filteredTests, finalContext);
+        return new TestDiscoveryResult(finalTests, finalContext);
     }
 
     // Project the resolved tests onto their contexts into a pre-sized list.

--- a/src/TUnit.Engine/TestSessionCoordinator.cs
+++ b/src/TUnit.Engine/TestSessionCoordinator.cs
@@ -50,12 +50,12 @@ internal sealed class TestSessionCoordinator : ITestExecutor, IDisposable, IAsyn
     }
 
     public async Task ExecuteTests(
-        IEnumerable<AbstractExecutableTest> tests,
+        List<AbstractExecutableTest> tests,
         ITestExecutionFilter? filter,
         IMessageBus messageBus,
         CancellationToken cancellationToken)
     {
-        var testList = tests.ToList();
+        var testList = tests;
 
         // Expand any deferred-enumeration placeholders into their real cases before counting/scheduling,
         // so the children flow through the normal pipeline (correct hooks + lifecycle counting).


### PR DESCRIPTION
Carries the discovery List directly into execution, directly builds one metadata item, and skips empty dependency HashSets. 31 paired runs: TUnit session median 114.994 ms to 113.208 ms (-1.786 ms, -1.55%); paired delta -1.469 ms. Validation: deferred expansion 11 passed; dependency path 2; filtered discovery 1; reflection 1.