### PR TITLE
perf: extract test metadata in attribute transforms

### DIFF
--- a/src/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
+++ b/src/TUnit.Core.SourceGenerator/Generators/TestMetadataGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -29,25 +30,17 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
                 return !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
             });
 
-        var compilationContext = context
-            .CompilationProvider
-            .Select(static (c, _) =>
-            {
-                var wellKnownTypes = new WellKnownTypes(c);
-                return new CompilationContext(
-                    (CSharpCompilation)c,
-                    new AttributeWriter(c),
-                    wellKnownTypes
-                );
-            });
+        var compilationContexts = new ConditionalWeakTable<Compilation, CompilationContext>();
+
+        CompilationContext GetCompilationContext(Compilation compilation) =>
+            compilationContexts.GetValue(compilation, static c =>
+                new CompilationContext((CSharpCompilation)c, new AttributeWriter(c), new WellKnownTypes(c)));
 
         var testMethodsProvider = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 "TUnit.Core.TestAttribute",
                 predicate: static (node, _) => node is MethodDeclarationSyntax,
-                transform: static (ctx, _) => ctx)
-            .Combine(compilationContext)
-            .Select(static (ctx, _) => GetTestMethodMetadata(ctx.Left, ctx.Right))
+                transform: (ctx, _) => GetTestMethodMetadata(ctx, GetCompilationContext(ctx.SemanticModel.Compilation)))
             .Where(static m => m is not null)
             .Combine(enabledProvider);
 
@@ -55,9 +48,7 @@ public sealed class TestMetadataGenerator : IIncrementalGenerator
             .ForAttributeWithMetadataName(
                 "TUnit.Core.InheritsTestsAttribute",
                 predicate: static (node, _) => node is ClassDeclarationSyntax,
-                transform: static (ctx, _) => ctx)
-            .Combine(compilationContext)
-            .Select(static (ctx, _) => GetInheritsTestsClassMetadata(ctx.Left, ctx.Right))
+                transform: (ctx, _) => GetInheritsTestsClassMetadata(ctx, GetCompilationContext(ctx.SemanticModel.Compilation)))
             .Where(static m => m is not null)
             .Combine(enabledProvider);
 

