### PR TITLE
fix: preserve executor registration, limiter precedence, and timeout classification

### DIFF
--- a/docs/docs/execution/parallelism.md
+++ b/docs/docs/execution/parallelism.md
@@ -131,6 +131,8 @@ Tests not assigned to any group run separately under normal parallel execution r
 
 The limit is shared across **all** tests referencing the same `IParallelLimit` type. Tests with a different limiter type or no limiter are unaffected.
 
+An explicit `[ParallelLimiter<T>]` always takes precedence over a limiter set programmatically through `TestRegisteredContext.SetParallelLimiter`, including one supplied by an executor. This precedence does not depend on registration callback order. Without an explicit attribute, the last programmatic limiter applies.
+
 ```csharp
 using TUnit.Core;
 

--- a/docs/docs/writing-tests/event-subscribing.md
+++ b/docs/docs/writing-tests/event-subscribing.md
@@ -21,6 +21,14 @@ The interfaces they can implement are:
 
 This can be useful especially when generating data that you need to track and maybe dispose later. By hooking into these events, we can do things like track and dispose our objects when we need.
 
+## Registration callbacks for executors
+
+An executor that implements `ITestRegisteredEventReceiver` receives `OnTestRegistered` when a registration receiver installs it through `SetTestExecutor` or `SetHookExecutor`, unless it has already received the callback for that test. Its callback runs after the installing receiver returns. Dynamically installed executors are not globally sorted by their own `Order`.
+
+Each receiver instance receives this callback at most once per test, using reference identity. This also applies when the same instance is already an eligible event object, installs itself, or is installed as both the test and hook executor. Distinct instances that compare equal still receive separate callbacks.
+
+An explicit `[ParallelLimiter<T>]` takes precedence over a limiter set through `TestRegisteredContext.SetParallelLimiter`, including one set by an executor, regardless of callback order.
+
 ## Execution Stage Control
 
 > **Note**: This feature is available on .NET 8.0+ only due to default interface member requirements.

--- a/src/TUnit.Core/Attributes/ParallelLimiterAttribute.cs
+++ b/src/TUnit.Core/Attributes/ParallelLimiterAttribute.cs
@@ -57,9 +57,9 @@ public sealed class ParallelLimiterAttribute<TParallelLimit> : TUnitAttribute, I
     public int Order => 0;
 
     /// <inheritdoc />
-public ValueTask OnTestRegistered(TestRegisteredContext context)
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
     {
-        context.SetParallelLimiter(new TParallelLimit());
+        context.SetExplicitParallelLimiter(new TParallelLimit());
         return default(ValueTask);
     }
 }

--- a/src/TUnit.Core/Contexts/TestRegisteredContext.cs
+++ b/src/TUnit.Core/Contexts/TestRegisteredContext.cs
@@ -11,6 +11,7 @@ public class TestRegisteredContext
 {
     private List<ITestRegisteredEventReceiver>? _executorReceivers;
     private int _dispatchedExecutorReceiverCount;
+    private IParallelLimit? _explicitParallelLimiter;
 
     public string TestName { get; }
     public string? CustomDisplayName { get; }
@@ -55,10 +56,17 @@ public class TestRegisteredContext
     }
 
     /// <summary>
-    /// Sets the parallel limiter for the test
+    /// Sets the programmatic parallel limiter for the test. An explicit
+    /// <see cref="ParallelLimiterAttribute{TParallelLimit}"/> takes precedence regardless of callback order.
     /// </summary>
     public void SetParallelLimiter(IParallelLimit parallelLimit)
     {
+        TestContext.ParallelLimiter = _explicitParallelLimiter ?? parallelLimit;
+    }
+
+    internal void SetExplicitParallelLimiter(IParallelLimit parallelLimit)
+    {
+        _explicitParallelLimiter = parallelLimit;
         TestContext.ParallelLimiter = parallelLimit;
     }
 
@@ -78,9 +86,8 @@ public class TestRegisteredContext
     /// </summary>
     /// <param name="executor">The executor a registration receiver has just installed.</param>
     /// <remarks>
-    /// An executor is neither an attribute, an argument nor the class instance, so the engine's
-    /// eligible-object pass cannot collect it: it comes into existence part-way through the dispatch of the
-    /// receivers that pass produced. An executor that is both an <see cref="ITestExecutor"/> and an
+    /// An executor installed during registration may not have been collected by the engine's
+    /// eligible-object pass. An executor that is both an <see cref="ITestExecutor"/> and an
     /// <see cref="IHookExecutor"/> arrives through two calls and is queued once.
     /// </remarks>
     private void QueueExecutorEventReceiver(object executor)

--- a/src/TUnit.Core/Contexts/TestRegisteredContext.cs
+++ b/src/TUnit.Core/Contexts/TestRegisteredContext.cs
@@ -92,10 +92,16 @@ public class TestRegisteredContext
 
         _executorReceivers ??= [];
 
-        if (!_executorReceivers.Contains(receiver))
+        // Identity, not equality: two distinct executors that compare equal each own their callback.
+        foreach (var queued in _executorReceivers)
         {
-            _executorReceivers.Add(receiver);
+            if (ReferenceEquals(queued, receiver))
+            {
+                return;
+            }
         }
+
+        _executorReceivers.Add(receiver);
     }
 
     /// <summary>

--- a/src/TUnit.Core/Contexts/TestRegisteredContext.cs
+++ b/src/TUnit.Core/Contexts/TestRegisteredContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using TUnit.Core.Interfaces;
 
 namespace TUnit.Core;
@@ -8,6 +9,9 @@ namespace TUnit.Core;
 /// </summary>
 public class TestRegisteredContext
 {
+    private List<ITestRegisteredEventReceiver>? _executorReceivers;
+    private int _dispatchedExecutorReceiverCount;
+
     public string TestName { get; }
     public string? CustomDisplayName { get; }
     public TestContext TestContext { get; }
@@ -37,6 +41,7 @@ public class TestRegisteredContext
     public void SetTestExecutor(ITestExecutor executor)
     {
         DiscoveredTest.TestExecutor = executor;
+        QueueExecutorEventReceiver(executor);
     }
 
     /// <summary>
@@ -46,6 +51,7 @@ public class TestRegisteredContext
     public void SetHookExecutor(IHookExecutor executor)
     {
         TestContext.CustomHookExecutor = executor;
+        QueueExecutorEventReceiver(executor);
     }
 
     /// <summary>
@@ -65,5 +71,48 @@ public class TestRegisteredContext
     {
         TestContext.SkipReason = reason;
         TestContext.Metadata.TestDetails.ClassInstance = SkippedTestInstance.Instance;
+    }
+
+    /// <summary>
+    /// Queues an executor that is itself an <see cref="ITestRegisteredEventReceiver"/> for dispatch.
+    /// </summary>
+    /// <param name="executor">The executor a registration receiver has just installed.</param>
+    /// <remarks>
+    /// An executor is neither an attribute, an argument nor the class instance, so the engine's
+    /// eligible-object pass cannot collect it: it comes into existence part-way through the dispatch of the
+    /// receivers that pass produced. An executor that is both an <see cref="ITestExecutor"/> and an
+    /// <see cref="IHookExecutor"/> arrives through two calls and is queued once.
+    /// </remarks>
+    private void QueueExecutorEventReceiver(object executor)
+    {
+        if (executor is not ITestRegisteredEventReceiver receiver)
+        {
+            return;
+        }
+
+        _executorReceivers ??= [];
+
+        if (!_executorReceivers.Contains(receiver))
+        {
+            _executorReceivers.Add(receiver);
+        }
+    }
+
+    /// <summary>
+    /// Dequeues the next executor awaiting its registration callback.
+    /// </summary>
+    /// <param name="receiver">When this method returns, contains the executor to dispatch to.</param>
+    /// <returns><see langword="true"/> if an executor was awaiting dispatch; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>Each executor is returned once, however many times it was installed.</remarks>
+    internal bool TryDequeueExecutorEventReceiver([NotNullWhen(true)] out ITestRegisteredEventReceiver? receiver)
+    {
+        if (_executorReceivers is null || _dispatchedExecutorReceiverCount == _executorReceivers.Count)
+        {
+            receiver = null;
+            return false;
+        }
+
+        receiver = _executorReceivers[_dispatchedExecutorReceiverCount++];
+        return true;
     }
 }

--- a/src/TUnit.Core/Interfaces/ITestRegisteredEventReceiver.cs
+++ b/src/TUnit.Core/Interfaces/ITestRegisteredEventReceiver.cs
@@ -21,6 +21,13 @@ namespace TUnit.Core.Interfaces;
 /// The <see cref="IEventReceiver.Order"/> property can be used to control the execution order
 /// when multiple implementations of this interface exist.
 /// </para>
+/// <para>
+/// Executors installed through <see cref="TestRegisteredContext.SetTestExecutor"/> or
+/// <see cref="TestRegisteredContext.SetHookExecutor"/> during registration are invoked after
+/// their installing receiver returns, rather than being globally sorted by their own Order.
+/// Each receiver instance is invoked at most once per test, even when it is both an eligible
+/// event object and an installed executor. Distinct instances are compared by reference identity.
+/// </para>
 /// </remarks>
 public interface ITestRegisteredEventReceiver : IEventReceiver
 {

--- a/src/TUnit.Core/TestContext.Execution.cs
+++ b/src/TUnit.Core/TestContext.Execution.cs
@@ -20,9 +20,10 @@ public partial class TestContext
     private volatile bool _testCancellationRequested;
     private List<CancellationToken>? _externalCancellationTokens;
     private CancellationTokenSource? _linkedCancellationTokenSource;
+    private CancellationToken _linkedCancellationBaseToken;
     // Token copies can escape into user code and remain in use through teardown (#6339).
     // Keep replaced sources alive until the complete test lifecycle has finished.
-    private List<CancellationTokenSource>? _retiredLinkedCancellationTokenSources;
+    private List<(CancellationTokenSource Source, CancellationToken BaseToken)>? _retiredLinkedCancellationTokenSources;
     internal CancellationToken CancellationToken { get; private set; }
 
     // Linked source backing the per-test timeout token. Owned for the whole test lifecycle — the body
@@ -297,11 +298,40 @@ public partial class TestContext
 
         if (_linkedCancellationTokenSource is { } previousLinkedCancellationTokenSource)
         {
-            (_retiredLinkedCancellationTokenSources ??= []).Add(previousLinkedCancellationTokenSource);
+            (_retiredLinkedCancellationTokenSources ??= []).Add((previousLinkedCancellationTokenSource, _linkedCancellationBaseToken));
         }
 
         _linkedCancellationTokenSource = linkedCancellationTokenSource;
+        _linkedCancellationBaseToken = _baseCancellationToken;
         CancellationToken = linkedCancellationTokenSource.Token;
+    }
+
+    internal bool IsLinkedCancellationToken(CancellationToken token, CancellationToken baseToken)
+    {
+        lock (Lock)
+        {
+            if (_linkedCancellationTokenSource is { } currentSource
+                && _linkedCancellationBaseToken == baseToken
+                && currentSource.Token == token)
+            {
+                return true;
+            }
+
+            // A test can still use a captured token after another linked token or retry replaces it.
+            // Match its original base as well, so earlier attempts cannot become the current timeout.
+            if (_retiredLinkedCancellationTokenSources is { } retiredSources)
+            {
+                foreach (var retired in retiredSources)
+                {
+                    if (retired.BaseToken == baseToken && retired.Source.Token == token)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 
     internal void DisposeLinkedCancellationTokenSources()
@@ -329,7 +359,7 @@ public partial class TestContext
         {
             for (var i = retiredLinkedCancellationTokenSources.Count - 1; i >= 0; i--)
             {
-                retiredLinkedCancellationTokenSources[i].Dispose();
+                retiredLinkedCancellationTokenSources[i].Source.Dispose();
             }
 
             _retiredLinkedCancellationTokenSources = null;

--- a/src/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/src/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -1,3 +1,4 @@
+using TUnit.Core;
 using TUnit.Engine.Constants;
 
 namespace TUnit.Engine.Helpers;
@@ -55,6 +56,7 @@ internal static class TimeoutHelper
     /// <param name="timeoutCts">Caller-owned CTS, already linked to <paramref name="externalToken"/>. Not disposed here.</param>
     /// <param name="externalToken">The external token the CTS is linked to; used to distinguish timeout from external cancellation.</param>
     /// <param name="timeoutMessage">Optional custom timeout message. If null, uses default message.</param>
+    /// <param name="testContext">Tracks execution tokens linked to the timeout token, including captured tokens replaced during execution.</param>
     /// <exception cref="TimeoutException">Thrown when the timeout elapses before task completion.</exception>
     /// <exception cref="OperationCanceledException">Thrown when cancellation is requested.</exception>
     public static async Task ExecuteWithTimeoutAsync(
@@ -62,7 +64,8 @@ internal static class TimeoutHelper
         TimeSpan timeout,
         CancellationTokenSource timeoutCts,
         CancellationToken externalToken,
-        string? timeoutMessage = null)
+        string? timeoutMessage = null,
+        TestContext? testContext = null)
     {
         // Set up cancellation detection BEFORE scheduling timeout to avoid race condition
         // where timeout fires before registration completes (with very small timeouts)
@@ -87,7 +90,7 @@ internal static class TimeoutHelper
             }
             catch (OperationCanceledException exception)
                 when (timeoutCts.IsCancellationRequested
-                    && exception.CancellationToken == timeoutCts.Token)
+                    && IsTimeoutCancellationToken(exception.CancellationToken, timeoutCts.Token, testContext))
             {
                 // The operation can observe cancellation before the detection task wins WhenAny.
                 // Classify that cancellation through the same timeout/external-cancellation path.
@@ -105,7 +108,7 @@ internal static class TimeoutHelper
 
         // Routine cancellation adds no useful context; preserve exceptions explicitly
         // thrown while handling cancellation, such as Aspire's diagnostic exception.
-        var exceptionToPreserve = IsRoutineCancellation(executionException, timeoutCts.Token)
+        var exceptionToPreserve = IsRoutineCancellation(executionException, timeoutCts.Token, testContext)
             ? null
             : executionException;
 
@@ -115,13 +118,16 @@ internal static class TimeoutHelper
         throw new TimeoutException(diagnosticMessage, exceptionToPreserve);
     }
 
-    private static bool IsRoutineCancellation(Exception? exception, CancellationToken timeoutToken)
+    private static bool IsTimeoutCancellationToken(CancellationToken token, CancellationToken timeoutToken, TestContext? testContext)
+        => token == timeoutToken || testContext?.IsLinkedCancellationToken(token, timeoutToken) == true;
+
+    private static bool IsRoutineCancellation(Exception? exception, CancellationToken timeoutToken, TestContext? testContext)
     {
         if (exception is not OperationCanceledException
             {
                 InnerException: null
             } operationCanceledException
-            || operationCanceledException.CancellationToken != timeoutToken)
+            || !IsTimeoutCancellationToken(operationCanceledException.CancellationToken, timeoutToken, testContext))
         {
             return false;
         }

--- a/src/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/src/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -85,7 +85,9 @@ internal static class TimeoutHelper
                 await executionTask.ConfigureAwait(false);
                 return;
             }
-            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            catch (OperationCanceledException exception)
+                when (timeoutCts.IsCancellationRequested
+                    && exception.CancellationToken == timeoutCts.Token)
             {
                 // The operation can observe cancellation before the detection task wins WhenAny.
                 // Classify that cancellation through the same timeout/external-cancellation path.

--- a/src/TUnit.Engine/Helpers/TimeoutHelper.cs
+++ b/src/TUnit.Engine/Helpers/TimeoutHelper.cs
@@ -78,30 +78,39 @@ internal static class TimeoutHelper
 
         var winner = await Task.WhenAny(executionTask, cancelledTcs.Task).ConfigureAwait(false);
 
-        if (winner == cancelledTcs.Task)
+        if (winner == executionTask)
         {
-            // Determine if it was external cancellation or timeout
-            if (externalToken.IsCancellationRequested)
+            try
             {
-                throw new OperationCanceledException(externalToken);
+                await executionTask.ConfigureAwait(false);
+                return;
             }
-
-            // Timeout occurred - give the execution task a brief grace period to clean up
-            var executionException = await ObserveExceptionDuringGracePeriodAsync(executionTask).ConfigureAwait(false);
-
-            // Routine cancellation adds no useful context; preserve exceptions explicitly
-            // thrown while handling cancellation, such as Aspire's diagnostic exception.
-            var exceptionToPreserve = IsRoutineCancellation(executionException, timeoutCts.Token)
-                ? null
-                : executionException;
-
-            // Even if task completed during grace period, timeout already elapsed so we throw
-            var baseMessage = timeoutMessage ?? $"Operation timed out after {timeout}";
-            var diagnosticMessage = TimeoutDiagnostics.BuildTimeoutDiagnosticsMessage(baseMessage, executionTask, exceptionToPreserve);
-            throw new TimeoutException(diagnosticMessage, exceptionToPreserve);
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                // The operation can observe cancellation before the detection task wins WhenAny.
+                // Classify that cancellation through the same timeout/external-cancellation path.
+            }
         }
 
-        await executionTask.ConfigureAwait(false);
+        // Determine if it was external cancellation or timeout
+        if (externalToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(externalToken);
+        }
+
+        // Timeout occurred - give the execution task a brief grace period to clean up
+        var executionException = await ObserveExceptionDuringGracePeriodAsync(executionTask).ConfigureAwait(false);
+
+        // Routine cancellation adds no useful context; preserve exceptions explicitly
+        // thrown while handling cancellation, such as Aspire's diagnostic exception.
+        var exceptionToPreserve = IsRoutineCancellation(executionException, timeoutCts.Token)
+            ? null
+            : executionException;
+
+        // Even if task completed during grace period, timeout already elapsed so we throw
+        var baseMessage = timeoutMessage ?? $"Operation timed out after {timeout}";
+        var diagnosticMessage = TimeoutDiagnostics.BuildTimeoutDiagnosticsMessage(baseMessage, executionTask, exceptionToPreserve);
+        throw new TimeoutException(diagnosticMessage, exceptionToPreserve);
     }
 
     private static bool IsRoutineCancellation(Exception? exception, CancellationToken timeoutToken)

--- a/src/TUnit.Engine/Services/TestFilterService.cs
+++ b/src/TUnit.Engine/Services/TestFilterService.cs
@@ -61,6 +61,19 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         return filteredTests;
     }
 
+    private async Task InvokeTestRegisteredReceiver(ITestRegisteredEventReceiver receiver, TestRegisteredContext context)
+    {
+        try
+        {
+            await receiver.OnTestRegistered(context).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}").ConfigureAwait(false);
+            throw;
+        }
+    }
+
     private async Task RegisterTest(AbstractExecutableTest test, bool isForExecution)
     {
         var registeredReceivers = test.Context.GetTestRegisteredReceivers();
@@ -86,14 +99,16 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
 
             foreach (var receiver in registeredReceivers)
             {
-                try
+                await InvokeTestRegisteredReceiver(receiver, registeredContext).ConfigureAwait(false);
+
+                // The receiver above may have installed an executor that is an ITestRegisteredEventReceiver
+                // in its own right, as DedicatedThreadExecutor is. GetTestRegisteredReceivers cannot have
+                // collected it, because it did not exist when that list was built. Dispatching it here
+                // rather than after the loop keeps its contribution at the position of the attribute that
+                // installed it, so a later attribute still overrides it.
+                while (registeredContext.TryDequeueExecutorEventReceiver(out var executorReceiver))
                 {
-                    await receiver.OnTestRegistered(registeredContext).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    await logger.LogErrorAsync($"Error in test registered event receiver: {ex.Message}").ConfigureAwait(false);
-                    throw;
+                    await InvokeTestRegisteredReceiver(executorReceiver, registeredContext).ConfigureAwait(false);
                 }
             }
         }

--- a/src/TUnit.Engine/Services/TestFilterService.cs
+++ b/src/TUnit.Engine/Services/TestFilterService.cs
@@ -61,8 +61,15 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
         return filteredTests;
     }
 
-    private async Task InvokeTestRegisteredReceiver(ITestRegisteredEventReceiver receiver, TestRegisteredContext context)
+    private async Task InvokeTestRegisteredReceiver(ITestRegisteredEventReceiver receiver, TestRegisteredContext context,
+        HashSet<ITestRegisteredEventReceiver> invokedReceivers)
     {
+        // Record identity before invoking: a receiver can install itself as an executor.
+        if (!invokedReceivers.Add(receiver))
+        {
+            return;
+        }
+
         try
         {
             await receiver.OnTestRegistered(context).ConfigureAwait(false);
@@ -96,19 +103,17 @@ internal class TestFilterService(TUnitFrameworkLogger logger, TestArgumentRegist
             };
 
             test.Context.InternalDiscoveredTest = discoveredTest;
+            var invokedReceivers = new HashSet<ITestRegisteredEventReceiver>(Core.Helpers.ReferenceEqualityComparer.Instance);
 
             foreach (var receiver in registeredReceivers)
             {
-                await InvokeTestRegisteredReceiver(receiver, registeredContext).ConfigureAwait(false);
+                await InvokeTestRegisteredReceiver(receiver, registeredContext, invokedReceivers).ConfigureAwait(false);
 
-                // The receiver above may have installed an executor that is an ITestRegisteredEventReceiver
-                // in its own right, as DedicatedThreadExecutor is. GetTestRegisteredReceivers cannot have
-                // collected it, because it did not exist when that list was built. Dispatching it here
-                // rather than after the loop keeps its contribution at the position of the attribute that
-                // installed it, so a later attribute still overrides it.
+                // Dynamically installed executor callbacks run after their installer, regardless of their
+                // own Order. The shared identity set also covers executors in the original receiver list.
                 while (registeredContext.TryDequeueExecutorEventReceiver(out var executorReceiver))
                 {
-                    await InvokeTestRegisteredReceiver(executorReceiver, registeredContext).ConfigureAwait(false);
+                    await InvokeTestRegisteredReceiver(executorReceiver, registeredContext, invokedReceivers).ConfigureAwait(false);
                 }
             }
         }

--- a/src/TUnit.Engine/TestExecutor.cs
+++ b/src/TUnit.Engine/TestExecutor.cs
@@ -367,7 +367,8 @@ internal class TestExecutor
                         testTimeout.Value,
                         testBodyTimeoutCts,
                         testCancellationToken,
-                        timeoutMessage).ConfigureAwait(false);
+                        timeoutMessage,
+                        context).ConfigureAwait(false);
                 }
                 else
                 {

--- a/tests/TUnit.Engine.Tests/TimeoutTests1.cs
+++ b/tests/TUnit.Engine.Tests/TimeoutTests1.cs
@@ -6,6 +6,27 @@ namespace TUnit.Engine.Tests;
 public class TimeoutTests1(TestMode testMode) : InvokableTestBase(testMode)
 {
     [Test]
+    public async Task LinkedTokensAreReportedAsTimeouts()
+    {
+        await RunTestsWithFilter(
+            "/*/*/LinkedTokenTimeoutTests/*",
+            [
+                result => result.ResultSummary.Counters.Total.ShouldBe(3),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(3),
+                result =>
+                {
+                    foreach (var test in result.Results)
+                    {
+                        test.Output!.ErrorInfo!.Message.ToLowerInvariant().ShouldContain("timed out");
+                    }
+
+                    result.Results.Single(test => test.TestName.Contains("CustomLinkedCancellationDiagnostic"))
+                        .Output!.ErrorInfo!.Message.ShouldContain("Linked timeout diagnostic");
+                }
+            ]);
+    }
+
+    [Test]
     public async Task Test()
     {
         await RunTestsWithFilter(

--- a/tests/TUnit.TestProject/Bugs/6767/ExecutorEventReceiverTests.cs
+++ b/tests/TUnit.TestProject/Bugs/6767/ExecutorEventReceiverTests.cs
@@ -1,0 +1,82 @@
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6767;
+
+/// <summary>
+/// Regression test for https://github.com/thomhurst/TUnit/issues/6767
+/// An executor that also implements ITestRegisteredEventReceiver must receive
+/// OnTestRegistered, so the parallel limit it declares during registration is applied.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+[TestExecutor<SerialExecutor>]
+public class ExecutorEventReceiverTests
+{
+    private static int s_concurrent;
+    private static int s_peak;
+
+    [Before(Class)]
+    public static void Reset()
+    {
+        s_concurrent = 0;
+        s_peak = 0;
+    }
+
+    [Test]
+    public async Task ExecutorSetsTheLimiter()
+    {
+        await Assert.That(TestContext.Current!.Parallelism.Limiter).IsTypeOf<SerialLimit>();
+    }
+
+    [Test, Repeat(9)]
+    public Task Measure() => MeasureAsync();
+
+    [Test, DependsOn(nameof(Measure))]
+    public async Task PeakIsOne()
+    {
+        await Assert.That(s_peak).IsEqualTo(1);
+    }
+
+    private static async Task MeasureAsync()
+    {
+        var current = Interlocked.Increment(ref s_concurrent);
+
+        int old;
+        do
+        {
+            old = s_peak;
+            if (current <= old)
+            {
+                break;
+            }
+        }
+        while (Interlocked.CompareExchange(ref s_peak, current, old) != old);
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        Interlocked.Decrement(ref s_concurrent);
+    }
+}
+
+/// <summary>
+/// An executor is installed by an attribute part-way through registration, so it can only
+/// declare its parallel limit through its own ITestRegisteredEventReceiver implementation.
+/// </summary>
+internal sealed class SerialExecutor : GenericAbstractExecutor, ITestRegisteredEventReceiver
+{
+    public int Order => 0;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        context.SetParallelLimiter(new SerialLimit());
+        return default;
+    }
+
+    protected override ValueTask ExecuteAsync(Func<ValueTask> action) => action();
+}
+
+internal sealed class SerialLimit : IParallelLimit
+{
+    public int Limit => 1;
+}

--- a/tests/TUnit.TestProject/Bugs/6767/ExecutorEventReceiverTests.cs
+++ b/tests/TUnit.TestProject/Bugs/6767/ExecutorEventReceiverTests.cs
@@ -80,3 +80,66 @@ internal sealed class SerialLimit : IParallelLimit
 {
     public int Limit => 1;
 }
+
+/// <summary>
+/// Two distinct executors that compare equal each own their registration callback, so the queue
+/// behind that dispatch has to hold them apart by reference and not by equality.
+/// </summary>
+[EngineTest(ExpectedResult.Pass)]
+[TwoEqualExecutors]
+public class EqualExecutorInstanceTests
+{
+    [Test]
+    public async Task BothInstancesAreRegistered()
+    {
+        using (Assert.Multiple())
+        {
+            await Assert.That(TwoEqualExecutorsAttribute.TestExecutor!.IsRegistered).IsTrue();
+            await Assert.That(TwoEqualExecutorsAttribute.HookExecutor!.IsRegistered).IsTrue();
+        }
+    }
+}
+
+internal sealed class TwoEqualExecutorsAttribute : Attribute, ITestRegisteredEventReceiver
+{
+    public static EqualByTypeExecutor? TestExecutor { get; private set; }
+    public static EqualByTypeExecutor? HookExecutor { get; private set; }
+
+    public int Order => 0;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        var testExecutor = new EqualByTypeExecutor();
+        var hookExecutor = new EqualByTypeExecutor();
+
+        context.SetTestExecutor(testExecutor);
+        context.SetHookExecutor(hookExecutor);
+
+        TestExecutor = testExecutor;
+        HookExecutor = hookExecutor;
+
+        return default;
+    }
+}
+
+/// <summary>
+/// Every instance compares equal to every other, so a queue keyed on equality would drop the second.
+/// </summary>
+internal sealed class EqualByTypeExecutor : GenericAbstractExecutor, ITestRegisteredEventReceiver
+{
+    public bool IsRegistered { get; private set; }
+
+    public int Order => 0;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        IsRegistered = true;
+        return default;
+    }
+
+    public override bool Equals(object? obj) => obj is EqualByTypeExecutor;
+
+    public override int GetHashCode() => nameof(EqualByTypeExecutor).GetHashCode();
+
+    protected override ValueTask ExecuteAsync(Func<ValueTask> action) => action();
+}

--- a/tests/TUnit.TestProject/Bugs/6767/RegistrationReceiverRegressionTests.cs
+++ b/tests/TUnit.TestProject/Bugs/6767/RegistrationReceiverRegressionTests.cs
@@ -1,0 +1,186 @@
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._6767;
+
+[EngineTest(ExpectedResult.Pass)]
+public class ExecutorReceiverOverlapTests
+{
+    [Test]
+    [EligibleExecutor]
+    [InstallEligibleExecutor(-100)]
+    public async Task InstalledBeforeOriginalReceiver()
+    {
+        await Assert.That(TestContext.Current!.StateBag.Items["EligibleRegistrationCount"]).IsEqualTo(1);
+        await Assert.That((bool)TestContext.Current.StateBag.Items["AlreadyRegisteredAtInstallation"]!).IsFalse();
+    }
+
+    [Test]
+    [EligibleExecutor]
+    [InstallEligibleExecutor(100)]
+    public async Task InstalledAfterOriginalReceiver()
+    {
+        await Assert.That(TestContext.Current!.StateBag.Items["EligibleRegistrationCount"]).IsEqualTo(1);
+        await Assert.That((bool)TestContext.Current.StateBag.Items["AlreadyRegisteredAtInstallation"]!).IsTrue();
+    }
+}
+
+internal sealed class EligibleExecutorAttribute : Attribute, ITestExecutor, ITestRegisteredEventReceiver
+{
+    public int Order => 0;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        context.StateBag.AddOrUpdate("EligibleRegistrationCount", 1, static (_, count) => (int)count! + 1);
+        return default;
+    }
+
+    public ValueTask ExecuteTest(TestContext context, Func<ValueTask> action) => action();
+}
+
+internal sealed class InstallEligibleExecutorAttribute(int order) : Attribute, ITestRegisteredEventReceiver
+{
+    public int Order => order;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        var executor = context.TestDetails.GetAllAttributes().OfType<EligibleExecutorAttribute>().Single();
+        context.StateBag["AlreadyRegisteredAtInstallation"] = context.StateBag.ContainsKey("EligibleRegistrationCount");
+        context.SetTestExecutor(executor);
+        return default;
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public class SelfInstallingExecutorTests
+{
+    [Test]
+    [SelfInstallingExecutor]
+    public async Task AttributeInstallsItselfOnlyOnce()
+    {
+        await Assert.That(TestContext.Current!.StateBag.Items["SelfRegistrationCount"]).IsEqualTo(1);
+    }
+}
+
+internal sealed class SelfInstallingExecutorAttribute : Attribute, ITestExecutor, ITestRegisteredEventReceiver
+{
+    public int Order => 0;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        context.StateBag.AddOrUpdate("SelfRegistrationCount", 1, static (_, count) => (int)count! + 1);
+        context.SetTestExecutor(this);
+        return default;
+    }
+
+    public ValueTask ExecuteTest(TestContext context, Func<ValueTask> action) => action();
+}
+
+[EngineTest(ExpectedResult.Pass)]
+[TestExecutor<WideExecutor>]
+public class ClassExecutorLimiterPrecedenceTests
+{
+    [Test]
+    [ParallelLimiter<SerialLimit>]
+    public async Task MethodLimiterOverridesClassExecutor()
+    {
+        await Assert.That(TestContext.Current!.Parallelism.Limiter).IsTypeOf<SerialLimit>();
+        await Assert.That((bool)TestContext.Current.StateBag.Items["ExecutorSawExplicitLimiter"]!).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecutorLimiterAppliesWithoutExplicitAttribute()
+    {
+        await Assert.That(TestContext.Current!.Parallelism.Limiter).IsTypeOf<WideLimit>();
+        await Assert.That(TestContext.Current.StateBag.Items["WideExecutorRegistrationCount"]).IsEqualTo(1);
+    }
+
+    [Test]
+    [TestExecutor<SerialExecutor>]
+    [ParallelLimiter<WideLimit>]
+    public async Task ExplicitLimiterCanIncreaseExecutorLimit()
+    {
+        await Assert.That(TestContext.Current!.Parallelism.Limiter).IsTypeOf<WideLimit>();
+    }
+}
+
+[EngineTest(ExpectedResult.Pass)]
+public class ExplicitLimiterPrecedenceTests
+{
+    [Test]
+    [ParallelLimiter<SerialLimit>]
+    [SetWideLimiter(-100, false)]
+    public Task ProgrammaticLimiterBeforeAttribute() => AssertExplicitLimiter(false, false);
+
+    [Test]
+    [ParallelLimiter<SerialLimit>]
+    [SetWideLimiter(100, false)]
+    public Task ProgrammaticLimiterAfterAttribute() => AssertExplicitLimiter(true, false);
+
+    [Test]
+    [ParallelLimiter<SerialLimit>]
+    [SetWideLimiter(-100, true)]
+    public Task ExecutorBeforeAttribute() => AssertExplicitLimiter(false, true);
+
+    [Test]
+    [ParallelLimiter<SerialLimit>]
+    [SetWideLimiter(100, true)]
+    public Task ExecutorAfterAttribute() => AssertExplicitLimiter(true, true);
+
+    private static async Task AssertExplicitLimiter(bool explicitLimiterWasAlreadySet, bool executorInstalled)
+    {
+        var context = TestContext.Current!;
+        await Assert.That(context.Parallelism.Limiter).IsTypeOf<SerialLimit>();
+        await Assert.That(context.StateBag.Items["ProgrammaticReceiverSawExplicitLimiter"])
+            .IsEqualTo(explicitLimiterWasAlreadySet);
+        if (executorInstalled)
+        {
+            await Assert.That(context.StateBag.Items["ExecutorSawExplicitLimiter"]).IsEqualTo(explicitLimiterWasAlreadySet);
+            await Assert.That(context.StateBag.Items["WideExecutorRegistrationCount"]).IsEqualTo(1);
+        }
+    }
+}
+
+internal sealed class SetWideLimiterAttribute(int order, bool installExecutor) : Attribute, ITestRegisteredEventReceiver
+{
+    public int Order => order;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        context.StateBag["ProgrammaticReceiverSawExplicitLimiter"] = context.TestContext.Parallelism.Limiter is SerialLimit;
+        if (installExecutor)
+        {
+            var executor = new WideExecutor();
+            context.SetTestExecutor(executor);
+            context.SetHookExecutor(executor);
+        }
+        else
+        {
+            context.SetParallelLimiter(new WideLimit());
+        }
+
+        return default;
+    }
+}
+
+internal sealed class WideExecutor : GenericAbstractExecutor, ITestRegisteredEventReceiver
+{
+    // Dynamic dispatch follows the installer, even when this Order would place it later.
+    int IEventReceiver.Order => 1000;
+
+    public ValueTask OnTestRegistered(TestRegisteredContext context)
+    {
+        context.StateBag["ExecutorSawExplicitLimiter"] = context.TestContext.Parallelism.Limiter is SerialLimit;
+        context.StateBag.AddOrUpdate("WideExecutorRegistrationCount", 1, static (_, count) => (int)count! + 1);
+        context.SetParallelLimiter(new WideLimit());
+        return default;
+    }
+
+    protected override ValueTask ExecuteAsync(Func<ValueTask> action) => action();
+}
+
+internal sealed class WideLimit : IParallelLimit
+{
+    public int Limit => 8;
+}

--- a/tests/TUnit.TestProject/LinkedTokenTimeoutTests.cs
+++ b/tests/TUnit.TestProject/LinkedTokenTimeoutTests.cs
@@ -1,0 +1,46 @@
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject;
+
+[EngineTest(ExpectedResult.Failure)]
+[TestExecutor<LinkedTimeoutExecutor>]
+[Timeout(1000)]
+public class LinkedTokenTimeoutTests
+{
+    [Test]
+    public async Task CurrentLinkedToken(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public async Task CapturedLinkedToken(CancellationToken cancellationToken)
+    {
+        TestContext.Current!.Execution.AddLinkedCancellationToken(CancellationToken.None);
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    [Test]
+    public async Task CustomLinkedCancellationDiagnostic(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw new OperationCanceledException("Linked timeout diagnostic", cancellationToken);
+        }
+    }
+}
+
+internal sealed class LinkedTimeoutExecutor : ITestExecutor
+{
+    public ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        context.Execution.AddLinkedCancellationToken(CancellationToken.None);
+        return action();
+    }
+}

--- a/tests/TUnit.UnitTests/TimeoutHelperTests.cs
+++ b/tests/TUnit.UnitTests/TimeoutHelperTests.cs
@@ -1,3 +1,4 @@
+using TUnit.Core;
 using TUnit.Engine.Helpers;
 
 namespace TUnit.UnitTests;
@@ -151,8 +152,105 @@ public class TimeoutHelperTests
             _ => Task.CompletedTask, Timeout.InfiniteTimeSpan, CancellationToken.None);
     }
 
+    [Test]
+    [Arguments(true, false)]
+    [Arguments(true, true)]
+    [Arguments(false, false)]
+    [Arguments(false, true)]
+    public async Task Linked_Timeout_Cancellation_Is_Classified_Without_Routine_Diagnostics(
+        bool executionCompletesFirst, bool rebuildAfterCapture)
+    {
+        var context = CreateContext();
+        context.Execution.AddLinkedCancellationToken(CancellationToken.None);
+
+        try
+        {
+            var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
+                    _ =>
+                    {
+                        var capturedToken = context.Execution.CancellationToken;
+                        if (rebuildAfterCapture)
+                        {
+                            context.Execution.AddLinkedCancellationToken(CancellationToken.None);
+                        }
+
+                        return Task.FromCanceled(capturedToken);
+                    }, executionCompletesFirst, context))
+                .ThrowsExactly<TimeoutException>();
+
+            await Assert.That(exception!.InnerException).IsNull();
+            await Assert.That(exception.Message).DoesNotContain(nameof(TaskCanceledException));
+        }
+        finally
+        {
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Linked_Timeout_Preserves_Custom_Diagnostics(bool executionCompletesFirst)
+    {
+        var context = CreateContext();
+        context.Execution.AddLinkedCancellationToken(CancellationToken.None);
+        OperationCanceledException? expected = null;
+
+        try
+        {
+            var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
+                    _ =>
+                    {
+                        expected = new OperationCanceledException("Linked timeout diagnostic", context.Execution.CancellationToken);
+                        return Task.FromException(expected);
+                    }, executionCompletesFirst, context))
+                .ThrowsExactly<TimeoutException>();
+
+            await Assert.That(exception!.InnerException).IsSameReferenceAs(expected);
+            await Assert.That(exception.Message).Contains("Linked timeout diagnostic");
+        }
+        finally
+        {
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+
+    [Test]
+    public async Task Linked_Cancellation_From_An_Earlier_Base_Is_Not_The_Current_Timeout()
+    {
+        var context = CreateContext();
+        using var earlierSource = new CancellationTokenSource();
+        context.SetCancellationToken(earlierSource.Token);
+        context.Execution.AddLinkedCancellationToken(CancellationToken.None);
+        var earlierToken = context.Execution.CancellationToken;
+        earlierSource.Cancel();
+
+        try
+        {
+            var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
+                    _ => Task.FromCanceled(earlierToken), executionCompletesFirst: true, context))
+                .ThrowsExactly<TaskCanceledException>();
+
+            await Assert.That(exception!.CancellationToken).IsEqualTo(earlierToken);
+        }
+        finally
+        {
+            context.DisposeLinkedCancellationTokenSources();
+            context.RemoveFromRegistry();
+        }
+    }
+
+    private static TestContext CreateContext()
+    {
+        var currentContext = TestContext.Current!;
+        return new TestContext(nameof(TimeoutHelperTests), currentContext.ServiceProvider, currentContext.ClassContext,
+            new TestBuilderContext { TestMetadata = currentContext.TestDetails.MethodMetadata }, CancellationToken.None);
+    }
+
     private static async Task ExecuteWithControlledTimeoutAsync(
-        Func<CancellationToken, Task> operation, bool executionCompletesFirst)
+        Func<CancellationToken, Task> operation, bool executionCompletesFirst, TestContext? testContext = null)
     {
         using var timeoutCts = new CancellationTokenSource();
         var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -160,10 +258,11 @@ public class TimeoutHelperTests
         var timeoutTask = TimeoutHelper.ExecuteWithTimeoutAsync(
             cancellationToken =>
             {
+                testContext?.SetCancellationToken(cancellationToken);
                 // Cancel the caller-owned timeout source without depending on a timer or scheduler delay.
                 timeoutCts.Cancel();
                 return executionCompletesFirst ? operation(cancellationToken) : CompleteAfterReleaseAsync(cancellationToken);
-            }, Timeout.InfiniteTimeSpan, timeoutCts, CancellationToken.None);
+            }, Timeout.InfiniteTimeSpan, timeoutCts, CancellationToken.None, testContext: testContext);
 
         // When both tasks are already complete, WhenAny selects execution (the first argument).
         // Otherwise timeout detection wins before the operation is released into the grace period.

--- a/tests/TUnit.UnitTests/TimeoutHelperTests.cs
+++ b/tests/TUnit.UnitTests/TimeoutHelperTests.cs
@@ -109,6 +109,30 @@ public class TimeoutHelperTests
     }
 
     [Test]
+    public async Task Independent_Operation_Cancellation_Is_Preserved_When_Timeout_Is_Also_Cancelled()
+    {
+        var operationToken = new CancellationToken(true);
+
+        var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
+                _ => Task.FromCanceled(operationToken), executionCompletesFirst: true))
+            .ThrowsExactly<TaskCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(operationToken);
+    }
+
+    [Test]
+    public async Task Tokenless_Operation_Cancellation_Is_Preserved_When_Timeout_Is_Also_Cancelled()
+    {
+        var expected = new OperationCanceledException("Independent cancellation");
+
+        var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
+                _ => Task.FromException(expected), executionCompletesFirst: true))
+            .ThrowsExactly<OperationCanceledException>();
+
+        await Assert.That(exception).IsSameReferenceAs(expected);
+    }
+
+    [Test]
     public async Task Operation_Failure_Is_Preserved_Before_Timeout()
     {
         var expected = new InvalidOperationException("Operation failed");

--- a/tests/TUnit.UnitTests/TimeoutHelperTests.cs
+++ b/tests/TUnit.UnitTests/TimeoutHelperTests.cs
@@ -5,28 +5,24 @@ namespace TUnit.UnitTests;
 public class TimeoutHelperTests
 {
     [Test]
-    public async Task Timeout_Preserves_Exception_Thrown_During_Cancellation()
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Timeout_Preserves_Exception_Thrown_During_Cancellation(bool executionCompletesFirst)
     {
         const string cancellationMessage = "Failed due to XYZ";
 
-        var exception = await Assert.That(async () =>
-            await TimeoutHelper.ExecuteWithTimeoutAsync(
+        var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
                 async cancellationToken =>
                 {
                     try
                     {
-                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                        await Task.FromCanceled(cancellationToken);
                     }
                     catch (OperationCanceledException ex)
                     {
-                        // Keep execution incomplete long enough for timeout detection to win before
-                        // cancellation diagnostics finish, matching the Aspire failure in #6688.
-                        await Task.Delay(50);
                         throw new OperationCanceledException(cancellationMessage, ex.CancellationToken);
                     }
-                },
-                TimeSpan.FromMilliseconds(50),
-                CancellationToken.None))
+                }, executionCompletesFirst))
             .ThrowsExactly<TimeoutException>();
 
         await Assert.That(exception!.Message).Contains(cancellationMessage);
@@ -35,23 +31,22 @@ public class TimeoutHelperTests
     }
 
     [Test]
-    public async Task Timeout_Does_Not_Preserve_Routine_Operation_Cancellation()
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Timeout_Does_Not_Preserve_Routine_Operation_Cancellation(bool executionCompletesFirst)
     {
-        var exception = await Assert.That(async () =>
-            await TimeoutHelper.ExecuteWithTimeoutAsync(
+        var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
                 async cancellationToken =>
                 {
                     try
                     {
-                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                        await Task.FromCanceled(cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                     }
-                },
-                TimeSpan.FromMilliseconds(50),
-                CancellationToken.None))
+                }, executionCompletesFirst))
             .ThrowsExactly<TimeoutException>();
 
         await Assert.That(exception!.InnerException).IsNull();
@@ -59,31 +54,103 @@ public class TimeoutHelperTests
     }
 
     [Test]
-    public async Task Timeout_Preserves_Custom_Task_Cancellation()
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Timeout_Preserves_Custom_Task_Cancellation(bool executionCompletesFirst)
     {
         const string cancellationMessage = "Custom task cancellation diagnostic";
         var diagnosticException = new InvalidOperationException("Inner diagnostic");
 
-        var exception = await Assert.That(async () =>
-            await TimeoutHelper.ExecuteWithTimeoutAsync(
+        var exception = await Assert.That(() => ExecuteWithControlledTimeoutAsync(
                 async cancellationToken =>
                 {
                     try
                     {
-                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                        await Task.FromCanceled(cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {
-                        await Task.Delay(50);
                         throw new TaskCanceledException(cancellationMessage, diagnosticException, cancellationToken);
                     }
-                },
-                TimeSpan.FromMilliseconds(50),
-                CancellationToken.None))
+                }, executionCompletesFirst))
             .ThrowsExactly<TimeoutException>();
 
         var taskCanceledException = await Assert.That(exception!.InnerException).IsTypeOf<TaskCanceledException>();
         await Assert.That(taskCanceledException!.Message).IsEqualTo(cancellationMessage);
         await Assert.That(taskCanceledException.InnerException).IsSameReferenceAs(diagnosticException);
+    }
+
+    [Test]
+    public async Task External_Cancellation_Preserves_External_Token_When_Execution_Completes_First()
+    {
+        using var externalCts = new CancellationTokenSource();
+
+        var exception = await Assert.That(() => TimeoutHelper.ExecuteWithTimeoutAsync(
+                cancellationToken =>
+                {
+                    externalCts.Cancel();
+                    return Task.FromCanceled(cancellationToken);
+                }, Timeout.InfiniteTimeSpan, externalCts.Token))
+            .ThrowsExactly<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(externalCts.Token);
+    }
+
+    [Test]
+    public async Task Independent_Operation_Cancellation_Is_Not_A_Timeout()
+    {
+        var operationToken = new CancellationToken(true);
+
+        var exception = await Assert.That(() => TimeoutHelper.ExecuteWithTimeoutAsync(
+                _ => Task.FromCanceled(operationToken), Timeout.InfiniteTimeSpan, CancellationToken.None))
+            .ThrowsExactly<TaskCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(operationToken);
+    }
+
+    [Test]
+    public async Task Operation_Failure_Is_Preserved_Before_Timeout()
+    {
+        var expected = new InvalidOperationException("Operation failed");
+
+        var exception = await Assert.That(() => TimeoutHelper.ExecuteWithTimeoutAsync(
+                _ => Task.FromException(expected), Timeout.InfiniteTimeSpan, CancellationToken.None))
+            .ThrowsExactly<InvalidOperationException>();
+
+        await Assert.That(exception).IsSameReferenceAs(expected);
+    }
+
+    [Test]
+    public async Task Operation_Can_Complete_Before_Timeout()
+    {
+        await TimeoutHelper.ExecuteWithTimeoutAsync(
+            _ => Task.CompletedTask, Timeout.InfiniteTimeSpan, CancellationToken.None);
+    }
+
+    private static async Task ExecuteWithControlledTimeoutAsync(
+        Func<CancellationToken, Task> operation, bool executionCompletesFirst)
+    {
+        using var timeoutCts = new CancellationTokenSource();
+        var releaseOperation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var timeoutTask = TimeoutHelper.ExecuteWithTimeoutAsync(
+            cancellationToken =>
+            {
+                // Cancel the caller-owned timeout source without depending on a timer or scheduler delay.
+                timeoutCts.Cancel();
+                return executionCompletesFirst ? operation(cancellationToken) : CompleteAfterReleaseAsync(cancellationToken);
+            }, Timeout.InfiniteTimeSpan, timeoutCts, CancellationToken.None);
+
+        // When both tasks are already complete, WhenAny selects execution (the first argument).
+        // Otherwise timeout detection wins before the operation is released into the grace period.
+        releaseOperation.SetResult();
+        await timeoutTask;
+        return;
+
+        async Task CompleteAfterReleaseAsync(CancellationToken cancellationToken)
+        {
+            await releaseOperation.Task;
+            await operation(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Description

Executors installed during registration can implement `ITestRegisteredEventReceiver`, but the original receiver list is built before those executors are installed. Their callbacks were therefore missed, including the parallel limiter supplied by `DedicatedThreadExecutor`.

Keep the deferred executor queue and drain it after each installing receiver returns. Track reference identity across both the original receiver list and queued executors, recording each receiver before invoking it. This prevents duplicate callbacks for overlapping receivers, self-installation, and an instance installed as both test and hook executor, while preserving callbacks for distinct instances that compare equal.

An explicit `[ParallelLimiter<T>]` always overrides a programmatic limiter, including one supplied by an executor, regardless of callback order. `TestRegisteredContext` records the explicit limiter separately, and the attribute uses an internal setter. For example, a class-level executor supplying limit 8 cannot overwrite a method-level explicit limit 1; an explicit limit can also increase an executor's default.

Dynamically installed executor callbacks run after their installer, unless already invoked for that test. Their own `Order` does not establish global ordering. The event receiver documentation now states this contract. `ScopedAttributeFilter` and unrelated event ordering are unchanged; the broader pipeline redesign remains in #6775.

The timeout test exposed a separate race: an operation can observe timeout cancellation and complete before the detection task wins `Task.WhenAny`. `TimeoutHelper` now classifies that cancellation through the same timeout/external-cancellation path when the exception carries the timeout token or a context-owned token linked to that timeout, preserving custom diagnostics and the external token. `TestContext` records the base token for current and retired linked sources, so captured tokens remain attributable after rebuilding while tokens from earlier timeout attempts stay distinct. Independent and tokenless cancellation remain unchanged even when timeout cancellation coincides. The timeout unit tests force both completion orders using a controlled cancellation source and completion gate instead of timer delays.

Fixes #6767.

## Validation

Validated on Windows targeting .NET 10, using the SDK selected by `global.json`:

- Added 10 integration regression tests covering identity overlap in both orders, self-installation, class executor/method limiter precedence, both explicit/programmatic callback orders, shared test/hook executor identity, executor defaults, and explicit limits above an executor's default.
- All 23 cases under `Bugs/6767` pass in source-generated and reflection discovery modes. Before applying the fixes, six new regression tests failed in each mode.
- Separate targeted runs of `ParallelLimiterTests` (12), `ParallelLimiterExceedsLimitTests` (22), `HookExecutorTests` (5), `SetHookExecutorTests` (2), and `STAThreadTests` (1,515) pass in both modes.
- `TUnit.UnitTests`: all 298 tests pass; the preceding 289-test suite also passed five consecutive full-suite runs. The 19 deterministic timeout cases cover both completion orders, custom diagnostics, external and independent cancellation, ordinary failures, and success; four failed before the timeout helper fix, and the two coincident independent/tokenless cancellation regressions failed before the token-identity guard. Five linked-token cases failed before adding token-origin tracking.
- `TimeoutTests1`, `DefaultTimeoutClassificationTests`, and `TestExecutorCancellationTokenTests` pass their reflection integration cases. Their AOT cases are skipped by the existing local-run policy.
- Re-ran all 23 executor registration cases in both discovery modes after the timeout fix; all pass.
- `TUnit.PublicAPI`: all 5 tests pass with unchanged snapshots.
- The three `LinkedTokenTimeoutTests` cases are correctly reported as timeouts in both discovery modes, with custom diagnostics preserved. The engine harness checks these outcomes and includes AOT coverage for CI.
- Existing `LinkedCancellationTokenFromBeforeHookTests` and all 23 registration cases pass in both discovery modes after the linked-token fix.
- `git diff --check` passes.

Both discovery modes share this registration path. No generator output or public API signatures change. The receiver identity set is local to each test registration; executor queues remain lazy. No reflection paths are added or changed. AOT publishing and the full intentionally failing test application were not run.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Executor-provided event receivers now reliably receive test-registration callbacks.
  - Distinct executor instances are registered separately, even when they compare as equal.
  - Explicit parallel-limit attributes take precedence over programmatically configured limits.
  - Programmatic parallel limits are applied consistently, including serial execution scenarios.
  - Timeout handling now preserves cancellation and operation outcomes correctly.

- **Documentation**
  - Clarified executor callback behavior, invocation order, duplicate handling, and parallel-limit precedence.

- **Tests**
  - Added regression coverage for executor callbacks, dynamic registration, concurrency limits, duplicate-looking instances, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



