### PR TITLE
chore: switch to fillable checkboxes for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,12 +7,18 @@ body:
     attributes:
       value: |
         Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
-
-        **Before submitting**, please check:
-        - [ ] I've searched [existing issues](https://github.com/thomhurst/TUnit/issues) to ensure this isn't a duplicate
-        - [ ] I've read the [documentation](https://tunit.dev/) and this isn't expected behavior
-        - [ ] I'm using the latest version of TUnit
-
+  - type: checkboxes
+    id: bug-checklist
+    attributes:
+      label: Bug report checklist
+      description: Before submitting, please check
+      options:
+        - label: I've searched [existing issues](https://github.com/thomhurst/TUnit/issues) to ensure this isn't a duplicate
+          required: true
+        - label: I've read the [documentation](https://tunit.dev/) and this isn't expected behavior
+          required: true
+        - label: I'm using the latest version of TUnit
+          required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,12 +7,18 @@ body:
     attributes:
       value: |
         Thanks for suggesting a feature! We appreciate your input in making TUnit better.
-
-        **Before submitting**, please:
-        - [ ] Search [existing issues](https://github.com/thomhurst/TUnit/issues) and [discussions](https://github.com/thomhurst/TUnit/discussions) to ensure this hasn't been suggested before
-        - [ ] Check the [documentation](https://tunit.dev/) to confirm this feature doesn't already exist
-        - [ ] Consider starting a [discussion](https://github.com/thomhurst/TUnit/discussions/new?category=ideas) first for larger features to get community feedback
-
+  - type: checkboxes
+    id: feature-checklist
+    attributes:
+      label: Feature request checklist
+      description: Before submitting, please check
+      options:
+        - label: Search [existing issues](https://github.com/thomhurst/TUnit/issues) and [discussions](https://github.com/thomhurst/TUnit/discussions) to ensure this hasn't been suggested before
+          required: true
+        - label: Check the [documentation](https://tunit.dev/) to confirm this feature doesn't already exist
+          required: true
+        - label: Consider starting a [discussion](https://github.com/thomhurst/TUnit/discussions/new?category=ideas) first for larger features to get community feedback
+          required: true
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Description

This PR makes the checkboxes in the issue template interactable and required before opening an issue.

## Type of Change

- [x] Documentation update

## Checklist

### Required

- [x] I have read the [Contributing Guidelines](https://github.com/thomhurst/TUnit/blob/main/.github/CONTRIBUTING.md)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated bug report and feature request forms with structured checklists.
  * Made all checklist items required to help ensure submissions include essential information.
  * Preserved checks for duplicate reports, documentation review, and use of the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->