### PR TITLE
Clarify ClassDataSource constructor requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ public class OrderRepositoryTests
 }
 ```
 
-Property injection keeps base test classes clean — subclasses inherit the fixture without re-threading constructor parameters. Prefer a constructor parameter on the test class? That works too. Types created by `ClassDataSource<T>` require an accessible parameterless constructor; use property injection for their nested dependencies. Disposal is reference-counted, so shared fixtures are torn down exactly when the last test using them finishes.
+Property injection keeps base test classes clean — subclasses inherit the fixture without re-threading constructor parameters. Prefer a constructor parameter on the test class? That works too. Types created by `ClassDataSource<T>` require a public parameterless constructor; use property injection for their nested dependencies. Disposal is reference-counted, so shared fixtures are torn down exactly when the last test using them finishes.
 
 ### Parallelism you control
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ public class OrderRepositoryTests
 }
 ```
 
-Property injection keeps base test classes clean — subclasses inherit the fixture without re-threading constructor parameters. Prefer a constructor param? That works too. Disposal is reference-counted, so shared fixtures are torn down exactly when the last test using them finishes.
+Property injection keeps base test classes clean — subclasses inherit the fixture without re-threading constructor parameters. Prefer a constructor parameter on the test class? That works too. Types created by `ClassDataSource<T>` require an accessible parameterless constructor; use property injection for their nested dependencies. Disposal is reference-counted, so shared fixtures are torn down exactly when the last test using them finishes.
 
 ### Parallelism you control
 

--- a/docs/docs/writing-tests/class-data-source.md
+++ b/docs/docs/writing-tests/class-data-source.md
@@ -4,6 +4,50 @@ The `ClassDataSource` attribute is used to instantiate and inject in new classes
 
 The attribute takes a generic type argument, which is the type of data you want to inject into your test.
 
+The type created by `ClassDataSource<T>` must have an accessible parameterless constructor. Constructor injection is supported on the test class receiving the data source, but not on the data source type itself.
+
+For nested dependencies, use property injection on the data source type:
+
+```csharp
+[ClassDataSource<ApplicationFixture>(Shared = SharedType.PerTestSession)]
+public class ApplicationTests(ApplicationFixture fixture)
+{
+    [Test]
+    public async Task Application_Is_Available()
+    {
+        await Assert.That(fixture.IsAvailable).IsTrue();
+    }
+}
+
+public class ApplicationFixture : IAsyncInitializer
+{
+    [ClassDataSource<DatabaseFixture>(Shared = SharedType.PerTestSession)]
+    public required DatabaseFixture Database { get; init; }
+
+    public bool IsAvailable { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        // Database has already been initialized.
+        IsAvailable = Database.IsAvailable;
+        return Task.CompletedTask;
+    }
+}
+
+public class DatabaseFixture : IAsyncInitializer
+{
+    public bool IsAvailable { get; private set; }
+
+    public Task InitializeAsync()
+    {
+        IsAvailable = true;
+        return Task.CompletedTask;
+    }
+}
+```
+
+See [Nested Property Injection](property-injection.md#nested-property-injection) for dependency chains and lifecycle details.
+
 It also takes an optional `Shared` argument, controlling whether you want to share the instance among other tests. This is useful when it is expensive to create an object and you want to reuse the same instance across many tests.
 
 Avoid mutating the state of shared objects within tests. Because tests run concurrently, the execution order is unpredictable, and shared mutable state leads to flaky tests.

--- a/docs/docs/writing-tests/class-data-source.md
+++ b/docs/docs/writing-tests/class-data-source.md
@@ -4,7 +4,7 @@ The `ClassDataSource` attribute is used to instantiate and inject in new classes
 
 The attribute takes a generic type argument, which is the type of data you want to inject into your test.
 
-The type created by `ClassDataSource<T>` must have an accessible parameterless constructor. Constructor injection is supported on the test class receiving the data source, but not on the data source type itself.
+The type created by `ClassDataSource<T>` must have a public parameterless constructor. Constructor injection is supported on the test class receiving the data source, but not on the data source type itself.
 
 For nested dependencies, use property injection on the data source type:
 

--- a/docs/docs/writing-tests/nested-data-sources.md
+++ b/docs/docs/writing-tests/nested-data-sources.md
@@ -23,7 +23,7 @@ This typically leads to complex setup code with manual initialization chains.
 
 TUnit automatically initializes nested data sources in the correct order using any data source attribute that implements `IDataSourceAttribute` (such as `[ClassDataSource<T>]`).
 
-Declare nested data sources on properties. Constructor-injected dependencies inside a data source type are not currently supported because `ClassDataSource<T>` requires that type to have an accessible parameterless constructor.
+Declare nested data sources on properties. Constructor-injected dependencies inside a data source type are not currently supported because `ClassDataSource<T>` requires that type to have a public parameterless constructor.
 
 ## Basic Example
 

--- a/docs/docs/writing-tests/nested-data-sources.md
+++ b/docs/docs/writing-tests/nested-data-sources.md
@@ -23,6 +23,8 @@ This typically leads to complex setup code with manual initialization chains.
 
 TUnit automatically initializes nested data sources in the correct order using any data source attribute that implements `IDataSourceAttribute` (such as `[ClassDataSource<T>]`).
 
+Declare nested data sources on properties. Constructor-injected dependencies inside a data source type are not currently supported because `ClassDataSource<T>` requires that type to have an accessible parameterless constructor.
+
 ## Basic Example
 
 Here's a complete example of setting up integration tests with Redis and WebApplicationFactory:


### PR DESCRIPTION
## Summary

- Document the accessible parameterless constructor requirement for `ClassDataSource<T>` types.
- Distinguish supported test-class constructor injection from unsupported constructor injection inside data source types.
- Add a nested property-injection example and cross-reference the detailed guide.

## Validation

- `yarn build` from `docs`

Refs #6694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that `ClassDataSource<T>` types require a public parameterless constructor.
  - Recommended property injection for nested dependencies within data sources.
  - Added guidance and an example for asynchronously initializing dependent fixtures.
  - Documented that constructor-injected dependencies inside data source types are not currently supported.
  - Updated shared-fixture guidance to clarify test-class constructor parameter usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->