### PR TITLE
Skip unused scheduler work for unconstrained suites

### DIFF
--- a/src/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/src/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -94,7 +94,7 @@ internal sealed class TestScheduler : ITestScheduler
 
         var hasDependencies = HasDependencies(testList);
         var executableTests = hasDependencies
-            ? await RemoveCircularDependenciesAsync(testList).ConfigureAwait(false)
+            ? await RemoveCircularDependenciesAsync(testList, cancellationToken).ConfigureAwait(false)
             : testList;
 
         if (executableTests.Count == 0)
@@ -156,16 +156,22 @@ internal sealed class TestScheduler : ITestScheduler
     }
 
     private async Task<List<AbstractExecutableTest>> RemoveCircularDependenciesAsync(
-        List<AbstractExecutableTest> tests)
+        List<AbstractExecutableTest> tests,
+        CancellationToken cancellationToken)
     {
-        var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(tests);
-        var testsInCircularDependencies = new HashSet<AbstractExecutableTest>();
+        cancellationToken.ThrowIfCancellationRequested();
+        var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(tests, cancellationToken);
+        HashSet<AbstractExecutableTest>? testsInCircularDependencies = null;
 
         foreach (var (_, dependencyChain) in circularDependencies)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            testsInCircularDependencies ??= [];
+
             var simpleNames = new List<string>(dependencyChain.Count);
             foreach (var test in dependencyChain)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 simpleNames.Add($"{test.Metadata.TestClassType.Name}.{test.Metadata.TestMethodName}");
             }
 
@@ -174,6 +180,7 @@ internal sealed class TestScheduler : ITestScheduler
 
             foreach (var test in dependencyChain)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (testsInCircularDependencies.Add(test))
                 {
                     _testStateManager.MarkCircularDependencyFailed(test, exception);
@@ -183,7 +190,7 @@ internal sealed class TestScheduler : ITestScheduler
             }
         }
 
-        if (testsInCircularDependencies.Count == 0)
+        if (testsInCircularDependencies is null)
         {
             return tests;
         }
