### PR TITLE
perf: cache reporting properties on test contexts

### DIFF
--- a/src/TUnit.Core/TestContext.cs
+++ b/src/TUnit.Core/TestContext.cs
@@ -231,6 +231,16 @@ public partial class TestContext : Context,
         Volatile.Write(ref CachedReportingProperties, null);
     }
 
+    internal static void ClearReportingCaches()
+    {
+        // Discovery-only sessions and failures before execution can leave contexts
+        // registered. Release their reporting metadata when the engine resets.
+        foreach (var entry in _testContextsByGuid)
+        {
+            Volatile.Write(ref entry.Value.CachedReportingProperties, null);
+        }
+    }
+
     /// <summary>
     /// Gets the dictionary of test parameters indexed by parameter name.
     /// </summary>

--- a/src/TUnit.Core/TestContext.cs
+++ b/src/TUnit.Core/TestContext.cs
@@ -223,7 +223,13 @@ public partial class TestContext : Context,
     public static TestContext? GetById(string id) =>
         Guid.TryParse(id, out var guid) ? _testContextsByGuid.GetValueOrDefault(guid) : null;
 
-    internal void RemoveFromRegistry() => _testContextsByGuid.TryRemove(_idGuid, out _);
+    internal void RemoveFromRegistry()
+    {
+        _testContextsByGuid.TryRemove(_idGuid, out _);
+        // Reporting has completed. Do not retain its cached properties with a
+        // context that user code or session summaries keep alive after execution.
+        Volatile.Write(ref CachedReportingProperties, null);
+    }
 
     /// <summary>
     /// Gets the dictionary of test parameters indexed by parameter name.
@@ -398,6 +404,9 @@ public partial class TestContext : Context,
     internal IClassConstructor? ClassConstructor => _testBuilderContext.ClassConstructor;
 
     internal object[]? CachedEligibleEventObjects { get; set; }
+
+    // Owned by the engine; object keeps Core independent of MTP reporting types.
+    internal object? CachedReportingProperties;
 
     // Pre-computed typed event receivers (filtered, sorted, scoped-attribute filtered)
     // These are computed lazily on first access and cached

--- a/src/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/src/TUnit.Engine/Extensions/TestExtensions.cs
@@ -36,6 +36,7 @@ internal static class TestExtensions
     {
         AssemblyFullNameCache.Clear();
         Volatile.Write(ref _reportingCacheScope, new object());
+        TestContext.ClearReportingCaches();
         _cachedIsTrxEnabled = null;
     }
 
@@ -55,6 +56,12 @@ internal static class TestExtensions
 
         var properties = CreateCachedProperties(testContext, scope);
         Volatile.Write(ref testContext.CachedReportingProperties, properties);
+        // A reset may have swept this context while its properties were being
+        // created. Do not retain an entry published after that sweep.
+        if (!ReferenceEquals(scope, Volatile.Read(ref _reportingCacheScope)))
+        {
+            Interlocked.CompareExchange(ref testContext.CachedReportingProperties, null, properties);
+        }
         return properties;
 
         static CachedTestNodeProperties CreateCachedProperties(TestContext testContext, object scope)
@@ -238,6 +245,13 @@ internal static class TestExtensions
             DisplayName = testContext.GetDisplayName(),
             Properties = propertyBag
         };
+
+        if (isFinalState)
+        {
+            // Placeholders and failures before execution do not reach the
+            // coordinator's registry cleanup. The node owns its property snapshot.
+            Volatile.Write(ref testContext.CachedReportingProperties, null);
+        }
 
         return testNode;
     }

--- a/src/TUnit.Engine/Extensions/TestExtensions.cs
+++ b/src/TUnit.Engine/Extensions/TestExtensions.cs
@@ -17,10 +17,13 @@ internal static class TestExtensions
     private static bool? _cachedIsTrxEnabled;
 
     private static readonly ConcurrentDictionary<Assembly, string> AssemblyFullNameCache = new();
