### PR TITLE
fix: fold inner exceptions into IDE test failure output

### DIFF
--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -40,7 +40,7 @@ internal sealed class FlattenedException : TUnitFailedException
     /// </summary>
     public static Exception Wrap(Exception exception)
     {
-        return exception.InnerException is null
+        return ChainSource(exception).InnerException is null
             ? exception
             : new FlattenedException(exception);
     }
@@ -60,13 +60,15 @@ internal sealed class FlattenedException : TUnitFailedException
     /// </summary>
     internal static string CombineMessages(Exception exception)
     {
-        if (exception.InnerException is null)
+        var chainSource = ChainSource(exception);
+
+        if (chainSource.InnerException is null)
         {
             return exception.Message;
         }
 
         var builder = new StringBuilder(exception.Message);
-        AppendInnerMessages(builder, exception);
+        AppendInnerMessages(builder, chainSource);
 
         return builder.ToString();
     }
@@ -77,15 +79,28 @@ internal sealed class FlattenedException : TUnitFailedException
     /// </summary>
     internal static string CombineStackTraces(Exception exception)
     {
-        if (exception.InnerException is null)
+        var chainSource = ChainSource(exception);
+
+        if (chainSource.InnerException is null)
         {
             return exception.StackTrace ?? string.Empty;
         }
 
         var builder = new StringBuilder(exception.StackTrace);
-        AppendInnerStackTraces(builder, exception);
+        AppendInnerStackTraces(builder, chainSource);
 
         return builder.ToString();
+    }
+
+    // The console wrapper (TestFailedException) keeps only the first member of a wrapped
+    // AggregateException as its InnerException, so the chain is folded from the wrapped original to
+    // keep every sibling; the wrapper's own (filtered) Message and StackTrace still lead the output.
+    // A FlattenedException is already folded: its InnerException is null, so nothing is appended.
+    private static Exception ChainSource(Exception exception)
+    {
+        return exception is TUnitFailedException { WrappedException: { } wrapped } and not FlattenedException
+            ? wrapped
+            : exception;
     }
 
     private static void AppendInnerMessages(StringBuilder builder, Exception exception)

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -41,12 +41,14 @@ internal sealed class FlattenedException : TUnitFailedException
             Data[entry.Key] = entry.Value;
         }
 
-        // Classification uses the first aggregate member. Preserve its assertion diff when the
-        // aggregate itself has no expected/actual values, without copying unrelated sibling data.
-        if (ChainSource(exception) is AggregateException { InnerExceptions.Count: > 0 } aggregate)
+        // Follow the first member through nested aggregates to preserve its assertion diff.
+        // Outer values take precedence; unrelated data and sibling data are not copied.
+        var source = ChainSource(exception);
+        while (source is AggregateException { InnerExceptions.Count: > 0 } aggregate)
         {
-            CopyAssertionData(aggregate.InnerExceptions[0], "assert.expected");
-            CopyAssertionData(aggregate.InnerExceptions[0], "assert.actual");
+            source = aggregate.InnerExceptions[0];
+            CopyAssertionData(source, "assert.expected");
+            CopyAssertionData(source, "assert.actual");
         }
     }
 

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Text;
+using TUnit.Core.Exceptions;
 
 namespace TUnit.Engine.Exceptions;
 
@@ -39,6 +40,22 @@ internal sealed class FlattenedException : TUnitFailedException
         {
             Data[entry.Key] = entry.Value;
         }
+
+        // Classification uses the first aggregate member. Preserve its assertion diff when the
+        // aggregate itself has no expected/actual values, without copying unrelated sibling data.
+        if (ChainSource(exception) is AggregateException { InnerExceptions.Count: > 0 } aggregate)
+        {
+            CopyAssertionData(aggregate.InnerExceptions[0], "assert.expected");
+            CopyAssertionData(aggregate.InnerExceptions[0], "assert.actual");
+        }
+    }
+
+    private void CopyAssertionData(Exception source, string key)
+    {
+        if (!Data.Contains(key) && source.Data.Contains(key))
+        {
+            Data[key] = source.Data[key];
+        }
     }
 
     /// <summary>
@@ -64,8 +81,7 @@ internal sealed class FlattenedException : TUnitFailedException
     /// <summary>
     /// The outer message followed by one <c> ---> Type: Message</c> line per inner exception,
     /// outermost first. Every member of an <see cref="AggregateException"/> is included; an inner
-    /// aggregate itself gets no line, and an inner message the enclosing exception already embeds
-    /// is not repeated.
+    /// aggregate itself gets no line, and messages embedded by known TUnit wrappers are not repeated.
     /// </summary>
     internal static string CombineMessages(Exception exception)
     {
@@ -77,7 +93,7 @@ internal sealed class FlattenedException : TUnitFailedException
         }
 
         var builder = new StringBuilder(exception.Message);
-        AppendInnerMessages(builder, chainSource, chainSource is AggregateException ? null : chainSource.Message);
+        AppendInnerMessages(builder, chainSource, EmbeddedMessage(chainSource));
 
         return builder.ToString();
     }
@@ -116,12 +132,25 @@ internal sealed class FlattenedException : TUnitFailedException
             : exception;
     }
 
-    // ancestorMessage is the message of the nearest enclosing non-aggregate exception, or null when
-    // the chain starts at an AggregateException reported whole. An inner exception whose message
-    // that ancestor already embeds is not repeated: hook wrappers splice the cause into their own
-    // message, and Assert.Multiple lists every failure in the outer message before attaching them
-    // as an AggregateException. Its own inner exceptions are still visited. An inner aggregate gets
-    // no line of its own; its Message is boilerplate plus the member messages listed individually.
+    // Only known TUnit wrappers embed their causes. Arbitrary user exceptions may contain the
+    // same text by coincidence, so substring matches must never suppress their inner exceptions.
+    private static string? EmbeddedMessage(Exception exception)
+    {
+        if (exception is BeforeTestException or BeforeClassException or BeforeAssemblyException
+            or BeforeTestSessionException or BeforeTestDiscoveryException
+            or AfterTestException or AfterClassException or AfterAssemblyException
+            or AfterTestSessionException or AfterTestDiscoveryException
+            || (exception.GetType().FullName == "TUnit.Assertions.Exceptions.AssertionException"
+                && exception.InnerException is AggregateException))
+        {
+            return exception.Message;
+        }
+
+        return null;
+    }
+
+    // Keep the embedding wrapper's message across an inner aggregate, which only groups members.
+    // Descendants are still visited even when a known wrapper already includes a member's message.
     private static void AppendInnerMessages(StringBuilder builder, Exception exception, string? ancestorMessage)
     {
         foreach (var inner in GetInnerExceptions(exception))
@@ -134,8 +163,8 @@ internal sealed class FlattenedException : TUnitFailedException
 
             var message = inner.Message;
 
-            if (message.Length > 0
-                && (ancestorMessage is null || ancestorMessage.IndexOf(message, StringComparison.Ordinal) < 0))
+            if (message.Length == 0
+                || ancestorMessage is null || ancestorMessage.IndexOf(message, StringComparison.Ordinal) < 0)
             {
                 builder.Append(Environment.NewLine)
                     .Append(InnerMessagePrefix)
@@ -144,7 +173,7 @@ internal sealed class FlattenedException : TUnitFailedException
                     .Append(message);
             }
 
-            AppendInnerMessages(builder, inner, message);
+            AppendInnerMessages(builder, inner, EmbeddedMessage(inner));
         }
     }
 

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -1,0 +1,140 @@
+using System.Text;
+
+namespace TUnit.Engine.Exceptions;
+
+/// <summary>
+/// Folds an exception's inner-exception chain into <see cref="Exception.Message"/> and
+/// <see cref="Exception.StackTrace"/> so that consumers which read only those two members still
+/// see the whole chain.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Microsoft.Testing.Platform's server-mode (IDE) serializer sends a failed test node as
+/// <c>error.message</c> (the explanation or <see cref="Exception.Message"/>) and
+/// <c>error.stacktrace</c> (<see cref="Exception.StackTrace"/>). It never walks
+/// <see cref="Exception.InnerException"/>, so Rider and Visual Studio showed only the outermost
+/// exception (https://github.com/thomhurst/TUnit/issues/1327). The console and <c>dotnet test</c>
+/// paths flatten the chain themselves, which is why the CLI was never affected.
+/// </para>
+/// <para>
+/// <see cref="Exception.InnerException"/> is deliberately <see langword="null"/> so that consumers
+/// which do walk the chain do not print the inner exceptions twice. The original exception remains
+/// reachable through <see cref="TUnitFailedException.WrappedException"/> for reporters that want the
+/// structured chain (<see cref="TUnitFailedException.Unwrap"/>).
+/// </para>
+/// </remarks>
+internal sealed class FlattenedException : TUnitFailedException
+{
+    private const string InnerMessagePrefix = " ---> ";
+    private const string InnerStackTracePrefix = "--- Inner exception stack trace (";
+    private const string InnerStackTraceSuffix = ") ---";
+
+    private FlattenedException(Exception exception)
+        : base(CombineMessages(exception), CombineStackTraces(exception), exception)
+    {
+    }
+
+    /// <summary>
+    /// Returns <paramref name="exception"/> unchanged when it has no inner exception, otherwise a
+    /// <see cref="FlattenedException"/> presenting the whole chain.
+    /// </summary>
+    public static Exception Wrap(Exception exception)
+    {
+        return exception.InnerException is null
+            ? exception
+            : new FlattenedException(exception);
+    }
+
+    public override string ToString()
+    {
+        var type = WrappedException?.GetType().FullName ?? GetType().FullName;
+
+        return StackTrace.Length == 0
+            ? $"{type}: {Message}"
+            : $"{type}: {Message}{Environment.NewLine}{StackTrace}";
+    }
+
+    /// <summary>
+    /// The outer message followed by one <c> ---> Type: Message</c> line per inner exception,
+    /// outermost first. Every inner exception of an <see cref="AggregateException"/> is included.
+    /// </summary>
+    internal static string CombineMessages(Exception exception)
+    {
+        if (exception.InnerException is null)
+        {
+            return exception.Message;
+        }
+
+        var builder = new StringBuilder(exception.Message);
+        AppendInnerMessages(builder, exception);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The outer stack trace followed by each inner exception's stack trace, each introduced by a
+    /// separator line naming the inner exception type, outermost first.
+    /// </summary>
+    internal static string CombineStackTraces(Exception exception)
+    {
+        if (exception.InnerException is null)
+        {
+            return exception.StackTrace ?? string.Empty;
+        }
+
+        var builder = new StringBuilder(exception.StackTrace);
+        AppendInnerStackTraces(builder, exception);
+
+        return builder.ToString();
+    }
+
+    private static void AppendInnerMessages(StringBuilder builder, Exception exception)
+    {
+        foreach (var inner in GetInnerExceptions(exception))
+        {
+            builder.Append(Environment.NewLine)
+                .Append(InnerMessagePrefix)
+                .Append(inner.GetType().FullName)
+                .Append(": ")
+                .Append(inner.Message);
+
+            AppendInnerMessages(builder, inner);
+        }
+    }
+
+    private static void AppendInnerStackTraces(StringBuilder builder, Exception exception)
+    {
+        foreach (var inner in GetInnerExceptions(exception))
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(Environment.NewLine);
+            }
+
+            builder.Append(InnerStackTracePrefix)
+                .Append(inner.GetType().FullName)
+                .Append(InnerStackTraceSuffix);
+
+            if (!string.IsNullOrEmpty(inner.StackTrace))
+            {
+                builder.Append(Environment.NewLine).Append(inner.StackTrace);
+            }
+
+            AppendInnerStackTraces(builder, inner);
+        }
+    }
+
+    // An AggregateException's InnerException is only its first member; enumerate them all so
+    // sibling failures (e.g. from Task.WhenAll) are not silently dropped.
+    private static IEnumerable<Exception> GetInnerExceptions(Exception exception)
+    {
+        if (exception is AggregateException aggregate)
+        {
+            return aggregate.InnerExceptions;
+        }
+
+        return exception.InnerException is { } inner
+            ? [inner]
+            : [];
+    }
+}

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text;
 
 namespace TUnit.Engine.Exceptions;
