### PR TITLE
fix: suppress nullability warnings after Should NotBeNull assertions

### DIFF
--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -189,6 +189,12 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         if (assertThatCall is null
             || assertThatCall.ArgumentList.Arguments.Count != 1
             || !IsTUnitMethod(
+                invocation,
+                semanticModel,
+                cancellationToken,
+                "global::TUnit.Assertions.Extensions.AssertionExtensions",
+                "IsNotNull")
+            || !IsTUnitMethod(
                 assertThatCall,
                 semanticModel,
                 cancellationToken,

--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -9,7 +9,8 @@ namespace TUnit.Assertions.Analyzers;
 
 /// <summary>
 /// Suppresses nullability warnings (CS8600, CS8602, CS8604, CS8618, CS8629) for variables
-/// after they have been asserted as non-null using Assert.That(x).IsNotNull().
+/// after they have been asserted as non-null using Assert.That(x).IsNotNull()
+/// or x.Should().NotBeNull().
 ///
 /// Note: This suppressor only hides the warnings; it does not change the compiler's
 /// null-state flow analysis. Variables will still appear as nullable in IntelliSense.
@@ -187,7 +188,12 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         var assertThatCall = FindAssertThatInChain(invocation);
         if (assertThatCall is null
             || assertThatCall.ArgumentList.Arguments.Count != 1
-            || !IsTUnitMethod(assertThatCall, semanticModel, cancellationToken, "global::TUnit.Assertions.Assert.That"))
+            || !IsTUnitMethod(
+                assertThatCall,
+                semanticModel,
+                cancellationToken,
+                "global::TUnit.Assertions.Assert",
+                "That"))
         {
             return null;
         }
@@ -202,7 +208,12 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
     {
         var shouldCall = FindShouldInChain(invocation);
         if (shouldCall is null
-            || !IsTUnitMethod(shouldCall, semanticModel, cancellationToken, "global::TUnit.Assertions.Should.ShouldExtensions.Should"))
+            || !IsTUnitMethod(
+                shouldCall,
+                semanticModel,
+                cancellationToken,
+                "global::TUnit.Assertions.Should.ShouldExtensions",
+                "Should"))
         {
             return null;
         }
@@ -217,9 +228,18 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        string fullyQualifiedNonGenericName)
-        => semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol symbol
-           && symbol.GloballyQualifiedNonGeneric() == fullyQualifiedNonGenericName;
+        string fullyQualifiedContainingTypeName,
+        string methodName)
+    {
+        if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
+        {
+            return false;
+        }
+
+        var method = symbol.ReducedFrom ?? symbol;
+        return method.Name == methodName
+               && method.ContainingType.GloballyQualifiedNonGeneric() == fullyQualifiedContainingTypeName;
+    }
 
     private bool ExpressionsMatch(
         ExpressionSyntax assertArgument,
@@ -261,8 +281,8 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         => FindInvocationInChain(invocation, identifierName: "That", parentName: "Assert");
 
     // Should() is an extension method, so its receiver is the asserted value (any expression).
-    // parentName MUST stay null — constraining it would break the suppressor for user-defined
-    // assertion entry points and for Should() reached via using-aliases / namespace imports.
+    // parentName MUST stay null because the receiver is the asserted value. Semantic validation
+    // in GetShouldReceiver still ensures that only TUnit's Should extension qualifies.
     private static InvocationExpressionSyntax? FindShouldInChain(InvocationExpressionSyntax invocation)
         => FindInvocationInChain(invocation, identifierName: "Should", parentName: null);
 
@@ -338,6 +358,6 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         => new(
             id: $"{id}Suppression",
             suppressedDiagnosticId: id,
-            justification: $"Suppress {id} for variables asserted as non-null via Assert.That(x).IsNotNull()."
+            justification: $"Suppress {id} for variables asserted as non-null via Assert.That(x).IsNotNull() or x.Should().NotBeNull()."
         );
 }

