### PR TITLE
fix: restore null suppression for built-in assertion methods

### DIFF
--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -188,12 +188,7 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         var assertThatCall = FindAssertThatInChain(invocation);
         if (assertThatCall is null
             || assertThatCall.ArgumentList.Arguments.Count != 1
-            || !IsTUnitMethod(
-                invocation,
-                semanticModel,
-                cancellationToken,
-                "global::TUnit.Assertions.Extensions.AssertionExtensions",
-                "IsNotNull")
+            || !IsTUnitIsNotNullMethod(invocation, semanticModel, cancellationToken)
             || !IsTUnitMethod(
                 assertThatCall,
                 semanticModel,
@@ -205,6 +200,34 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         }
 
         return assertThatCall.ArgumentList.Arguments[0].Expression;
+    }
+
+    private static bool IsTUnitIsNotNullMethod(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol symbol)
+        {
+            return false;
+        }
+
+        var method = symbol.ReducedFrom ?? symbol;
+
+        // Collections and async sources provide instance methods instead of using the
+        // general extension. Validate the declaring type so custom IsNotNull methods
+        // still cannot suppress warnings, including methods that hide inherited members.
+        return method.Name == "IsNotNull"
+               && method.ContainingType.GloballyQualifiedNonGeneric() is
+                   "global::TUnit.Assertions.Extensions.AssertionExtensions"
+                   or "global::TUnit.Assertions.Sources.CollectionAssertionBase"
+                   or "global::TUnit.Assertions.Sources.ListAssertionBase"
+                   or "global::TUnit.Assertions.Sources.ReadOnlyListAssertionBase"
+                   or "global::TUnit.Assertions.Sources.DictionaryAssertionBase"
+                   or "global::TUnit.Assertions.Sources.MutableDictionaryAssertionBase"
+                   or "global::TUnit.Assertions.Sources.SetAssertionBase"
+                   or "global::TUnit.Assertions.Sources.AsyncEnumerableAssertionBase"
+                   or "global::TUnit.Assertions.Sources.AsyncDelegateAssertion";
     }
 
     private static ExpressionSyntax? GetShouldReceiver(

--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -215,7 +215,8 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
 
         var method = symbol.ReducedFrom ?? symbol;
 
-        if (method.Name != "IsNotNull")
+        if (method.Name != "IsNotNull"
+            || !IsReferencedAssertionAssembly(method.ContainingAssembly, semanticModel.Compilation))
         {
             return false;
         }
@@ -236,9 +237,16 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
             return false;
         }
 
+        var asyncEnumerableBase = semanticModel.Compilation.GetTypeByMetadataName(
+            "TUnit.Assertions.Sources.AsyncEnumerableAssertionBase`1");
+        var asyncDelegate = semanticModel.Compilation.GetTypeByMetadataName(
+            "TUnit.Assertions.Sources.AsyncDelegateAssertion");
+
         for (var type = method.ContainingType; type is not null; type = type.BaseType)
         {
-            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, collectionBase))
+            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, collectionBase)
+                || SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, asyncEnumerableBase)
+                || SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, asyncDelegate))
             {
                 return true;
             }
@@ -307,9 +315,6 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
             }
         }
 
-        var assertionAssembly = semanticModel.Compilation.GetTypeByMetadataName("TUnit.Assertions.Assert")?.ContainingAssembly;
-        var entryAssembly = semanticModel.GetSymbolInfo(entryPoint, cancellationToken).Symbol?.ContainingAssembly;
-
         // An external method/property can return a TUnit assertion on another value.
         // Do not trace a null check back across such a transformation.
         for (ExpressionSyntax? current = nullCheck; current is not null; current = GetChainReceiver(current))
@@ -322,9 +327,7 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
             if (current is not ParenthesizedExpressionSyntax)
             {
                 var symbol = semanticModel.GetSymbolInfo(current, cancellationToken).Symbol;
-                if (symbol is null
-                    || !(SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, assertionAssembly)
-                         || SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, entryAssembly)))
+                if (!IsReferencedAssertionAssembly(symbol?.ContainingAssembly, semanticModel.Compilation))
                 {
                     return false;
                 }
@@ -356,7 +359,16 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
 
         var method = symbol.ReducedFrom ?? symbol;
         return method.Name == methodName