@@ -32,6 +33,12 @@ internal sealed class FlattenedException : TUnitFailedException
     private FlattenedException(Exception exception)
         : base(CombineMessages(exception), CombineStackTraces(exception), exception)
     {
+        // MTP's server-mode serializer reads Data["assert.expected"] / Data["assert.actual"] from the
+        // reported exception as its expected/actual fallback, so keep the original entries reachable.
+        foreach (DictionaryEntry entry in exception.Data)
+        {
+            Data[entry.Key] = entry.Value;
+        }
     }
 
     /// <summary>
@@ -56,7 +63,9 @@ internal sealed class FlattenedException : TUnitFailedException
 
     /// <summary>
     /// The outer message followed by one <c> ---> Type: Message</c> line per inner exception,
-    /// outermost first. Every inner exception of an <see cref="AggregateException"/> is included.
+    /// outermost first. Every member of an <see cref="AggregateException"/> is included; an inner
+    /// aggregate itself gets no line, and an inner message the enclosing exception already embeds
+    /// is not repeated.
     /// </summary>
     internal static string CombineMessages(Exception exception)
     {
@@ -68,14 +77,14 @@ internal sealed class FlattenedException : TUnitFailedException
         }
 
         var builder = new StringBuilder(exception.Message);
-        AppendInnerMessages(builder, chainSource);
+        AppendInnerMessages(builder, chainSource, chainSource is AggregateException ? null : chainSource.Message);
 
         return builder.ToString();
     }
 
     /// <summary>
-    /// The outer stack trace followed by each inner exception's stack trace, each introduced by a
-    /// separator line naming the inner exception type, outermost first.
+    /// The outer stack trace followed by each thrown inner exception's stack trace, each introduced
+    /// by a separator line naming the inner exception type, outermost first.
     /// </summary>
     internal static string CombineStackTraces(Exception exception)
     {
@@ -86,8 +95,12 @@ internal sealed class FlattenedException : TUnitFailedException
             return exception.StackTrace ?? string.Empty;
         }
 
+        // A TUnit wrapper presents a filtered outer trace (TUnit internals omitted); keep the inner
+        // traces consistent with it instead of reintroducing engine frames below the hint.
+        var filter = exception is TUnitFailedException;
+
         var builder = new StringBuilder(exception.StackTrace);
-        AppendInnerStackTraces(builder, chainSource);
+        AppendInnerStackTraces(builder, chainSource, filter);
 
         return builder.ToString();
     }
@@ -103,39 +116,61 @@ internal sealed class FlattenedException : TUnitFailedException
             : exception;
     }
 
-    private static void AppendInnerMessages(StringBuilder builder, Exception exception)
+    // ancestorMessage is the message of the nearest enclosing non-aggregate exception, or null when
+    // the chain starts at an AggregateException reported whole. An inner exception whose message
+    // that ancestor already embeds is not repeated: hook wrappers splice the cause into their own
+    // message, and Assert.Multiple lists every failure in the outer message before attaching them
+    // as an AggregateException. Its own inner exceptions are still visited. An inner aggregate gets
+    // no line of its own; its Message is boilerplate plus the member messages listed individually.
+    private static void AppendInnerMessages(StringBuilder builder, Exception exception, string? ancestorMessage)
     {
         foreach (var inner in GetInnerExceptions(exception))
         {
-            builder.Append(Environment.NewLine)
-                .Append(InnerMessagePrefix)
-                .Append(inner.GetType().FullName)
-                .Append(": ")
-                .Append(inner.Message);
+            if (inner is AggregateException)
+            {
+                AppendInnerMessages(builder, inner, ancestorMessage);
+                continue;
+            }
 
-            AppendInnerMessages(builder, inner);
+            var message = inner.Message;
+
+            if (message.Length > 0
+                && (ancestorMessage is null || ancestorMessage.IndexOf(message, StringComparison.Ordinal) < 0))
+            {
+                builder.Append(Environment.NewLine)
+                    .Append(InnerMessagePrefix)
+                    .Append(inner.GetType().FullName)
+                    .Append(": ")
+                    .Append(message);
+            }
+
+            AppendInnerMessages(builder, inner, message);
         }
     }
 
-    private static void AppendInnerStackTraces(StringBuilder builder, Exception exception)
+    // An inner exception that was never thrown (an Assert.Multiple member, a hand-built cause) has
+    // no frames; its type is already on the message line, so no separator is emitted for it.
+    private static void AppendInnerStackTraces(StringBuilder builder, Exception exception, bool filter)
     {
         foreach (var inner in GetInnerExceptions(exception))
         {
-            if (builder.Length > 0)
+            var stackTrace = inner.StackTrace;
+
+            if (!string.IsNullOrEmpty(stackTrace))
             {
-                builder.Append(Environment.NewLine);
+                if (builder.Length > 0)
+                {
+                    builder.Append(Environment.NewLine);
+                }
+
+                builder.Append(InnerStackTracePrefix)
+                    .Append(inner.GetType().FullName)
+                    .Append(InnerStackTraceSuffix)
+                    .Append(Environment.NewLine)
+                    .Append(filter ? FilterStackTrace(stackTrace) : stackTrace);
             }
 
-            builder.Append(InnerStackTracePrefix)
-                .Append(inner.GetType().FullName)
-                .Append(InnerStackTraceSuffix);
-
-            if (!string.IsNullOrEmpty(inner.StackTrace))
-            {
-                builder.Append(Environment.NewLine).Append(inner.StackTrace);
-            }
-
-            AppendInnerStackTraces(builder, inner);
+            AppendInnerStackTraces(builder, inner, filter);
         }
     }
 

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -140,6 +140,7 @@ internal sealed class FlattenedException : TUnitFailedException
             or BeforeTestSessionException or BeforeTestDiscoveryException
             or AfterTestException or AfterClassException or AfterAssemblyException
             or AfterTestSessionException or AfterTestDiscoveryException
