### PR TITLE
fix: preserve concurrent Assert.Multiple failures

### DIFF
--- a/src/TUnit.Assertions/AssertionScope.cs
+++ b/src/TUnit.Assertions/AssertionScope.cs
@@ -14,6 +14,7 @@ internal class AssertionScope : IDisposable
     private static readonly AsyncLocal<AssertionScope?> CurrentScope = new();
     private readonly AssertionScope? _parent;
     private readonly List<Exception> _exceptions = [];
+    private readonly Lock _exceptionsLock = new();
 
     internal AssertionScope()
     {
@@ -21,42 +22,55 @@ internal class AssertionScope : IDisposable
         SetCurrentAssertionScope(this);
     }
 
+    // Chains and pre-work must inspect only their own failures across awaits.
+    // The child merges its final failures into the shared parent when disposed.
+    internal static AssertionScope? CreateIsolatedScope()
+    {
+        return GetCurrentAssertionScope() is null ? null : new AssertionScope();
+    }
+
     public void Dispose()
     {
         SetCurrentAssertionScope(_parent);
 
+        Exception[] exceptions;
+        lock (_exceptionsLock)
+        {
+            exceptions = _exceptions.ToArray();
+        }
+
+        if (exceptions.Length == 0)
+        {
+            return;
+        }
+
         if (_parent != null)
         {
-            foreach (var exception in _exceptions)
+            lock (_parent._exceptionsLock)
             {
-                _parent._exceptions.Add(exception);
+                _parent._exceptions.AddRange(exceptions);
             }
 
             return;
         }
 
-        if (_exceptions.Count == 0)
+        if (exceptions.Length == 1)
         {
-            return;
-        }
-
-        if (_exceptions.Count == 1)
-        {
-            ExceptionDispatchInfo.Capture(_exceptions[0]).Throw();
+            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
         }
 
         // Use StringBuilder for message concatenation instead of LINQ
         var sb = new StringBuilder();
-        for (int i = 0; i < _exceptions.Count; i++)
+        for (int i = 0; i < exceptions.Length; i++)
         {
             if (i > 0)
             {
                 sb.Append(Environment.NewLine).Append(Environment.NewLine);
             }
-            sb.Append(_exceptions[i].Message);
+            sb.Append(exceptions[i].Message);
         }
         var message = sb.ToString();
-        throw new AssertionException(message, new AggregateException(_exceptions));
+        throw new AssertionException(message, new AggregateException(exceptions));
     }
 
     internal static AssertionScope? GetCurrentAssertionScope()
@@ -71,30 +85,51 @@ internal class AssertionScope : IDisposable
 
     internal void AddException(AssertionException exception)
     {
-        _exceptions.Add(exception);
+        lock (_exceptionsLock)
+        {
+            _exceptions.Add(exception);
+        }
     }
 
-    internal bool HasExceptions => _exceptions.Count > 0;
+    internal bool HasExceptions => ExceptionCount > 0;
 
-    internal int ExceptionCount => _exceptions.Count;
+    internal int ExceptionCount
+    {
+        get
+        {
+            lock (_exceptionsLock)
+            {
+                return _exceptions.Count;
+            }
+        }
+    }
 
     internal Exception GetFirstException()
     {
-        return _exceptions.Count > 0 ? _exceptions[0] : throw new InvalidOperationException("No exceptions in scope");
+        lock (_exceptionsLock)
+        {
+            return _exceptions.Count > 0 ? _exceptions[0] : throw new InvalidOperationException("No exceptions in scope");
+        }
     }
 
     internal Exception GetLastException()
     {
-        return _exceptions.Count > 0 ? _exceptions[^1] : throw new InvalidOperationException("No exceptions in scope");
+        lock (_exceptionsLock)
+        {
+            return _exceptions.Count > 0 ? _exceptions[^1] : throw new InvalidOperationException("No exceptions in scope");
+        }
     }
 
     internal void RemoveLastExceptions(int count)
     {
-        if (count > _exceptions.Count)
+        lock (_exceptionsLock)
         {
-            throw new InvalidOperationException($"Cannot remove {count} exceptions when only {_exceptions.Count} exist");
-        }
+            if (count > _exceptions.Count)
+            {
+                throw new InvalidOperationException($"Cannot remove {count} exceptions when only {_exceptions.Count} exist");
+            }
 
-        _exceptions.RemoveRange(_exceptions.Count - count, count);
+            _exceptions.RemoveRange(_exceptions.Count - count, count);
+        }
     }
 }