@@ -191,6 +198,7 @@ internal sealed class TestScheduler : ITestScheduler
         var executableTests = new List<AbstractExecutableTest>(tests.Count - testsInCircularDependencies.Count);
         foreach (var test in tests)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!testsInCircularDependencies.Contains(test))
             {
                 executableTests.Add(test);
@@ -383,6 +391,13 @@ internal sealed class TestScheduler : ITestScheduler
 
                 if (!visitedDependencyTargets.Add(dependencyTarget))
                 {
+                    continue;
+                }
+
+                if (dependencyTarget.State == TestState.Failed &&
+                    dependencyTarget.Result?.Exception is CircularDependencyException)
+                {
+                    dependencyTarget.ExecutionTask ??= Task.CompletedTask;
                     continue;
                 }
 

--- a/src/TUnit.Engine/Scheduling/TestScheduler.cs
+++ b/src/TUnit.Engine/Scheduling/TestScheduler.cs
@@ -92,42 +92,10 @@ internal sealed class TestScheduler : ITestScheduler
         if (_logger.IsDebugEnabled)
             await _logger.LogDebugAsync($"Scheduling execution of {testList.Count} tests").ConfigureAwait(false);
 
-        var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(testList);
-
-        var testsInCircularDependencies = new HashSet<AbstractExecutableTest>();
-
-        foreach (var (test, dependencyChain) in circularDependencies)
-        {
-            // Format the error message to match the expected format
-            var simpleNames = new List<string>(dependencyChain.Count);
-            foreach (var t in dependencyChain)
-            {
-                simpleNames.Add($"{t.Metadata.TestClassType.Name}.{t.Metadata.TestMethodName}");
-            }
-
-            var errorMessage = $"DependsOn Conflict: {string.Join(" > ", simpleNames)}";
-            var exception = new CircularDependencyException(errorMessage);
-
-            // Mark all tests in the dependency chain as failed
-            foreach (var chainTest in dependencyChain)
-            {
-                if (testsInCircularDependencies.Add(chainTest))
-                {
-                    _testStateManager.MarkCircularDependencyFailed(chainTest, exception);
-                    TestSessionContext.Current?.MarkFailure();
-                    await _messageBus.Failed(chainTest.Context, exception, DateTimeOffset.UtcNow).ConfigureAwait(false);
-                }
-            }
-        }
-
-        var executableTests = new List<AbstractExecutableTest>(testList.Count);
-        foreach (var test in testList)
-        {
-            if (!testsInCircularDependencies.Contains(test))
-            {
-                executableTests.Add(test);
-            }
-        }
+        var hasDependencies = HasDependencies(testList);
+        var executableTests = hasDependencies
+            ? await RemoveCircularDependenciesAsync(testList).ConfigureAwait(false)
+            : testList;
 
         if (executableTests.Count == 0)
         {
@@ -144,7 +112,10 @@ internal sealed class TestScheduler : ITestScheduler
         // Group tests by their parallel constraints
         var groupedTests = await _groupingService.GroupTestsByConstraintsAsync(executableTests).ConfigureAwait(false);
 
-        MarkDependencyRelatedTestsForExecutionDedup(executableTests);
+        if (hasDependencies)
+        {
+            MarkDependencyRelatedTestsForExecutionDedup(executableTests);
+        }
 
         // Suites with no global [NotInParallel] tests skip the runtime exclusion
         // lock entirely. Once enabled, the flag is monotonic — dynamic batches
@@ -169,6 +140,64 @@ internal sealed class TestScheduler : ITestScheduler
         }
 
         return true;
+    }
+
+    private static bool HasDependencies(List<AbstractExecutableTest> tests)
+    {
+        foreach (var test in tests)
+        {
+            if (test.Dependencies.Length != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<List<AbstractExecutableTest>> RemoveCircularDependenciesAsync(
+        List<AbstractExecutableTest> tests)
+    {
+        var circularDependencies = _circularDependencyDetector.DetectCircularDependencies(tests);
+        var testsInCircularDependencies = new HashSet<AbstractExecutableTest>();
+
+        foreach (var (_, dependencyChain) in circularDependencies)
+        {
+            var simpleNames = new List<string>(dependencyChain.Count);
+            foreach (var test in dependencyChain)
+            {
+                simpleNames.Add($"{test.Metadata.TestClassType.Name}.{test.Metadata.TestMethodName}");
+            }
+
+            var exception = new CircularDependencyException(
+                $"DependsOn Conflict: {string.Join(" > ", simpleNames)}");
+
+            foreach (var test in dependencyChain)
+            {
+                if (testsInCircularDependencies.Add(test))
+                {
+                    _testStateManager.MarkCircularDependencyFailed(test, exception);
+                    TestSessionContext.Current?.MarkFailure();
+                    await _messageBus.Failed(test.Context, exception, DateTimeOffset.UtcNow).ConfigureAwait(false);
+                }
+            }
+        }
+
+        if (testsInCircularDependencies.Count == 0)
+        {
+            return tests;
+        }
+
+        var executableTests = new List<AbstractExecutableTest>(tests.Count - testsInCircularDependencies.Count);
+        foreach (var test in tests)
+        {
+            if (!testsInCircularDependencies.Contains(test))
+            {
+                executableTests.Add(test);
+            }
+        }
+
+        return executableTests;
     }
 
     #if NET

--- a/src/TUnit.Engine/Services/CircularDependencyDetector.cs
+++ b/src/TUnit.Engine/Services/CircularDependencyDetector.cs
@@ -12,10 +12,13 @@ internal sealed class CircularDependencyDetector
     /// Detects circular dependencies in the given collection of tests
     /// </summary>
     /// <param name="tests">Tests to analyze for circular dependencies</param>
+    /// <param name="cancellationToken">Token used to cancel graph traversal</param>
     /// <returns>List of tests with circular dependencies and their dependency chains</returns>
     public List<(AbstractExecutableTest Test, List<AbstractExecutableTest> DependencyChain)> DetectCircularDependencies(
-        IEnumerable<AbstractExecutableTest> tests)
+        IEnumerable<AbstractExecutableTest> tests,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var testList = tests as IList<AbstractExecutableTest> ?? tests.ToList();
         var circularDependencies = new List<(AbstractExecutableTest Test, List<AbstractExecutableTest> DependencyChain)>();
         var visitedStates = new Dictionary<string, VisitState>(capacity: testList.Count);
@@ -23,6 +26,7 @@ internal sealed class CircularDependencyDetector
 
         foreach (var test in testList)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (visitedStates.ContainsKey(test.TestId))
             {
                 continue;
@@ -32,7 +36,7 @@ internal sealed class CircularDependencyDetector
             pathBuffer.Clear();
 
             // Typical cycle depth is small (2-5 tests), pre-size to 4
-            if (HasCycleDfs(test, testList, visitedStates, pathBuffer))
+            if (HasCycleDfs(test, visitedStates, pathBuffer, cancellationToken))
             {
                 // Found a cycle - add all tests in the cycle to circular dependencies
                 var cycle = new List<AbstractExecutableTest>(pathBuffer);
@@ -52,10 +56,11 @@ internal sealed class CircularDependencyDetector
 
     private bool HasCycleDfs(
         AbstractExecutableTest test,
-        IList<AbstractExecutableTest> allTests,
         Dictionary<string, VisitState> visitedStates,
-        List<AbstractExecutableTest> currentPath)
+        List<AbstractExecutableTest> currentPath,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (visitedStates.TryGetValue(test.TestId, out var state))
         {
             if (state == VisitState.Visiting)
@@ -78,7 +83,8 @@ internal sealed class CircularDependencyDetector
         // Check all dependencies
         foreach (var dependency in test.Dependencies)
         {
-            if (HasCycleDfs(dependency.Test, allTests, visitedStates, currentPath))
+            cancellationToken.ThrowIfCancellationRequested();
+            if (HasCycleDfs(dependency.Test, visitedStates, currentPath, cancellationToken))
             {
                 return true;
             }

--- a/src/TUnit.Engine/Services/TestGroupingService.cs
+++ b/src/TUnit.Engine/Services/TestGroupingService.cs
@@ -61,11 +61,13 @@ internal sealed class TestGroupingService : ITestGroupingService
     {
         var testCount = tests is ICollection<AbstractExecutableTest> collection ? collection.Count : 0;
         var testsWithKeys = new List<(AbstractExecutableTest Test, TestSortKey Key)>(testCount > 0 ? testCount : 16);
+        var hasParallelConstraints = false;
         foreach (var test in tests)
         {
             NotInParallelConstraint? notInParallelConstraint = null;
             foreach (var constraint in test.Context.ParallelConstraints)
             {
+                hasParallelConstraints = true;
                 if (constraint is NotInParallelConstraint nip)
                 {
                     notInParallelConstraint = nip;
@@ -93,6 +95,24 @@ internal sealed class TestGroupingService : ITestGroupingService
 
             return a.Key.NotInParallelOrder.CompareTo(b.Key.NotInParallelOrder);
         });
+
+        if (!hasParallelConstraints && traceMessages is null)
+        {
+            var orderedTests = new AbstractExecutableTest[testsWithKeys.Count];
+            for (var i = 0; i < testsWithKeys.Count; i++)
+            {
+                orderedTests[i] = testsWithKeys[i].Test;
+            }
+
+            return new GroupedTests
+            {
+                Parallel = orderedTests,
+                NotInParallel = [],
+                KeyedNotInParallel = [],
+                ParallelGroups = [],
+                ConstrainedParallelGroups = []
+            };
+        }
 
         var estimatedCount = testsWithKeys.Count;
         var notInParallelList = new List<(AbstractExecutableTest Test, string ClassName, TestPriority Priority)>(estimatedCount / 4);

--- a/tests/TUnit.UnitTests/TestRunnerTests.cs
+++ b/tests/TUnit.UnitTests/TestRunnerTests.cs
@@ -1,6 +1,8 @@
 using TUnit.Core;
+using TUnit.Core.Exceptions;
 using TUnit.Engine.Interfaces;
 using TUnit.Engine.Scheduling;
+using TUnit.Engine.Services;
 using TUnit.Engine.Services.TestExecution;
 
 namespace TUnit.UnitTests;
@@ -113,6 +115,40 @@ public class TestRunnerTests
         await Assert.That(leaf.RequiresExecutionDedup).IsTrue();
     }
 
+    [Test, Timeout(5_000)]
+    public async Task ExecuteTestAsync_WithFailedCircularDependency_SkipsDependentWithoutReentry(
+        CancellationToken cancellationToken)
+    {
+        var runner = CreateRunner(out var coordinator);
+        var firstCycleTest = CreateTest("cycle-a");
+        var secondCycleTest = CreateTest("cycle-b", [firstCycleTest]);
+        firstCycleTest.Dependencies = [CreateResolvedDependency(secondCycleTest)];
+        var dependent = CreateTest("dependent", [firstCycleTest]);
+        var exception = new CircularDependencyException("cycle");
+        var stateManager = new TestStateManager();
+        stateManager.MarkCircularDependencyFailed(firstCycleTest, exception);
+        stateManager.MarkCircularDependencyFailed(secondCycleTest, exception);
+        TestScheduler.MarkDependencyRelatedTestsForExecutionDedup([dependent]);
+
+        await runner.ExecuteTestAsync(dependent, cancellationToken);
+
+        await Assert.That(dependent.State).IsEqualTo(TestState.Skipped);
+        await Assert.That(coordinator.GetCallCount(firstCycleTest)).IsEqualTo(0);
+        await Assert.That(coordinator.GetCallCount(secondCycleTest)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DetectCircularDependencies_WithCancelledToken_Throws()
+    {
+        var detector = new CircularDependencyDetector();
+        var test = CreateTest("test");
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.That(() => detector.DetectCircularDependencies([test], cancellationTokenSource.Token))
+            .ThrowsExactly<OperationCanceledException>();
+    }
+
     private static TestRunner CreateRunner(out FakeTestCoordinator coordinator)
     {
         coordinator = new FakeTestCoordinator();
@@ -160,15 +196,17 @@ public class TestRunnerTests
             Metadata = metadata,
             Arguments = [],
             Context = context,
-            Dependencies = dependencies?.Select(dependency => new ResolvedDependency
-            {
-                Test = dependency,
-                Metadata = TestDependency.FromMethodName(dependency.Metadata.TestMethodName)
-            }).ToArray() ?? []
+            Dependencies = dependencies?.Select(CreateResolvedDependency).ToArray() ?? []
         };
 
         return test;
     }
+
+    private static ResolvedDependency CreateResolvedDependency(AbstractExecutableTest dependency) => new()
+    {
+        Test = dependency,
+        Metadata = TestDependency.FromMethodName(dependency.Metadata.TestMethodName)
+    };
 
     private static TestMetadata<TestRunnerTests> CreateMetadata(string testId)
     {


### PR DESCRIPTION
## What changed

- Detect dependency-free suites once and skip circular-dependency detection, executable-test copying, and dependency dedup traversal.
- Fast-path constraint-free grouping after preserving existing execution-priority and class-name sorting.
- Keep the full grouping path when trace logging is enabled, preserving detailed grouping diagnostics.

This targets normal suites containing many independent tests. It does not add a single-test execution path and still uses the standard parallel scheduler.

## Benchmark

Source-generated .NET 10 executable with exact 10, 100, and 1,000 empty independent tests. Baseline and branch binaries were built separately. Each result uses 5 warmups and 31 alternating paired runs with Microsoft Testing Platform and .NET CLI telemetry disabled. Metric is the TUnit report's `totalDurationMs`, excluding process startup and report shutdown.

| Tests | Baseline median | Current median | Change | Paired median delta |
|---:|---:|---:|---:|---:|
| 10 | 124.374 ms | 122.822 ms | -1.25% | -1.611 ms |
| 100 | 131.781 ms | 129.169 ms | -1.98% | -2.355 ms |
| 1,000 | 158.011 ms | 156.077 ms | -1.22% | -3.455 ms |

The 1,000-test row was rerun after review fixes. CPU-sampling traces were also captured before and after for the 1,000-test workload. Short-trace sampling is too coarse to attribute the small setup reduction reliably, so the paired session timings are the primary evidence.

## Validation

- `dotnet build TUnit.Dev.slnx --no-restore -graphBuild:True`
- `TestRunnerTests` on net8.0, net9.0, and net10.0
- `ConflictingDependsOnTests` in source-generated and reflection modes
- `KeyedNotInParallelCrossPhaseTests` in source-generated and reflection modes
- `DynamicTests` in source-generated and reflection modes
- `PriorityTests` on net8.0, net9.0, and net10.0
- combined constraint tests on net8.0, net9.0, and net10.0
- dynamic test index tests on net8.0, net9.0, and net10.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of circular test dependencies by marking affected tests as failed and excluding them from execution.
  - Avoided unnecessary dependency checks when tests have no dependencies.
  - Prevented redundant dependency execution.
  - Added cancellation support while detecting circular dependencies.

- **Performance**
  - Streamlined test grouping when no parallel constraints or tracing are configured, enabling faster test execution setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->