+            or TestExecutionException
             || (exception.GetType().FullName == "TUnit.Assertions.Exceptions.AssertionException"
                 && exception.InnerException is AggregateException))
         {

--- a/src/TUnit.Engine/Exceptions/FlattenedException.cs
+++ b/src/TUnit.Engine/Exceptions/FlattenedException.cs
@@ -47,7 +47,7 @@ internal sealed class FlattenedException : TUnitFailedException
 
     public override string ToString()
     {
-        var type = WrappedException?.GetType().FullName ?? GetType().FullName;
+        var type = WrappedException!.GetType().FullName;
 
         return StackTrace.Length == 0
             ? $"{type}: {Message}"

--- a/src/TUnit.Engine/Exceptions/TUnitFailedException.cs
+++ b/src/TUnit.Engine/Exceptions/TUnitFailedException.cs
@@ -20,6 +20,16 @@ public abstract class TUnitFailedException : TUnitException
         StackTrace = FilterStackTrace(innerException?.StackTrace);
     }
 
+    /// <summary>
+    /// Presents a pre-computed <paramref name="message"/> and <paramref name="stackTrace"/> for
+    /// <paramref name="wrappedException"/> without carrying its inner-exception chain.
+    /// </summary>
+    internal TUnitFailedException(string message, string stackTrace, Exception wrappedException) : base(message)
+    {
+        WrappedException = wrappedException;
+        StackTrace = stackTrace;
+    }
+
     public override string StackTrace { get; }
 
     [return: NotNullIfNotNull(nameof(exception))]

--- a/src/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/src/TUnit.Engine/Extensions/TestExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using TUnit.Core;
 using TUnit.Core.Extensions;
 using TUnit.Engine.Capabilities;
+using TUnit.Engine.Exceptions;
 using TUnit.Engine.Helpers;
 using TUnit.Engine.Reporters;
 #pragma warning disable TPEXP
@@ -196,7 +197,14 @@ internal static class TestExtensions
 
                 if (exception is not null)
                 {
-                    propertyBag.Add(new TrxExceptionProperty(exception.Message, exception.StackTrace));
+                    // A TRX ErrorInfo only carries a message and a stack trace, so fold the inner-exception
+                    // chain into both (#1327). IDE clients already receive a FlattenedException (no inner
+                    // chain, so this is a no-op); console clients still hand over the full chain here.
+                    var stackTrace = FlattenedException.CombineStackTraces(exception);
+
+                    propertyBag.Add(new TrxExceptionProperty(
+                        FlattenedException.CombineMessages(exception),
+                        stackTrace.Length == 0 ? null : stackTrace));
                 }
                 else if (!string.IsNullOrEmpty(explanation))
                 {

--- a/src/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/src/TUnit.Engine/Extensions/TestExtensions.cs
@@ -200,11 +200,11 @@ internal static class TestExtensions
                     // A TRX ErrorInfo only carries a message and a stack trace, so fold the inner-exception
                     // chain into both (#1327). IDE clients already receive a FlattenedException (no inner
                     // chain, so this is a no-op); console clients still hand over the full chain here.
-                    var stackTrace = FlattenedException.CombineStackTraces(exception);
+                    var folded = FlattenedException.Wrap(exception);
 
                     propertyBag.Add(new TrxExceptionProperty(
-                        FlattenedException.CombineMessages(exception),
-                        stackTrace.Length == 0 ? null : stackTrace));
+                        folded.Message,
+                        string.IsNullOrEmpty(folded.StackTrace) ? null : folded.StackTrace));
                 }
                 else if (!string.IsNullOrEmpty(explanation))
                 {

--- a/src/TUnit.Engine/Framework/TUnitTestFramework.cs
+++ b/src/TUnit.Engine/Framework/TUnitTestFramework.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions;
@@ -6,6 +6,7 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Requests;
 using TUnit.Core;
+using TUnit.Engine.Exceptions;
 using TUnit.Engine.Services;
 
 namespace TUnit.Engine.Framework;
@@ -139,6 +140,13 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
 
     private async Task ReportUnhandledException(ExecuteRequestContext context, Exception exception)
     {
+        // Same IDE fold as TUnitMessageBus.GetFailureStateProperty: server-mode clients only see
+        // Exception.Message and Exception.StackTrace, so a discovery hook failure would otherwise
+        // lose its cause (#1327).
+        var reported = _frameworkServiceProvider.IsConsoleClient()
+            ? exception
+            : FlattenedException.Wrap(exception);
+
         await context.MessageBus.PublishAsync(
             dataProducer: this,
             data: new TestNodeUpdateMessage(
@@ -147,7 +155,7 @@ internal sealed class TUnitTestFramework : ITestFramework, IDataProducer
                 {
                     DisplayName = $"Unhandled exception - {exception.GetType().Name}: {exception.Message}",
                     Uid = new TestNodeUid(Guid.NewGuid().ToString()),
-                    Properties = new PropertyBag(new ErrorTestNodeStateProperty(exception))
+                    Properties = new PropertyBag(new ErrorTestNodeStateProperty(reported))
                 }));
     }
 

--- a/src/TUnit.Engine/Services/ClientInfoExtensions.cs
+++ b/src/TUnit.Engine/Services/ClientInfoExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Testing.Platform.Services;
+
+#pragma warning disable TPEXP // Experimental API - GetClientInfo
+
+namespace TUnit.Engine.Services;
+
+internal static class ClientInfoExtensions
+{
+    /// <summary>
+    /// Whether the test host was started by a console client (<c>dotnet run</c>, <c>dotnet test</c>),
+    /// as opposed to an IDE or another server-mode client. Console hosts register the
+    /// <c>testingplatform-console</c> client id; server-mode hosts register whatever the client sent.
+    /// Defaults to console when the client info is unavailable.
+    /// </summary>
+    public static bool IsConsoleClient(this IServiceProvider serviceProvider)
+    {
+        try
+        {
+            return serviceProvider.GetClientInfo().Id.Contains("console", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to determine console environment: {ex}");
+            return true;
+        }
+    }
+}

--- a/src/TUnit.Engine/Services/VerbosityService.cs
+++ b/src/TUnit.Engine/Services/VerbosityService.cs
@@ -22,7 +22,7 @@ public sealed class VerbosityService
     {
         _isDetailedOutput = GetOutputLevel(commandLineOptions, serviceProvider);
         _logLevel = GetLogLevel(commandLineOptions);
-        IsIdeClient = !IsConsoleEnvironment(serviceProvider);
+        IsIdeClient = !serviceProvider.IsConsoleClient();
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public sealed class VerbosityService
         }
 
         // Smart defaults: Normal for console (buffered output), Detailed for IDE (real-time output)
-        return !IsConsoleEnvironment(serviceProvider);
+        return !serviceProvider.IsConsoleClient();
     }
 
     private static LogLevel GetLogLevel(ICommandLineOptions commandLineOptions)
@@ -85,20 +85,5 @@ public sealed class VerbosityService
         }
 
         return LogLevel.Information;
-    }
-
-    private static bool IsConsoleEnvironment(IServiceProvider serviceProvider)
-    {
-        try
-        {
-            var clientInfo = serviceProvider.GetClientInfo();
-            return clientInfo.Id.Contains("console", StringComparison.InvariantCultureIgnoreCase);
-        }
-        catch (Exception ex)
-        {
-            // If we can't determine, default to console behavior
-            System.Diagnostics.Debug.WriteLine($"Failed to determine console environment: {ex}");
-            return true;
-        }
     }
 }

--- a/src/TUnit.Engine/TUnitMessageBus.cs
+++ b/src/TUnit.Engine/TUnitMessageBus.cs
@@ -23,7 +23,7 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
     private readonly SessionUid _sessionSessionUid = context.Request.Session.SessionUid;
 
     private bool? _isConsole;
-    private bool IsConsole => _isConsole ??= serviceProvider.GetClientInfo().Id.Contains("console", StringComparison.InvariantCultureIgnoreCase);
+    private bool IsConsole => _isConsole ??= serviceProvider.IsConsoleClient();
 
     // Tests created by expanding a deferred-enumeration placeholder (or runtime variants) carry a
     // ParentTestId; surfacing it as the MTP parentTestNodeUid makes IDEs nest them under that node.
@@ -157,8 +157,10 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
 
         // MTP's server-mode (IDE) serializer only transmits Exception.Message and Exception.StackTrace,
         // never the InnerException chain, so Rider/VS showed just the outermost exception (#1327).
-        // Fold the chain into those two members for IDE clients. Console output is left untouched:
-        // MTP's terminal reporter walks InnerException itself and would otherwise print the chain twice.
+        // Fold the chain into those two members for IDE clients only. The console keeps the raw
+        // exception because MTP's terminal reporter already renders the chain from InnerException,
+        // labels error/timeout outcomes with the exception's runtime type (which would otherwise
+        // read FlattenedException), and gives each inner exception its own highlighted block.
         var reported = IsConsole ? reportedRoot : FlattenedException.Wrap(reportedRoot);
 
         if (category == FailureCategory.Timeout

--- a/src/TUnit.Engine/TUnitMessageBus.cs
+++ b/src/TUnit.Engine/TUnitMessageBus.cs
@@ -153,7 +153,11 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
         // never the InnerException chain, so Rider/VS showed just the outermost exception (#1327).
         // Fold the chain into those two members for IDE clients. Console output is left untouched:
         // MTP's terminal reporter walks InnerException itself and would otherwise print the chain twice.
-        var reported = IsConsole ? unwrapped : FlattenedException.Wrap(unwrapped);
+        // A multi-member AggregateException (e.g. several failing [After] hooks) is folded whole so
+        // every sibling is listed; a single-member one stays reduced to its real cause.
+        var reported = IsConsole
+            ? unwrapped
+            : FlattenedException.Wrap(e is AggregateException { InnerExceptions.Count: > 1 } ? e : unwrapped);
 
         if (category == FailureCategory.Timeout
             && testContext.Metadata.TestDetails.Timeout != null
@@ -165,7 +169,13 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
 
             if (diagnosticException is not null)
             {
-                explanation = $"{explanation}{Environment.NewLine}{diagnosticException.Message}";
+                // The explanation becomes error.message for IDE clients, so fold the diagnostic
+                // exception's own inner messages in for them; console output walks the chain itself.
+                var diagnosticMessage = IsConsole
+                    ? diagnosticException.Message
+                    : FlattenedException.CombineMessages(diagnosticException);
+
+                explanation = $"{explanation}{Environment.NewLine}{diagnosticMessage}";
             }
 
             return new TimeoutTestNodeStateProperty(reported, explanation);

--- a/src/TUnit.Engine/TUnitMessageBus.cs
+++ b/src/TUnit.Engine/TUnitMessageBus.cs
@@ -149,15 +149,17 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
         var category = FailureCategorizer.Categorize(unwrapped);
         var categoryLabel = FailureCategorizer.GetLabel(category);
 
+        // A multi-member AggregateException (e.g. several failing [After] hooks) is reported whole so
+        // every sibling is listed; a single-member one stays reduced to its real cause. This applies
+        // to console runs too: with --detailed-stacktrace the aggregate arrives unwrapped, and MTP's
+        // terminal reporter flattens a top-level aggregate itself.
+        var reportedRoot = e is AggregateException { InnerExceptions.Count: > 1 } ? e : unwrapped;
+
         // MTP's server-mode (IDE) serializer only transmits Exception.Message and Exception.StackTrace,
         // never the InnerException chain, so Rider/VS showed just the outermost exception (#1327).
         // Fold the chain into those two members for IDE clients. Console output is left untouched:
         // MTP's terminal reporter walks InnerException itself and would otherwise print the chain twice.
-        // A multi-member AggregateException (e.g. several failing [After] hooks) is folded whole so
-        // every sibling is listed; a single-member one stays reduced to its real cause.
-        var reported = IsConsole
-            ? unwrapped
-            : FlattenedException.Wrap(e is AggregateException { InnerExceptions.Count: > 1 } ? e : unwrapped);
+        var reported = IsConsole ? reportedRoot : FlattenedException.Wrap(reportedRoot);
 
         if (category == FailureCategory.Timeout
             && testContext.Metadata.TestDetails.Timeout != null

--- a/src/TUnit.Engine/TUnitMessageBus.cs
+++ b/src/TUnit.Engine/TUnitMessageBus.cs
@@ -76,7 +76,8 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
 
         var duration = testContext.Execution.TestEnd - testContext.Execution.TestStart;
 
-        var updateType = GetFailureStateProperty(testContext, exception, duration ?? TimeSpan.Zero);
+        var updateType = GetFailureStateProperty(exception, testContext.Metadata.TestDetails.Timeout,
+            duration ?? TimeSpan.Zero, IsConsole);
 
         var testNode = testContext.ToTestNode(updateType);
 
@@ -139,7 +140,7 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
         )));
     }
 