--- a/src/TUnit.Assertions/Chaining/AndAssertion.cs
+++ b/src/TUnit.Assertions/Chaining/AndAssertion.cs
@@ -28,7 +28,7 @@ public class AndAssertion<TValue> : Assertion<TValue>
 
     public override async Task<TValue?> AssertAsync()
     {
-        var currentScope = AssertionScope.GetCurrentAssertionScope();
+        using var currentScope = AssertionScope.CreateIsolatedScope();
 
         // Try first assertion - use ExecuteCoreAsync to avoid recursion
         if (currentScope != null)

--- a/src/TUnit.Assertions/Chaining/OrAssertion.cs
+++ b/src/TUnit.Assertions/Chaining/OrAssertion.cs
@@ -28,7 +28,7 @@ public class OrAssertion<TValue> : Assertion<TValue>
 
     public override async Task<TValue?> AssertAsync()
     {
-        var currentScope = AssertionScope.GetCurrentAssertionScope();
+        using var currentScope = AssertionScope.CreateIsolatedScope();
         Exception? firstException = null;
 
         // Try first assertion - use ExecuteCoreAsync to avoid recursion

--- a/src/TUnit.Assertions/Core/Assertion.cs
+++ b/src/TUnit.Assertions/Core/Assertion.cs
@@ -165,13 +165,12 @@ public abstract class Assertion<TValue> : IAssertion
         }
 
         Context.PendingPreWork = null; // Clear before execution to prevent re-entry.
-        var currentScope = AssertionScope.GetCurrentAssertionScope();
-        var exceptionCountBefore = currentScope?.ExceptionCount ?? 0;
+        using var currentScope = AssertionScope.CreateIsolatedScope();
         await preWork();
 
         return !Context.SkipAssertionOnPreWorkFailure
                || currentScope is null
-               || currentScope.ExceptionCount <= exceptionCountBefore;
+               || !currentScope.HasExceptions;
     }
 
     // Create EvaluationMetadata in a separate scope to avoid creating additional

