### PR TITLE
perf: remove unused class metadata generation

### DIFF
--- a/src/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/src/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -2965,19 +2965,6 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Pre-generates shared local variable declarations for the top of GetTests() and Materialize().
-    /// Generates __classMetadata and __classType locals that are referenced by factory calls.
-    /// </summary>
-    private static string PreGenerateSharedLocals(INamedTypeSymbol typeSymbol, string className)
-    {
-        var writer = new CodeWriter(includeHeader: false);
-        var classMetadataExpr = MetadataGenerationHelper.GenerateClassMetadataGetOrAddWithParentExpression(typeSymbol, writer.IndentLevel);
-        writer.AppendLine($"var __classMetadata = {classMetadataExpr};");
-        writer.AppendLine($"var __classType = typeof({className});");
-        return writer.ToString();
-    }
-
-    /// <summary>
     /// Generates __classMetadata and __classType as static readonly fields instead of local variables.
     /// Used by the per-class path to inline MethodMetadata construction into field initializers,
     /// eliminating the separate __InitMethodMetadatas method and saving one JIT per class.
@@ -3307,7 +3294,6 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
                     AttributeGroups = distinctBodies.ToEquatableArray(),
                     InstanceFactoryBodyCode = InstanceFactoryGenerator.GenerateInstanceFactoryBody(typeSymbol),
                     ReflectionFieldAccessorsCode = PreGenerateReflectionFieldAccessors(typeSymbol),
-                    SharedLocalsCode = PreGenerateSharedLocals(typeSymbol, className),
                     SharedFieldsCode = PreGenerateSharedFields(typeSymbol, className),
                 };
             });

--- a/src/TUnit.Core.SourceGenerator/Models/ClassTestGroup.cs
+++ b/src/TUnit.Core.SourceGenerator/Models/ClassTestGroup.cs
@@ -17,7 +17,6 @@ public sealed record ClassTestGroup
 
     public required string InstanceFactoryBodyCode { get; init; }
     public required string ReflectionFieldAccessorsCode { get; init; }
-    public required string SharedLocalsCode { get; init; }
 
     /// <summary>
     /// Pre-generated static readonly field declarations for ClassMetadata and classType.

--- a/src/TUnit.Core.SourceGenerator/Utilities/MetadataGenerationHelper.cs
+++ b/src/TUnit.Core.SourceGenerator/Utilities/MetadataGenerationHelper.cs
@@ -121,7 +121,7 @@ internal static class MetadataGenerationHelper
 
     /// <summary>
     /// Generates ClassMetadata with recursive parent as a string expression.
-    /// Used by the per-class path to pre-generate shared locals.
+    /// Used by test-source generation to pre-generate shared fields.
     /// </summary>
     public static string GenerateClassMetadataGetOrAddWithParentExpression(INamedTypeSymbol typeSymbol, int indentLevel = 0)
     {


### PR DESCRIPTION
Each non-generic test class still generates and retains local-variable declarations for class metadata, although the emitter only uses the equivalent static fields. This repeats constructor/property metadata traversal and string formatting, then stores an unused string in the incremental class model.

Remove `PreGenerateSharedLocals`, its call, and `ClassTestGroup.SharedLocalsCode`. The patch removes 15 lines of unused generation/model code, corrects one related XML comment, and produces identical generated source.

BenchmarkDotNet comparisons use actual generator assemblies built from `e322d68799` and this commit. Every workload has 10,000 tests:

| Layout | Before allocated | After allocated | Reduction |
| --- | ---: | ---: | ---: |
| 100 classes × 100 tests | 178.55 MB | 177.46 MB | 1.09 MB (0.6%) |
| 1,000 classes × 10 tests | 216.40 MB | 206.09 MB | 10.31 MB (4.8%) |
| 1,000 classes × 10 tests, 20 properties each | 533.58 MB | 393.85 MB | 139.73 MB (26.2%) |

The property-heavy workload measures 417.0 ms before and 293.2 ms after. **Timing tradeoff:** the sparse layout measures slower after the change in both three-launch follow-ups: 190.9 to 217.2 ms, then 154.7 to 189.9 ms with reversed benchmark order. The cause remains unresolved. This PR reduces allocations; it is not a general throughput improvement. Full results are in the evidence comment. These are isolated `TestMetadataGenerator` passes over prebuilt compilations; no whole-build speedup is claimed.

Validation: 122 generator tests pass with one existing skip and no snapshot changes. Roslyn 4.4 and 4.14 builds pass with zero warnings/errors. Benchmark setup verifies exact equality of generated filenames and source text for all three workloads.

Environment: BenchmarkDotNet 0.15.8, Roslyn 4.14.0, Windows 11, i7-12700K, .NET 10.0.12, SDK 11.0.100-preview.7.26381.103. Main run: 15 measured iterations, 6 warmups, 1 launch, one generator pass per iteration. Full reports, confidence intervals, runnable benchmark source, and reproduction commands are posted in the evidence comment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined how test metadata and related test resources are prepared and shared during test execution.
  - Consolidated generated metadata and access information for each test class.
  - No changes to public APIs or user-facing test behavior are expected.
- **Documentation**
  - Updated internal documentation to accurately describe the metadata generation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->