-    private TestNodeStateProperty GetFailureStateProperty(TestContext testContext, Exception e, TimeSpan duration)
+    internal static TestNodeStateProperty GetFailureStateProperty(Exception e, TimeSpan? timeout, TimeSpan duration, bool isConsole)
     {
         // Unwrap AggregateException once so all downstream logic sees the real cause
         var unwrapped = e is AggregateException { InnerExceptions.Count: > 0 } agg
@@ -161,25 +162,29 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
         // exception because MTP's terminal reporter already renders the chain from InnerException,
         // labels error/timeout outcomes with the exception's runtime type (which would otherwise
         // read FlattenedException), and gives each inner exception its own highlighted block.
-        var reported = IsConsole ? reportedRoot : FlattenedException.Wrap(reportedRoot);
+        var reported = isConsole ? reportedRoot : FlattenedException.Wrap(reportedRoot);
 
         if (category == FailureCategory.Timeout
-            && testContext.Metadata.TestDetails.Timeout != null
-            && duration >= testContext.Metadata.TestDetails.Timeout.Value)
+            && timeout != null
+            && duration >= timeout.Value)
         {
-            var explanation = $"[{categoryLabel}] Test timed out after {testContext.Metadata.TestDetails.Timeout.Value.TotalMilliseconds}ms";
-            var diagnosticException = unwrapped.InnerException
-                ?? (unwrapped is OperationCanceledException and not TaskCanceledException ? unwrapped : null);
+            var explanation = $"[{categoryLabel}] Test timed out after {timeout.Value.TotalMilliseconds}ms";
 
-            if (diagnosticException is not null)
+            if (!isConsole)
             {
-                // The explanation becomes error.message for IDE clients, so fold the diagnostic
-                // exception's own inner messages in for them; console output walks the chain itself.
-                var diagnosticMessage = IsConsole
-                    ? diagnosticException.Message
-                    : FlattenedException.CombineMessages(diagnosticException);
+                // IDE clients receive the explanation instead of Exception.Message. Include the
+                // complete reported root so both cancellation diagnostics and aggregate siblings survive.
+                explanation = $"{explanation}{Environment.NewLine}{reported.Message}";
+            }
+            else
+            {
+                var diagnosticException = unwrapped.InnerException
+                    ?? (unwrapped is OperationCanceledException and not TaskCanceledException ? unwrapped : null);
 
-                explanation = $"{explanation}{Environment.NewLine}{diagnosticMessage}";
+                if (diagnosticException is not null)
+                {
+                    explanation = $"{explanation}{Environment.NewLine}{diagnosticException.Message}";
+                }
             }
 
             return new TimeoutTestNodeStateProperty(reported, explanation);

--- a/src/TUnit.Engine/TUnitMessageBus.cs
+++ b/src/TUnit.Engine/TUnitMessageBus.cs
@@ -139,7 +139,7 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
         )));
     }
 
-    private static TestNodeStateProperty GetFailureStateProperty(TestContext testContext, Exception e, TimeSpan duration)
+    private TestNodeStateProperty GetFailureStateProperty(TestContext testContext, Exception e, TimeSpan duration)
     {
         // Unwrap AggregateException once so all downstream logic sees the real cause
         var unwrapped = e is AggregateException { InnerExceptions.Count: > 0 } agg
@@ -148,6 +148,12 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
 
         var category = FailureCategorizer.Categorize(unwrapped);
         var categoryLabel = FailureCategorizer.GetLabel(category);
+
+        // MTP's server-mode (IDE) serializer only transmits Exception.Message and Exception.StackTrace,
+        // never the InnerException chain, so Rider/VS showed just the outermost exception (#1327).
+        // Fold the chain into those two members for IDE clients. Console output is left untouched:
+        // MTP's terminal reporter walks InnerException itself and would otherwise print the chain twice.
+        var reported = IsConsole ? unwrapped : FlattenedException.Wrap(unwrapped);
 
         if (category == FailureCategory.Timeout
             && testContext.Metadata.TestDetails.Timeout != null
@@ -162,15 +168,15 @@ internal class TUnitMessageBus(IExtension extension, ICommandLineOptions command
                 explanation = $"{explanation}{Environment.NewLine}{diagnosticException.Message}";
             }
 
-            return new TimeoutTestNodeStateProperty(unwrapped, explanation);
+            return new TimeoutTestNodeStateProperty(reported, explanation);
         }
 
         if (category == FailureCategory.Assertion)
         {
-            return new FailedTestNodeStateProperty(unwrapped, $"[{categoryLabel}] {unwrapped.Message}");
+            return new FailedTestNodeStateProperty(reported, $"[{categoryLabel}] {reported.Message}");
         }
 
-        return new ErrorTestNodeStateProperty(unwrapped, $"[{categoryLabel}] {unwrapped.Message}");
+        return new ErrorTestNodeStateProperty(reported, $"[{categoryLabel}] {reported.Message}");
     }
 
     public Task<bool> IsEnabledAsync()

--- a/tests/TUnit.Engine.Tests/ExceptionReportingTests.cs
+++ b/tests/TUnit.Engine.Tests/ExceptionReportingTests.cs
@@ -51,11 +51,18 @@ public class ExceptionReportingTests
     }
 
     [Test]
-    public void IdeAggregateAssertion_PreservesFirstMembersDiffAndAllSiblingMessages()
+    [Arguments(false)]
+    [Arguments(true)]
+    public void IdeAggregateAssertion_PreservesFirstMembersDiffAndAllSiblingMessages(bool nested)
     {
-        var first = new AssertionException("First assertion failure");
+        Exception first = new AssertionException("First assertion failure");
         first.Data["assert.expected"] = "1";
         first.Data["assert.actual"] = "2";
+        if (nested)
+        {
+            first = new AggregateException(first, new Exception("Nested sibling diagnostic"));
+        }
+
         var exception = new AggregateException(first, new Exception("Cleanup sibling diagnostic"));
 
         var state = TUnitMessageBus.GetFailureStateProperty(exception, null, TimeSpan.Zero, isConsole: false);
@@ -67,5 +74,9 @@ public class ExceptionReportingTests
         failed.Explanation.ShouldContain("[Assertion Failure]");
         failed.Explanation.ShouldContain("First assertion failure");
         failed.Explanation.ShouldContain("System.Exception: Cleanup sibling diagnostic");
+        if (nested)
+        {
+            failed.Explanation.ShouldContain("System.Exception: Nested sibling diagnostic");
+        }
     }
 }

--- a/tests/TUnit.Engine.Tests/ExceptionReportingTests.cs
+++ b/tests/TUnit.Engine.Tests/ExceptionReportingTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Shouldly;
+using TUnit.Assertions.Exceptions;
+
+namespace TUnit.Engine.Tests;
+
+public class ExceptionReportingTests
+{
+    [Test]
+    public void IdeTimeoutExplanation_IncludesEveryAggregateMember()
+    {
+        var exception = new AggregateException("Timeout and cleanup failures",
+            new TaskCanceledException("Custom cancellation diagnostic",
+                new InvalidOperationException("Inner diagnostic")),
+            new FormatException("Cleanup sibling diagnostic"));
+
+        var state = TUnitMessageBus.GetFailureStateProperty(exception,
+            TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100), isConsole: false);
+
+        var timeout = state.ShouldBeOfType<TimeoutTestNodeStateProperty>();
+        timeout.Explanation.ShouldStartWith("[Timeout] Test timed out after 50ms");
+        timeout.Explanation.ShouldContain("Custom cancellation diagnostic");
+        timeout.Explanation.ShouldContain("System.InvalidOperationException: Inner diagnostic");
+        timeout.Explanation.ShouldContain("System.FormatException: Cleanup sibling diagnostic");
+    }
+
+    [Test]
+    public void IdeTimeoutExplanation_IncludesCancellationMessageWithoutInnerException()
+    {
+        var exception = new TaskCanceledException("Custom cancellation diagnostic");
+
+        var state = TUnitMessageBus.GetFailureStateProperty(exception,
+            TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100), isConsole: false);
+
+        state.ShouldBeOfType<TimeoutTestNodeStateProperty>().Explanation.ShouldBe(
+            $"[Timeout] Test timed out after 50ms{Environment.NewLine}Custom cancellation diagnostic");
+    }
+
+    [Test]
+    public void ConsoleTimeoutExplanation_KeepsImmediateDiagnostic()
+    {
+        var exception = new TaskCanceledException("Custom cancellation diagnostic",
+            new InvalidOperationException("Inner diagnostic", new FormatException("Root cause")));
+
+        var state = TUnitMessageBus.GetFailureStateProperty(exception,
+            TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(100), isConsole: true);
+
+        var timeout = state.ShouldBeOfType<TimeoutTestNodeStateProperty>();
+        timeout.Exception.ShouldBeSameAs(exception);
+        timeout.Explanation.ShouldBe($"[Timeout] Test timed out after 50ms{Environment.NewLine}Inner diagnostic");
+    }
+
+    [Test]
+    public void IdeAggregateAssertion_PreservesFirstMembersDiffAndAllSiblingMessages()
+    {
+        var first = new AssertionException("First assertion failure");
+        first.Data["assert.expected"] = "1";
+        first.Data["assert.actual"] = "2";
+        var exception = new AggregateException(first, new Exception("Cleanup sibling diagnostic"));
+
+        var state = TUnitMessageBus.GetFailureStateProperty(exception, null, TimeSpan.Zero, isConsole: false);
+
+        var failed = state.ShouldBeOfType<FailedTestNodeStateProperty>();
+        failed.Exception!.Data["assert.expected"].ShouldBe("1");
+        failed.Exception.Data["assert.actual"].ShouldBe("2");
+        failed.Explanation.ShouldNotBeNull();
+        failed.Explanation.ShouldContain("[Assertion Failure]");
+        failed.Explanation.ShouldContain("First assertion failure");
+        failed.Explanation.ShouldContain("System.Exception: Cleanup sibling diagnostic");
+    }
+}

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -1,4 +1,6 @@
 using Shouldly;