-    private static readonly ConcurrentDictionary<string, CachedTestNodeProperties> TestNodePropertiesCache = new();
+    // Changing the scope invalidates entries even when callers retain a context
+    // across service-provider resets, without a global per-test dictionary.
+    private static object _reportingCacheScope = new();
 
     private sealed class CachedTestNodeProperties
     {
+        public required object Scope { get; init; }
         public required TestFileLocationProperty FileLocation { get; init; }
         public required TestMethodIdentifierProperty MethodIdentifier { get; init; }
         public TestMetadataProperty[]? CategoryProperties { get; init; }
@@ -32,7 +35,7 @@ internal static class TestExtensions
     internal static void ClearCaches()
     {
         AssemblyFullNameCache.Clear();
-        TestNodePropertiesCache.Clear();
+        Volatile.Write(ref _reportingCacheScope, new object());
         _cachedIsTrxEnabled = null;
     }
 
@@ -43,9 +46,18 @@ internal static class TestExtensions
 
     private static CachedTestNodeProperties GetOrCreateCachedProperties(TestContext testContext)
     {
-        var testId = testContext.Metadata.TestDetails.TestId;
+        var scope = Volatile.Read(ref _reportingCacheScope);
+        if (Volatile.Read(ref testContext.CachedReportingProperties) is CachedTestNodeProperties cached &&
+            ReferenceEquals(cached.Scope, scope))
+        {
+            return cached;
+        }
 
-        return TestNodePropertiesCache.GetOrAdd(testId, static (_, testContext) =>
+        var properties = CreateCachedProperties(testContext, scope);
+        Volatile.Write(ref testContext.CachedReportingProperties, properties);
+        return properties;
+
+        static CachedTestNodeProperties CreateCachedProperties(TestContext testContext, object scope)
         {
             var testDetails = testContext.Metadata.TestDetails;
 
@@ -106,6 +118,7 @@ internal static class TestExtensions
 
             return new CachedTestNodeProperties
             {
+                Scope = scope,
                 FileLocation = fileLocation,
                 MethodIdentifier = methodIdentifier,
                 CategoryProperties = categoryProps,
@@ -113,7 +126,7 @@ internal static class TestExtensions
                 TrxFullyQualifiedTypeName = trxTypeName,
                 TrxCategories = trxCategories
             };
-        }, testContext);
+        }
     }
 
     internal static TestNode ToTestNode(this TestContext testContext, TestNodeStateProperty stateProperty)

--- a/tests/TUnit.Engine.Tests/TestNodeLocationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestNodeLocationTests.cs
@@ -8,8 +8,59 @@ using TUnit.Engine.Reporters;
 
 namespace TUnit.Engine.Tests;
 