--- a/tests/TUnit.Assertions.Tests/ConcurrentAssertMultipleTests.cs
+++ b/tests/TUnit.Assertions.Tests/ConcurrentAssertMultipleTests.cs
@@ -1,0 +1,139 @@
+namespace TUnit.Assertions.Tests;
+
+public class ConcurrentAssertMultipleTests
+{
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ConcurrentFailuresAreAllRetained(bool nestedScopes)
+    {
+        const int workers = 8;
+        const int failuresPerWorker = 2_000;
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var exception = await Assert.That(async () =>
+        {
+            using (Assert.Multiple())
+            {
+                var tasks = Enumerable.Range(0, workers).Select(worker => Task.Run(async () =>
+                {
+                    await start.Task;
+                    using var nested = nestedScopes ? Assert.Multiple() : null;
+                    for (var i = 0; i < failuresPerWorker; i++)
+                    {
+                        Assert.Fail($"Worker {worker}, failure {i}");
+                    }
+                })).ToArray();
+
+                start.SetResult();
+                await Task.WhenAll(tasks);
+            }
+        }).Throws<AssertionException>();
+
+        var failures = ((AggregateException)exception!.InnerException!).InnerExceptions;
+        await Assert.That(failures.Count).IsEqualTo(workers * failuresPerWorker);
+        await Assert.That(failures.Select(failure => failure.Message).Distinct().Count())
+            .IsEqualTo(workers * failuresPerWorker);
+    }
+
+    [Test]
+    public async Task PassingOrChainDoesNotConsumeConcurrentFailure()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var exception = await Assert.That(async () =>
+        {
+            using (Assert.Multiple())
+            {
+                async Task RunChainAsync()
+                {
+                    await Assert.That(async () =>
+                    {
+                        started.SetResult();
+                        await release.Task;
+                        return 1;
+                    }).IsEqualTo(1).Or.IsEqualTo(2);
+                }
+
+                var chain = RunChainAsync();
+
+                await started.Task;
+                Assert.Fail("Independent failure");
+                release.SetResult();
+                await chain;
+            }
+        }).Throws<AssertionException>();
+
+        await Assert.That(exception!.Message).IsEqualTo("Independent failure");
+    }
+
+    [Test]
+    public async Task AndChainStillChecksSecondAssertionAfterConcurrentFailure()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var exception = await Assert.That(async () =>
+        {
+            using (Assert.Multiple())
+            {
+                async Task RunChainAsync()
+                {
+                    await Assert.That(async () =>
+                    {
+                        started.SetResult();
+                        await release.Task;
+                        return 1;
+                    }).IsEqualTo(1).And.IsEqualTo(2);
+                }
+
+                var chain = RunChainAsync();
+
+                await started.Task;
+                Assert.Fail("Independent failure");
+                release.SetResult();
+                await chain;
+            }
+        }).Throws<AssertionException>();
+
+        var failures = ((AggregateException)exception!.InnerException!).InnerExceptions;
+        await Assert.That(failures.Count).IsEqualTo(2);
+        await Assert.That(failures[0].Message).IsEqualTo("Independent failure");
+        await Assert.That(failures[1].Message).Contains("and to be 2");
+    }
+
+    [Test]
+    public async Task SuccessfulPreWorkDoesNotSkipItemAssertionAfterConcurrentFailure()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var exception = await Assert.That(async () =>
+        {
+            using (Assert.Multiple())
+            {
+                async Task RunChainAsync()
+                {
+                    await Assert.That(async () =>
+                    {
+                        started.SetResult();
+                        await release.Task;
+                        return (IEnumerable<int>)[1];
+                    }).HasSingleItem().Item.IsEqualTo(2);
+                }
+
+                var chain = RunChainAsync();
+                await started.Task;
+                Assert.Fail("Independent failure");
+                release.SetResult();
+                await chain;
+            }
+        }).Throws<AssertionException>();
+
+        var failures = ((AggregateException)exception!.InnerException!).InnerExceptions;
+        await Assert.That(failures.Count).IsEqualTo(2);
+        await Assert.That(failures[0].Message).IsEqualTo("Independent failure");
+        await Assert.That(failures[1].Message).Contains("Expected to be 2");
+    }
+}


### PR DESCRIPTION
## Description

Concurrent assertions inside `Assert.Multiple()` inherit the same scope. Unsynchronized writes can lose failures, and `.And`/`.Or` can mistake another assertion's failure for their own. For example, a passing `.Or` chain interrupted by an independent failure can replace that failure with an incorrect chain failure.

Synchronize scope collection access and merge nested scopes atomically. Give chains and pending pre-work isolated child scopes so their failure counts and removals apply only to their own execution. Successful child scopes skip the parent merge.

Add regressions for concurrent failure collection, nested scopes, interleaved `.And`/`.Or` chains, and item assertions after successful pre-work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Read the contributing guidelines.
- [x] Follow the existing code style.
- [x] Add regression tests proving the fix.
- [x] Keep changes internal; no public API or generator output changes.
- [x] Avoid child-scope allocation outside `Assert.Multiple()`.

## Testing

- Before the fix: three of the four initial regression cases failed on .NET 10.
- `dotnet test --project tests/TUnit.Assertions.Tests/TUnit.Assertions.Tests.csproj -c Release` — 6,619 passed across .NET 8, 9, and 10, including all five final regression cases on each target.
- `dotnet build src/TUnit.Assertions/TUnit.Assertions.csproj -c Release -f netstandard2.0` — passed without warnings or errors.

Validation ran on Windows. Discovery metadata and reflection behavior are unchanged; no snapshot updates are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent and nested multiple assertions by retaining all failures.
  * Fixed chained `And` and `Or` assertions so independent failures do not interfere with subsequent checks.
  * Ensured successful pre-work does not incorrectly skip assertion evaluations.
* **Tests**
  * Added coverage for concurrent failures, nested assertion scopes, and chained assertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->