+using TUnit.Assertions.Exceptions;
+using TUnit.Core.Exceptions;
 using TUnit.Engine.Exceptions;
 
 namespace TUnit.Engine.Tests;
@@ -142,7 +144,7 @@ public class FlattenedExceptionTests
         // every member message is already in the outer message and no member was ever thrown.
         var first = new InvalidOperationException("Expected 1 but was 2");
         var second = new InvalidOperationException("Expected true but was false");
-        var exception = Throw(() => new Exception(
+        var exception = Throw(() => new AssertionException(
             $"Expected 1 but was 2{Environment.NewLine}{Environment.NewLine}Expected true but was false",
             new AggregateException(first, second)));
 
@@ -176,7 +178,7 @@ public class FlattenedExceptionTests
     {
         // Hook wrappers splice the cause into their own message: "BeforeTest hook failed: boom".
         var cause = Throw(() => new InvalidOperationException("boom", Throw(() => new FormatException("root cause"))));
-        var exception = Throw(() => new Exception("BeforeTest hook failed: boom", cause));
+        var exception = Throw(() => new BeforeTestException("BeforeTest hook failed: boom", cause));
 
         var wrapped = FlattenedException.Wrap(exception);
 
@@ -199,6 +201,38 @@ public class FlattenedExceptionTests
         wrapped.Message.ShouldStartWith(aggregate.Message);
         wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: first");
         wrapped.Message.ShouldContain(" ---> System.ArgumentException: second");
+    }
+
+    [Test]
+    public void UnrelatedParentContainingInnerMessage_PreservesInnerException()
+    {
+        var exception = new Exception("operation boom failed", new InvalidOperationException("boom"));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldBe(string.Join(Environment.NewLine,
+            "operation boom failed",
+            " ---> System.InvalidOperationException: boom"));
+    }
+
+    [Test]
+    public void UnrelatedParentContainingAggregateMemberMessages_PreservesEveryMember()
+    {
+        var exception = new Exception("Invalid id format: 1", new AggregateException(
+            new ArgumentException("id"), new FormatException("1")));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldContain(" ---> System.ArgumentException: id");
+        wrapped.Message.ShouldContain(" ---> System.FormatException: 1");
+    }
+
+    [Test]
+    public void InnerExceptionWithEmptyMessage_PreservesType()
+    {
+        var wrapped = FlattenedException.Wrap(new Exception("outer", new InvalidOperationException("")));
+
+        wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: ");
     }
 
     [Test]
@@ -229,6 +263,39 @@ public class FlattenedExceptionTests
 
         wrapped.Data["assert.expected"].ShouldBe("1");
         wrapped.Data["assert.actual"].ShouldBe("2");
+    }
+
+    [Test]
+    public void AggregateException_CopiesAssertionDataFromFirstMemberOnly()
+    {
+        var first = new AssertionException("first");
+        first.Data["assert.expected"] = "1";
+        first.Data["assert.actual"] = "2";
+        first.Data["unrelated"] = "private member data";
+        var second = new AssertionException("second");
+        second.Data["assert.expected"] = "3";
+        second.Data["assert.actual"] = "4";
+
+        var wrapped = FlattenedException.Wrap(new AggregateException(first, second));
+
+        wrapped.Data["assert.expected"].ShouldBe("1");
+        wrapped.Data["assert.actual"].ShouldBe("2");
+        wrapped.Data.Contains("unrelated").ShouldBeFalse();
+    }
+
+    [Test]
+    public void AggregateException_PreservesRootAssertionData()
+    {
+        var first = new AssertionException("first");
+        first.Data["assert.expected"] = "member expected";
+        first.Data["assert.actual"] = "member actual";
+        var aggregate = new AggregateException(first, new Exception("second"));
+        aggregate.Data["assert.expected"] = "root expected";
+
+        var wrapped = FlattenedException.Wrap(aggregate);
+
+        wrapped.Data["assert.expected"].ShouldBe("root expected");
+        wrapped.Data["assert.actual"].ShouldBe("member actual");
     }
 
     [Test]

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -135,6 +135,40 @@ public class FlattenedExceptionTests
         wrapped.StackTrace!.ShouldContain(nameof(Throw));
     }
 
+    [Test]
+    public void ConsoleWrapperAroundAggregate_FoldsEverySiblingFromWrappedOriginal()
+    {
+        // TestFailedException (the console-mode wrapper) exposes only the first aggregate member as
+        // InnerException; folding must read the chain from WrappedException instead.
+        var first = Throw(() => new InvalidOperationException("first"));
+        var second = Throw(() => new ArgumentException("second", Throw(() => new FormatException("second-inner"))));
+        var aggregate = Throw(() => new AggregateException("aggregate", first, second));
+        var wrapper = new TestFailedException(aggregate);
+
+        var message = FlattenedException.CombineMessages(wrapper);
+        var stackTrace = FlattenedException.CombineStackTraces(wrapper);
+
+        message.ShouldStartWith(wrapper.Message);
+        message.ShouldContain(" ---> System.InvalidOperationException: first");
+        message.ShouldContain(" ---> System.ArgumentException: second");
+        message.ShouldContain(" ---> System.FormatException: second-inner");
+
+        stackTrace.ShouldStartWith(wrapper.StackTrace);
+        stackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        stackTrace.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        stackTrace.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
+    }
+
+    [Test]
+    public void AlreadyFlattened_CombineIsNoOp()
+    {
+        var wrapped = FlattenedException.Wrap(CreateNestedException());
+
+        FlattenedException.CombineMessages(wrapped).ShouldBe(wrapped.Message);
+        FlattenedException.CombineStackTraces(wrapped).ShouldBe(wrapped.StackTrace);
+        FlattenedException.Wrap(wrapped).ShouldBeSameAs(wrapped);
+    }
+
     private static Exception CreateNestedException()
     {
         try

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -123,16 +123,112 @@ public class FlattenedExceptionTests
     }
 
     [Test]
-    public void InnerExceptionWithoutStackTrace_StillListedInMessageAndStackTrace()
+    public void InnerExceptionWithoutStackTrace_ListedInMessage_NoFramelessSeparator()
     {
-        // Inner exception constructed but never thrown: its StackTrace is null.
+        // Inner exception constructed but never thrown: its StackTrace is null, so the type is
+        // carried by the message line only.
         var exception = Throw(() => new Exception("outer", new InvalidOperationException("never thrown")));
 
         var wrapped = FlattenedException.Wrap(exception);
 
         wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: never thrown");
+        wrapped.StackTrace.ShouldBe(exception.StackTrace);
+    }
+
+    [Test]
+    public void AssertMultipleShape_DoesNotRepeatMemberMessages()
+    {
+        // Assert.Multiple throws AssertionException(joinedMessages, new AggregateException(members)):
+        // every member message is already in the outer message and no member was ever thrown.
+        var first = new InvalidOperationException("Expected 1 but was 2");
+        var second = new InvalidOperationException("Expected true but was false");
+        var exception = Throw(() => new Exception(
+            $"Expected 1 but was 2{Environment.NewLine}{Environment.NewLine}Expected true but was false",
+            new AggregateException(first, second)));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldBe(exception.Message);
+        wrapped.StackTrace.ShouldBe(exception.StackTrace);
+    }
+
+    [Test]
+    public void InnerAggregate_GetsNoLineOfItsOwn_MembersAreListed()
+    {
+        var first = Throw(() => new InvalidOperationException("first"));
+        var second = Throw(() => new ArgumentException("second"));
+        var exception = Throw(() => new Exception("wrapper", new AggregateException(first, second)));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldBe(string.Join(Environment.NewLine,
+            "wrapper",
+            " ---> System.InvalidOperationException: first",
+            " ---> System.ArgumentException: second"));
+        wrapped.Message.ShouldNotContain("System.AggregateException");
         wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
-        wrapped.StackTrace!.ShouldContain(nameof(Throw));
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        wrapped.StackTrace!.ShouldNotContain("(System.AggregateException)");
+    }
+
+    [Test]
+    public void InnerMessageEmbeddedInParentMessage_NotRepeated_DeeperCauseStillListed()
+    {
+        // Hook wrappers splice the cause into their own message: "BeforeTest hook failed: boom".
+        var cause = Throw(() => new InvalidOperationException("boom", Throw(() => new FormatException("root cause"))));
+        var exception = Throw(() => new Exception("BeforeTest hook failed: boom", cause));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldBe(string.Join(Environment.NewLine,
+            "BeforeTest hook failed: boom",
+            " ---> System.FormatException: root cause"));
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
+    }
+
+    [Test]
+    public void RootAggregate_MembersListedEvenThoughAggregateMessageEmbedsThem()
+    {
+        var first = Throw(() => new InvalidOperationException("first"));
+        var second = Throw(() => new ArgumentException("second"));
+        var aggregate = Throw(() => new AggregateException("two failures", first, second));
+
+        var wrapped = FlattenedException.Wrap(aggregate);
+
+        wrapped.Message.ShouldStartWith(aggregate.Message);
+        wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: first");
+        wrapped.Message.ShouldContain(" ---> System.ArgumentException: second");
+    }
+
+    [Test]
+    public void ConsoleWrapper_FiltersInnerStackTracesLikeTheOuterOne()
+    {
+        var inner = new StackTraceOverrideException("inner", string.Join(Environment.NewLine,
+            "   at MyApp.Tests.UserTests.TestGetUser() in C:\\src\\Tests.cs:line 15",
+            "   at TUnit.Core.RunHelpers.RunAsync()",
+            "   at TUnit.Engine.TestExecutor.ExecuteAsync()"));
+        var wrapper = new TestFailedException(Throw(() => new Exception("outer", inner)));
+
+        var stackTrace = FlattenedException.CombineStackTraces(wrapper);
+
+        stackTrace.ShouldStartWith(wrapper.StackTrace);
+        stackTrace.ShouldContain("MyApp.Tests.UserTests.TestGetUser");
+        stackTrace.ShouldNotContain("TUnit.Core.RunHelpers");
+        stackTrace.ShouldNotContain("TUnit.Engine.TestExecutor");
+    }
+
+    [Test]
+    public void Wrap_CopiesExceptionData()
+    {
+        var exception = CreateNestedException();
+        exception.Data["assert.expected"] = "1";
+        exception.Data["assert.actual"] = "2";
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Data["assert.expected"].ShouldBe("1");
+        wrapped.Data["assert.actual"].ShouldBe("2");
     }
 
     [Test]
