### PR TITLE
perf: skip receiver registration for ordinary objects

### DIFF
--- a/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
+++ b/src/TUnit.Engine/Services/EventReceiverOrchestrator.cs
@@ -49,6 +49,13 @@ internal sealed class EventReceiverOrchestrator
 
         foreach (var obj in context.GetEligibleEventObjects())
         {
+            // Ordinary attributes, arguments and test instances cannot receive events.
+            // Avoid retaining them in the deduplication set or scanning every receiver interface.
+            if (obj is not IEventReceiver)
+            {
+                continue;
+            }
+
             // Use single TryAdd operation instead of Contains + Add
             if (!_initializedObjects.Add(obj))
             {
@@ -88,7 +95,7 @@ internal sealed class EventReceiverOrchestrator
     {
         var classInstance = context.Metadata.TestDetails.ClassInstance;
         Debug.Assert(classInstance is not null, "RegisterClassInstanceReceiver should only be called after ClassInstance is assigned.");
-        if (classInstance is null)
+        if (classInstance is not IEventReceiver)
         {
             return;
         }

--- a/tests/TUnit.UnitTests/EventReceiverRegistrationTests.cs
+++ b/tests/TUnit.UnitTests/EventReceiverRegistrationTests.cs
@@ -1,0 +1,84 @@
+using TUnit.Core.Interfaces;
+using TUnit.Engine.Services;
+
+namespace TUnit.UnitTests;
+
+public class EventReceiverRegistrationTests
+{
+    [Test]
+    public void OrdinaryObjectsDoNotParticipateInReceiverDeduplication()
+    {
+        var context = CreateContext(new OrdinaryObject(), [new OrdinaryAttribute()]);
+        try
+        {
+            var orchestrator = new EventReceiverOrchestrator(null!);
+            orchestrator.RegisterReceivers(context);
+            orchestrator.RegisterClassInstanceReceiver(context);
+        }
+        finally
+        {
+            context.RemoveFromRegistry();
+            context.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task AttributeAndClassReceiversStillReceiveEvents()
+    {
+        var attribute = new ReceiverAttribute();
+        var instance = new ReceiverAttribute();
+        var context = CreateContext(null!, [attribute]);
+        try
+        {
+            var orchestrator = new EventReceiverOrchestrator(null!);
+            orchestrator.RegisterReceivers(context);
+            context.Metadata.TestDetails.ClassInstance = instance;
+            orchestrator.RegisterClassInstanceReceiver(context);
+            orchestrator.RegisterClassInstanceReceiver(context);
+
+            await orchestrator.InvokeTestStartEventReceiversAsync(context, CancellationToken.None);
+            await Assert.That(attribute.Calls).IsEqualTo(1);
+            await Assert.That(instance.Calls).IsEqualTo(1);
+        }
+        finally
+        {
+            context.RemoveFromRegistry();
+            context.Dispose();
+        }
+    }
+
+    private static TestContext CreateContext(object instance, Attribute[] attributes)
+    {
+        var current = TestContext.Current!;
+        var context = new TestContext("Registration", current.ServiceProvider, current.ClassContext,
+            new TestBuilderContext { TestMetadata = current.TestDetails.MethodMetadata }, CancellationToken.None);
+        context.Metadata.TestDetails = new TestDetails(attributes)
+        {
+            TestId = context.Id, TestName = "Registration", ClassType = typeof(EventReceiverRegistrationTests),
+            MethodName = "Registration", ClassInstance = instance, TestMethodArguments = [], TestClassArguments = [],
+            MethodMetadata = current.TestDetails.MethodMetadata, ReturnType = typeof(void),
+            AttributesByType = new Dictionary<Type, IReadOnlyList<Attribute>>()
+        };
+        return context;
+    }
+
+    private sealed class OrdinaryObject
+    {
+        public override int GetHashCode() => throw new InvalidOperationException("Not an event receiver");
+    }
+
+    private sealed class OrdinaryAttribute : Attribute
+    {
+        public override int GetHashCode() => throw new InvalidOperationException("Not an event receiver");
+    }
+
+    private sealed class ReceiverAttribute : Attribute, ITestStartEventReceiver
+    {
+        public int Calls { get; private set; }
+        public ValueTask OnTestStart(TestContext context)
+        {
+            Calls++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
EventReceiverOrchestrator currently inserts every eligible attribute, argument, context and test instance into its concurrent deduplication set, then scans all event interfaces, even when an object implements none. Filter on IEventReceiver before deduplication in both registration entry points. Actual receivers retain the existing ordering and registration paths.

For a fresh 1,000-test session, registration of plain tests takes **117.3 us instead of 575.1 us (79.6% less)** and allocates **112.01 KB instead of 965.11 KB (88.4% less)**. With a real ITestStartEventReceiver on every class instance, time falls **32.3%**, with **10.6% fewer allocations**. These measurements include eligible-object cache reconstruction and both registration stages; they exclude constructing TestContext objects and running test bodies.

Validation: all 290 net10.0 unit tests passed, including new checks that ordinary objects are not hashed and that attribute/class receivers still receive callbacks. The generated 10,000-test executable passed in source-generated and reflection modes.

Whole-executable check: 20 alternating AB/BA pairs after three warmups per variant, each run required exactly 10,000 successful tests. Before: mean 980.79 ms, median 969.34 ms. After: mean 963.89 ms, median 957.15 ms. Paired mean reduction: 16.89 ms; approximate 95% t interval **[-1.04, 34.83] ms**. This does not establish a significant end-to-end speedup. The strong result is the isolated registration cost reduction.

Baseline: `656b66e723`; candidate: `57f4d2857e`. BenchmarkDotNet 0.15.8, SDK 11.0.100-preview.7.26381.103, .NET 10.0.12, Windows 11, Intel i7-12700K. Both saved engine DLLs use the same Core/MTP dependencies and isolated AssemblyLoadContexts. InProcessEmitToolchain, 20 iterations and six warmups, sequential execution; no other builds/tests launched by this task during measurement. A fresh orchestrator is created per operation; every context's receiver caches are reset before registration, avoiding a warmed-dedup benchmark.
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=20  WarmupCount=6  

```
| Method | WithReceivers | Mean       | Error    | StdDev   | Ratio | RatioSD | Gen0     | Gen1     | Allocated  | Alloc Ratio |
|------- |-------------- |-----------:|---------:|---------:|------:|--------:|---------:|---------:|-----------:|------------:|
| **Before** | **False**         |   **575.1 μs** |  **2.29 μs** |  **2.25 μs** |  **1.00** |    **0.01** |  **75.1953** |  **24.4141** |  **965.11 KB** |        **1.00** |
| After  | False         |   117.3 μs |  0.68 μs |  0.73 μs |  0.20 |    0.00 |   8.6670 |   1.2207 |  112.01 KB |        0.12 |
|        |               |            |          |          |       |         |          |          |            |             |
| **Before** | **True**          | **1,198.4 μs** | **18.32 μs** | **18.81 μs** |  **1.00** |    **0.02** | **404.2969** | **136.7188** | **5163.37 KB** |        **1.00** |
| After  | True          |   811.7 μs | 22.06 μs | 25.40 μs |  0.68 |    0.02 | 361.3281 | 120.1172 |  4616.6 KB |        0.89 |

<details><summary>Reproduce the microbenchmark</summary>

Save the project and source below in an external RuntimeBench directory. Replace the signing-key checkout path in the project. Build the baseline and PR into sibling baseline-runner and idea3-runner directories:

```powershell
$env:PERF_ROOT = 'C:/path/to/evidence'
dotnet build C:/path/to/baseline/src/TUnit.Engine -c Release -f net10.0 -p:CopyLocalLockFileAssemblies=true -o "$env:PERF_ROOT/baseline-runner"
dotnet build C:/path/to/candidate/src/TUnit.Engine -c Release -f net10.0 -p:CopyLocalLockFileAssemblies=true -o "$env:PERF_ROOT/idea3-runner"
Set-Location "$env:PERF_ROOT/RuntimeBench"
dotnet run -c Release -- --filter '*ReceiverBench*' --job Dry --inProcess --artifacts ../dry
dotnet run -c Release --no-build -- --filter '*ReceiverBench*' --inProcess --iterationCount 20 --warmupCount 6 --artifacts ../results --exporters fulljson
```

RuntimeBench.csproj:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <AssemblyName>TUnit.UnitTests</AssemblyName>
    <SignAssembly>true</SignAssembly>
    <AssemblyOriginatorKeyFile>C:/git/TUnit-perf-blog/eng/strongname.snk</AssemblyOriginatorKeyFile>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <Reference Include="TUnit.Core"><HintPath>../baseline-runner/TUnit.Core.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Platform"><HintPath>../baseline-runner/Microsoft.Testing.Platform.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions"><HintPath>../baseline-runner/Microsoft.Testing.Extensions.TrxReport.Abstractions.dll</HintPath></Reference>
  </ItemGroup>

</Project>

```

Program.cs:
```csharp
BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(ReceiverBench).Assembly).Run(args);

```

ReceiverBench.cs:
```csharp
using System.Linq.Expressions;
using System.Reflection;
using System.Runtime.Loader;
using BenchmarkDotNet.Attributes;
using TUnit.Core;
using TUnit.Core.Interfaces;

[MemoryDiagnoser]
public class ReceiverBench
{
    [Params(false, true)]
    public bool WithReceivers { get; set; }
    private TestContext[] _contexts = null!;
    private object[] _instances = null!;
    private Func<object> _beforeFactory = null!, _afterFactory = null!;
    private Action<object, TestContext> _beforeRegister = null!, _afterRegister = null!;
    private Action<object, TestContext> _beforeClass = null!, _afterClass = null!;

    [GlobalSetup]
    public void Setup()
    {
        var root = Environment.GetEnvironmentVariable("PERF_ROOT") ?? "C:/git/TUnit-perf-evidence-20260912";
        (_beforeFactory, _beforeRegister, _beforeClass) = Load(root + "/baseline-runner/TUnit.Engine.dll");
        (_afterFactory, _afterRegister, _afterClass) = Load(root + "/idea3-runner/TUnit.Engine.dll");
        _instances = Enumerable.Range(0, 1000).Select(_ => WithReceivers ? (object)new Receiver() : new object()).ToArray();
        _contexts = Enumerable.Range(0, 1000).Select(i =>
        {
            var context = new TestContext("Test", null!, null!, new TestBuilderContext { TestMetadata = null! }, CancellationToken.None);
            context.Metadata.TestDetails = new TestDetails([new TestAttribute()])
            {
                TestId = i.ToString(), TestName = "Test", ClassType = typeof(ReceiverBench), MethodName = "Test",
                ClassInstance = null!, TestMethodArguments = [], TestClassArguments = [], MethodMetadata = null!,
                ReturnType = typeof(void), AttributesByType = new Dictionary<Type, IReadOnlyList<Attribute>>()
            };
            return context;
        }).ToArray();
        Validate(Before());
        Validate(After());
    }

    private void Validate(object orchestrator)
    {
        var registry = orchestrator.GetType().GetField("_registry", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(orchestrator)!;
        var hasReceivers = (bool)registry.GetType().GetMethod("HasTestStartReceivers")!.Invoke(registry, null)!;
        if (hasReceivers != WithReceivers) throw new Exception("Incorrect receiver registration");
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        foreach (var context in _contexts) { context.RemoveFromRegistry(); context.Dispose(); }
    }

    [Benchmark(Baseline = true)]
    public object Before() => Register(_beforeFactory, _beforeRegister, _beforeClass);
    [Benchmark]
    public object After() => Register(_afterFactory, _afterRegister, _afterClass);

    private object Register(Func<object> factory, Action<object, TestContext> register, Action<object, TestContext> registerClass)
    {
        var orchestrator = factory();
        // One operation registers a 1,000-test suite in a fresh session. The loop is
        // the actual workload, not artificial repetition of a single warmed registration.
        for (var i = 0; i < _contexts.Length; i++)
        {
            var context = _contexts[i];
            context.Metadata.TestDetails.ClassInstance = null!;
            context.InvalidateEventReceiverCaches();
            register(orchestrator, context);
            context.Metadata.TestDetails.ClassInstance = _instances[i];
            registerClass(orchestrator, context);
        }
        return orchestrator;
    }

    private static (Func<object>, Action<object, TestContext>, Action<object, TestContext>) Load(string path)
    {
        var loadContext = new AssemblyLoadContext(path, isCollectible: true);
        var type = loadContext.LoadFromAssemblyPath(Path.GetFullPath(path)).GetType("TUnit.Engine.Services.EventReceiverOrchestrator", true)!;
        var constructor = type.GetConstructors().Single();
        var factory = Expression.Lambda<Func<object>>(Expression.Convert(
            Expression.New(constructor, Expression.Constant(null, constructor.GetParameters()[0].ParameterType)), typeof(object))).Compile();
        return (factory, Bind("RegisterReceivers"), Bind("RegisterClassInstanceReceiver"));

        Action<object, TestContext> Bind(string name)
        {
            var instance = Expression.Parameter(typeof(object));
            var context = Expression.Parameter(typeof(TestContext));
            return Expression.Lambda<Action<object, TestContext>>(Expression.Call(
                Expression.Convert(instance, type), type.GetMethod(name)!, context), instance, context).Compile();
        }
    }

    public class Receiver : ITestStartEventReceiver
    {
        public ValueTask OnTestStart(TestContext context) => ValueTask.CompletedTask;
    }
}

```
</details>
<details><summary>Raw whole-executable samples (milliseconds)</summary>
```csv
"Pair","Variant","Milliseconds"
"1","Before","969.5005"
"1","After","945.695"
"2","After","939.51"
"2","Before","994.2921"
"3","Before","1059.775"
"3","After","1011.7146"
"4","After","935.254"
"4","Before","949.9259"
"5","Before","956.6343"
"5","After","971.3426"
"6","After","979.22"
"6","Before","973.7481"
"7","Before","986.6671"
"7","After","951.7484"
"8","After","955.8747"
"8","Before","1047.395"
"9","Before","990.9323"
"9","After","961.0989"
"10","After","934.141"
"10","Before","954.4484"
"11","Before","1014.3478"
"11","After","950.412"
"12","After","958.4172"
"12","Before","948.5221"
"13","Before","944.0799"
"13","After","990.4228"
"14","After","955.0782"
"14","Before","969.1712"
"15","Before","959.1917"
"15","After","935.0701"
"16","After","991.0562"
"16","Before","957.9144"
"17","Before","977.7508"
"17","After","947.2239"
"18","After","979.8796"
"18","Before","1048.004"
"19","Before","961.7752"
"19","After","1002.1741"
"20","After","982.5291"
"20","Before","951.6738"

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event receiver registration to ignore objects that do not support event receiving.
  * Prevented invalid objects and attributes from affecting receiver deduplication.
  * Ensured registered event receivers receive test-start notifications only once, including when registered repeatedly.

* **Tests**
  * Added coverage for receiver filtering, deduplication, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->