### PR TITLE
fix: preserve original HTTP mock request content

### DIFF
--- a/src/TUnit.Mocks.Http/MockHttpHandler.cs
+++ b/src/TUnit.Mocks.Http/MockHttpHandler.cs
@@ -165,7 +165,8 @@ public sealed class MockHttpHandler : HttpMessageHandler
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var originalContentType = request.Content?.Headers.ContentType;
+        // ReadAsStringAsync buffers the original content, so response factories can
+        // reread it without replacing its bytes, headers, or stream ownership.
         var bodyContent = request.Content != null
             ? await request.Content.ReadAsStringAsync(
 #if NET8_0_OR_GREATER
@@ -195,12 +196,6 @@ public sealed class MockHttpHandler : HttpMessageHandler
                     captured.Matched = true;
                     if (response.Delay.HasValue)
                         await Task.Delay(response.Delay.Value, cancellationToken).ConfigureAwait(false);
-                    // Restore content so factory delegates can re-read the body
-                    if (bodyContent != null)
-                    {
-                        request.Content = new StringContent(bodyContent, System.Text.Encoding.UTF8,
-                            originalContentType?.MediaType ?? "application/octet-stream");
-                    }
                     return response.Build(request);
                 }
             }

--- a/tests/TUnit.Mocks.Http.Tests/RequestContentPreservationTests.cs
+++ b/tests/TUnit.Mocks.Http.Tests/RequestContentPreservationTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace TUnit.Mocks.Http.Tests;
+
+public class RequestContentPreservationTests
+{
+    [Test]
+    [Arguments("binary")]
+    [Arguments("text")]
+    [Arguments("multipart")]
+    public async Task ResponseFactoryReceivesOriginalContent(string contentKind)
+    {
+        using var handler = new MockHttpHandler();
+        using var client = handler.CreateClient("https://example.test");
+        using var content = CreateContent(contentKind);
+        content.Headers.Add("X-Body-Tag", "original");
+        var originalBytes = await content.ReadAsByteArrayAsync();
+        var originalContentType = content.Headers.ContentType?.ToString();
+        HttpContent? factoryContent = null;
+
+        handler.OnPost("/upload").RespondWith(request =>
+        {
+            factoryContent = request.Content;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        using var response = await client.PostAsync("/upload", content);
+        var factoryBytes = await factoryContent!.ReadAsByteArrayAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(Convert.ToHexString(factoryBytes)).IsEqualTo(Convert.ToHexString(originalBytes));
+            await Assert.That(factoryContent.Headers.ContentType?.ToString()).IsEqualTo(originalContentType);
+            await Assert.That(factoryContent.Headers.Contains("X-Body-Tag")).IsTrue();
+            await Assert.That(factoryContent).IsSameReferenceAs(content);
+        }
+    }
+
+    [Test]
+    public async Task ResponseFactoryCanRereadNonSeekableContent()
+    {
+        using var handler = new MockHttpHandler();
+        using var client = handler.CreateClient("https://example.test");
+        byte[] bytes = [0x00, 0xff, 0x80, 0x01];
+        using var stream = new NonSeekableStream(bytes);
+        using var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        Task<byte[]>? factoryRead = null;
+
+        handler.OnPost("/upload").RespondWith(request =>
+        {
+            factoryRead = request.Content!.ReadAsByteArrayAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        using var response = await client.PostAsync("/upload", content);
+        var factoryBytes = await factoryRead!;
+
+        await Assert.That(Convert.ToHexString(factoryBytes)).IsEqualTo(Convert.ToHexString(bytes));
+    }
+
+    private static HttpContent CreateContent(string contentKind)
+    {
+        return contentKind switch
+        {
+            "binary" => new ByteArrayContent([0x00, 0xff, 0x80, 0x01]),
+            "text" => new StringContent("café", Encoding.Unicode, "text/plain"),
+            "multipart" => new MultipartFormDataContent("test-boundary")
+            {
+                { new ByteArrayContent([0x00, 0xff, 0x80, 0x01]), "file", "upload.bin" }
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(contentKind))
+        };
+    }
+
+    private sealed class NonSeekableStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        public override bool CanSeek => false;
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Description

Matched HTTP mock requests were replacing their original content with a UTF-8 `StringContent` before invoking the response factory. This corrupted binary payloads, changed text encodings, and discarded content headers such as multipart boundaries and custom headers.

Keep the original `HttpContent`. The existing `ReadAsStringAsync` call already buffers it for body matching, allowing factories to reread it without reconstructing the request.

Add regressions covering binary bytes, UTF-16 text, multipart content and boundaries, custom headers, content identity, and rereading a non-seekable stream.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Read the contributing guidelines.
- [x] Follow the existing code style.
- [x] Add regression tests proving the fix.
- [x] Preserve public APIs and avoid new reflection.
- [x] Remove the extra request-content allocation.

## Testing

- Before the fix: all four new regression cases failed on .NET 10.
- `dotnet test --project tests/TUnit.Mocks.Http.Tests/TUnit.Mocks.Http.Tests.csproj -c Release` — 174 passed across .NET 8, 9, and 10.

Validation ran on Windows. No generator output or public API changes require snapshot updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Request content is now preserved when handled by mock HTTP requests, including binary, text, and multipart content.
  - Original content headers, custom headers, bytes, and object identity remain intact.
  - Response factories can reread request bodies, including non-seekable content.

- **Tests**
  - Added coverage validating request-content preservation and rereading behavior across supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->