### PR TITLE
perf: skip teardown analysis when no disposable members need cleanup

### DIFF
--- a/src/TUnit.Analyzers/DisposableFieldPropertyAnalyzer.cs
+++ b/src/TUnit.Analyzers/DisposableFieldPropertyAnalyzer.cs
@@ -61,6 +61,12 @@ public class DisposableFieldPropertyAnalyzer : ConcurrentDiagnosticAnalyzer
             CheckSetUps(context, methodSymbol, createdObjects);
         }
 
+        // Teardown analysis can only remove members discovered during setup.
+        if (createdObjects.IsEmpty)
+        {
+            return;
+        }
+
         foreach (var methodSymbol in methodSymbols)
         {
             CheckTeardowns(context, methodSymbol, createdObjects);


### PR DESCRIPTION
`DisposableFieldPropertyAnalyzer` currently scans every method for teardown calls even when field, property, constructor, and setup analysis found no disposable members. This can resolve hundreds of thousands of invocation operations that cannot affect any diagnostic.

Return after setup analysis when the tracked-member collection is empty. Classes with disposable members continue through the existing teardown and reporting paths; instance and static analysis remain separate.

Measured with BenchmarkDotNet 0.15.8 over 10,000 tests in 100 classes, using the actual baseline (`b43fecac6d`) and PR analyzer assemblies:

| Workload | Before mean | After mean | Before allocated | After allocated |
| --- | ---: | ---: | ---: | ---: |
| Small method bodies, no fixtures | 419.9 ms | 272.1 ms | 168.23 MB | 129.74 MB |
| 20 additional calls per method, no fixtures | 2,448.5 ms | 1,383.2 ms | 1,055.14 MB | 723.07 MB |
| Larger bodies with undisposed fixtures (control) | 2,620.8 ms | 2,134.4 ms | 1,014.01 MB | 1,019.71 MB |

The larger-body workload allocated approximately 31% less. Timing is indicative: the unchanged fixture path also moved substantially between processes, and an earlier incomplete run did not show a small-body speedup. The full report below includes confidence intervals. No whole-build or test-execution speedup is claimed.

The benchmark includes Roslyn driver costs, excludes parsing and initial compilation validation, and runs one complete suite per iteration with analyzer concurrency disabled. Environment: Windows 11, i7-12700K, .NET 10.0.12, SDK 11.0.100-preview.7.26381.103; 10 measured iterations, 5 warmups, 1 launch.

Validation: all 47 `DisposableFieldPropertyAnalyzerTests` pass. Benchmark setup verifies identical diagnostics, including the same 100 `TUnit0023` warnings for the fixture control. Analyzer builds succeed; the existing `RS2007` release-header warning appears in both revisions. Reproduction source and full results are posted in the PR comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis efficiency by skipping unnecessary teardown checks when no disposable fields or properties are present.
  * Prevented irrelevant final diagnostics from being generated in cases where there is nothing to analyze.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->