--- a/tests/TUnit.Core.SourceGenerator.Tests/TestMetadataIncrementalTests.cs
+++ b/tests/TUnit.Core.SourceGenerator.Tests/TestMetadataIncrementalTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Core.SourceGenerator.Generators;
+
+namespace TUnit.Core.SourceGenerator.Tests;
+
+public class TestMetadataIncrementalTests
+{
+    [Test]
+    public async Task EditingAnotherFileRefreshesTestMetadata()
+    {
+        var testTree = CSharpSyntaxTree.ParseText("""
+            using TUnit.Core;
+            public class Tests
+            {
+                [Test, Category(Settings.Category)]
+                public void Check() { }
+            }
+            """);
+        var settingsTree = CSharpSyntaxTree.ParseText("""
+            public static class Settings { public const string Category = "before"; }
+            """);
+        var compilation = CreateCompilation(testTree, settingsTree);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new TestMetadataGenerator());
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(GetSource(driver)).Contains("before");
+
+        compilation = compilation.ReplaceSyntaxTree(settingsTree,
+            CSharpSyntaxTree.ParseText(settingsTree.ToString().Replace("before", "after")));
+        driver = driver.RunGenerators(compilation);
+
+        await Assert.That(GetSource(driver)).Contains("after");
+        await Assert.That(GetSource(driver)).IsEqualTo(GetSource(
+            CSharpGeneratorDriver.Create(new TestMetadataGenerator()).RunGenerators(compilation)));
+        await Assert.That(driver.GetRunResult().Diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task RemovingAndRestoringTestAttributeRefreshesReusedDriver()
+    {
+        const string source = "using TUnit.Core; public class Tests { [Test] public void Check() { } }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CreateCompilation(tree);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new TestMetadataGenerator());
+        driver = driver.RunGenerators(compilation);
+        var original = GetSource(driver);
+        await Assert.That(original).IsNotEmpty();
+
+        var plainTree = CSharpSyntaxTree.ParseText(source.Replace("[Test]", ""));
+        var withoutTest = compilation.ReplaceSyntaxTree(tree, plainTree);
+        driver = driver.RunGenerators(withoutTest);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(GetSource(driver)).IsEqualTo(original);
+        await Assert.That(driver.GetRunResult().Diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task AddingAndRemovingCoreReferenceRefreshesReusedDriver()
+    {
+        var compilation = CreateCompilation(CSharpSyntaxTree.ParseText(
+            "using TUnit.Core; public class Tests { [Test] public void Check() { } }"));
+        var withoutCore = compilation.WithReferences(ReferencesHelper.References.Where(reference =>
+            !string.Equals(Path.GetFileName(reference.FilePath), "TUnit.Core.dll", StringComparison.OrdinalIgnoreCase)));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new TestMetadataGenerator());
+        driver = driver.RunGenerators(withoutCore);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+
+        driver = driver.RunGenerators(compilation);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsNotEmpty();
+
+        driver = driver.RunGenerators(withoutCore);
+        await Assert.That(driver.GetRunResult().GeneratedTrees).IsEmpty();
+        await Assert.That(driver.GetRunResult().Diagnostics).IsEmpty();
+    }
+
+    private static string GetSource(GeneratorDriver driver) =>
+        string.Join("\n", driver.GetRunResult().GeneratedTrees.Select(tree => tree.ToString()));
+
+    private static CSharpCompilation CreateCompilation(params SyntaxTree[] trees) => CSharpCompilation.Create(
+        "MetadataEdits", trees, ReferencesHelper.References,
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+}


### PR DESCRIPTION
Test metadata currently passes through a compilation-wide Combine and a separate Select after ForAttributeWithMetadataName. Extract it directly in each attribute transform instead. A per-initialization ConditionalWeakTable shares formatting/type caches for the exact Compilation while allowing obsolete compilations to be collected. Both direct tests and InheritsTests use this path.

For a 10,000-test suite, a fresh single-file body edit takes **141.4 ms instead of 161.1 ms (12.2% lower mean)**, and allocates **139.09 MB instead of 144.22 MB (3.6% less)**. This is a reused Roslyn generator-driver measurement, relevant to IDE incremental generation; it is not a promise about the wall-clock time of dotnet build. The existing all-class Collect remains unchanged.

Validation: source-generator snapshot suite passed on net10.0 (151 passed, one existing skip), including new tests for cross-file constant changes, adding/removing TestAttribute, and adding/removing the Core reference. The baseline/candidate harness verifies all 100 generated files match for original and edited compilations. A generated 10,000-test executable passed in both source-generated and reflection modes.

Baseline: `656b66e723`; candidate: `67cb20b225`. Windows 11, Intel i7-12700K, .NET 10.0.12 runtime, SDK 11.0.100-preview.7.26381.103, Roslyn 4.14.0, BenchmarkDotNet 0.15.8. Saved DLLs load into isolated AssemblyLoadContexts; both use InProcessEmitToolchain. No other benchmarks, builds or tests from this task run during measurement.

Every edit iteration creates a NEW syntax tree and Compilation in IterationSetup, outside the timer, then runs once from the original warmed immutable driver. This prevents the candidate's compilation cache from receiving an artificial advantage from repeatedly benchmarking the same edited Compilation. A preliminary run that reused that Compilation was discarded. Cold measurements construct a new generator/driver on every operation. Cold timing is noisy; the reliable cold result is the 2.93 MB allocation reduction.

Fresh edit (30 iterations, six warmups):
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  InvocationCount=1  IterationCount=30  
UnrollFactor=1  WarmupCount=6  Categories=Edit  

```
| Method     | Mean     | Error   | StdDev   | Ratio | RatioSD | Gen0       | Gen1      | Allocated | Alloc Ratio |
|----------- |---------:|--------:|---------:|------:|--------:|-----------:|----------:|----------:|------------:|
| BeforeEdit | 161.1 ms | 7.77 ms | 11.63 ms |  1.00 |    0.10 | 11000.0000 | 3000.0000 | 144.22 MB |        1.00 |
| AfterEdit  | 141.4 ms | 3.09 ms |  4.53 ms |  0.88 |    0.07 | 10000.0000 | 3000.0000 | 139.09 MB |        0.96 |

Cold generation (15 iterations, six warmups):
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=15  WarmupCount=6  
Categories=Cold  

```
| Method     | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0       | Gen1      | Gen2     | Allocated | Alloc Ratio |
|----------- |---------:|---------:|---------:|------:|--------:|-----------:|----------:|---------:|----------:|------------:|
| BeforeCold | 150.3 ms | 44.28 ms | 41.42 ms |  1.07 |    0.40 | 10500.0000 | 3000.0000 |        - |  164.1 MB |        1.00 |
| AfterCold  | 118.6 ms |  8.17 ms |  7.64 ms |  0.85 |    0.22 | 10800.0000 | 3200.0000 | 200.0000 | 161.17 MB |        0.98 |
<details>
<summary>Reproduce the comparison</summary>

Create separate checkouts of the baseline and this PR. In an external working directory, save the project and Program.cs below as GeneratorBench. Use these commands (replace checkout paths):

```powershell
$baselineCheckout = 'C:/path/to/baseline'
$candidateCheckout = 'C:/path/to/candidate'
$env:PERF_ROOT = 'C:/path/to/evidence'
dotnet build "$baselineCheckout/src/TUnit.Core.SourceGenerator" -c Release -o "$env:PERF_ROOT/baseline-generator"
dotnet build "$candidateCheckout/src/TUnit.Core.SourceGenerator" -c Release -o "$env:PERF_ROOT/candidate-generator"
dotnet build "$candidateCheckout/src/TUnit.Core" -c Release -f net10.0
Copy-Item "$candidateCheckout/src/TUnit.Core/bin/Release/net10.0/TUnit.Core.dll" "$env:PERF_ROOT/TUnit.Core.dll"
Set-Location "$env:PERF_ROOT/GeneratorBench"
dotnet run -c Release -- --validate
dotnet run -c Release --no-build -- --filter '*Cold*' --job Dry --inProcess --artifacts ../dry
dotnet run -c Release --no-build -- --filter '*Edit*' --inProcess --iterationCount 30 --warmupCount 6 --artifacts ../results --exporters fulljson
```

GeneratorBench.csproj:

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
  </ItemGroup>

</Project>

```

Program.cs:

```csharp
using System.Runtime.Loader;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Running;
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.CSharp;

if (args.Contains("--validate"))
{
    var benchmark = new GeneratorBench();
    benchmark.Setup();
    Console.WriteLine("Baseline and candidate produce identical output for cold and edited compilations.");
    return;
}
BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[MemoryDiagnoser]
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
[CategoriesColumn]
public class GeneratorBench
{
    private CSharpCompilation _compilation = null!;
    private CSharpCompilation _edited = null!;
    private GeneratorDriver _before = null!, _after = null!, _beforeWarm = null!, _afterWarm = null!;
    private Type _beforeType = null!, _afterType = null!;
    private string _editedSource = null!;
    private static readonly CSharpParseOptions ParseOptions = new(LanguageVersion.Preview);

    [GlobalSetup]
    public void Setup()
    {
        var root = Environment.GetEnvironmentVariable("PERF_ROOT") ?? "C:/git/TUnit-perf-evidence-20260912";
        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!).Split(Path.PathSeparator)
            .Select(path => MetadataReference.CreateFromFile(path)).ToList();
        references.Add(MetadataReference.CreateFromFile(root + "/TUnit.Core.dll"));
        var trees = Enumerable.Range(0, 100).Select(i => CSharpSyntaxTree.ParseText(
            "using TUnit.Core; public class Tests" + i + " { " +
            string.Join("\n", Enumerable.Range(0, 100).Select(j =>
                $"[Test] public void Test{j}() {{ if (Compute({j}) != {j * j + 1}) throw new System.Exception(); }}")) +
            "private static int Compute(int x) => x*x+1; }", ParseOptions, $"Tests{i}.cs")).ToArray();
        _compilation = CSharpCompilation.Create("BenchmarkTests", trees, references,
            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
        var errors = _compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
        if (errors.Length > 0) throw new Exception(string.Join("\n", errors.AsEnumerable()));
        _editedSource = trees[0].ToString().Replace("Compute(0)", "Compute(0 + 0)");
        PrepareEdit();
        _beforeType = Load(root + "/baseline-generator/TUnit.Core.SourceGenerator.dll");
        _afterType = Load(root + "/candidate-generator/TUnit.Core.SourceGenerator.dll");
        _before = CreateDriver(_beforeType);
        _after = CreateDriver(_afterType);
        _beforeWarm = _before.RunGenerators(_compilation);
        _afterWarm = _after.RunGenerators(_compilation);
        Equal(_beforeWarm, _afterWarm);
        Equal(_beforeWarm.RunGenerators(_edited), _afterWarm.RunGenerators(_edited));
    }

    [IterationSetup(Targets = new[] { nameof(BeforeEdit), nameof(AfterEdit) })]
    public void PrepareEdit() => _edited = _compilation.ReplaceSyntaxTree(_compilation.SyntaxTrees.First(),
        CSharpSyntaxTree.ParseText(_editedSource, ParseOptions, "Tests0.cs"));

    private static Type Load(string path)
    {
        var context = new AssemblyLoadContext(Path.GetDirectoryName(path), isCollectible: true);
        var assembly = context.LoadFromAssemblyPath(Path.GetFullPath(path));
        return assembly.GetType("TUnit.Core.SourceGenerator.Generators.TestMetadataGenerator", true)!;
    }

    private static GeneratorDriver CreateDriver(Type generatorType)
    {
        var generator = (IIncrementalGenerator)Activator.CreateInstance(generatorType)!;
        return CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: ParseOptions);
    }

    private static void Equal(GeneratorDriver before, GeneratorDriver after)
    {
        var left = before.GetRunResult();
        var right = after.GetRunResult();
        if (left.Diagnostics.Length != 0 || right.Diagnostics.Length != 0)
            throw new Exception(string.Join("\n", left.Diagnostics.Concat(right.Diagnostics)));
        var a = left.Results.Single().GeneratedSources.OrderBy(s => s.HintName).ToArray();
        var b = right.Results.Single().GeneratedSources.OrderBy(s => s.HintName).ToArray();
        if (a.Length != 100 || a.Length != b.Length) throw new Exception($"Unexpected output count: {a.Length}/{b.Length}");
        for (var i = 0; i < a.Length; i++)
            if (a[i].HintName != b[i].HintName || !a[i].SourceText.ContentEquals(b[i].SourceText))
                throw new Exception("Generated output differs: " + a[i].HintName);
    }

    [Benchmark(Baseline = true), BenchmarkCategory("Cold")]
    public GeneratorDriver BeforeCold() => CreateDriver(_beforeType).RunGenerators(_compilation);
    [Benchmark, BenchmarkCategory("Cold")]
    public GeneratorDriver AfterCold() => CreateDriver(_afterType).RunGenerators(_compilation);
    [Benchmark(Baseline = true), BenchmarkCategory("Edit")]
    public GeneratorDriver BeforeEdit() => _beforeWarm.RunGenerators(_edited);
    [Benchmark, BenchmarkCategory("Edit")]
    public GeneratorDriver AfterEdit() => _afterWarm.RunGenerators(_edited);
}

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test metadata generation when source files are edited or test attributes and core references are added or removed.
  * Ensured generated metadata refreshes correctly when reusing the same build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->