### PR TITLE
perf: reuse argument-free attribute initializer text

### DIFF
--- a/src/TUnit.Core.SourceGenerator/CodeGenerators/Writers/AttributeWriter.cs
+++ b/src/TUnit.Core.SourceGenerator/CodeGenerators/Writers/AttributeWriter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TUnit.Core.SourceGenerator.CodeGenerators.Helpers;
 using TUnit.Core.SourceGenerator.Extensions;
@@ -10,6 +10,7 @@ public class AttributeWriter(Compilation compilation)
     private const string TUnitRootNamespace = "TUnit";
 
     private readonly Dictionary<AttributeData, string> _attributeObjectInitializerCache = new();
+    private readonly Dictionary<INamedTypeSymbol, string> _argumentFreeAttributeInitializerCache = new(SymbolEqualityComparer.Default);
     private readonly Dictionary<INamedTypeSymbol, bool> _tunitRelatedCache = new(SymbolEqualityComparer.Default);
 
     public void WriteAttributes(ICodeWriter sourceCodeWriter,
@@ -66,6 +67,23 @@ public class AttributeWriter(Compilation compilation)
 
     public string GetAttributeObjectInitializer(AttributeData attributeData)
     {
+        // Argument-free attributes such as [Test] have the same initializer at every
+        // application site. Cache by type so large suites only format it once.
+        if (attributeData.AttributeClass is { } attributeClass &&
+            attributeData.ApplicationSyntaxReference?.GetSyntax() is AttributeSyntax
+            {
+                ArgumentList: null or { Arguments.Count: 0 }
+            })
+        {
+            if (!_argumentFreeAttributeInitializerCache.TryGetValue(attributeClass, out var argumentFreeInitializer))
+            {
+                argumentFreeInitializer = GetAttributeObjectInitializerInner(compilation, attributeData);
+                _argumentFreeAttributeInitializerCache.Add(attributeClass, argumentFreeInitializer);
+            }
+
+            return argumentFreeInitializer;
+        }
+
         if (_attributeObjectInitializerCache.TryGetValue(attributeData, out var initializer))
         {
             return initializer;

--- a/tests/TUnit.Core.SourceGenerator.Tests/AttributeInitializerCacheTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/AttributeInitializerCacheTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.CodeGenerators.Writers;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class AttributeInitializerCacheTests
+{
+    [Test]
+    public async Task ArgumentFreeApplicationsDoNotReplaceExplicitArguments()
+    {
+        var compilation = CreateCompilation("""
+            public class MarkerAttribute : System.Attribute
+            {
+                public MarkerAttribute(int value = 0) { }
+                public int Value { get; set; }
+            }
+            public class Tests
+            {
+                [Marker] public void First() { }
+                [Marker()] public void Second() { }
+                [Marker(42)] public void Explicit() { }
+                [Marker(Value = 17)] public void Named() { }
+            }
+            """);
+        var writer = new AttributeWriter(compilation);
+
+        await Assert.That(Initializer("First")).IsEqualTo("new global::MarkerAttribute()");
+        await Assert.That(Initializer("Second")).IsEqualTo("new global::MarkerAttribute()");
+        await Assert.That(Initializer("Explicit")).IsEqualTo("new global::MarkerAttribute(42)");
+        await Assert.That(Initializer("Named")).Contains("Value = 17");
+        await Assert.That(Initializer("First")).IsEqualTo("new global::MarkerAttribute()");
+
+        string Initializer(string method) => writer.GetAttributeObjectInitializer(
+            compilation.GetTypeByMetadataName("Tests")!.GetMembers(method).Single().GetAttributes().Single());
+    }
+
+    [Test]
+    public async Task ConstructedAttributeTypesKeepDistinctInitializers()
+    {
+        var compilation = CreateCompilation("""
+            public class MarkerAttribute<T> : System.Attribute { }
+            public class Tests
+            {
+                [Marker<int>] public void First() { }
+                [Marker<string>] public void Second() { }
+            }
+            """);
+        var writer = new AttributeWriter(compilation);
+        var methods = compilation.GetTypeByMetadataName("Tests")!.GetMembers();
+        var first = writer.GetAttributeObjectInitializer(methods.Single(m => m.Name == "First").GetAttributes().Single());
+        var second = writer.GetAttributeObjectInitializer(methods.Single(m => m.Name == "Second").GetAttributes().Single());
+
+        await Assert.That(first).IsNotEqualTo(second);
+        await Assert.That(first).Contains("MarkerAttribute<int>");
+        await Assert.That(second).Contains("MarkerAttribute<string>");
+    }
+
+    private static CSharpCompilation CreateCompilation(string source) => CSharpCompilation.Create(
+        "AttributeInitializers",
+        [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+        ReferencesHelper.References,
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+}


### PR DESCRIPTION
Large test suites repeatedly format identical argument-free attribute applications such as `[Test]`. Cache the emitted initializer text by constructed attribute type within each compilation, while keeping explicit arguments and named properties on the existing per-application path. Optional caller-info parameters retain the same generated syntax as before.

The complete TestMetadataGenerator benchmark (10,000 tests, 100 classes of 100 methods) allocates **12.87 MB less per generation, a 7.8% reduction**. Mean elapsed time decreased from 112.5 ms to 107.5 ms, but the timing distributions overlap: this PR claims the allocation improvement, not a statistically established whole-build speedup.

Validation: generator snapshot suite on net10.0 passed (150 passed, one existing skip). Added regression checks for omitted versus explicit/named arguments and different constructed generic attribute types. The benchmark also compares all 100 generated files byte-for-byte between baseline and candidate for both original and edited compilations; output is identical. A separate executable compiled and passed all 10,000 generated tests.

Baseline: `656b66e723`. Candidate: `706200fd2c` (final local-variable rename only after measurement). Generator assemblies built with repository-selected SDK 11.0.100-preview.7.26381.103. Benchmark host uses .NET 10.0.12, Roslyn 4.14.0 and BenchmarkDotNet 0.15.8 on Windows 11 / Intel i7-12700K. Runs are sequential, with no other builds or tests launched by this task during measurement. The separate-process BDN build stalled, so both versions use InProcessEmitToolchain and isolated AssemblyLoadContexts. Compilation construction is outside measurement; each operation runs the full generator from an unrun immutable driver. This measures generator work, not process startup or end-to-end MSBuild time.
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.401
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  Categories=Cold  

```
| Method     | Mean     | Error   | StdDev   | Ratio | RatioSD | Gen0       | Gen1      | Gen2     | Allocated | Alloc Ratio |
|----------- |---------:|--------:|---------:|------:|--------:|-----------:|----------:|---------:|----------:|------------:|
| BeforeCold | 112.5 ms | 2.50 ms |  7.22 ms |  1.00 |    0.09 | 10500.0000 | 3000.0000 |        - |  164.1 MB |        1.00 |
| AfterCold  | 107.5 ms | 3.75 ms | 11.00 ms |  0.96 |    0.11 |  9800.0000 | 2800.0000 | 200.0000 | 151.23 MB |        0.92 |

<details>
<summary>Reproduce the comparison</summary>

Create separate checkouts of the baseline and this PR. In an external working directory, save the project and Program.cs below as GeneratorBench. Use these commands (replace checkout paths):

```powershell
$baselineCheckout = 'C:/path/to/baseline'
$candidateCheckout = 'C:/path/to/candidate'
$env:PERF_ROOT = 'C:/path/to/evidence'
dotnet build "$baselineCheckout/src/TUnit.Core.SourceGenerator" -c Release -o "$env:PERF_ROOT/baseline-generator"
dotnet build "$candidateCheckout/src/TUnit.Core.SourceGenerator" -c Release -o "$env:PERF_ROOT/candidate-generator"
dotnet build "$candidateCheckout/src/TUnit.Core" -c Release -f net10.0
Copy-Item "$candidateCheckout/src/TUnit.Core/bin/Release/net10.0/TUnit.Core.dll" "$env:PERF_ROOT/TUnit.Core.dll"
Set-Location "$env:PERF_ROOT/GeneratorBench"
dotnet run -c Release -- --validate
dotnet run -c Release --no-build -- --filter '*Cold*' --job Dry --inProcess --artifacts ../dry
dotnet run -c Release --no-build -- --filter '*Cold*' --inProcess --artifacts ../results --exporters fulljson
```

GeneratorBench.csproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
  </ItemGroup>

</Project>

```

Program.cs:

```csharp
using System.Runtime.Loader;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Running;
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.CSharp;

if (args.Contains("--validate"))
{
    var benchmark = new GeneratorBench();
    benchmark.Setup();
    Console.WriteLine("Baseline and candidate produce identical output for cold and edited compilations.");
    return;
}
BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[MemoryDiagnoser]
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
[CategoriesColumn]
public class GeneratorBench
{
    private CSharpCompilation _compilation = null!;
    private CSharpCompilation _edited = null!;
    private GeneratorDriver _before = null!, _after = null!, _beforeWarm = null!, _afterWarm = null!;
    private static readonly CSharpParseOptions ParseOptions = new(LanguageVersion.Preview);

    [GlobalSetup]
    public void Setup()
    {
        var root = Environment.GetEnvironmentVariable("PERF_ROOT") ?? "C:/git/TUnit-perf-evidence-20260912";
        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!).Split(Path.PathSeparator)
            .Select(path => MetadataReference.CreateFromFile(path)).ToList();
        references.Add(MetadataReference.CreateFromFile(root + "/TUnit.Core.dll"));
        var trees = Enumerable.Range(0, 100).Select(i => CSharpSyntaxTree.ParseText(
            "using TUnit.Core; public class Tests" + i + " { " +
            string.Join("\n", Enumerable.Range(0, 100).Select(j =>
                $"[Test] public void Test{j}() {{ if (Compute({j}) != {j * j + 1}) throw new System.Exception(); }}")) +
            "private static int Compute(int x) => x*x+1; }", ParseOptions, $"Tests{i}.cs")).ToArray();
        _compilation = CSharpCompilation.Create("BenchmarkTests", trees, references,
            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
        var errors = _compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
        if (errors.Length > 0) throw new Exception(string.Join("\n", errors.AsEnumerable()));
        _edited = _compilation.ReplaceSyntaxTree(trees[0], CSharpSyntaxTree.ParseText(
            trees[0].ToString().Replace("Compute(0)", "Compute(0 + 0)"), ParseOptions, "Tests0.cs"));
        _before = Load(root + "/baseline-generator/TUnit.Core.SourceGenerator.dll");
        _after = Load(root + "/candidate-generator/TUnit.Core.SourceGenerator.dll");
        _beforeWarm = _before.RunGenerators(_compilation);
        _afterWarm = _after.RunGenerators(_compilation);
        Equal(_beforeWarm, _afterWarm);
        Equal(_beforeWarm.RunGenerators(_edited), _afterWarm.RunGenerators(_edited));
    }

    private static GeneratorDriver Load(string path)
    {
        var context = new AssemblyLoadContext(Path.GetDirectoryName(path), isCollectible: true);
        var assembly = context.LoadFromAssemblyPath(Path.GetFullPath(path));
        var generator = (IIncrementalGenerator)Activator.CreateInstance(
            assembly.GetType("TUnit.Core.SourceGenerator.Generators.TestMetadataGenerator", true)!)!;
        return CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: ParseOptions);
    }

    private static void Equal(GeneratorDriver before, GeneratorDriver after)
    {
        var left = before.GetRunResult();
        var right = after.GetRunResult();
        if (left.Diagnostics.Length != 0 || right.Diagnostics.Length != 0)
            throw new Exception(string.Join("\n", left.Diagnostics.Concat(right.Diagnostics)));
        var a = left.Results.Single().GeneratedSources.OrderBy(s => s.HintName).ToArray();
        var b = right.Results.Single().GeneratedSources.OrderBy(s => s.HintName).ToArray();
        if (a.Length != 100 || a.Length != b.Length) throw new Exception($"Unexpected output count: {a.Length}/{b.Length}");
        for (var i = 0; i < a.Length; i++)
            if (a[i].HintName != b[i].HintName || !a[i].SourceText.ContentEquals(b[i].SourceText))
                throw new Exception("Generated output differs: " + a[i].HintName);
    }

    [Benchmark(Baseline = true), BenchmarkCategory("Cold")]
    public GeneratorDriver BeforeCold() => _before.RunGenerators(_compilation);
    [Benchmark, BenchmarkCategory("Cold")]
    public GeneratorDriver AfterCold() => _after.RunGenerators(_compilation);
    [Benchmark(Baseline = true), BenchmarkCategory("Edit")]
    public GeneratorDriver BeforeEdit() => _beforeWarm.RunGenerators(_edited);
    [Benchmark, BenchmarkCategory("Edit")]
    public GeneratorDriver AfterEdit() => _afterWarm.RunGenerators(_edited);
}

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of repeated argument-free attributes, reducing redundant formatting work while preserving attributes with explicit arguments.
* **Bug Fixes**
  * Ensured generic attribute types continue to receive distinct initializers.
* **Tests**
  * Added coverage for argument-free attributes with and without parentheses, explicit positional and named arguments, and constructed generic attribute types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->