@@ -209,6 +305,11 @@ public class FlattenedExceptionTests
     private static void Method3()
     {
         throw new InvalidOperationException("Thrown from Method3");
+    }
+
+    private sealed class StackTraceOverrideException(string message, string stackTrace) : Exception(message)
+    {
+        public override string StackTrace { get; } = stackTrace;
     }
 
     private static Exception Throw(Func<Exception> factory)

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -190,6 +190,46 @@ public class FlattenedExceptionTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public void TestExecutionException_SingleFailure_DoesNotRepeatMessage(bool consoleWrapper)
+    {
+        var cause = Throw(() => new InvalidOperationException("test failure"));
+        var exception = Throw(() => new TestExecutionException(cause, [], []));
+        var reported = consoleWrapper ? new TestFailedException(exception) : exception;
+
+        var wrapped = FlattenedException.Wrap(reported);
+
+        wrapped.Message.ShouldBe(reported.Message);
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public void TestExecutionException_CombinedFailures_DoesNotRepeatMessages_PreservesDeeperCauses(bool consoleWrapper)
+    {
+        var cause = Throw(() => new InvalidOperationException("test failure",
+            Throw(() => new FormatException("root cause"))));
+        var hook = Throw(() => new AfterTestException("AfterTest hook failed: cleanup failure",
+            Throw(() => new ArgumentException("cleanup failure"))));
+        var receiver = Throw(() => new ApplicationException("receiver failure"));
+        var exception = Throw(() => new TestExecutionException(cause, [hook], [receiver]));
+        var reported = consoleWrapper ? new TestFailedException(exception) : exception;
+
+        var wrapped = FlattenedException.Wrap(reported);
+
+        wrapped.Message.ShouldBe(string.Join(Environment.NewLine,
+            reported.Message,
+            " ---> System.FormatException: root cause"));
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (TUnit.Core.Exceptions.AfterTestException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.ApplicationException) ---");
+    }
+
+    [Test]
     public void RootAggregate_MembersListedEvenThoughAggregateMessageEmbedsThem()
     {
         var first = Throw(() => new InvalidOperationException("first"));

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -47,7 +47,7 @@ public class FlattenedExceptionTests
 
         var wrapped = FlattenedException.Wrap(exception);
 
-        var stackTrace = wrapped.StackTrace;
+        var stackTrace = wrapped.StackTrace!;
         stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method1)}()");
         stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method2)}()");
         stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method3)}()");
@@ -117,9 +117,9 @@ public class FlattenedExceptionTests
         wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: first");
         wrapped.Message.ShouldContain(" ---> System.ArgumentException: second");
         wrapped.Message.ShouldContain(" ---> System.FormatException: second-inner");
-        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
-        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
-        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
     }
 
     [Test]
@@ -131,8 +131,8 @@ public class FlattenedExceptionTests
         var wrapped = FlattenedException.Wrap(exception);
 
         wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: never thrown");
-        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
-        wrapped.StackTrace.ShouldContain(nameof(Throw));
+        wrapped.StackTrace!.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace!.ShouldContain(nameof(Throw));
     }
 
     private static Exception CreateNestedException()

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -306,9 +306,12 @@ public class FlattenedExceptionTests
     }
 
     [Test]
-    public void AggregateException_CopiesAssertionDataFromFirstMemberOnly()
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    public void AggregateException_CopiesAssertionDataFromFirstMemberOnly(int depth)
     {
-        var first = new AssertionException("first");
+        Exception first = new AssertionException("first");
         first.Data["assert.expected"] = "1";
         first.Data["assert.actual"] = "2";
         first.Data["unrelated"] = "private member data";
@@ -316,7 +319,12 @@ public class FlattenedExceptionTests
         second.Data["assert.expected"] = "3";
         second.Data["assert.actual"] = "4";
 
-        var wrapped = FlattenedException.Wrap(new AggregateException(first, second));
+        for (var i = 0; i < depth; i++)
+        {
+            first = new AggregateException(first, second);
+        }
+
+        var wrapped = FlattenedException.Wrap(first);
 
         wrapped.Data["assert.expected"].ShouldBe("1");
         wrapped.Data["assert.actual"].ShouldBe("2");
@@ -324,11 +332,19 @@ public class FlattenedExceptionTests
     }
 
     [Test]
-    public void AggregateException_PreservesRootAssertionData()
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    public void AggregateException_PreservesRootAssertionData(int depth)
     {
-        var first = new AssertionException("first");
+        Exception first = new AssertionException("first");
         first.Data["assert.expected"] = "member expected";
         first.Data["assert.actual"] = "member actual";
+        for (var i = 1; i < depth; i++)
+        {
+            first = new AggregateException(first, new Exception("nested sibling"));
+        }
+
         var aggregate = new AggregateException(first, new Exception("second"));
         aggregate.Data["assert.expected"] = "root expected";
 

--- a/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
+++ b/tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs
@@ -1,0 +1,191 @@
+using Shouldly;
+using TUnit.Engine.Exceptions;
+
+namespace TUnit.Engine.Tests;
+
+// Regression coverage for https://github.com/thomhurst/TUnit/issues/1327: IDE clients only receive
+// Exception.Message and Exception.StackTrace, so the inner-exception chain must be folded into them.
+public class FlattenedExceptionTests
+{
+    [Test]
+    public void Wrap_ExceptionWithoutInner_ReturnsSameInstance()
+    {
+        var exception = Throw(() => new InvalidOperationException("leaf"));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.ShouldBeSameAs(exception);
+    }
+
+    [Test]
+    public void Wrap_ExceptionWithInner_ReturnsFlattenedException()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.ShouldBeOfType<FlattenedException>();
+    }
+
+    [Test]
+    public void Message_ListsEveryInnerExceptionOutermostFirst()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldBe(string.Join(Environment.NewLine,
+            "Thrown from Method1",
+            " ---> System.ArgumentException: Thrown from Method2",
+            " ---> System.InvalidOperationException: Thrown from Method3"));
+    }
+
+    [Test]
+    public void StackTrace_ContainsFramesOfEveryInnerException()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        var stackTrace = wrapped.StackTrace;
+        stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method1)}()");
+        stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method2)}()");
+        stackTrace.ShouldContain($"{nameof(FlattenedExceptionTests)}.{nameof(Method3)}()");
+        stackTrace.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        stackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+    }
+
+    [Test]
+    public void StackTrace_OrdersOuterFramesBeforeInnerFrames()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        var stackTrace = wrapped.StackTrace!;
+        var method1 = stackTrace.IndexOf($"{nameof(Method1)}()", StringComparison.Ordinal);
+        var method2 = stackTrace.IndexOf($"{nameof(Method2)}()", StringComparison.Ordinal);
+        var method3 = stackTrace.IndexOf($"{nameof(Method3)}()", StringComparison.Ordinal);
+
+        method1.ShouldBeLessThan(method2);
+        method2.ShouldBeLessThan(method3);
+    }
+
+    [Test]
+    public void InnerException_IsNull_SoChainWalkersDoNotDuplicateOutput()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.InnerException.ShouldBeNull();
+    }
+
+    [Test]
+    public void Unwrap_ReturnsOriginalException()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        TUnitFailedException.Unwrap(wrapped).ShouldBeSameAs(exception);
+    }
+
+    [Test]
+    public void ToString_ReportsOriginalTypeMessageAndFoldedStackTrace()
+    {
+        var exception = CreateNestedException();
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        var text = wrapped.ToString();
+        text.ShouldStartWith("System.Exception: Thrown from Method1");
+        text.ShouldContain(" ---> System.InvalidOperationException: Thrown from Method3");
+        text.ShouldContain($"{nameof(Method3)}()");
+        text.ShouldNotContain("TUnit.Engine.Exceptions.FlattenedException");
+    }
+
+    [Test]
+    public void AggregateException_IncludesEverySiblingAndTheirInnerChains()
+    {
+        var first = Throw(() => new InvalidOperationException("first"));
+        var second = Throw(() => new ArgumentException("second", Throw(() => new FormatException("second-inner"))));
+        var aggregate = new AggregateException("aggregate", first, second);
+
+        var wrapped = FlattenedException.Wrap(aggregate);
+
+        wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: first");
+        wrapped.Message.ShouldContain(" ---> System.ArgumentException: second");
+        wrapped.Message.ShouldContain(" ---> System.FormatException: second-inner");
+        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.ArgumentException) ---");
+        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.FormatException) ---");
+    }
+
+    [Test]
+    public void InnerExceptionWithoutStackTrace_StillListedInMessageAndStackTrace()
+    {
+        // Inner exception constructed but never thrown: its StackTrace is null.
+        var exception = Throw(() => new Exception("outer", new InvalidOperationException("never thrown")));
+
+        var wrapped = FlattenedException.Wrap(exception);
+
+        wrapped.Message.ShouldContain(" ---> System.InvalidOperationException: never thrown");
+        wrapped.StackTrace.ShouldContain("--- Inner exception stack trace (System.InvalidOperationException) ---");
+        wrapped.StackTrace.ShouldContain(nameof(Throw));
+    }
+
+    private static Exception CreateNestedException()
+    {
+        try
+        {
+            Method1();
+            throw new InvalidOperationException("Method1 should have thrown");
+        }
+        catch (Exception e) when (e.Message == "Thrown from Method1")
+        {
+            return e;
+        }
+    }
+
+    private static void Method1()
+    {
+        try
+        {
+            Method2();
+        }
+        catch (Exception e)
+        {
+            throw new Exception("Thrown from Method1", e);
+        }
+    }
+
+    private static void Method2()
+    {
+        try
+        {
+            Method3();
+        }
+        catch (Exception e)
+        {
+            throw new ArgumentException("Thrown from Method2", e);
+        }
+    }
+
+    private static void Method3()
+    {
+        throw new InvalidOperationException("Thrown from Method3");
+    }
+
+    private static Exception Throw(Func<Exception> factory)
+    {
+        try
+        {
+            throw factory();
+        }
+        catch (Exception e)
+        {
+            return e;
+        }
+    }
+}

