### PR TITLE
perf: read inline argument metadata without reflection

### DIFF
--- a/src/TUnit.Engine/Helpers/DataSourceMetadataExtractor.cs
+++ b/src/TUnit.Engine/Helpers/DataSourceMetadataExtractor.cs
@@ -30,6 +30,14 @@ internal static class DataSourceMetadataExtractor
             return null;
         }
 
+        // ArgumentsAttribute is sealed, so these reads have the same semantics as reflection.
+        if (dataSource is ArgumentsAttribute arguments)
+        {
+            return arguments.DisplayName is null && arguments.Skip is null && arguments.Categories is null
+                ? null
+                : new TestDataRowMetadata(arguments.DisplayName, null, arguments.Skip, arguments.Categories);
+        }
+
         var type = dataSource.GetType();
 
         // Try to get DisplayName property

--- a/tests/TUnit.UnitTests/DataSourceMetadataExtractorTests.cs
+++ b/tests/TUnit.UnitTests/DataSourceMetadataExtractorTests.cs
@@ -1,0 +1,89 @@
+using TUnit.Engine.Helpers;
+
+namespace TUnit.UnitTests;
+
+public class DataSourceMetadataExtractorTests
+{
+    [Test]
+    public async Task NullDataSource_ReturnsNull()
+    {
+        await Assert.That(DataSourceMetadataExtractor.ExtractFromAttribute(null)).IsNull();
+    }
+
+    [Test]
+    public async Task CustomDataSource_PreservesReflectionFallback()
+    {
+        var source = new CustomDataSource { DisplayName = "custom", Skip = "skip", Categories = ["category"] };
+        var metadata = DataSourceMetadataExtractor.ExtractFromAttribute(source)!;
+
+        await Assert.That(metadata.DisplayName).IsEqualTo(source.DisplayName);
+        await Assert.That(metadata.Skip).IsEqualTo(source.Skip);
+        await Assert.That(metadata.Categories).IsSameReferenceAs(source.Categories);
+    }
+
+    [Test]
+    public async Task ArgumentsWithoutMetadata_ReturnsNull()
+    {
+        await Assert.That(DataSourceMetadataExtractor.ExtractFromAttribute(new ArgumentsAttribute(42))).IsNull();
+    }
+
+    [Test]
+    public async Task ArgumentsWithMetadata_PreservesAllValues()
+    {
+        var arguments = new ArgumentsAttribute(42)
+        {
+            DisplayName = "row name",
+            Skip = "row skip",
+            Categories = ["one", "two"]
+        };
+
+        var metadata = DataSourceMetadataExtractor.ExtractFromAttribute(arguments)!;
+
+        await Assert.That(metadata.DisplayName).IsEqualTo(arguments.DisplayName);
+        await Assert.That(metadata.Skip).IsEqualTo(arguments.Skip);
+        await Assert.That(metadata.Categories).IsSameReferenceAs(arguments.Categories);
+        await Assert.That(metadata.DataExpression).IsNull();
+    }
+
+    [Test]
+    public async Task ArgumentsWithEmptyMetadata_DoesNotTreatEmptyAsNull()
+    {
+        var arguments = new ArgumentsAttribute(42)
+        {
+            DisplayName = "",
+            Skip = "",
+            Categories = []
+        };
+
+        var metadata = DataSourceMetadataExtractor.ExtractFromAttribute(arguments)!;
+
+        await Assert.That(metadata.DisplayName).IsEqualTo("");
+        await Assert.That(metadata.Skip).IsEqualTo("");
+        await Assert.That(metadata.Categories).IsSameReferenceAs(arguments.Categories);
+    }
+
+    [Test]
+    public async Task ArgumentsMetadata_IsReadAgainAfterMutation()
+    {
+        var arguments = new ArgumentsAttribute(42);
+        await Assert.That(DataSourceMetadataExtractor.ExtractFromAttribute(arguments)).IsNull();
+
+        arguments.Skip = "updated";
+        await Assert.That(DataSourceMetadataExtractor.ExtractFromAttribute(arguments)!.Skip).IsEqualTo("updated");
+
+        arguments.Skip = null;
+        await Assert.That(DataSourceMetadataExtractor.ExtractFromAttribute(arguments)).IsNull();
+    }
+
+    private sealed class CustomDataSource : IDataSourceAttribute
+    {
+        public string? DisplayName { get; set; }
+        public string? Skip { get; set; }
+        public string[]? Categories { get; set; }
+        public bool SkipIfEmpty { get; set; }
+        public bool DeferEnumeration { get; set; }
+
+        public IAsyncEnumerable<Func<Task<object?[]?>>> GetDataRowsAsync(DataGeneratorMetadata metadata)
+            => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Inline `[Arguments]` rows currently use three reflection property lookups to read `DisplayName`, `Skip`, and `Categories`. Read these properties directly for the sealed `ArgumentsAttribute`; retain the existing reflection fallback for all other data-source types.

The change preserves null versus empty metadata, the category array reference, and changes to attribute values between calls. It changes shared execution code, so source-generated and reflection discovery both use it. No public API changes.

## Performance evidence

Investigated after [the test-framework comparison](https://www.meziantou.net/benchmarking-dotnet-test-frameworks-xunit-v3-nunit-mstest-and-tunit.htm). This is a small, isolated improvement, **not an explanation or fix for the full inline-data timing gap in that article**.

Baseline: `a27cfb34bb`. BenchmarkDotNet 0.15.8 default job, Windows 11, Intel Core i7-12700K (20 logical processors), .NET 10.0.12 x64. The repository's `global.json` selects SDK `11.0.100-preview.7.26381.103` on this machine. Both implementations run in the same benchmark executable; inputs are stored in a field and results are returned. Setup checks that the outputs agree.

| Metadata | Before mean | After mean | Before error | After error | Allocated before / after |
|---|---:|---:|---:|---:|---:|
| All properties null | 40.1593 ns | 0.8595 ns | 0.7332 ns | 0.0309 ns | 0 B / 0 B |
| Name, skip, categories populated | 45.7552 ns | 6.3029 ns | 0.4328 ns | 0.1675 ns | 48 B / 48 B |

Error is BenchmarkDotNet's 99.9% confidence-interval half-width. The null case becomes a tiny inlineable field-check path; its absolute timing is close to measurement overhead. Savings are about 39 ns per extraction in this warm microbenchmark. Do not extrapolate the ratio to an entire test run. No end-to-end suite speedup is claimed.

## Validation

- Six targeted regression tests pass with source-generated discovery.
- The same six pass with `--reflection`.
- Native AOT publish and execution pass on Linux x64, SDK 10.0.401. A standalone smoke application compiles the actual modified helper and metadata record against the built TUnit.Core assembly. It checks default, populated, mutated, and custom reflection-fallback metadata. This is targeted helper validation, not a full-suite AOT run.
- Native AOT smoke output: `Native AOT metadata checks passed: default, populated, mutated, custom reflection fallback.`
- BenchmarkDotNet Dry job passed before the measured run.

```powershell
dotnet run --project tests/TUnit.UnitTests -c Release -f net10.0 -- --treenode-filter '/*/*/DataSourceMetadataExtractorTests/*' --progress off
dotnet run --project tests/TUnit.UnitTests -c Release -f net10.0 --no-build -- --treenode-filter '/*/*/DataSourceMetadataExtractorTests/*' --reflection --progress off
```

The benchmark source and reproduction steps are posted in a PR comment. Temporary measurement projects and generated benchmark artifacts are intentionally outside the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of argument metadata, including display names, skip settings, and categories.
  * Metadata changes are now reflected correctly, including when values are cleared.
  * Empty metadata values are preserved accurately instead of being treated as missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->