--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -206,6 +206,16 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
+        if (!IsTUnitMethod(
+                invocation,
+                semanticModel,
+                cancellationToken,
+                "global::TUnit.Assertions.Should.Extensions.ShouldAssertionExtensions",
+                "NotBeNull"))
+        {
+            return null;
+        }
+
         var shouldCall = FindShouldInChain(invocation);
         if (shouldCall is null
             || !IsTUnitMethod(

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -54,6 +54,156 @@ public class IsNotNullAssertionSuppressorTests
     }
 
     [Test]
+    public async Task Suppresses_CS8602_After_Should_NotBeNull_Assertion()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? nullableString = GetNullableString();
+
+                    await nullableString.Should().NotBeNull();
+
+                    var length = {|#0:nullableString|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(true))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    public async Task Does_Not_Suppress_CS8602_After_Should_Assertion_Without_NotBeNull()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? nullableString = GetNullableString();
+
+                    await nullableString.Should().BeNull();
+
+                    var length = {|#0:nullableString|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    public async Task Does_Not_Suppress_CS8602_After_Unrelated_Should_NotBeNull_Assertion()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using OtherLibrary;
+
+            namespace OtherLibrary
+            {
+                public sealed class Wrapper
+                {
+                    public Task NotBeNull() => Task.CompletedTask;
+                }
+
+                public static class ShouldExtensions
+                {
+                    public static Wrapper Should(this string? value) => new();
+                }
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? nullableString = GetNullableString();
+
+                    await nullableString.Should().NotBeNull();
+
+                    var length = {|#0:nullableString|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    public async Task Suppresses_CS8602_After_Should_NotBeNull_In_Assertion_Chains()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? notBeNullFirst = GetNullableString();
+                    string? notBeNullLast = GetNullableString();
+
+                    await notBeNullFirst.Should().NotBeNull().And.Contain("test");
+                    await notBeNullLast.Should().Contain("test").And.NotBeNull();
+
+                    var firstLength = {|#0:notBeNullFirst|}.Length;
+                    var lastLength = {|#1:notBeNullLast|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(
+                CS8602.WithLocation(0).WithIsSuppressed(true),
+                CS8602.WithLocation(1).WithIsSuppressed(true)
+            )
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
     public async Task Suppresses_CS8604_After_IsNotNull_Assertion()
     {
         const string code = """

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -165,6 +165,48 @@ public class IsNotNullAssertionSuppressorTests
     }
 
     [Test]
+    public async Task Does_Not_Suppress_CS8602_After_Custom_NotBeNull_Assertion()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using CustomAssertions;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Core;
+
+            namespace CustomAssertions
+            {
+                public static class ShouldSourceExtensions
+                {
+                    public static Task NotBeNull(this ShouldSource<string> source) => Task.CompletedTask;
+                }
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? nullableString = GetNullableString();
+
+                    await nullableString.Should().NotBeNull();
+
+                    var length = {|#0:nullableString|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
     public async Task Suppresses_CS8602_After_Should_NotBeNull_In_Assertion_Chains()
     {
         const string code = """

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -54,6 +54,48 @@ public class IsNotNullAssertionSuppressorTests
     }
 
     [Test]
+    public async Task Does_Not_Suppress_CS8602_After_Custom_IsNotNull_Assertion()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using CustomAssertions;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Sources;
+
+            namespace CustomAssertions
+            {
+                public static class ValueAssertionExtensions
+                {
+                    public static Task IsNotNull(this ValueAssertion<string> source) => Task.CompletedTask;
+                }
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod()
+                {
+                    string? nullableString = GetNullableString();
+
+                    await Assert.That(nullableString).IsNotNull();
+
+                    var length = {|#0:nullableString|}.Length;
+                }
+
+                private string? GetNullableString() => "test";
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
     public async Task Suppresses_CS8602_After_Should_NotBeNull_Assertion()
     {
         const string code = """


### PR DESCRIPTION
## Description

Add a focused suppressor regression using the reported pattern and the existing analyzer-test references for `TUnit.Assertions.Should`, proving that CS8602 is suppressed only after an awaited TUnit `NotBeNull` chain. Use that failing test to correct the existing `NotBeNull` chain recognition or receiver extraction in `IsNotNullAssertionSuppressor`, retaining semantic-symbol validation so similarly named third-party or user-defined `Should()` methods cannot suppress compiler diagnostics. Keep the established statement-order and expression-symbol matching behavior shared with `Assert.That(...).IsNotNull()` rather than introducing a second suppression algorithm.

TUnit's documented Should syntax promises that awaiting `value.Should().NotBeNull()` suppresses subsequent nullable-flow diagnostics for that value, but the reported nullable-string example still emits CS8602 on property access. The analyzer already has a Should-specific recognition path, while its suppressor test suite exercises only the `Assert.That(value).IsNotNull()` entry point. This leaves a concrete mismatch between the documented rule and the behavior shipped to Should users. The fix is limited to the nullability suppressor and its analyzer regression coverage; it does not change assertion runtime behavior or broadly mark every `Should()` receiver as non-null.

Closes #6673

## Related Issue

Fixes #6673

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

Not applicable to this change.

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

- [x] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
  - [ ] Reflection path (`TUnit.Engine`)
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
  - [ ] I committed the updated `.verified.txt` files
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
    Not run: no test command resolved in this workspace, so nothing was executed to pass.
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`
    Not run: no test command resolved in this workspace, so nothing was executed to pass.

### Testing

- [ ] All existing tests pass (`dotnet test`)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] I have added tests that cover my changes
- [x] I have tested both source-generated and reflection modes (if applicable)
- A nullable string followed by `await value.Should().NotBeNull()` and then `value.Length` has its CS8602 diagnostic reported as suppressed. - The same nullable dereference without a preceding `NotBeNull()` assertion remains unsuppressed. - A custom or third-party `Should().NotBeNull()` chain with matching method names remains unsuppressed because its symbols are not TUnit's entry point.

## Additional Notes

Nothing beyond what is described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability warning suppression for supported `Should().NotBeNull()` and `Assert.That(...).IsNotNull()` assertions.
  * Prevented suppression for unrelated or custom assertion extensions and for `Should().BeNull()`.
  * Added reliable handling for supported assertions within chains, reducing false positives and missed suppressions.

* **Tests**
  * Added coverage for valid, invalid, unrelated, custom, and chained assertion scenarios across both supported assertion styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->