+               && IsReferencedAssertionAssembly(method.ContainingAssembly, semanticModel.Compilation)
                && method.ContainingType.GloballyQualifiedNonGeneric() == fullyQualifiedContainingTypeName;
+    }
+
+    private static bool IsReferencedAssertionAssembly(IAssemblySymbol? assembly, Compilation compilation)
+    {
+        // Matching namespace/type names alone also accepts source-defined lookalikes.
+        return assembly is not null
+               && (assembly.Identity.Name is "TUnit.Assertions" or "TUnit.Assertions.Should")
+               && !SymbolEqualityComparer.Default.Equals(assembly, compilation.Assembly);
     }
 
     private bool ExpressionsMatch(

--- a/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
+++ b/src/TUnit.Assertions.Analyzers/IsNotNullAssertionSuppressor.cs
@@ -188,6 +188,7 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
         var assertThatCall = FindAssertThatInChain(invocation);
         if (assertThatCall is null
             || assertThatCall.ArgumentList.Arguments.Count != 1
+            || !IsSupportedAssertionChain(invocation, assertThatCall, semanticModel, cancellationToken)
             || !IsTUnitIsNotNullMethod(invocation, semanticModel, cancellationToken)
             || !IsTUnitMethod(
                 assertThatCall,
@@ -214,20 +215,36 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
 
         var method = symbol.ReducedFrom ?? symbol;
 
-        // Collections and async sources provide instance methods instead of using the
-        // general extension. Validate the declaring type so custom IsNotNull methods
-        // still cannot suppress warnings, including methods that hide inherited members.
-        return method.Name == "IsNotNull"
-               && method.ContainingType.GloballyQualifiedNonGeneric() is
-                   "global::TUnit.Assertions.Extensions.AssertionExtensions"
-                   or "global::TUnit.Assertions.Sources.CollectionAssertionBase"
-                   or "global::TUnit.Assertions.Sources.ListAssertionBase"
-                   or "global::TUnit.Assertions.Sources.ReadOnlyListAssertionBase"
-                   or "global::TUnit.Assertions.Sources.DictionaryAssertionBase"
-                   or "global::TUnit.Assertions.Sources.MutableDictionaryAssertionBase"
-                   or "global::TUnit.Assertions.Sources.SetAssertionBase"
-                   or "global::TUnit.Assertions.Sources.AsyncEnumerableAssertionBase"
-                   or "global::TUnit.Assertions.Sources.AsyncDelegateAssertion";
+        if (method.Name != "IsNotNull")
+        {
+            return false;
+        }
+
+        if (method.ContainingType.GloballyQualifiedNonGeneric() == "global::TUnit.Assertions.Extensions.AssertionExtensions")
+        {
+            return true;
+        }
+
+        var collectionBase = semanticModel.Compilation.GetTypeByMetadataName(
+            "TUnit.Assertions.Sources.CollectionAssertionBase`2");
+
+        // Check the declaring assembly as well as the shared base: a custom subclass
+        // can hide IsNotNull, but that does not make its method a TUnit null check.
+        if (collectionBase is null
+            || !SymbolEqualityComparer.Default.Equals(method.ContainingAssembly, collectionBase.ContainingAssembly))
+        {
+            return false;
+        }
+
+        for (var type = method.ContainingType; type is not null; type = type.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, collectionBase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static ExpressionSyntax? GetShouldReceiver(
@@ -247,6 +264,7 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
 
         var shouldCall = FindShouldInChain(invocation);
         if (shouldCall is null
+            || !IsSupportedAssertionChain(invocation, shouldCall, semanticModel, cancellationToken)
             || !IsTUnitMethod(
                 shouldCall,
                 semanticModel,
@@ -262,6 +280,67 @@ public class IsNotNullAssertionSuppressor : DiagnosticSuppressor
             ? memberAccess.Expression
             : null;
     }
+
+    private static bool IsSupportedAssertionChain(
+        InvocationExpressionSyntax nullCheck,
+        InvocationExpressionSyntax entryPoint,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        ExpressionSyntax outermost = nullCheck;
+        while ((outermost.Parent is MemberAccessExpressionSyntax member && member.Expression == outermost)
+               || (outermost.Parent is InvocationExpressionSyntax call && call.Expression == outermost)
+               || outermost.Parent is ParenthesizedExpressionSyntax)
+        {
+            outermost = (ExpressionSyntax)outermost.Parent;
+        }
+
+        // Or on either side makes the null check optional. Walk only the receiver
+        // chain, not nested arguments or lambdas belonging to another assertion.
+        for (ExpressionSyntax? current = outermost;
+             current is not null && current != entryPoint;
+             current = GetChainReceiver(current))
+        {
+            if (current is MemberAccessExpressionSyntax { Name.Identifier.Text: "Or" })
+            {
+                return false;
+            }
+        }
+
+        var assertionAssembly = semanticModel.Compilation.GetTypeByMetadataName("TUnit.Assertions.Assert")?.ContainingAssembly;
+        var entryAssembly = semanticModel.GetSymbolInfo(entryPoint, cancellationToken).Symbol?.ContainingAssembly;
+
+        // An external method/property can return a TUnit assertion on another value.
+        // Do not trace a null check back across such a transformation.
+        for (ExpressionSyntax? current = nullCheck; current is not null; current = GetChainReceiver(current))
+        {
+            if (current == entryPoint)
+            {
+                return true;
+            }
+
+            if (current is not ParenthesizedExpressionSyntax)
+            {
+                var symbol = semanticModel.GetSymbolInfo(current, cancellationToken).Symbol;
+                if (symbol is null
+                    || !(SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, assertionAssembly)
+                         || SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, entryAssembly)))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static ExpressionSyntax? GetChainReceiver(ExpressionSyntax expression) => expression switch
+    {
+        InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax member } => member.Expression,
+        MemberAccessExpressionSyntax member => member.Expression,
+        ParenthesizedExpressionSyntax parenthesized => parenthesized.Expression,
+        _ => null,
+    };
 
     private static bool IsTUnitMethod(
         InvocationExpressionSyntax invocation,

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -114,6 +114,153 @@ public class IsNotNullAssertionSuppressorTests
     }
 
     [Test]
+    [Arguments("Assert.That(values).IsNull().Or.IsNotNull()")]
+    [Arguments("Assert.That(values).IsNotNull().Or.IsNull()")]
+    [Arguments("values.Should().BeNull().Or.NotBeNull()")]
+    [Arguments("values.Should().NotBeNull().Or.BeNull()")]
+    public async Task Does_Not_Suppress_After_Disjunctive_Null_Check(string assertion)
+    {
+        var code = $$"""
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Extensions;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod(IList<int>? values)
+                {
+                    await {{assertion}};
+                    _ = {|#0:values|}.Count;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    [Arguments("Assert.That(model.Or).IsNotNull().Because(nameof(MyTests.Or))")]
+    [Arguments("model.Or.Should().NotBeNull().Because(nameof(MyTests.Or))")]
+    public async Task Suppresses_When_Or_Is_Outside_The_Assertion_Chain(string assertion)
+    {
+        var code = $$"""
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Extensions;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            public class MyTests
+            {
+                public IList<int>? Or { get; set; }
+
+                public async Task TestMethod(MyTests model)
+                {
+                    await {{assertion}};
+                    _ = {|#0:model.Or|}.Count;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(true))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    public async Task Does_Not_Suppress_After_Custom_Should_Transform()
+    {
+        const string code = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Core;
+            using TUnit.Assertions.Should.Extensions;
+
+            public static class CustomAssertions
+            {
+                public static ShouldSource<string> CustomTransform(this ShouldSource<string> source) => "other".Should();
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod(string? value)
+                {
+                    await value.Should().CustomTransform().NotBeNull();
+                    _ = {|#0:value|}.Length;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    [Arguments("CustomTransform()")]
+    [Arguments("CustomPropertyTransform().Other")]
+    public async Task Does_Not_Suppress_After_Custom_Transform_With_BuiltIn_IsNotNull(string transform)
+    {
+        var code = $$"""
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Sources;
+
+            public static class CustomAssertions
+            {
+                public static OtherAssertion CustomTransform(this ListAssertion<int> source) => new OtherAssertion();
+                public static OtherAssertion CustomPropertyTransform(this ListAssertion<int> source) => new OtherAssertion();
+            }
+
+            public class OtherAssertion : ListAssertion<int>
+            {
+                public OtherAssertion() : base(new List<int>(), null) { }
+                public ListAssertion<int> Other => new ListAssertion<int>(new List<int>(), null);
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod(IList<int>? values)
+                {
+                    await Assert.That(values).{{transform}}.IsNotNull();
+                    _ = {|#0:values|}.Count;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
     public async Task Does_Not_Suppress_After_Custom_IsNotNull_Instance_Method()
     {
         const string code = """
@@ -732,7 +879,7 @@ public class IsNotNullAssertionSuppressorTests
     }
 
     [Test]
-    public async Task Suppresses_After_IsNotNull_With_Or_Chain()
+    public async Task Does_Not_Suppress_After_IsNotNull_With_Or_Chain()
     {
         const string code = """
             #nullable enable
@@ -749,7 +896,7 @@ public class IsNotNullAssertionSuppressorTests
                     // IsNotNull with Or chain
                     await Assert.That(nullableString).IsNotNull().Or.IsEqualTo("fallback");
 
-                    // After the assertion, should be suppressed
+                    // IsNotNull is optional in an Or chain, so retain the warning.
                     var length = {|#0:nullableString|}.Length;
                 }
 
@@ -761,7 +908,7 @@ public class IsNotNullAssertionSuppressorTests
             .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
             .IgnoringDiagnostics("CS1591")
             .WithSpecificDiagnostics(CS8602)
-            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(true))
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
             .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
             .RunAsync();
     }

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -20,6 +20,131 @@ public class IsNotNullAssertionSuppressorTests
     private static readonly DiagnosticResult CS8629 = new("CS8629", DiagnosticSeverity.Warning);
 
     [Test]
+    [Arguments("Assert.That(value).IsNotNull()")]
+    [Arguments("value.Should().NotBeNull()")]
+    public async Task Does_Not_Suppress_For_Source_Defined_TUnit_Lookalikes(string assertion)
+    {
+        var code = $$"""
+            #nullable enable
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Extensions;
+            using TUnit.Assertions.Should;
+            using TUnit.Assertions.Should.Extensions;
+
+            namespace TUnit.Assertions
+            {
+                public class FakeSource { }
+                public static class Assert
+                {
+                    public static FakeSource That<T>(T? value) => new FakeSource();
+                }
+            }
+
+            namespace TUnit.Assertions.Extensions
+            {
+                public static class AssertionExtensions
+                {
+                    public static Task IsNotNull(this FakeSource source) => Task.CompletedTask;
+                }
+            }
+
+            namespace TUnit.Assertions.Should
+            {
+                public static class ShouldExtensions
+                {
+                    public static FakeSource Should(this string? value) => new FakeSource();
+                }
+            }
+
+            namespace TUnit.Assertions.Should.Extensions
+            {
+                public static class ShouldAssertionExtensions
+                {
+                    public static Task NotBeNull(this FakeSource source) => Task.CompletedTask;
+                }
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod(string? value)
+                {
+                    await {{assertion}};
+                    _ = {|#0:value|}.Length;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591", "CS0436")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(CS8602.WithLocation(0).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    [Arguments("IAsyncEnumerable<int>", true)]
+    [Arguments("Task", true)]
+    [Arguments("Func<Task>", true)]
+    [Arguments("IAsyncEnumerable<int>", false)]
+    [Arguments("Task", false)]
+    [Arguments("Func<Task>", false)]
+    public async Task Recognizes_Async_IsNotNull_Instance_Methods(string valueType, bool assertNotNull)
+    {
+        var nullAssertion = assertNotNull ? "IsNotNull" : "IsNull";
+        var code = $$"""
+            #nullable enable
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod({{valueType}}? value)
+                {
+                    await Assert.That({|#0:value|}).{{nullAssertion}}();
+                    _ = value.GetHashCode();
+                }
+            }
+            """;
+
+        // The async overloads take non-nullable parameters: CS8604 occurs at That,
+        // then the compiler promotes value's null state, so there is no later CS8602.
+        // Use the runtime libraries: the netstandard2.0 Assert lacks the async-enumerable
+        // overload. Matching framework references avoid the standard helper's CS1705 issue.
+        var test = new AnalyzerTestHelpers.CSharpSuppressorTest<IsNotNullAssertionSuppressor, DefaultVerifier>
+        {
+            TestCode = code,
+#if NET10_0_OR_GREATER
+            ReferenceAssemblies = new ReferenceAssemblies("net10.0",
+                new PackageIdentity("Microsoft.NETCore.App.Ref", "10.0.0"), Path.Combine("ref", "net10.0")),
+#elif NET9_0_OR_GREATER
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+#else
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+#endif
+        };
+        test.TestState.AdditionalReferences.AddRange([
+            MetadataReference.CreateFromFile(typeof(TUnitAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location),
+#if NET8_0
+            MetadataReference.CreateFromFile(TUnit.Tests.Shared.AnalyzerTestCompatibility.GetSystemTextJson9DllPath()),
+#endif
+        ]);
+
+        await test
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8604)
+            .WithExpectedDiagnosticsResults(CS8604.WithLocation(0).WithIsSuppressed(assertNotNull))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
     [Arguments("int[]")]
     [Arguments("IList<int>")]
     [Arguments("IReadOnlyList<int>")]

--- a/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
+++ b/tests/TUnit.Assertions.Analyzers.Tests/IsNotNullAssertionSuppressorTests.cs
@@ -14,9 +14,158 @@ namespace TUnit.Assertions.Analyzers.Tests;
 /// </summary>
 public class IsNotNullAssertionSuppressorTests
 {
+    private static readonly DiagnosticResult CS8600 = new("CS8600", DiagnosticSeverity.Warning);
     private static readonly DiagnosticResult CS8602 = new("CS8602", DiagnosticSeverity.Warning);
     private static readonly DiagnosticResult CS8604 = new("CS8604", DiagnosticSeverity.Warning);
     private static readonly DiagnosticResult CS8629 = new("CS8629", DiagnosticSeverity.Warning);
+
+    [Test]
+    [Arguments("int[]")]
+    [Arguments("IList<int>")]
+    [Arguments("IReadOnlyList<int>")]
+    [Arguments("IEnumerable<int>")]
+    [Arguments("ICollection<int>")]
+    [Arguments("IReadOnlyCollection<int>")]
+    [Arguments("IDictionary<string, int>")]
+    [Arguments("IReadOnlyDictionary<string, int>")]
+    [Arguments("ISet<int>")]
+    public async Task Suppresses_After_Collection_IsNotNull_Instance_Method(string collectionType)
+    {
+        var code = $$"""
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Extensions;
+
+            public class MyTests
+            {
+                public async Task TestMethod({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsNotNull();
+                    Consume({|#0:values|});
+                }
+
+                public async Task DereferenceTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsNotNull();
+                    _ = {|#1:values|}.GetHashCode();
+                }
+
+                public {{collectionType}}? Values { get; set; }
+
+                public async Task PropertyTest(MyTests model)
+                {
+                    await Assert.That(model.Values).IsNotNull();
+                    Consume(model.Values!);
+                    Consume({|#2:model.Values|});
+                }
+
+                public async Task ForeachTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsNotNull();
+                    Consume(values!);
+                    foreach (var item in {|#3:values|}) { }
+                }
+
+                public async Task ChainStartTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsNotNull().And.IsEmpty();
+                    Consume({|#4:values|});
+                }
+
+                public async Task ChainEndTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsEmpty().And.IsNotNull();
+                    Consume({|#5:values|});
+                }
+
+                public async Task AssignmentTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsNotNull();
+                    {{collectionType}} nonNullable = {|#6:values|};
+                }
+
+                public async Task WithoutNullAssertionTest({{collectionType}}? values)
+                {
+                    await Assert.That(values).IsEmpty();
+                    Consume({|#7:values|});
+                }
+
+                private static void Consume({{collectionType}} values) { }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8600, CS8602, CS8604)
+            .WithExpectedDiagnosticsResults(
+                CS8604.WithLocation(0).WithIsSuppressed(true),
+                CS8602.WithLocation(1).WithIsSuppressed(true),
+                CS8604.WithLocation(2).WithIsSuppressed(true),
+                CS8602.WithLocation(3).WithIsSuppressed(true),
+                CS8604.WithLocation(4).WithIsSuppressed(true),
+                CS8604.WithLocation(5).WithIsSuppressed(true),
+                CS8600.WithLocation(6).WithIsSuppressed(true),
+                CS8604.WithLocation(7).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
+
+    [Test]
+    public async Task Does_Not_Suppress_After_Custom_IsNotNull_Instance_Method()
+    {
+        const string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using TUnit.Assertions;
+            using TUnit.Assertions.Sources;
+
+            public static class CustomAssertions
+            {
+                public static CustomAssertion Custom(this ListAssertion<int> source) => new CustomAssertion();
+                public static CustomDerivedAssertion CustomDerived(this ListAssertion<int> source) => new CustomDerivedAssertion();
+            }
+
+            public class CustomAssertion
+            {
+                public Task IsNotNull() => Task.CompletedTask;
+            }
+
+            public class CustomDerivedAssertion : ListAssertion<int>
+            {
+                public CustomDerivedAssertion() : base(null, null) { }
+                public new Task IsNotNull() => Task.CompletedTask;
+            }
+
+            public class MyTests
+            {
+                public async Task TestMethod(IList<int>? values)
+                {
+                    await Assert.That(values).Custom().IsNotNull();
+                    _ = {|#0:values|}.Count;
+                }
+
+                public async Task HiddenMethodTest(IList<int>? values)
+                {
+                    await Assert.That(values).CustomDerived().IsNotNull();
+                    _ = {|#1:values|}.Count;
+                }
+            }
+            """;
+
+        await AnalyzerTestHelpers
+            .CreateSuppressorTest<IsNotNullAssertionSuppressor>(code)
+            .IgnoringDiagnostics("CS1591")
+            .WithSpecificDiagnostics(CS8602)
+            .WithExpectedDiagnosticsResults(
+                CS8602.WithLocation(0).WithIsSuppressed(false),
+                CS8602.WithLocation(1).WithIsSuppressed(false))
+            .WithCompilerDiagnostics(CompilerDiagnostics.Warnings)
+            .RunAsync();
+    }
 
     [Test]
     public async Task Suppresses_CS8602_After_IsNotNull_Assertion()


### PR DESCRIPTION
## Description

TUnit 1.66.8 reintroduced nullable warnings for collection and async `Assert.That(value).IsNotNull()` assertions, breaking builds that treat warnings as errors. The validation added in #6700 accepted only `AssertionExtensions.IsNotNull`, while these assertions resolve to instance methods.

Recognize built-in null checks using the shared collection and async source type symbols and the declaring assembly. This covers specialized collection bases without enumerating their names, while rejecting custom methods that hide inherited members. Require referenced TUnit assertion assemblies so source-defined lookalike types cannot suppress diagnostics.

Validate intermediate assertion members so an external transform returning a TUnit assertion on another value cannot suppress warnings on the original value. Retain warnings for chains containing `.Or` before or after the null check, since the null check is optional. Both safeguards apply to `Assert.That(...).IsNotNull()` and `Should().NotBeNull()`.

## Related Issue

Regression introduced by #6700; reproduced in https://github.com/thomhurst/Dekaf/pull/3009.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Read contributing guidelines and followed project code style.
- [x] Added collection regression tests before the fix, in a separate commit.
- [x] Covered arrays, lists, read-only lists, enumerable/collection interfaces, mutable/read-only dictionaries, and sets.
- [x] Covered actual IAsyncEnumerable, Task, and Func<Task> overloads, with positive and negative controls.
- [x] Covered CS8600, CS8602, CS8604, properties, foreach, intervening null-forgiving uses, and conjunctions.
- [x] Covered custom/hidden methods, external transforms, disjunctions, and source-defined TUnit lookalikes on both assertion APIs.
- [x] Verified unrelated properties named `Or` and assertion arguments do not disable valid suppression.

## Testing

- Reproduced failures before corresponding fixes: **9 collection cases, 7 chain-safety cases, 3 async cases, and 2 source-lookalike cases**.
- Final full `TUnit.Assertions.Analyzers.Tests` suite: **324 passed, 0 failed** (108 each on net8.0, net9.0, net10.0).
- `dotnet test --project tests/TUnit.Assertions.Analyzers.Tests --output Normal`
- `git diff --check` passed.

Async tests use the actual framework-specific TUnit libraries with matching framework references: the netstandard2.0 build lacks the async-enumerable entry point. These overloads emit CS8604 at `Assert.That(value)` and then promote the compiler's null state, so the tests verify that real entry-point diagnostic rather than expecting a later CS8602.

## Additional Notes

Analyzer-only change; no public API, source-generator output, engine metadata, or reflection changes. Full repository suite and downstream Dekaf build were not run locally. An existing RS2007 analyzer release-header warning remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nullability warning suppression after supported `IsNotNull()` and `NotBeNull()` assertions, including collection-derived and asynchronous assertion types.
  * Prevented warnings from being incorrectly suppressed when assertion chains include `Or`, custom transformations, external assertion types, or custom and shadowed methods with similar names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->