--- a/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
+++ b/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
@@ -1,0 +1,34 @@
+using Shouldly;
+using TUnit.Engine.Tests.Enums;
+
+namespace TUnit.Engine.Tests;
+
+// Regression for https://github.com/thomhurst/TUnit/issues/1327: a TRX ErrorInfo only carries a
+// message and a stack trace, so the inner-exception chain has to be folded into both or the
+// report shows just the outermost exception.
+public class NestedExceptionTrxTests(TestMode testMode) : InvokableTestBase(testMode)
+{
+    [Test]
+    public async Task Trx_ErrorInfo_Includes_Every_Inner_Exception()
+    {
+        await RunTestsWithFilter(
+            "/*/*/NestedExceptionTests/Test",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result =>
+                {
+                    var errorInfo = result.Results.Single().Output?.ErrorInfo;
+                    errorInfo.ShouldNotBeNull();
+
+                    errorInfo.Message.ShouldContain("Thrown from Method1");
+                    errorInfo.Message.ShouldContain("System.ArgumentException: Thrown from Method2");
+                    errorInfo.Message.ShouldContain("System.InvalidOperationException: Thrown from Method3");
+
+                    errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method1()");
+                    errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method2()");
+                    errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method3()");
+                },
+            ]);
+    }
+}

--- a/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
+++ b/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
@@ -56,4 +56,31 @@ public class NestedExceptionTrxTests(TestMode testMode) : InvokableTestBase(test
                 },
             ]);
     }
+
+    [Test]
+    public async Task Trx_ErrorInfo_Includes_Every_Aggregate_Member_With_Detailed_StackTrace()
+    {
+        // With --detailed-stacktrace the console host reports the raw AggregateException instead of
+        // the TestFailedException wrapper; it must still be reported whole rather than reduced to
+        // its first member.
+        await RunTestsWithFilter(
+            "/*/*/IdeExceptionReportingTests/AggregateFailures",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result =>
+                {
+                    var errorInfo = result.Results.Single().Output?.ErrorInfo;
+                    errorInfo.ShouldNotBeNull();
+
+                    errorInfo.Message.ShouldContain("System.InvalidOperationException: First failure");
+                    errorInfo.Message.ShouldContain("System.ArgumentException: Second failure");
+                    errorInfo.Message.ShouldContain("System.FormatException: Second failure cause");
+
+                    errorInfo.StackTrace.ShouldContain("IdeExceptionReportingTests.First()");
+                    errorInfo.StackTrace.ShouldContain("IdeExceptionReportingTests.Second()");
+                },
+            ],
+            new RunOptions().WithArgument("--detailed-stacktrace"));
+    }
 }

--- a/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
+++ b/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
@@ -25,9 +25,16 @@ public class NestedExceptionTrxTests(TestMode testMode) : InvokableTestBase(test
                     errorInfo.Message.ShouldContain("System.ArgumentException: Thrown from Method2");
                     errorInfo.Message.ShouldContain("System.InvalidOperationException: Thrown from Method3");
 
-                    errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method1()");
+                    // The outer trace is filtered in a default console run (the TestProject namespace
+                    // starts with "TUnit." and is stripped as internal), so only the inner traces and
+                    // their order are load-bearing here.
                     errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method2()");
                     errorInfo.StackTrace.ShouldContain("NestedExceptionTests.Method3()");
+
+                    var argumentSeparator = errorInfo.StackTrace.IndexOf("--- Inner exception stack trace (System.ArgumentException) ---", StringComparison.Ordinal);
+                    var invalidOperationSeparator = errorInfo.StackTrace.IndexOf("--- Inner exception stack trace (System.InvalidOperationException) ---", StringComparison.Ordinal);
+                    argumentSeparator.ShouldBeGreaterThan(-1);
+                    invalidOperationSeparator.ShouldBeGreaterThan(argumentSeparator);
                 },
             ]);
     }

--- a/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
+++ b/tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs
@@ -31,4 +31,29 @@ public class NestedExceptionTrxTests(TestMode testMode) : InvokableTestBase(test
                 },
             ]);
     }
+
+    [Test]
+    public async Task Trx_ErrorInfo_Includes_Every_Aggregate_Member()
+    {
+        // The console host wraps the AggregateException in TestFailedException before the TRX
+        // property is built; the fold must still list every member, not just the first.
+        await RunTestsWithFilter(
+            "/*/*/IdeExceptionReportingTests/AggregateFailures",
+            [
+                result => result.ResultSummary.Outcome.ShouldBe("Failed"),
+                result => result.ResultSummary.Counters.Failed.ShouldBe(1),
+                result =>
+                {
+                    var errorInfo = result.Results.Single().Output?.ErrorInfo;
+                    errorInfo.ShouldNotBeNull();
+
+                    errorInfo.Message.ShouldContain("System.InvalidOperationException: First failure");
+                    errorInfo.Message.ShouldContain("System.ArgumentException: Second failure");
+                    errorInfo.Message.ShouldContain("System.FormatException: Second failure cause");
+
+                    errorInfo.StackTrace.ShouldContain("IdeExceptionReportingTests.First()");
+                    errorInfo.StackTrace.ShouldContain("IdeExceptionReportingTests.Second()");
+                },
+            ]);
+    }
 }

--- a/tests/TUnit.RpcTests/Tests.cs
+++ b/tests/TUnit.RpcTests/Tests.cs
@@ -1,4 +1,4 @@
-﻿using TUnit.RpcTests.Models;
+using TUnit.RpcTests.Models;
 
 namespace TUnit.RpcTests;
 
@@ -211,6 +211,85 @@ public class Tests
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method1()");
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method2()");
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method3()");
+        }
+    }
+
+    // Regression for https://github.com/thomhurst/TUnit/issues/1327 - a multi-member AggregateException
+    // used to be reduced to its first member before reporting, so IDE clients never saw the siblings.
+    [Test]
+    [Timeout(300_000)]
+    [Retry(3)]
+    [MethodDataSource(nameof(Frameworks))]
+    public async Task RunTests_WithAggregateException_ReportsEverySiblingToIdeClients(string framework, CancellationToken cancellationToken)
+    {
+        await using var session = await TestHostSession.StartAsync(framework, cancellationToken);
+
+        var discovered = await session.DiscoverAsync(cancellationToken);
+
+        var aggregateTests = discovered
+            .Select(x => x.Node)
+            .Where(node => node.Uid.Contains(".IdeExceptionReportingTests.") && node.Uid.Contains(".AggregateFailures."))
+            .ToArray();
+
+        await Assert.That(aggregateTests).Count().IsEqualTo(1);
+
+        var runUpdates = await session.RunAsync(aggregateTests, cancellationToken);
+
+        var failed = runUpdates
+            .Select(x => x.Node)
+            .Where(node => node.ExecutionState is "error" or "failed")
+            .ToArray();
+
+        await Assert.That(failed).Count().IsEqualTo(1);
+
+        var errorMessage = failed[0].ExtensionData?["error.message"].GetString();
+        var errorStackTrace = failed[0].ExtensionData?["error.stacktrace"].GetString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(errorMessage).Contains("System.InvalidOperationException: First failure");
+            await Assert.That(errorMessage).Contains("System.ArgumentException: Second failure");
+            await Assert.That(errorMessage).Contains("System.FormatException: Second failure cause");
+            await Assert.That(errorStackTrace).Contains("IdeExceptionReportingTests.First()");
+            await Assert.That(errorStackTrace).Contains("IdeExceptionReportingTests.Second()");
+        }
+    }
+
+    // Regression for https://github.com/thomhurst/TUnit/issues/1327 - the timeout explanation is what IDE
+    // clients receive as error.message, and it used to carry only the immediate diagnostic message.
+    [Test]
+    [Timeout(300_000)]
+    [Retry(3)]
+    [MethodDataSource(nameof(Frameworks))]
+    public async Task RunTests_WithTimeoutDiagnosticChain_ReportsEveryDiagnosticMessageToIdeClients(string framework, CancellationToken cancellationToken)
+    {
+        await using var session = await TestHostSession.StartAsync(framework, cancellationToken);
+
+        var discovered = await session.DiscoverAsync(cancellationToken);
+
+        var timeoutTests = discovered
+            .Select(x => x.Node)
+            .Where(node => node.Uid.Contains(".IdeExceptionReportingTests.") && node.Uid.Contains("Timeout_With_Nested_Diagnostic"))
+            .ToArray();
+
+        await Assert.That(timeoutTests).Count().IsEqualTo(1);
+
+        var runUpdates = await session.RunAsync(timeoutTests, cancellationToken);
+
+        var timedOut = runUpdates
+            .Select(x => x.Node)
+            .Where(node => node.ExecutionState is "timed-out")
+            .ToArray();
+
+        await Assert.That(timedOut).Count().IsEqualTo(1);
+
+        var errorMessage = timedOut[0].ExtensionData?["error.message"].GetString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(errorMessage).Contains("timed out");
+            await Assert.That(errorMessage).Contains("Inner diagnostic");
+            await Assert.That(errorMessage).Contains("System.FormatException: Root cause");
         }
     }
 }

--- a/tests/TUnit.RpcTests/Tests.cs
+++ b/tests/TUnit.RpcTests/Tests.cs
@@ -208,6 +208,7 @@ public class Tests
             await Assert.That(errorMessage).Contains("Thrown from Method1");
             await Assert.That(errorMessage).Contains("System.ArgumentException: Thrown from Method2");
             await Assert.That(errorMessage).Contains("System.InvalidOperationException: Thrown from Method3");
+            await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Test()");
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method1()");
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method2()");
             await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method3()");

--- a/tests/TUnit.RpcTests/Tests.cs
+++ b/tests/TUnit.RpcTests/Tests.cs
@@ -289,6 +289,7 @@ public class Tests
         using (Assert.Multiple())
         {
             await Assert.That(errorMessage).Contains("timed out");
+            await Assert.That(errorMessage).Contains("Custom task cancellation diagnostic");
             await Assert.That(errorMessage).Contains("Inner diagnostic");
             await Assert.That(errorMessage).Contains("System.FormatException: Root cause");
         }

