### PR TITLE
perf: avoid line allocations when writing generated source

### DIFF
--- a/src/TUnit.Core.SourceGenerator/CodeWriter.cs
+++ b/src/TUnit.Core.SourceGenerator/CodeWriter.cs
@@ -215,35 +215,56 @@ public class CodeWriter : ICodeWriter
             return this;
         }
 
-        var lines = multilineText.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
-
-        // Skip leading empty lines
-        var startIndex = 0;
-        while (startIndex < lines.Length && string.IsNullOrWhiteSpace(lines[startIndex]))
+        var position = 0;
+        var hasContent = false;
+        var pendingBlankLines = 0;
+        while (position < multilineText.Length)
         {
-            startIndex++;
-        }
-
-        // Skip trailing empty lines
-        var endIndex = lines.Length - 1;
-        while (endIndex >= startIndex && string.IsNullOrWhiteSpace(lines[endIndex]))
-        {
-            endIndex--;
-        }
-
-        // Process remaining lines, preserving blank lines within the content
-        for (var i = startIndex; i <= endIndex; i++)
-        {
-            var line = lines[i].TrimEnd();
-            if (line.Length == 0)
+            var lineStart = position;
+            while (position < multilineText.Length && multilineText[position] is not '\r' and not '\n')
             {
-                // Preserve blank lines by forcing a newline even when already at line start
+                position++;
+            }
+
+            var lineEnd = position;
+            if (position < multilineText.Length)
+            {
+                var newline = multilineText[position++];
+                if (newline == '\r' && position < multilineText.Length && multilineText[position] == '\n')
+                {
+                    position++;
+                }
+            }
+
+            while (lineEnd > lineStart && char.IsWhiteSpace(multilineText[lineEnd - 1]))
+            {
+                lineEnd--;
+            }
+
+            if (lineEnd == lineStart)
+            {
+                if (hasContent)
+                {
+                    pendingBlankLines++;
+                }
+                continue;
+            }
+
+            // Delay blank lines so leading/trailing ones are omitted, while interior ones survive.
+            while (pendingBlankLines > 0)
+            {
                 _builder.AppendLine();
+                pendingBlankLines--;
             }
-            else
+
+            if (_isNewLine)
             {
-                AppendLine(line);
+                _builder.Append(GetIndentation(_indentLevel));
             }
+            _builder.Append(multilineText, lineStart, lineEnd - lineStart);
+            _builder.AppendLine();
+            _isNewLine = true;
+            hasContent = true;
         }
 
         return this;

--- a/tests/TUnit.Core.SourceGenerator.Tests/CodeWriterTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/CodeWriterTests.cs
@@ -1,0 +1,52 @@
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class CodeWriterTests
+{
+    [Test]
+    [Arguments("", "")]
+    [Arguments(" \t\r\n\u00a0\r\u2003\n", "")]
+    [Arguments("first", "    first\n")]
+    [Arguments("first\nsecond", "    first\n    second\n")]
+    [Arguments("first\rsecond", "    first\n    second\n")]
+    [Arguments("first\r\nsecond", "    first\n    second\n")]
+    [Arguments("\r\n \t\n  first \t\r\n\r\n\t\rsecond\n \t\n", "      first\n\n\n    second\n")]
+    [Arguments("first\u00a0\u2003\r\n\u00a0\nsecond\u0085", "    first\n\n    second\n")]
+    [Arguments("first\r\r\nsecond\n\n", "    first\n\n    second\n")]
+    [Arguments("first\u2028middle\nsecond", "    first\u2028middle\n    second\n")]
+    public async Task AppendRaw_PreservesFormatting(string input, string expected)
+    {
+        var writer = new CodeWriter(includeHeader: false);
+        writer.Indent();
+        writer.AppendRaw(input);
+        writer.Append("tail");
+
+        await Assert.That(writer.ToString()).IsEqualTo(expected.Replace("\n", Environment.NewLine) + "    tail");
+    }
+
+    [Test]
+    public async Task AppendRaw_PreservesPartialLineAndSubsequentWrites()
+    {
+        var writer = new CodeWriter(indentString: "--", includeHeader: false);
+        writer.Indent();
+        writer.Append("prefix:");
+        writer.AppendRaw("\n  \r\nfirst \t\r\n\t\n second\r\n\n");
+        writer.AppendRaw("third\n");
+        writer.Append("tail");
+
+        await Assert.That(writer.ToString()).IsEqualTo(
+            "--prefix:first\n\n-- second\n--third\n--tail".Replace("\n", Environment.NewLine));
+    }
+
+    [Test]
+    public async Task AppendRaw_EmptyInputDoesNotEndPartialLine()
+    {
+        var writer = new CodeWriter(includeHeader: false);
+        writer.Append("prefix:");
+        writer.AppendRaw(null!);
+        writer.AppendRaw("");
+        writer.AppendRaw(" \t\r\n\u00a0\n");
+        writer.Append("tail");
+
+        await Assert.That(writer.ToString()).IsEqualTo("prefix:tail");
+    }
+}


### PR DESCRIPTION
`CodeWriter.AppendRaw` splits every generated fragment into an array of line strings and trims each string before writing it. The per-class test-metadata pipeline calls it repeatedly while assembling generated source.

Scan the original string and append each line directly with `StringBuilder.Append(string, startIndex, count)`. Defer blank lines until the next content line so leading/trailing blank lines remain omitted and interior blank lines remain intact. Preserve indentation, partial-line writes, CR/LF/CRLF handling, and Unicode trailing-whitespace trimming. Generated source is unchanged.

BenchmarkDotNet 0.15.8 results using actual baseline (`b43fecac6d`) and modified generator assemblies:

| Workload | Before mean | After mean | Before allocated | After allocated |
| --- | ---: | ---: | ---: | ---: |
| Write a 300-line generated fragment | 25.726 μs | 8.872 μs | 66.34 KB | 35.75 KB |
| TestMetadataGenerator, 10,000 bare tests | 169.0 ms | 110.4 ms | 178.55 MB | 162.47 MB |
| TestMetadataGenerator, 10,000 inline-data tests | 239.5 ms | 224.8 ms | 384.87 MB | 358.63 MB |

The writer is about 2.9× faster and allocates 46% less in its focused workload. The complete metadata-generation passes allocate approximately 9% and 7% less. Timing varies in the larger workloads, and the inline-data confidence intervals overlap; its timing improvement is inconclusive. These measurements exclude parsing and compiling generated code, so they do not establish a whole-build speedup.

Validation:

- 134 generator tests pass, with one existing skip and no snapshot changes.
- All 12 new formatting cases pass on .NET 10 and .NET Framework 4.7.2.
- 1,000 randomized sequences of three writer calls match the baseline output exactly.
- Benchmark setup verifies identical generated filenames and source text for all 100 classes in each 10,000-test workload.
- Roslyn 4.4 and 4.14 variant builds pass with zero warnings/errors.

The PR comment includes full benchmark reports, confidence intervals, source, and reproduction commands. Environment: Windows 11, i7-12700K, .NET 10.0.12, SDK 11.0.100-preview.7.26381.103; 15 measured iterations, 6 warmups, 1 launch. Generator passes use one full suite per iteration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved raw text formatting, including indentation, blank lines, trailing whitespace handling, partial lines, and mixed newline formats.

* **Tests**
  * Added coverage for empty input, Unicode whitespace, formatting normalization, and combining raw text with subsequent writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->