+[NotInParallel]
 public class TestNodeLocationTests
 {
+    [Test]
+    public void ClearCaches_Refreshes_Metadata_For_Existing_Contexts()
+    {
+        var context = CreateTestContext(Guid.NewGuid().ToString("N"), "Before.cs", 1, 0, 1, 0);
+        try
+        {
+            var before = context.ToTestNode(DiscoveredTestNodeStateProperty.CachedInstance);
+            context.Metadata.TestDetails.TestFilePath = "After.cs";
+            TestExtensions.ClearCaches();
+            var after = context.ToTestNode(InProgressTestNodeStateProperty.CachedInstance);
+
+            before.Properties.AsEnumerable().OfType<TestFileLocationProperty>().Single().FilePath.ShouldBe("Before.cs");
+            after.Properties.AsEnumerable().OfType<TestFileLocationProperty>().Single().FilePath.ShouldBe("After.cs");
+            before.Properties.AsEnumerable().OfType<DiscoveredTestNodeStateProperty>().Count().ShouldBe(1);
+            after.Properties.AsEnumerable().OfType<InProgressTestNodeStateProperty>().Count().ShouldBe(1);
+            context.RemoveFromRegistry();
+            context.CachedReportingProperties.ShouldBeNull();
+        }
+        finally
+        {
+            context.RemoveFromRegistry();
+            context.Dispose();
+        }
+    }
+
+    [Test]
+    public void Concurrent_Updates_Keep_Separate_Message_State()
+    {
+        var context = CreateTestContext(Guid.NewGuid().ToString("N"), "Tests.cs", 1, 0, 1, 0);
+        try
+        {
+            var nodes = new TestNode[64];
+            Parallel.For(0, nodes.Length, i => nodes[i] = context.ToTestNode(i % 2 == 0
+                ? DiscoveredTestNodeStateProperty.CachedInstance
+                : InProgressTestNodeStateProperty.CachedInstance));
+
+            for (var i = 0; i < nodes.Length; i++)
+            {
+                var state = nodes[i].Properties.AsEnumerable().OfType<TestNodeStateProperty>().Single();
+                (state is DiscoveredTestNodeStateProperty).ShouldBe(i % 2 == 0);
+                nodes[i].Properties.AsEnumerable().OfType<TestFileLocationProperty>().Single().FilePath.ShouldBe("Tests.cs");
+            }
+        }
+        finally
+        {
+            context.RemoveFromRegistry();
+            context.Dispose();
+        }
+    }
+
     [Test]
     public void ToTestNode_Uses_Source_Span_For_Mtp_File_Location()
     {

--- a/tests/TUnit.Engine.Tests/TestNodeLocationTests.cs
+++ b/tests/TUnit.Engine.Tests/TestNodeLocationTests.cs
@@ -18,8 +18,10 @@ public class TestNodeLocationTests
         try
         {
             var before = context.ToTestNode(DiscoveredTestNodeStateProperty.CachedInstance);
+            context.CachedReportingProperties.ShouldNotBeNull();
             context.Metadata.TestDetails.TestFilePath = "After.cs";
             TestExtensions.ClearCaches();
+            context.CachedReportingProperties.ShouldBeNull();
             var after = context.ToTestNode(InProgressTestNodeStateProperty.CachedInstance);
 
             before.Properties.AsEnumerable().OfType<TestFileLocationProperty>().Single().FilePath.ShouldBe("Before.cs");
@@ -28,6 +30,49 @@ public class TestNodeLocationTests
             after.Properties.AsEnumerable().OfType<InProgressTestNodeStateProperty>().Count().ShouldBe(1);
             context.RemoveFromRegistry();
             context.CachedReportingProperties.ShouldBeNull();
+        }
+        finally
+        {
+            context.RemoveFromRegistry();
+            context.Dispose();
+        }
+    }
+
+    [Test]
+    [Arguments("Passed")]
+    [Arguments("Failed")]
+    [Arguments("Error")]
+    [Arguments("Timeout")]
+    [Arguments("Skipped")]
+    [Arguments("Cancelled")]
+    public void Final_Updates_Release_Cache_Without_Coordinator_Cleanup(string state)
+    {
+        var context = CreateTestContext(Guid.NewGuid().ToString("N"), "Tests.cs", 1, 0, 1, 0);
+        try
+        {
+            context.Metadata.TestDetails.Categories.Add("Category");
+            var discovered = context.ToTestNode(DiscoveredTestNodeStateProperty.CachedInstance);
+            context.CachedReportingProperties.ShouldNotBeNull();
+
+#pragma warning disable CS0618, MTP0001 // Exercise the engine's cancellation reporting path.
+            TestNodeStateProperty finalState = state switch
+            {
+                "Passed" => PassedTestNodeStateProperty.CachedInstance,
+                "Failed" => new FailedTestNodeStateProperty(new Exception("failure")),
+                "Error" => new ErrorTestNodeStateProperty(new Exception("error")),
+                "Timeout" => new TimeoutTestNodeStateProperty(),
+                "Skipped" => new SkippedTestNodeStateProperty("skipped"),
+                "Cancelled" => new CancelledTestNodeStateProperty(),
+                _ => throw new ArgumentOutOfRangeException(nameof(state))
+            };
+#pragma warning restore CS0618, MTP0001
+            var final = context.ToTestNode(finalState);
+
+            context.CachedReportingProperties.ShouldBeNull();
+            final.Properties.AsEnumerable().OfType<TestNodeStateProperty>().Single().ShouldBeSameAs(finalState);
+            final.Properties.AsEnumerable().OfType<TestFileLocationProperty>().Single().FilePath.ShouldBe("Tests.cs");
+            final.Properties.AsEnumerable().OfType<TestMetadataProperty>().Single()
+                .ShouldBeSameAs(discovered.Properties.AsEnumerable().OfType<TestMetadataProperty>().Single());
         }
         finally
         {


### PR DESCRIPTION
## Review fixes and current performance (751f6d3436)

Addressed both memory-retention findings. Every terminal `ToTestNode` update releases the context's cached reporting properties, including deferred-enumeration placeholders and failures before coordinator execution. `ClearCaches` also clears reporting fields on registered contexts, covering discovery-only requests. A scope check after publication removes stale properties if construction races with cache reset. Published nodes keep their independent property snapshots.

Regression verification: the new cleanup assertions fail in all seven cases against the previous PR's saved Core/Engine binaries (c994193334). The fixed binaries pass all 11 TestNodeLocationTests and all 17 GitHubReporterTests. The generated 10,000-test executable passes in both source-generated and reflection modes. Release builds pass for net10.0 and netstandard2.0; the test-project build reports existing analyzer/code-fixer warnings. The previously documented HtmlReporterTests baseline failure remains outside this fix; that suite was not rerun for this revision.

Reran the reporting benchmark with the original dictionary baseline, previous PR, and fixed implementation in the same BenchmarkDotNet run. `Before` = 656b66e723; `BeforeReview` = c994193334; `After` = 751f6d3436. Each operation resets caches and packages discovered, in-progress, and passed updates for 1,000 contexts. The measurement includes the new registry sweep and terminal cleanup. Context construction remains outside measurement, and all variants share the fixed Core assembly.

Against the original dictionary, the fixed implementation takes **38.1% less time without categories** and **31.4% less with three categories**, with **17.6% and 12.4% fewer allocated bytes**, respectively. Compared with the previous PR, the measured mean is 3.0% higher without categories and 9.5% lower with three categories; allocation totals are unchanged at the displayed precision. These are isolated reporting results, not whole-executable speedups. The whole-executable timing evidence below belongs to the original PR revision and was not rerun for this fix.

No builds, tests, or other benchmarks launched by this task overlapped this measurement. Dry validation passed first; the measured run used 20 iterations and six warmups.

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=20  WarmupCount=6  

```
| Method       | CategoryCount | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0     | Gen1    | Allocated  | Alloc Ratio |
|------------- |-------------- |---------:|---------:|---------:|------:|--------:|---------:|--------:|-----------:|------------:|
| **Before**       | **0**             | **466.4 μs** |  **6.40 μs** |  **7.12 μs** |  **1.00** |    **0.02** |  **90.3320** | **22.9492** |  **1159.1 KB** |        **1.00** |
| After        | 0             | 288.7 μs |  6.57 μs |  7.57 μs |  0.62 |    0.02 |  74.7070 |       - |  954.81 KB |        0.82 |
| BeforeReview | 0             | 280.3 μs |  2.73 μs |  2.92 μs |  0.60 |    0.01 |  74.7070 | 24.9023 |  954.81 KB |        0.82 |
|              |               |          |          |          |       |         |          |         |            |             |
| **Before**       | **3**             | **612.4 μs** |  **5.27 μs** |  **5.41 μs** |  **1.00** |    **0.01** | **128.9063** | **47.8516** | **1651.29 KB** |        **1.00** |
| After        | 3             | 420.0 μs |  7.63 μs |  8.48 μs |  0.69 |    0.01 | 113.2813 |  0.4883 |    1447 KB |        0.88 |
| BeforeReview | 3             | 464.3 μs | 12.81 μs | 14.75 μs |  0.76 |    0.02 | 113.2813 | 56.6406 |    1447 KB |        0.88 |

<details><summary>Reproduce the review comparison</summary>

Use the original reproduction instructions below to build 656b66e723 into `baseline-runner` and c994193334 into `idea4-runner`. Build 751f6d3436 into `pr6791-fixed`. Keep the three folders beside the benchmark project. Set `PERF_ROOT` to their parent, update the signing-key path, and use these project/source files. Program.cs remains the BenchmarkSwitcher entry point shown below.

```powershell
dotnet run -c Release -- --filter '*ReportingBench*' --job Dry --inProcess --artifacts ../review-dry
dotnet run -c Release --no-build -- --filter '*ReportingBench*' --inProcess --iterationCount 20 --warmupCount 6 --artifacts ../review-results --exporters fulljson
```

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <AssemblyName>TUnit.UnitTests</AssemblyName>
    <SignAssembly>true</SignAssembly>
    <AssemblyOriginatorKeyFile>C:/git/TUnit/eng/strongname.snk</AssemblyOriginatorKeyFile>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <Reference Include="TUnit.Core"><HintPath>../pr6791-fixed/TUnit.Core.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Platform"><HintPath>../baseline-runner/Microsoft.Testing.Platform.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions"><HintPath>../baseline-runner/Microsoft.Testing.Extensions.TrxReport.Abstractions.dll</HintPath></Reference>
  </ItemGroup>

</Project>


```
```csharp
using System.Reflection;
using System.Runtime.Loader;
using BenchmarkDotNet.Attributes;
using Microsoft.Testing.Platform.Extensions.Messages;
using TUnit.Core;

[MemoryDiagnoser]
public class ReportingBench
{
    [Params(0, 3)]
    public int CategoryCount { get; set; }
    private TestContext[] _contexts = null!;
    private Func<TestContext, TestNodeStateProperty, TestNode> _before = null!, _after = null!;
    private Action _clearBefore = null!, _clearAfter = null!;
    private Func<TestContext, TestNodeStateProperty, TestNode> _beforeReview = null!;
    private Action _clearBeforeReview = null!;

    [GlobalSetup]
    public void Setup()
    {
        var root = Environment.GetEnvironmentVariable("PERF_ROOT") ?? "C:/git/TUnit-perf-evidence-20260912";
        (_before, _clearBefore) = Load(root + "/baseline-runner/TUnit.Engine.dll");
        (_after, _clearAfter) = Load(root + "/pr6791-fixed/TUnit.Engine.dll");
        (_beforeReview, _clearBeforeReview) = Load(root + "/idea4-runner/TUnit.Engine.dll");
        var classMetadata = new ClassMetadata
        {
            TypeInfo = new ConcreteType(typeof(ReportingBench)), Type = typeof(ReportingBench), Name = nameof(ReportingBench),
            Namespace = "Benchmarks", Assembly = new AssemblyMetadata { Name = "Benchmarks" },
            Parameters = [], Properties = [], Parent = null
        };
        var methodMetadata = MethodMetadataFactory.Create("Test", typeof(ReportingBench), typeof(void), classMetadata);
        _contexts = Enumerable.Range(0, 1000).Select(i =>
        {
            var context = new TestContext("Test", new EmptyServices(), null!, new TestBuilderContext { TestMetadata = methodMetadata }, CancellationToken.None);
            context.Metadata.TestDetails = new TestDetails([])
            {
                TestId = "Benchmarks.ReportingBench.Test" + i, TestName = "Test" + i, ClassType = typeof(ReportingBench), MethodName = "Test",
                ClassInstance = this, TestMethodArguments = [], TestClassArguments = [], MethodMetadata = methodMetadata,
                ReturnType = typeof(void), AttributesByType = new Dictionary<Type, IReadOnlyList<Attribute>>(), TestFilePath = "Tests.cs", TestLineNumber = i + 1
            };
            for (var category = 0; category < CategoryCount; category++) context.TestDetails.Categories.Add("Category" + category);
            context.TestStart = new DateTimeOffset(2026, 9, 12, 12, 0, 0, TimeSpan.Zero);
            context.Execution.TestEnd = context.TestStart.Value.AddMilliseconds(1);
            return context;
        }).ToArray();
        var a = Before();
        var b = After();
        if (!a.Uid.Equals(b.Uid) || a.DisplayName != b.DisplayName || !Properties(a).SequenceEqual(Properties(b)))
            throw new Exception("Reporting output differs");
    }

    private static List<IProperty> Properties(TestNode node)
    {
        var result = new List<IProperty>();
        foreach (var property in node.Properties) result.Add(property);
        return result;
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        foreach (var context in _contexts) { context.RemoveFromRegistry(); context.Dispose(); }
        _clearBefore(); _clearAfter(); _clearBeforeReview();
    }

    [Benchmark(Baseline = true)]
    public TestNode Before() => Report(_before, _clearBefore);
    [Benchmark]
    public TestNode After() => Report(_after, _clearAfter);
    [Benchmark]
    public TestNode BeforeReview() => Report(_beforeReview, _clearBeforeReview);

    private TestNode Report(Func<TestContext, TestNodeStateProperty, TestNode> report, Action clear)
    {
        clear();
        TestNode last = null!;
        // One operation packages three updates for every test in a fresh 1,000-test session.
        foreach (var context in _contexts)
        {
            report(context, DiscoveredTestNodeStateProperty.CachedInstance);
            report(context, InProgressTestNodeStateProperty.CachedInstance);
            last = report(context, PassedTestNodeStateProperty.CachedInstance);
        }
        return last;
    }

    private static (Func<TestContext, TestNodeStateProperty, TestNode>, Action) Load(string path)
    {
        var loadContext = new AssemblyLoadContext(path, isCollectible: true);
        var type = loadContext.LoadFromAssemblyPath(Path.GetFullPath(path)).GetType("TUnit.Engine.Extensions.TestExtensions", true)!;
        return (type.GetMethod("ToTestNode", BindingFlags.Static | BindingFlags.NonPublic)!
            .CreateDelegate<Func<TestContext, TestNodeStateProperty, TestNode>>(),
            type.GetMethod("ClearCaches", BindingFlags.Static | BindingFlags.NonPublic)!.CreateDelegate<Action>());
    }

    private sealed class EmptyServices : IServiceProvider
    {
        public object? GetService(Type serviceType) => null;
    }
}


```
</details>

## Original revision evidence (c994193334)

Every test-node update looks up cached reporting metadata in a global ConcurrentDictionary keyed by TestId. Store that immutable metadata on its TestContext instead. A scope token preserves ClearCaches invalidation, volatile publication supports concurrent updates, and completion releases the cached properties so retained contexts do not retain reporting state. Every update still creates its own TestNode and PropertyBag.

Packaging discovered, in-progress and passed updates for 1,000 plain tests takes **286.2 us instead of 456.6 us (37.3% less)** and allocates **954.80 KB instead of 1159.09 KB (17.6% less)**. With three categories per test, time falls **23.7%** and allocations fall **12.4%**. These are reporting-operation measurements, not complete test executions.

The benchmark excludes TestContext construction. The implementation adds one object reference to each TestContext (8 bytes per field on this x64 machine); this cost is outside the allocation column. Both engine versions run against the candidate Core assembly to share compatible TestContext instances. Completion-time clearing was added after the isolated measurement; it is covered by the final executable comparison and regression test.

Validation:
- Five TestNodeLocationTests passed, including cache reset/completion cleanup and concurrent updates preserving independent states.
- All 17 GitHubReporterTests passed; 42 of 43 HtmlReporterTests passed. The remaining test, BuildReportData_Reconstructs_Attempts_From_RetryAttemptsProperty, also fails with the saved baseline Core and Engine DLLs: InvalidOperationException, "Sequence contains no matching element", HtmlReporterTests.cs:566. This is an existing failure, not hidden or disabled by this PR.
- Release builds passed for net10.0 and netstandard2.0.
- A generated executable passed exactly 10,000 tests in both source-generated and reflection modes. Benchmark setup compares the baseline/candidate node identity, display name and property values.

Whole-executable check, 20 alternating AB/BA pairs after three warmups per variant: before mean **1211.16 ms**, median **1031.23 ms**; after mean **1245.34 ms**, median **993.07 ms**. Paired mean reduction **-34.18 ms**, approximate 95% t interval **[-140.76, 72.40] ms**. This noisy result establishes neither an end-to-end gain nor a regression. A previous sample set overlapped a validation run and was discarded; only the clean rerun appears below. No whole-suite speedup is claimed.

Baseline `656b66e723`; candidate `c994193334`. Windows 11 / Intel i7-12700K, SDK 11.0.100-preview.7.26381.103, .NET 10.0.12, BenchmarkDotNet 0.15.8. Isolated AssemblyLoadContexts with shared Core/MTP dependencies, InProcessEmitToolchain, 20 iterations, six warmups. No other benchmarks/builds/tests launched by this task during the accepted measurements. Each operation resets reporting caches before packaging all three updates for every test.
```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9168/25H2/2025Update/HudsonValley2)
12th Gen Intel Core i7-12700K 3.60GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.12 (10.0.12, 10.0.1226.42308), X64 RyuJIT x86-64-v3

Toolchain=InProcessEmitToolchain  IterationCount=20  WarmupCount=6  

```
| Method | CategoryCount | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0     | Gen1    | Allocated  | Alloc Ratio |
|------- |-------------- |---------:|---------:|---------:|------:|--------:|---------:|--------:|-----------:|------------:|
| **Before** | **0**             | **456.6 μs** |  **6.02 μs** |  **6.69 μs** |  **1.00** |    **0.02** |  **90.3320** | **22.9492** | **1159.09 KB** |        **1.00** |
| After  | 0             | 286.2 μs |  5.92 μs |  6.58 μs |  0.63 |    0.02 |  74.7070 | 24.9023 |   954.8 KB |        0.82 |
|        |               |          |          |          |       |         |          |         |            |             |
| **Before** | **3**             | **610.3 μs** | **12.09 μs** | **13.93 μs** |  **1.00** |    **0.03** | **128.9063** | **47.8516** | **1651.27 KB** |        **1.00** |
| After  | 3             | 465.8 μs | 12.00 μs | 12.84 μs |  0.76 |    0.03 | 113.2813 | 56.6406 | 1446.99 KB |        0.88 |

<details><summary>Reproduce the microbenchmark</summary>

Save this project and source in an external RuntimeBench directory. Replace the signing-key checkout path in the project. Build the baseline and PR into sibling baseline-runner and idea4-runner directories:

```powershell
$env:PERF_ROOT = 'C:/path/to/evidence'
dotnet build C:/path/to/baseline/src/TUnit.Engine -c Release -f net10.0 -p:CopyLocalLockFileAssemblies=true -o "$env:PERF_ROOT/baseline-runner"
dotnet build C:/path/to/candidate/src/TUnit.Engine -c Release -f net10.0 -p:CopyLocalLockFileAssemblies=true -o "$env:PERF_ROOT/idea4-runner"
Set-Location "$env:PERF_ROOT/RuntimeBench"
dotnet run -c Release -- --filter '*ReportingBench*' --job Dry --inProcess --artifacts ../dry
dotnet run -c Release --no-build -- --filter '*ReportingBench*' --inProcess --iterationCount 20 --warmupCount 6 --artifacts ../results --exporters fulljson
```

Program.cs:
```csharp
BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(ReportingBench).Assembly).Run(args);
```

RuntimeBench.csproj:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <AssemblyName>TUnit.UnitTests</AssemblyName>
    <SignAssembly>true</SignAssembly>
    <AssemblyOriginatorKeyFile>C:/git/TUnit-perf-blog/eng/strongname.snk</AssemblyOriginatorKeyFile>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
    <Reference Include="TUnit.Core"><HintPath>../idea4-runner/TUnit.Core.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Platform"><HintPath>../baseline-runner/Microsoft.Testing.Platform.dll</HintPath></Reference>
    <Reference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions"><HintPath>../baseline-runner/Microsoft.Testing.Extensions.TrxReport.Abstractions.dll</HintPath></Reference>
  </ItemGroup>

</Project>

```

ReportingBench.cs:
```csharp
using System.Reflection;
using System.Runtime.Loader;
using BenchmarkDotNet.Attributes;
using Microsoft.Testing.Platform.Extensions.Messages;
using TUnit.Core;

[MemoryDiagnoser]
public class ReportingBench
{
    [Params(0, 3)]
    public int CategoryCount { get; set; }
    private TestContext[] _contexts = null!;
    private Func<TestContext, TestNodeStateProperty, TestNode> _before = null!, _after = null!;
    private Action _clearBefore = null!, _clearAfter = null!;

    [GlobalSetup]
    public void Setup()
    {
        var root = Environment.GetEnvironmentVariable("PERF_ROOT") ?? "C:/git/TUnit-perf-evidence-20260912";
        (_before, _clearBefore) = Load(root + "/baseline-runner/TUnit.Engine.dll");
        (_after, _clearAfter) = Load(root + "/idea4-runner/TUnit.Engine.dll");
        var classMetadata = new ClassMetadata
        {
            TypeInfo = new ConcreteType(typeof(ReportingBench)), Type = typeof(ReportingBench), Name = nameof(ReportingBench),
            Namespace = "Benchmarks", Assembly = new AssemblyMetadata { Name = "Benchmarks" },
            Parameters = [], Properties = [], Parent = null
        };
        var methodMetadata = MethodMetadataFactory.Create("Test", typeof(ReportingBench), typeof(void), classMetadata);
        _contexts = Enumerable.Range(0, 1000).Select(i =>
        {
            var context = new TestContext("Test", new EmptyServices(), null!, new TestBuilderContext { TestMetadata = methodMetadata }, CancellationToken.None);
            context.Metadata.TestDetails = new TestDetails([])
            {
                TestId = "Benchmarks.ReportingBench.Test" + i, TestName = "Test" + i, ClassType = typeof(ReportingBench), MethodName = "Test",
                ClassInstance = this, TestMethodArguments = [], TestClassArguments = [], MethodMetadata = methodMetadata,
                ReturnType = typeof(void), AttributesByType = new Dictionary<Type, IReadOnlyList<Attribute>>(), TestFilePath = "Tests.cs", TestLineNumber = i + 1
            };
            for (var category = 0; category < CategoryCount; category++) context.TestDetails.Categories.Add("Category" + category);
            context.TestStart = new DateTimeOffset(2026, 9, 12, 12, 0, 0, TimeSpan.Zero);
            context.Execution.TestEnd = context.TestStart.Value.AddMilliseconds(1);
            return context;
        }).ToArray();
        var a = Before();
        var b = After();
        if (!a.Uid.Equals(b.Uid) || a.DisplayName != b.DisplayName || !Properties(a).SequenceEqual(Properties(b)))
            throw new Exception("Reporting output differs");
    }

    private static List<IProperty> Properties(TestNode node)
    {
        var result = new List<IProperty>();
        foreach (var property in node.Properties) result.Add(property);
        return result;
    }

    [GlobalCleanup]
    public void Cleanup()
    {
        foreach (var context in _contexts) { context.RemoveFromRegistry(); context.Dispose(); }
        _clearBefore(); _clearAfter();
    }

    [Benchmark(Baseline = true)]
    public TestNode Before() => Report(_before, _clearBefore);
    [Benchmark]
    public TestNode After() => Report(_after, _clearAfter);

    private TestNode Report(Func<TestContext, TestNodeStateProperty, TestNode> report, Action clear)
    {
        clear();
        TestNode last = null!;
        // One operation packages three updates for every test in a fresh 1,000-test session.
        foreach (var context in _contexts)
        {
            report(context, DiscoveredTestNodeStateProperty.CachedInstance);
            report(context, InProgressTestNodeStateProperty.CachedInstance);
            last = report(context, PassedTestNodeStateProperty.CachedInstance);
        }
        return last;
    }

    private static (Func<TestContext, TestNodeStateProperty, TestNode>, Action) Load(string path)
    {
        var loadContext = new AssemblyLoadContext(path, isCollectible: true);
        var type = loadContext.LoadFromAssemblyPath(Path.GetFullPath(path)).GetType("TUnit.Engine.Extensions.TestExtensions", true)!;
        return (type.GetMethod("ToTestNode", BindingFlags.Static | BindingFlags.NonPublic)!
            .CreateDelegate<Func<TestContext, TestNodeStateProperty, TestNode>>(),
            type.GetMethod("ClearCaches", BindingFlags.Static | BindingFlags.NonPublic)!.CreateDelegate<Action>());
    }

    private sealed class EmptyServices : IServiceProvider
    {
        public object? GetService(Type serviceType) => null;
    }
}

```
</details>
<details><summary>Raw whole-executable samples (milliseconds)</summary>
```csv
"Pair","Variant","Milliseconds"
"1","Before","1844.8189"
"1","After","2023.8598"
"2","After","2266.0609"
"2","Before","2310.8018"
"3","Before","1471.2523"
"3","After","2150.7197"
"4","After","1503.5988"
"4","Before","1085.087"
"5","Before","1104.559"
"5","After","1196.6912"
"6","After","1825.4811"
"6","Before","1730.2069"
"7","Before","1637.9832"
"7","After","1123.7757"
"8","After","1103.8656"
"8","Before","1057.9552"
"9","Before","1115.3834"
"9","After","963.0704"
"10","After","976.8791"
"10","Before","958.4455"
"11","Before","989.8522"
"11","After","987.1668"
"12","After","954.4256"
"12","Before","968.6624"
"13","Before","981.9879"
"13","After","992.2406"
"14","After","967.3678"
"14","Before","1004.5135"
"15","Before","980.9562"
"15","After","978.1436"
"16","After","946.2435"
"16","Before","1090.6588"
"17","Before","993.9318"
"17","After","950.8155"
"18","After","993.9059"
"18","Before","970.9519"
"19","Before","968.484"
"19","After","1040.5333"
"20","After","962.0398"
"20","Before","956.7691"

```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing cached test metadata now refreshes information for existing test contexts.
  - Final test updates now release cached reporting information across all terminal states.
  - Improved isolation of test state during concurrent test execution, preserving accurate messages and file-location details.
  - Reporting information is refreshed when a test context is removed and recreated, reducing the risk of stale results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

