### PR TITLE
fix: isolated name is lowercase (#6727)

### DIFF
--- a/docs/docs/examples/aspnet.md
+++ b/docs/docs/examples/aspnet.md
@@ -115,8 +115,8 @@ When tests share resources like database tables, message queues, or cache keys, 
 protected override async Task SetupAsync()
 {
     // Each test gets unique resources that no other test will touch
-    var tableName = GetIsolatedName("todos");      // "Test_42_todos"
-    var queueName = GetIsolatedName("events");     // "Test_42_events"
+    var tableName = GetIsolatedName("todos");      // "test_42_todos"
+    var queueName = GetIsolatedName("events");     // "test_42_events"
     var cachePrefix = GetIsolatedPrefix();         // "test_42_"
 
     await CreateTableAsync(tableName);
@@ -279,8 +279,8 @@ Creates a unique name for resources like database tables:
 
 ```csharp
 // In a test with UniqueId = 42:
-var tableName = GetIsolatedName("todos");  // Returns "Test_42_todos"
-var topicName = GetIsolatedName("orders"); // Returns "Test_42_orders"
+var tableName = GetIsolatedName("todos");  // Returns "test_42_todos"
+var topicName = GetIsolatedName("orders"); // Returns "test_42_orders"
 ```
 
 ### GetIsolatedPrefix
@@ -641,7 +641,7 @@ public class IsolatedTableTests : TestsBase
     // ✅ GOOD: Each test gets its own table
     protected override async Task SetupAsync()
     {
-        TableName = GetIsolatedName("todos");  // "Test_42_todos"
+        TableName = GetIsolatedName("todos");  // "test_42_todos"
         await CreateTableAsync(TableName);
     }
 
@@ -911,7 +911,7 @@ public class OverrideConfigurationTests
 var sharedTableName = "todos";
 
 // GOOD: Each test gets its own table
-var isolatedTableName = GetIsolatedName("todos");  // "Test_42_todos", "Test_43_todos", etc.
+var isolatedTableName = GetIsolatedName("todos");  // "test_42_todos", "test_43_todos", etc.
 TestContext.Current!.Output.WriteLine($"{sharedTableName} -> {isolatedTableName}");
 ```
 
@@ -1142,7 +1142,7 @@ public class WebApplicationFactory : TestWebApplicationFactory<Program>
 
 | Method | Description |
 |--------|-------------|
-| `GetIsolatedName(string baseName)` | Returns `"Test_{UniqueId}_{baseName}"` |
+| `GetIsolatedName(string baseName)` | Returns `"test_{UniqueId}_{baseName}"` |
 | `GetIsolatedPrefix(string separator = "_")` | Returns `"test{separator}{UniqueId}{separator}"` |
 
 ### WebApplicationTestOptions

--- a/docs/docs/writing-tests/test-context.md
+++ b/docs/docs/writing-tests/test-context.md
@@ -68,8 +68,8 @@ The `TestContext` provides built-in helpers for creating isolated resource names
 var id = TestContext.Current!.Isolation.UniqueId;  // e.g. 42
 
 // Create isolated resource names
-var tableName = TestContext.Current!.Isolation.GetIsolatedName("todos");  // "Test_42_todos"
-var topicName = TestContext.Current!.Isolation.GetIsolatedName("orders"); // "Test_42_orders"
+var tableName = TestContext.Current!.Isolation.GetIsolatedName("todos");  // "test_42_todos"
+var topicName = TestContext.Current!.Isolation.GetIsolatedName("orders"); // "test_42_orders"
 
 // Create isolated key prefixes
 var prefix = TestContext.Current!.Isolation.GetIsolatedPrefix();       // "test_42_"

--- a/src/TUnit.AspNetCore.Core/WebApplicationTest.cs
+++ b/src/TUnit.AspNetCore.Core/WebApplicationTest.cs
@@ -34,12 +34,12 @@ public abstract class WebApplicationTest
     /// Use for database tables, Redis keys, Kafka topics, etc.
     /// </summary>
     /// <param name="baseName">The base name for the resource.</param>
-    /// <returns>A unique name in the format "Test_{UniqueId}_{baseName}".</returns>
+    /// <returns>A unique name in the format "test_{UniqueId}_{baseName}".</returns>
     /// <example>
     /// <code>
     /// // In a test with UniqueId = 42:
-    /// var tableName = GetIsolatedName("todos");  // Returns "Test_42_todos"
-    /// var topicName = GetIsolatedName("orders"); // Returns "Test_42_orders"
+    /// var tableName = GetIsolatedName("todos");  // Returns "test_42_todos"
+    /// var topicName = GetIsolatedName("orders"); // Returns "test_42_orders"
     /// </code>
     /// </example>
     protected string GetIsolatedName(string baseName) => TestContext.Current!.Isolation.GetIsolatedName(baseName);

--- a/src/TUnit.Core/Interfaces/ITestIsolation.cs
+++ b/src/TUnit.Core/Interfaces/ITestIsolation.cs
@@ -19,12 +19,12 @@ public interface ITestIsolation
     /// Use for database tables, Redis keys, Kafka topics, etc.
     /// </summary>
     /// <param name="baseName">The base name for the resource.</param>
-    /// <returns>A unique name in the format "Test_{UniqueId}_{baseName}".</returns>
+    /// <returns>A unique name in the format "test_{UniqueId}_{baseName}".</returns>
     /// <example>
     /// <code>
     /// // In a test with UniqueId = 42:
-    /// var tableName = TestContext.Current!.Isolation.GetIsolatedName("todos");  // Returns "Test_42_todos"
-    /// var topicName = TestContext.Current!.Isolation.GetIsolatedName("orders"); // Returns "Test_42_orders"
+    /// var tableName = TestContext.Current!.Isolation.GetIsolatedName("todos");  // Returns "test_42_todos"
+    /// var topicName = TestContext.Current!.Isolation.GetIsolatedName("orders"); // Returns "test_42_orders"
     /// </code>
     /// </example>
     string GetIsolatedName(string baseName);

--- a/src/TUnit.Core/TestContext.Isolation.cs
+++ b/src/TUnit.Core/TestContext.Isolation.cs
@@ -12,7 +12,7 @@ public partial class TestContext
     int ITestIsolation.UniqueId => IsolationUniqueId;
 
     /// <inheritdoc/>
-    string ITestIsolation.GetIsolatedName(string baseName) => $"Test_{IsolationUniqueId}_{baseName}";
+    string ITestIsolation.GetIsolatedName(string baseName) => $"test_{IsolationUniqueId}_{baseName}";
 
     /// <inheritdoc/>
     string ITestIsolation.GetIsolatedPrefix(string separator) => $"test{separator}{IsolationUniqueId}{separator}";

--- a/tests/TUnit.UnitTests/TestIsolationTests.cs
+++ b/tests/TUnit.UnitTests/TestIsolationTests.cs
@@ -40,7 +40,7 @@ public class TestIsolationTests
 
         var name = isolation.GetIsolatedName("foo");
 
-        await Assert.That(name).IsEqualTo($"Test_{id}_foo");
+        await Assert.That(name).IsEqualTo($"test_{id}_foo");
     }
 
     [Test]

--- a/tools/tunit-nuget-tester/TUnit.AspNetCore.NugetTester/TUnit.AspNetCore.NugetTester/HooksAndLifecycleTests.cs
+++ b/tools/tunit-nuget-tester/TUnit.AspNetCore.NugetTester/TUnit.AspNetCore.NugetTester/HooksAndLifecycleTests.cs
@@ -84,7 +84,7 @@ public class HooksAndLifecycleTests : TestsBase
         // Verifies that GetIsolatedName produces a unique isolation name
         await Assert.That(_isolatedName).IsNotNull();
         await Assert.That(_isolatedName).Contains("test-resource");
-        await Assert.That(_isolatedName).Contains("Test_");
+        await Assert.That(_isolatedName).Contains("test_");
     }
 
     [Test]


### PR DESCRIPTION
## Description

`TestContext.Current!.Isolation.GetIsolatedName()` is now lowercase

## Related Issue

fixes #6727

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)
- [ ] If this is a new feature, I started a [discussion](https://github.com/thomhurst/TUnit/discussions) first and received agreement
- [x] My code follows the project's code style (modern C# syntax, proper naming conventions)
- [x] I have written tests that prove my fix is effective or my feature works

### TUnit-Specific Requirements

<!-- These are critical for TUnit contributions - see CLAUDE.md for details -->

- [ ] **Dual-Mode Implementation**: If this change affects test discovery/execution, I have implemented it in BOTH:
  - [ ] Source Generator path (`TUnit.Core.SourceGenerator`)
  - [ ] Reflection path (`TUnit.Engine`)
- [ ] **Snapshot Tests**: If I changed source generator output or public APIs:
  - [ ] I ran `TUnit.Core.SourceGenerator.Tests` and/or `TUnit.PublicAPI` tests
  - [ ] I reviewed the `.received.txt` files and accepted them as `.verified.txt`
  - [ ] I committed the updated `.verified.txt` files
- [ ] **Performance**: If this change affects hot paths (test discovery, execution, assertions):
  - [ ] I minimized allocations and avoided LINQ in hot paths
  - [ ] I cached reflection results where appropriate
- [ ] **AOT Compatibility**: If this change uses reflection:
  - [ ] I added appropriate `[DynamicallyAccessedMembers]` annotations
  - [ ] I verified the change works with `dotnet publish -p:PublishAot=true`

### Testing

- [x] All existing tests pass (`dotnet test`)
- [ ] I have added tests that cover my changes
- [ ] I have tested both source-generated and reflection modes (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Isolated test resource names now use the lowercase `test_{UniqueId}_{baseName}` format, such as `test_42_todos`, instead of an uppercase prefix.
  * Updated API documentation, examples, FAQs, and test references to reflect the corrected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->