### PR TITLE
perf: avoid formatting interface names for data-source checks

### DIFF
--- a/src/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceAttributeHelper.cs
+++ b/src/TUnit.Core.SourceGenerator/CodeGenerators/Helpers/DataSourceAttributeHelper.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using TUnit.Core.SourceGenerator.Helpers;
+using TUnit.Core.SourceGenerator.Extensions;
 
 namespace TUnit.Core.SourceGenerator.CodeGenerators.Helpers;
 
@@ -12,8 +13,32 @@ internal static class DataSourceAttributeHelper
             return false;
         }
 
-        // Check if the attribute implements IDataSourceAttribute
-        return InterfaceHelper.ImplementsInterface(attributeClass, "global::TUnit.Core.IDataSourceAttribute");
+        foreach (var implementedInterface in attributeClass.AllInterfaces)
+        {
+            if (implementedInterface.Name != "IDataSourceAttribute")
+            {
+                continue;
+            }
+
+            // Match the usual interface without allocating its fully qualified display name.
+            if (implementedInterface.Arity == 0 && implementedInterface.ContainingType == null &&
+                implementedInterface.ContainingNamespace is
+                {
+                    Name: "Core",
+                    ContainingNamespace: { Name: "TUnit", ContainingNamespace.IsGlobalNamespace: true }
+                })
+            {
+                return true;
+            }
+
+            // Preserve the existing display-name matching for unusual nested or generic symbols.
+            if (implementedInterface.GloballyQualified() == "global::TUnit.Core.IDataSourceAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static bool IsTypedDataSourceAttribute(INamedTypeSymbol? attributeClass)

--- a/src/TUnit.Core.SourceGenerator/Extensions/AttributeDataExtensions.cs
+++ b/src/TUnit.Core.SourceGenerator/Extensions/AttributeDataExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using TUnit.Core.SourceGenerator.Helpers;
+using TUnit.Core.SourceGenerator.CodeGenerators.Helpers;
 
 namespace TUnit.Core.SourceGenerator.Extensions;
 
@@ -17,13 +18,7 @@ public static class AttributeDataExtensions
 
     public static bool IsDataSourceAttribute(this AttributeData? attributeData)
     {
-        if (attributeData?.AttributeClass == null)
-        {
-            return false;
-        }
-
-        return InterfaceHelper.ImplementsInterface(attributeData.AttributeClass,
-            WellKnownFullyQualifiedClassNames.IDataSourceAttribute.WithGlobalPrefix);
+        return DataSourceAttributeHelper.IsDataSourceAttribute(attributeData?.AttributeClass);
     }
 
     public static bool IsTypedDataSourceAttribute(this AttributeData? attributeData)

--- a/tests/TUnit.Core.SourceGenerator.Tests/DataSourceAttributeDetectionTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/DataSourceAttributeDetectionTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.Extensions;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class DataSourceAttributeDetectionTests
+{
+    [Test]
+    [Arguments("DirectSource", true)]
+    [Arguments("InheritedSource", true)]
+    [Arguments("IndirectSource", true)]
+    [Arguments("GenericSource<int>", true)]
+    [Arguments("Unrelated", false)]
+    [Arguments("OtherNamespace", false)]
+    [Arguments("PrefixedNamespace", false)]
+    [Arguments("GenericInterface", false)]
+    [Arguments("NestedInterface", false)]
+    public async Task RecognizesDataSourceInterfaces(string attributeName, bool expected)
+    {
+        var source = """
+            namespace TUnit.Core
+            {
+                public interface IDataSourceAttribute { }
+                public interface IDataSourceAttribute<T> { }
+                public interface IIndirect : IDataSourceAttribute { }
+            }
+            namespace Other { public interface IDataSourceAttribute { } }
+            namespace Other.TUnit.Core { public interface IDataSourceAttribute { } }
+            public class Container { public interface IDataSourceAttribute { } }
+            public class DirectSource : System.Attribute, TUnit.Core.IDataSourceAttribute { }
+            public class InheritedSource : DirectSource { }
+            public class IndirectSource : System.Attribute, TUnit.Core.IIndirect { }
+            public class GenericSource<T> : System.Attribute, TUnit.Core.IDataSourceAttribute { }
+            public class Unrelated : System.Attribute, System.ICloneable
+            {
+                public object Clone() => this;
+            }
+            public class OtherNamespace : System.Attribute, Other.IDataSourceAttribute { }
+            public class PrefixedNamespace : System.Attribute, Other.TUnit.Core.IDataSourceAttribute { }
+            public class GenericInterface : System.Attribute, TUnit.Core.IDataSourceAttribute<int> { }
+            public class NestedInterface : System.Attribute, Container.IDataSourceAttribute { }
+            """ + $"\n[{attributeName}] public class Subject {{ }}";
+
+        var attribute = await GetSubjectAttribute(source);
+        await Assert.That(attribute.IsDataSourceAttribute()).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task NestedInterfaceWithMatchingDisplayName_PreservesExistingBehavior()
+    {
+        // Display-name matching historically accepts this spelling even though Core is a type.
+        const string source = """
+            namespace TUnit
+            {
+                public class Core { public interface IDataSourceAttribute { } }
+            }
+            public class Source : System.Attribute, TUnit.Core.IDataSourceAttribute { }
+            [Source] public class Subject { }
+            """;
+
+        var attribute = await GetSubjectAttribute(source);
+        await Assert.That(attribute.IsDataSourceAttribute()).IsTrue();
+    }
+
+    [Test]
+    public async Task NullAttribute_IsNotDataSource()
+    {
+        await Assert.That(AttributeDataExtensions.IsDataSourceAttribute(null)).IsFalse();
+    }
+
+    private static async Task<AttributeData> GetSubjectAttribute(string source)
+    {
+        var compilation = CSharpCompilation.Create("AttributeDetection",
+            [CSharpSyntaxTree.ParseText(source)], ReferencesHelper.References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        await Assert.That(compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+        return compilation.GetTypeByMetadataName("Subject")!.GetAttributes().Single();
+    }
+}


### PR DESCRIPTION
Data-source detection repeatedly formats fully qualified names for implemented interfaces, including unrelated generic interfaces. This work runs while filtering and emitting test attributes.

Reject interfaces with a different simple name, then recognize the usual non-generic `TUnit.Core.IDataSourceAttribute` through symbol properties. Keep the previous display-name comparison as a fallback for unusual shapes. Route both existing detection entry points through the same implementation. Generated source remains unchanged.

Focused BenchmarkDotNet results using actual baseline (`e322d68799`) and modified generator assemblies:

| Attribute symbol | Before mean | After mean | Before allocated | After allocated |
| --- | ---: | ---: | ---: | ---: |
| `ArgumentsAttribute` | 187.82 ns | 31.86 ns | 152 B | 48 B |
| `ArgumentsAttribute<int>` | 528.26 ns | 45.71 ns | 408 B | 56 B |

The checks are approximately 6–12× faster and allocate 104–352 fewer bytes per call.

Complete `TestMetadataGenerator` passes over 10,000 tests in 100 classes:

| Workload | Before mean | After mean | Before allocated | After allocated |
| --- | ---: | ---: | ---: | ---: |
| Bare tests (control) | 218.8 ms | 162.9 ms | 178.24 MB | 178.55 MB |
| Inline data | 349.5 ms | 341.4 ms | 383.81 MB | 381.91 MB |
| Typed inline data | 454.3 ms | 307.8 ms | 392.98 MB | 382.90 MB |

The allocation reductions are approximately 1.9 MB and 10.1 MB for the data-driven suites. Full-generator timing improvements are inconclusive: confidence intervals overlap and the bare-test control also changed substantially. These measurements exclude parsing and compilation of generated code; no whole-build speedup is claimed.

Validation: 133 generator tests pass with one existing skip and no snapshot changes. All 11 new classification cases pass on .NET 10 and .NET Framework 4.7.2. Roslyn 4.4 and 4.14 builds pass without warnings/errors. Benchmark setup verifies identical generated filenames and source text for all three workloads. Tests explicitly preserve legacy matching of nested interfaces with the same display name.

Environment: BenchmarkDotNet 0.15.8, Roslyn 4.14.0, Windows 11, i7-12700K, .NET 10.0.12, SDK 11.0.100-preview.7.26381.103; 15 measured iterations, 6 warmups, 1 launch. Full reports, confidence intervals, source, and reproduction commands are in the PR comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of data source attributes across direct, inherited, indirect, generic, nested-interface, and namespace variations.
  * Preserved existing behavior for attributes identified by their display name.
  * Added safe handling for missing or null attributes, preventing incorrect data source classification.

* **Tests**
  * Added comprehensive coverage for data source attribute detection, including generated source validation and diagnostic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->