--- a/tests/TUnit.RpcTests/Tests.cs
+++ b/tests/TUnit.RpcTests/Tests.cs
@@ -1,4 +1,4 @@
-using TUnit.RpcTests.Models;
+﻿using TUnit.RpcTests.Models;
 
 namespace TUnit.RpcTests;
 
@@ -168,5 +168,49 @@ public class Tests
             .ToArray();
 
         await Assert.That(skipped).Count().IsGreaterThan(0);
+    }
+
+    // Regression for https://github.com/thomhurst/TUnit/issues/1327 - MTP's server-mode serializer only
+    // sends Exception.Message and Exception.StackTrace to IDE clients, never the InnerException chain,
+    // so Rider and Visual Studio showed just the outermost exception. The engine must fold the chain
+    // into both fields for non-console clients.
+    [Test]
+    [Timeout(300_000)]
+    [Retry(3)]
+    [MethodDataSource(nameof(Frameworks))]
+    public async Task RunTests_WithNestedException_ReportsInnerExceptionsToIdeClients(string framework, CancellationToken cancellationToken)
+    {
+        await using var session = await TestHostSession.StartAsync(framework, cancellationToken);
+
+        var discovered = await session.DiscoverAsync(cancellationToken);
+
+        var nestedExceptionTests = discovered
+            .Select(x => x.Node)
+            .Where(node => node.Uid.Contains(".NestedExceptionTests."))
+            .ToArray();
+
+        await Assert.That(nestedExceptionTests).Count().IsEqualTo(1);
+
+        var runUpdates = await session.RunAsync(nestedExceptionTests, cancellationToken);
+
+        var failed = runUpdates
+            .Select(x => x.Node)
+            .Where(node => node.ExecutionState is "error" or "failed")
+            .ToArray();
+
+        await Assert.That(failed).Count().IsEqualTo(1);
+
+        var errorMessage = failed[0].ExtensionData?["error.message"].GetString();
+        var errorStackTrace = failed[0].ExtensionData?["error.stacktrace"].GetString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(errorMessage).Contains("Thrown from Method1");
+            await Assert.That(errorMessage).Contains("System.ArgumentException: Thrown from Method2");
+            await Assert.That(errorMessage).Contains("System.InvalidOperationException: Thrown from Method3");
+            await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method1()");
+            await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method2()");
+            await Assert.That(errorStackTrace).Contains("NestedExceptionTests.Method3()");
+        }
     }
 }

--- a/tests/TUnit.TestProject/Bugs/_1327/IdeExceptionReportingTests.cs
+++ b/tests/TUnit.TestProject/Bugs/_1327/IdeExceptionReportingTests.cs
@@ -1,0 +1,64 @@
+using TUnit.TestProject.Attributes;
+
+namespace TUnit.TestProject.Bugs._1327;
+
+// Fixtures for the IDE (Microsoft.Testing.Platform server-mode) exception reporting regressions
+// driven from TUnit.RpcTests. Every test here is expected to fail.
+[EngineTest(ExpectedResult.Failure)]
+public class IdeExceptionReportingTests
+{
+    [Test]
+    public void AggregateFailures()
+    {
+        var failures = new List<Exception>();
+
+        foreach (var action in new Action[] { First, Second })
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                failures.Add(e);
+            }
+        }
+
+        throw new AggregateException("Two failures", failures);
+    }
+
+    [Test]
+    [Timeout(50)]
+    public async Task Timeout_With_Nested_Diagnostic(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        catch (OperationCanceledException ex)
+        {
+            await Task.Delay(50);
+            throw new TaskCanceledException(
+                "Custom task cancellation diagnostic",
+                new InvalidOperationException("Inner diagnostic", new FormatException("Root cause")),
+                ex.CancellationToken);
+        }
+    }
+
+    private static void First()
+    {
+        throw new InvalidOperationException("First failure");
+    }
+
+    private static void Second()
+    {
+        try
+        {
+            throw new FormatException("Second failure cause");
+        }
+        catch (Exception e)
+        {
+            throw new ArgumentException("Second failure", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1327. Upstream improvement for the platform itself: microsoft/testfx#11202.

Rider and Visual Studio showed only the outermost exception for a failed test, while `dotnet run` and `dotnet test` printed the full chain. JetBrains closed [RSRP-499947](https://youtrack.jetbrains.com/issue/RSRP-499947) as a TUnit-side problem, and that is correct:

- Microsoft.Testing.Platform's server-mode (JSON-RPC) serializer sends a failed node as `error.message` (`Explanation ?? Exception.Message`) and `error.stacktrace` (`Exception.StackTrace`). It never walks `InnerException`.
- The console reporter and the `dotnet test` IPC consumer flatten the chain themselves, so the CLI was never affected.
- TUnit handed MTP the raw exception with an explanation of `[Category] outer.Message`, so IDE clients only ever saw the outer exception. xUnit (`XunitException`), MSTest (`MSTestTestNodeException`) and NUnit (via the VSTest bridge) all fold the chain into `Message` and `StackTrace` before handing the exception to MTP.

The TRX report had the same gap in every client mode: `TrxExceptionProperty` was built from the outermost exception's `Message` and `StackTrace` only.

## Fix

- New internal `FlattenedException` (derives from `TUnitFailedException`). `Message` is the outer message plus one ` ---> Type: Message` line per inner exception. `StackTrace` is the outer trace plus each thrown inner exception's trace under a `--- Inner exception stack trace (Type) ---` separator. Every member of an `AggregateException` is included.
- Folding rules that keep the output readable: an inner message the enclosing exception already embeds is not repeated (hook wrappers splice the cause into their own message, and `Assert.Multiple` lists every failure in the outer message before attaching them as an `AggregateException`, which previously came out three times); an inner `AggregateException` gets no line of its own; an inner exception that was never thrown gets no stack-trace separator; when the outer trace is a filtered TUnit wrapper trace, the inner traces are filtered the same way instead of reintroducing engine frames below the hint.
- `InnerException` is `null` so consumers that walk the chain never print it twice, the original exception stays reachable through `WrappedException`, and `Data` is copied so MTP's `assert.expected`/`assert.actual` fallback still works. The HTML, GitHub and JUnit reporters already call `TUnitFailedException.Unwrap`, so their output is unchanged.
- `TUnitMessageBus.GetFailureStateProperty` applies the wrapper for non-console clients only. A multi-member `AggregateException` (for example several failing `[After]` hooks) is reported whole on both branches so every sibling is listed; a single-member one is still reduced to its real cause. Console and `dotnet test` output for nested exceptions is unchanged (verified manually against `NestedExceptionTests` in both modes); a detailed console run (`--detailed-stacktrace`) of a multi-member aggregate now lists every sibling instead of only the first, because MTP's terminal reporter flattens a top-level aggregate itself.
- The timeout explanation, which is what IDE clients receive as `error.message`, now folds the diagnostic exception's own inner messages in for non-console clients instead of only the immediate one.
- `TUnitTestFramework.ReportUnhandledException` (discovery-level failures such as a throwing `[Before(TestDiscovery)]` hook) applies the same fold for non-console clients.
- `TestExtensions.ToTestNode` builds `TrxExceptionProperty` through the same `FlattenedException.Wrap`, so TRX `ErrorInfo` now carries the whole chain for console and IDE runs alike. In console runs the state property holds the `TestFailedException` wrapper, whose `InnerException` is only the first aggregate member, so the fold reads the chain from `TUnitFailedException.WrappedException` while keeping the wrapper's filtered message and stack trace in front.
- The console/IDE client-id check that `TUnitMessageBus` and `VerbosityService` each had a copy of now lives in `ClientInfoExtensions.IsConsoleClient`.
- `TUnitFailedException` gains an internal constructor for the pre-computed message and stack trace. No public API change.

Known trade-off, shared with xUnit and MSTest: in IDE sessions the state property's exception is the wrapper type, so an MTP consumer that reads `exception.GetType()` without `TUnitFailedException.Unwrap` (for example the OpenTelemetry result handler) reports `FlattenedException` for nested failures.

Server-mode payload for `NestedExceptionTests` before:

```
error.message:    [Test Failure] Thrown from Method1
error.stacktrace: <outer frames only>
```

After:

```
error.message:    [Test Failure] Thrown from Method1
                   ---> System.ArgumentException: Thrown from Method2
                   ---> System.InvalidOperationException: Thrown from Method3
error.stacktrace: <outer frames>
                  --- Inner exception stack trace (System.ArgumentException) ---
                  <Method2 frames>
                  --- Inner exception stack trace (System.InvalidOperationException) ---
                  <Method3 frames>
```

## Tests

- `tests/TUnit.Engine.Tests/FlattenedExceptionTests.cs`: 18 unit tests covering message and stack-trace folding, frame ordering, `AggregateException` siblings (root and inner), the `Assert.Multiple` shape, embedded inner messages, inner exceptions without a stack trace, inner-trace filtering behind the console wrapper, `Data` copying, the already-flattened no-op, `Unwrap` and `ToString`.
- `tests/TUnit.RpcTests/Tests.cs`: three server-mode regressions on net8.0 and net10.0. `RunTests_WithNestedException_ReportsInnerExceptionsToIdeClients` asserts `error.message` and `error.stacktrace` contain every inner exception (on `main` the payload contains only the outer exception). `RunTests_WithAggregateException_ReportsEverySiblingToIdeClients` asserts both members of a thrown `AggregateException` and their inner chains are reported. `RunTests_WithTimeoutDiagnosticChain_ReportsEveryDiagnosticMessageToIdeClients` asserts a timed-out test's nested diagnostic messages reach `error.message`.
- `tests/TUnit.TestProject/Bugs/_1327/IdeExceptionReportingTests.cs`: the aggregate and nested-timeout fixtures those RPC tests drive.
- `tests/TUnit.Engine.Tests/NestedExceptionTrxTests.cs`: runs `NestedExceptionTests` and the aggregate fixture through the console host with `--report-trx` (the aggregate both with and without `--detailed-stacktrace`) and asserts the TRX `ErrorInfo` message and stack trace contain every inner exception, every aggregate member, and the separators in outer-to-inner order.
- Existing `StackTraceFilterTests`, `GitHubReporterTests`, `Issue6688Tests`, `DefaultTimeoutClassificationTests` and `DataSourceExceptionPropagationTests` still pass.

https://claude.ai/code/session_01LvWBihkYCSQiPDXcTVatEk
