### PR TITLE
perf: skip unannotated property data-source candidates

### DIFF
--- a/src/TUnit.Core.SourceGenerator/Generators/PropertyInjectionSourceGenerator.cs
+++ b/src/TUnit.Core.SourceGenerator/Generators/PropertyInjectionSourceGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TUnit.Core.SourceGenerator.Extensions;
 using TUnit.Core.SourceGenerator.Helpers;
@@ -26,9 +27,11 @@ public sealed class PropertyInjectionSourceGenerator : IIncrementalGenerator
             });
 
         // Pipeline 1: Find properties with IDataSourceAttribute and group by containing class
+        // Partial properties can receive attributes from their other declaration.
         var propertyDataSources = context.SyntaxProvider
             .CreateSyntaxProvider(
-                predicate: static (node, _) => node is PropertyDeclarationSyntax,
+                predicate: static (node, _) => node is PropertyDeclarationSyntax property
+                    && (property.AttributeLists.Count > 0 || property.Modifiers.Any(SyntaxKind.PartialKeyword)),
                 transform: static (ctx, _) => ExtractPropertyDataSource(ctx))
             .Where(static x => x is not null)
             .Select(static (x, _) => x!);

--- a/tests/TUnit.Core.SourceGenerator.Tests/PropertyInjectionIncrementalTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/PropertyInjectionIncrementalTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.Generators;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class PropertyInjectionIncrementalTests
+{
+    private const string Source = """
+        using TUnit.Core;
+        public class Fixture { }
+        public class Tests
+        {
+            [ClassDataSource<Fixture>]
+            public Fixture Value { get; set; }
+        }
+        """;
+
+    [Test]
+    public async Task AddingAndRemovingReferenceRefreshesCompilationTypes()
+    {
+        var withoutCore = ReferencesHelper.References
+            .Where(reference => !string.Equals(Path.GetFileName(reference.FilePath), "TUnit.Core.dll", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var compilation = CreateCompilation().WithReferences(withoutCore);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new PropertyInjectionSourceGenerator());
+
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+
+        compilation = compilation.WithReferences(ReferencesHelper.References);
+        await Assert.That(compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(GetSource(driver)).Contains("PropertyName = \"Value\"");
+
+        driver = driver.RunGenerators(compilation.WithReferences(withoutCore));
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+        await Assert.That(driver.GetRunResult().Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+    }
+
+    [Test]
+    public async Task PropertyEditUpdatesReusedDriver()
+    {
+        var compilation = CreateCompilation();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new PropertyInjectionSourceGenerator());
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(GetSource(driver)).Contains("PropertyName = \"Value\"");
+
+        var originalTree = compilation.SyntaxTrees.Single();
+        compilation = compilation.ReplaceSyntaxTree(originalTree,
+            CSharpSyntaxTree.ParseText(Source.Replace("Value", "Renamed")));
+        driver = driver.RunGenerators(compilation);
+
+        await Assert.That(GetSource(driver)).Contains("PropertyName = \"Renamed\"");
+        await Assert.That(GetSource(driver)).DoesNotContain("PropertyName = \"Value\"");
+        await Assert.That(driver.GetRunResult().Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+    }
+
+    private static string GetSource(GeneratorDriver driver) =>
+        string.Join("\n", driver.GetRunResult().GeneratedTrees.Select(tree => tree.ToString()));
+
+    [Test]
+    public async Task AddingAndRemovingAttributeUpdatesReusedDriver()
+    {
+        var plainSource = Source.Replace("[ClassDataSource<Fixture>]", "");
+        var compilation = CreateCompilation().RemoveAllSyntaxTrees().AddSyntaxTrees(CSharpSyntaxTree.ParseText(plainSource));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new PropertyInjectionSourceGenerator());
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+
+        compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.Single(), CSharpSyntaxTree.ParseText(Source));
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(GetSource(driver)).Contains("PropertyName = \"Value\"");
+
+        compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.Single(), CSharpSyntaxTree.ParseText(plainSource));
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+        await Assert.That(driver.GetRunResult().Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)).IsEmpty();
+    }
+
+    private static CSharpCompilation CreateCompilation() => CSharpCompilation.Create(
+        "PropertyInjectionEdits",
+        [CSharpSyntaxTree.ParseText(Source)],
+        ReferencesHelper.References,
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+}
+


### PR DESCRIPTION
`PropertyInjectionSourceGenerator` currently requests semantic information for every property while looking for data-source attributes. Ordinary unannotated properties cannot contribute to this pipeline, but still incur discovery and incremental tracking work.

Filter those declarations in the syntax predicate. Keep partial properties eligible because attributes can appear on the other declaration. The async-initializer and concrete-generic discovery pipelines are unchanged. Generated source remains identical.

Timing confirmation using actual baseline and modified generator assemblies, 10,000 properties across 100 classes:

| Workload | Mode | Before | After | Time reduction |
| --- | --- | ---: | ---: | ---: |
| Unannotated properties | Full generation | 18.649 ms | 12.080 ms | 35.2% |
| Unannotated properties | One-file edit | 7.698 ms | 4.494 ms | 41.6% |
| Mixed: one annotated property per class | Full generation | 20.290 ms | 13.607 ms | 32.9% |
| Mixed: one annotated property per class | One-file edit | 8.704 ms | 4.707 ms | 45.9% |

This confirmation reverses benchmark execution order and uses two process launches. The initial run also improves unannotated generation and mixed/unannotated edits. Its fully annotated edit control was noisy and slower; the confirmation does not reproduce that slowdown (28.998 ms before, 28.346 ms after). Both complete reports, including the unfavorable initial control result, are in the evidence comment. These are isolated generator-pass timings, not whole-build speedups.

Validation: 125 generator tests pass with one existing skip and no snapshot changes. Three new tests cover adding/removing attributes, renaming properties, and adding/removing the TUnit.Core reference on a reused driver; all also pass on .NET Framework 4.7.2. Roslyn 4.4 and 4.14 builds pass without warnings/errors. A separate Roslyn 4.14 check verifies attributes on either partial-property declaration: baseline and modified generated source match exactly and compile without errors.

Benchmark environment: BenchmarkDotNet 0.15.8, Roslyn 4.14.0, Windows 11, i7-12700K, .NET 10.0.12, SDK 11.0.100-preview.7.26381.103; 15 measured iterations, 10 warmups, 8 invocations per iteration. Baseline: `e322d68799`. Confirmation: two launches, modified version first. Runnable source and reproduction commands are posted in the evidence comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source generation reliability when properties lack relevant attributes or are not declared partial.
  * Ensured generated output updates correctly when references, property names, or data source attributes are added, removed, or changed.

* **Tests**
  * Added coverage for incremental source-generator updates and verified that these scenarios do not produce error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->