### PR TITLE
perf: limit converter discovery to declarations

### DIFF
--- a/src/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
+++ b/src/TUnit.Core.SourceGenerator/Generators/AotConverterGenerator.cs
@@ -107,6 +107,7 @@ public class AotConverterGenerator : IIncrementalGenerator
     private void ScanTestParameters(Compilation compilation, List<ConversionInfo> conversionInfos, CancellationToken cancellationToken)
     {
         var typesToScan = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
+        var baseTestAttribute = compilation.GetTypeByMetadataName(WellKnownFullyQualifiedClassNames.BaseTestAttribute.WithoutGlobalPrefix);
 
         foreach (var tree in compilation.SyntaxTrees)
         {
@@ -115,19 +116,26 @@ public class AotConverterGenerator : IIncrementalGenerator
             var semanticModel = compilation.GetSemanticModel(tree);
             var root = tree.GetRoot();
 
-            foreach(var nodes in root.DescendantNodes())
+            // Conversions depend on declarations and their attributes, never executable bodies.
+            foreach (var nodes in root.DescendantNodes(static node => node is not
+                         (BaseMethodDeclarationSyntax or BasePropertyDeclarationSyntax or BaseFieldDeclarationSyntax)))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if(nodes is MethodDeclarationSyntax method)
+                if (nodes is MethodDeclarationSyntax method)
                 {
+                    if (method.AttributeLists.Count == 0)
+                    {
+                        continue;
+                    }
+
                     var methodSymbol = semanticModel.GetDeclaredSymbol(method);
                     if (methodSymbol == null)
                     {
                         continue;
                     }
 
-                    if (!IsTestMethod(methodSymbol))
+                    if (!IsTestMethod(methodSymbol, baseTestAttribute))
                     {
                         continue;
                     }
@@ -148,7 +156,7 @@ public class AotConverterGenerator : IIncrementalGenerator
                         continue;
                     }
 
-                    if (!IsTestClass(classSymbol))
+                    if (!IsTestClass(classSymbol, baseTestAttribute))
                     {
                         continue;
                     }
@@ -179,35 +187,42 @@ public class AotConverterGenerator : IIncrementalGenerator
         }
     }
 
-    private static bool IsTestMethod(IMethodSymbol method)
+    private static bool IsTestMethod(IMethodSymbol method, INamedTypeSymbol? baseTestAttribute)
     {
-        return method.GetAttributes().Any(attr =>
+        foreach (var attr in method.GetAttributes())
         {
             var attrClass = attr.AttributeClass;
             if (attrClass == null)
             {
-                return false;
+                continue;
             }
 
             var baseType = attrClass;
             while (baseType != null)
             {
-                if (baseType.ToDisplayString() == WellKnownFullyQualifiedClassNames.BaseTestAttribute.WithoutGlobalPrefix)
+                if (SymbolEqualityComparer.Default.Equals(baseType, baseTestAttribute))
                 {
                     return true;
                 }
                 baseType = baseType.BaseType;
             }
 
-            return false;
-        });
+        }
+
+        return false;
     }
 
-    private bool IsTestClass(INamedTypeSymbol classSymbol)
+    private static bool IsTestClass(INamedTypeSymbol classSymbol, INamedTypeSymbol? baseTestAttribute)
     {
-        return classSymbol.GetMembers()
-            .OfType<IMethodSymbol>()
-            .Any(IsTestMethod);
+        foreach (var member in classSymbol.GetMembers())
+        {
+            if (member is IMethodSymbol method && IsTestMethod(method, baseTestAttribute))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void ScanAttributesForTypes(ImmutableArray<AttributeData> attributes, HashSet<ITypeSymbol> typesToScan)

--- a/tests/TUnit.Core.SourceGenerator.Tests/AotConverterScanTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/AotConverterScanTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.Generators;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class AotConverterScanTests
+{
+    [Test]
+    public async Task FindsConversionsInNestedAndPartialDeclarations()
+    {
+        const string source = """
+            using TUnit.Core;
+            public struct MethodValue { public static implicit operator MethodValue(int value) => new(); }
+            public struct ConstructorValue { public static implicit operator ConstructorValue(int value) => new(); }
+            public struct NestedValue { public static implicit operator NestedValue(int value) => new(); }
+            public struct PartialValue { public static implicit operator PartialValue(int value) => new(); }
+            public struct BodyOnlyValue { public static implicit operator BodyOnlyValue(int value) => new(); }
+            public partial class Tests
+            {
+                [Test]
+                public partial void Partial(System.Type value);
+
+                [Test, Arguments(1)]
+                public void Test(MethodValue value)
+                {
+                    BodyOnlyValue local = 1;
+                    void Helper() { BodyOnlyValue inner = 2; }
+                    Helper();
+                }
+                public class Nested
+                {
+                    [Test, Arguments(1)]
+                    public void Test(NestedValue value) { }
+                }
+            }
+            """;
+        const string secondPart = """
+            using TUnit.Core;
+            [Arguments(1)]
+            public partial class Tests
+            {
+                public partial void Partial([Arguments(typeof(PartialValue))] System.Type value) { }
+                public Tests(ConstructorValue value) { BodyOnlyValue local = 1; }
+                public BodyOnlyValue Property => 1;
+                private BodyOnlyValue field = 1;
+            }
+            """;
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compilation = CSharpCompilation.Create(
+            "ConverterDeclarations",
+            [CSharpSyntaxTree.ParseText(source, parseOptions), CSharpSyntaxTree.ParseText(secondPart, parseOptions)],
+            ReferencesHelper.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [new AotConverterGenerator().AsSourceGenerator()], parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var output, out var diagnostics);
+
+        await Assert.That(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+        await Assert.That(output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+
+        var generated = string.Join("\n", driver.GetRunResult().GeneratedTrees.Select(t => t.ToString()));
+        await Assert.That(generated).Contains("global::MethodValue");
+        await Assert.That(generated).Contains("global::ConstructorValue");
+        await Assert.That(generated).Contains("global::NestedValue");
+        await Assert.That(generated).Contains("global::PartialValue");
+        await Assert.That(generated).DoesNotContain("global::BodyOnlyValue");
+    }
+}


### PR DESCRIPTION
`AotConverterGenerator` walks every syntax node in every test body and repeatedly formats attribute type names while deciding which declarations need converters. Restrict traversal to declarations, resolve `BaseTestAttribute` once per compilation, and compare symbols directly. Avoid allocating LINQ predicates while checking methods and classes.

Nested classes, partial declarations, constructor parameters, parameter attributes on partial-method implementations, and existing conversion generation are preserved. No runtime execution or public API changes.

## Performance evidence

Baseline: `a27cfb34bb`. BenchmarkDotNet 0.15.8, 10 measured iterations and 5 warm-up iterations, Roslyn 4.14.0, Windows 11, Intel Core i7-12700K (20 logical processors), .NET 10.0.12 x64. SDK selected by the repository's `global.json`: `11.0.100-preview.7.26381.103`.

Each operation runs the converter generator over 10,000 tests in 100 classes. Setup creates and validates the compilation, loads the actual old and new generator assemblies in separate `AssemblyLoadContext` instances, and checks identical generated sources. The benchmark prints distinct assembly MVIDs and returns each resulting driver. Both builds are measured side by side, after a successful Dry run, without concurrent builds.

| Input | Before mean | After mean | Before error | After error | Allocated before | Allocated after |
|---|---:|---:|---:|---:|---:|---:|
| Bare synchronous tests | 39.33 ms | 14.59 ms | 3.253 ms | 3.616 ms | 17.25 MB | 4.54 MB |
| 20 additional statements per body | 232.64 ms | 15.20 ms | 40.241 ms | 3.715 ms | 151.53 MB | 4.54 MB |
| One inline-data row per method | 59.20 ms | 19.02 ms | 15.100 ms | 8.205 ms | 18.09 MB | 5.69 MB |

Error is BenchmarkDotNet's 99.9% confidence-interval half-width. Timings retain substantial variance, but the allocation reductions and large timing differences are clear. This table is a fresh run after stopping a lingering Docker setup process; earlier exploratory timings are not used here. These are **converter-only measurements**, excluding parsing, project startup, other generators, and compilation of generated code.

### Whole-project rebuild experiment

A separate project references TUnit 1.65.68 and replaces only its Core source-generator assembly with the baseline or modified build. It contains 10,000 bare tests in 100 files. Restore is outside timing; each timed `dotnet build -c Release --no-restore` follows an edit to one file. One warm-up per version is discarded, then five rounds alternate the version order. Both outputs execute exactly 10,000 passing tests.

| Round | Before rebuild | After rebuild |
|---|---:|---:|
| 1 | 11,018.03 ms | 7,670.69 ms |
| 2 | 5,937.24 ms | 5,673.31 ms |
| 3 | 7,930.87 ms | 8,019.65 ms |
| 4 | 5,892.08 ms | 5,202.96 ms |
| 5 | 5,392.31 ms | 7,267.76 ms |

**These exploratory rebuild timings are inconclusive.** They preceded the background-process cleanup above. The mean improves while the median worsens; noise exceeds the isolated saving for bare tests. This PR claims reduced converter work and allocations, not a demonstrated overall rebuild speedup or elimination of the gap in [the framework comparison](https://www.meziantou.net/benchmarking-dotnet-test-frameworks-xunit-v3-nunit-mstest-and-tunit.htm).

## Validation

- Full Core source-generator test/snapshot suite: 122 passed, one pre-existing skipped test, zero failures. No existing verified snapshots changed.
- New regression test compiles generated converters and covers nested classes, partial classes, constructor data, partial-method parameter attributes, and types referenced only inside bodies.
- The new regression test also passes against the original generator assembly.
- Roslyn 4.14 variant builds with zero warnings/errors; the base generator uses the repository's Roslyn 4.7 configuration.
- Synthetic baseline and modified test applications each execute 10,000 passing tests.
- Benchmark setup verifies identical generated sources for all three input shapes.

The complete benchmark source and reproduction steps are posted in a PR comment. Temporary benchmark projects and results are kept outside the repository.
